### PR TITLE
fix(capture): #680 a spool quarantine is never a silent drop — loud at the lane and counted in /health

### DIFF
--- a/docs/sme/entries/2026-08-09-a-hardcoded-zero-standing-in-for-an-unmeasured-quantity-is-a-silent-data-loss.md
+++ b/docs/sme/entries/2026-08-09-a-hardcoded-zero-standing-in-for-an-unmeasured-quantity-is-a-silent-data-loss.md
@@ -1,0 +1,77 @@
+---
+lane: gotcha-agent
+order: 68
+---
+## [2026-08-09] A hardcoded 0 standing in for an unmeasured quantity is a silent data loss
+
+**Severity:** HIGH
+**Source:** #680 (cutover blocker B2) — 15 raw turns and ~44 lifecycle records permanently abandoned while `/health` read `spool_pending:0, reason:"capture lane delivering"`
+**Scope:** any health block, metric, counter, or status field a vantage point cannot actually measure
+**Status:** active
+
+### Pattern
+
+A reporting surface needs a number it cannot observe, so it passes `0` — or
+`?? 0`, or omits the field so a reader defaults it. The value is not wrong in a
+way anyone notices, because zero is exactly what a HEALTHY system reports. The
+two states collapse into one:
+
+- **nothing is wrong** — measured, and the count really is zero.
+- **nobody looked** — unmeasured, rendered as if measured.
+
+Every alert, dashboard, and reviewer downstream now reads the second as the
+first. The failure is not that the surface is silent; it is that the surface is
+CONFIDENTLY GREEN over the exact condition it exists to report.
+
+Measured instance: `liveness-observer.ts` hardcoded `spoolPending: 0` because a
+server genuinely cannot enumerate client-side spool files. That reasoning was
+CORRECT for spool depth and was silently inherited by quarantine — a different
+quantity a client already computes (`SpoolStatus.quarantined_count`) and can
+simply report. Fifteen turns were confirmed absent from `ob_raw_turns` and
+present on disk in a sidecar, while the same session kept delivering 1,819
+further turns, so the lane looked healthy by every available signal. The count
+that would have revealed it had existed for weeks with zero consumers anywhere
+outside the module that computed it.
+
+### What to check in review
+
+1. **For every 0 in a status/health/metric construction, ask "measured, or
+   assumed?"** A literal `0`, a `?? 0`, or a default parameter on a field the
+   producer cannot see is the smell. The fix is ABSENT (`undefined`, field
+   omitted), never a neutral-looking number.
+2. **A computed value with no consumer is a defect, not dead code.** Grep the
+   count's name across the tree. If the only references are the module that
+   computes it and its own tests, the observability it represents does not
+   exist — someone built the measurement and never connected it.
+3. **When a module documents WHY it cannot observe something, check that the
+   reasoning still holds for every field it covers.** "A server cannot read
+   client files" is true of a spool's live depth and false of a count the
+   client already reports. Inherited justifications are how a correct argument
+   ends up defending an incorrect case.
+4. **Ask whether the fault is gated on liveness quorum, and whether it should
+   be.** "Is it working right now?" is meaningless on a quiet night and
+   correctly suppressed below quorum. "Is data already lost?" is equally true
+   at 3am — gating it hides precisely the deployment that stopped working
+   BECAUSE its records were being dropped.
+5. **A latch or dedupe that suppresses repeats must be checked against the
+   fact's LIFETIME.** State-change suppression is right for a transient
+   condition that resolves itself and wrong for a standing one that never
+   does: the recovery is exactly when a healthy-looking report buries the
+   permanent loss.
+
+### Test that proves it
+
+Assert the ABSENT case separately from the zero case, and mutation-test it —
+this class is invisible in a fully-green run:
+
+```ts
+it("omits the count entirely when nothing reported one", () => {
+  const reading = readCaptureLiveness(deliveringObservation()); // no input
+  expect(reading).not.toHaveProperty("quarantined_count");
+});
+```
+
+Replacing the conditional spread with `quarantined_count: quarantined ?? 0`
+(the defect's own shape) must turn the suite red. In #680 that mutant was
+killed by 2 tests; without the absent-case clause it would have survived, and
+the check would have certified the defect.

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -1617,3 +1617,77 @@ Review checks:
 ### Why it matters
 
 A done-means check exists to be the one thing that cannot be talked out of a verdict. A verdict channel that converts "crashed" into "passed" inverts exactly that guarantee, and it does so most reliably under the conditions the check was written for — a broken subject. Every clause downstream of the throw is silently skipped, so the more the subject is broken, the earlier the crash and the fewer clauses run.
+
+## [2026-08-09] A hardcoded 0 standing in for an unmeasured quantity is a silent data loss
+
+**Severity:** HIGH
+**Source:** #680 (cutover blocker B2) — 15 raw turns and ~44 lifecycle records permanently abandoned while `/health` read `spool_pending:0, reason:"capture lane delivering"`
+**Scope:** any health block, metric, counter, or status field a vantage point cannot actually measure
+**Status:** active
+
+### Pattern
+
+A reporting surface needs a number it cannot observe, so it passes `0` — or
+`?? 0`, or omits the field so a reader defaults it. The value is not wrong in a
+way anyone notices, because zero is exactly what a HEALTHY system reports. The
+two states collapse into one:
+
+- **nothing is wrong** — measured, and the count really is zero.
+- **nobody looked** — unmeasured, rendered as if measured.
+
+Every alert, dashboard, and reviewer downstream now reads the second as the
+first. The failure is not that the surface is silent; it is that the surface is
+CONFIDENTLY GREEN over the exact condition it exists to report.
+
+Measured instance: `liveness-observer.ts` hardcoded `spoolPending: 0` because a
+server genuinely cannot enumerate client-side spool files. That reasoning was
+CORRECT for spool depth and was silently inherited by quarantine — a different
+quantity a client already computes (`SpoolStatus.quarantined_count`) and can
+simply report. Fifteen turns were confirmed absent from `ob_raw_turns` and
+present on disk in a sidecar, while the same session kept delivering 1,819
+further turns, so the lane looked healthy by every available signal. The count
+that would have revealed it had existed for weeks with zero consumers anywhere
+outside the module that computed it.
+
+### What to check in review
+
+1. **For every 0 in a status/health/metric construction, ask "measured, or
+   assumed?"** A literal `0`, a `?? 0`, or a default parameter on a field the
+   producer cannot see is the smell. The fix is ABSENT (`undefined`, field
+   omitted), never a neutral-looking number.
+2. **A computed value with no consumer is a defect, not dead code.** Grep the
+   count's name across the tree. If the only references are the module that
+   computes it and its own tests, the observability it represents does not
+   exist — someone built the measurement and never connected it.
+3. **When a module documents WHY it cannot observe something, check that the
+   reasoning still holds for every field it covers.** "A server cannot read
+   client files" is true of a spool's live depth and false of a count the
+   client already reports. Inherited justifications are how a correct argument
+   ends up defending an incorrect case.
+4. **Ask whether the fault is gated on liveness quorum, and whether it should
+   be.** "Is it working right now?" is meaningless on a quiet night and
+   correctly suppressed below quorum. "Is data already lost?" is equally true
+   at 3am — gating it hides precisely the deployment that stopped working
+   BECAUSE its records were being dropped.
+5. **A latch or dedupe that suppresses repeats must be checked against the
+   fact's LIFETIME.** State-change suppression is right for a transient
+   condition that resolves itself and wrong for a standing one that never
+   does: the recovery is exactly when a healthy-looking report buries the
+   permanent loss.
+
+### Test that proves it
+
+Assert the ABSENT case separately from the zero case, and mutation-test it —
+this class is invisible in a fully-green run:
+
+```ts
+it("omits the count entirely when nothing reported one", () => {
+  const reading = readCaptureLiveness(deliveringObservation()); // no input
+  expect(reading).not.toHaveProperty("quarantined_count");
+});
+```
+
+Replacing the conditional spread with `quarantined_count: quarantined ?? 0`
+(the defect's own shape) must turn the suite red. In #680 that mutant was
+killed by 2 tests; without the absent-case clause it would have survived, and
+the check would have certified the defect.

--- a/python/openbrain/src/openbrain/apps/capture/outage.py
+++ b/python/openbrain/src/openbrain/apps/capture/outage.py
@@ -240,19 +240,57 @@ _MIGRATIONS = (
 )
 
 
-def spool_notice(notice: str, pending: int | None) -> str:
-    """Render one notice, with the spool depth when it is known.
+#: The line printed when reachability is UNCHANGED but records are abandoned.
+#:
+#: Its own notice rather than a reuse of :data:`DEGRADED_NOTICE`, because the
+#: brain is not unreachable in this case -- it is very likely delivering
+#: perfectly, which is what makes the situation dangerous. Saying "unreachable"
+#: would send an operator to check a service that is fine and would go stale
+#: the moment they confirmed it, teaching them the line is noise. The subject
+#: here is the records, not the connection.
+QUARANTINE_ONLY_NOTICE = "open-brain capture - records abandoned by replay"
+
+#: Appended to a notice when records have been ABANDONED, not merely held.
+#:
+#: Deliberately different wording from the spool depth, because the two need
+#: different operator actions and a line that cannot tell them apart is a line
+#: the operator learns to skip. A spool depth drains itself the moment the
+#: server comes back; a quarantined unit never will -- it has already used up
+#: its ``quarantine_threshold`` replay attempts and is retried by NOTHING. The
+#: memory-capacity reference states it plainly under "Quarantine threshold":
+#: never retried automatically, triage is operator-managed. "Held for replay"
+#: is reassuring and, for these records, false.
+QUARANTINE_NOTICE = "ABANDONED - replay gave up, operator action required"
+
+
+def spool_notice(
+    notice: str,
+    pending: int | None,
+    quarantined: int | None = 0,
+) -> str:
+    """Render one notice, with the spool depth and any ABANDONED records.
 
     Args:
         notice: :data:`DEGRADED_NOTICE` or :data:`RECOVERED_NOTICE`.
-        pending: How many records are waiting in the spool, or ``None`` when
+        pending: The count of records waiting in the spool, or ``None`` when
             the count could not be read.
+        quarantined: The count of units abandoned into the quarantine sidecar,
+            or ``None`` when that count could not be read. Defaults to ``0`` so
+            existing two-argument callers keep their exact behaviour.
 
     Returns:
-        The line to print. The depth is appended only when it is genuinely
-        known -- an unreadable spool prints no count rather than a ``?`` or a
-        guessed ``0``, because a count is the one thing on this line an
-        operator would act on.
+        The line to print. Each count is appended only when it is genuinely
+        known and non-zero -- an unreadable spool prints no count rather than a
+        ``?`` or a guessed ``0``, because a count is the one thing on this line
+        an operator would act on.
+
+    WHY QUARANTINE IS NOT FOLDED INTO THE SPOOL DEPTH (#680). It would have
+    been one character cheaper to add the two numbers together, and it would
+    have rebuilt the defect: a single depth reads as backlog, backlog reads as
+    self-healing, and the operator's correct response to backlog is to wait.
+    Waiting is exactly wrong here. On 2026-07-30 fifteen turns were abandoned
+    while this line reported a healthy spool, so the abandoned records get
+    their own clause, in words that ask for a human.
 
     Example:
         >>> spool_notice(DEGRADED_NOTICE, 3)
@@ -261,10 +299,15 @@ def spool_notice(notice: str, pending: int | None) -> str:
         'open-brain unreachable - turn held for replay'
         >>> spool_notice(DEGRADED_NOTICE, 0)
         'open-brain unreachable - turn held for replay'
+        >>> spool_notice(DEGRADED_NOTICE, 0, 2)
+        'open-brain unreachable - turn held for replay (quarantined: 2 - ABANDONED - replay gave up, operator action required)'
     """
-    if not pending:
-        return notice
-    return f"{notice} (spool: {pending})"
+    line = notice
+    if pending:
+        line = f"{line} (spool: {pending})"
+    if quarantined:
+        line = f"{line} (quarantined: {quarantined} - {QUARANTINE_NOTICE})"
+    return line
 
 
 def spool_pending(path: Path | None) -> int | None:
@@ -296,6 +339,101 @@ def spool_pending(path: Path | None) -> int | None:
     except OSError:
         return None
     return sum(1 for line in text.split("\n") if _is_json_object_line(line))
+
+
+#: Schema marker on a quarantine sidecar's envelope lines.
+#:
+#: Mirrors ``openbrain_memory.spool.QUARANTINE_ENVELOPE_SCHEMA`` rather than
+#: importing it, exactly as ``spool_pending`` re-derives its own path
+#: resolution and line counting: ``openbrain`` does not depend on the provider
+#: package, and this module runs inside a 5-second ``Stop`` deadline where it
+#: must not import a client to print one number. The value is pinned against
+#: the writer's constant by a test, so the two cannot drift silently.
+QUARANTINE_ENVELOPE_SCHEMA = "openbrain.spool_quarantine.v1"
+
+#: Suffix the provider appends to a spool path to name its quarantine sidecar.
+#: Mirrors ``JsonlSpool.quarantine_path`` (``path.with_suffix(suffix +
+#: ".quarantine.jsonl")``), pinned by the same test.
+QUARANTINE_SUFFIX = ".quarantine.jsonl"
+
+
+def quarantine_path(spool_path: Path) -> Path:
+    """Where the provider parks units it has given up on.
+
+    Args:
+        spool_path: The live spool file.
+
+    Returns:
+        The sidecar path, derived exactly as ``JsonlSpool`` derives it.
+    """
+    return spool_path.with_suffix(spool_path.suffix + QUARANTINE_SUFFIX)
+
+
+def spool_quarantined(path: Path | None) -> int | None:
+    """Count the units the provider ABANDONED into the quarantine sidecar.
+
+    Args:
+        path: The LIVE spool file (not the sidecar), or ``None`` when no spool
+            is configured. The sidecar is derived from it, so callers pass the
+            same path they already pass to :func:`spool_pending`.
+
+    Returns:
+        The count of quarantine envelopes, ``0`` for an absent or empty
+        sidecar, or ``None`` when the sidecar exists but could not be read.
+
+    THE DEFECT THIS EXISTS TO END (#680, cutover blocker B2). After
+    ``quarantine_threshold`` consecutive replay failures the provider moves a
+    unit out of the live spool and into a sidecar, and stops retrying it. Every
+    operator-facing count in this module reads the LIVE spool, so the move made
+    the number go DOWN: on 2026-07-30 fifteen real turns and roughly forty-four
+    lifecycle events were abandoned while ``/health`` reported
+    ``spool_pending:0, reason:"capture lane delivering"``. The records were
+    confirmed absent from ``ob_raw_turns`` and present on disk in the sidecar.
+    ``SpoolStatus.quarantined_count`` had existed the whole time with no
+    consumer anywhere outside the provider package.
+
+    ENVELOPES, NOT LINES. The sidecar interleaves one content-free envelope per
+    abandoned unit with that unit's original record lines, so counting lines
+    would report a number that moves with payload size rather than with the
+    thing an operator cares about. Counting envelopes counts abandoned units,
+    which is what ``quarantined_count`` means on the writing side.
+
+    UNREADABLE IS ``None``, NEVER ``0``. Inherited deliberately from
+    :func:`spool_pending`: a guessed zero for a sidecar that could not be read
+    is this very defect rebuilt one directory over, and the operator acts on
+    this count.
+    """
+    if path is None:
+        return 0
+    sidecar = quarantine_path(path)
+    try:
+        if not sidecar.exists():
+            return 0
+        if sidecar.stat().st_size == 0:
+            return 0
+        text = sidecar.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    return sum(1 for line in text.split("\n") if _is_quarantine_envelope(line))
+
+
+def _is_quarantine_envelope(line: str) -> bool:
+    """Whether one sidecar line is a quarantine envelope (not a record line).
+
+    A truncated or non-object line is a crash artifact, and a record line
+    belongs to a unit already counted by its own envelope -- neither is an
+    abandoned unit.
+    """
+    if not line.strip():
+        return False
+    try:
+        parsed = json.loads(line)
+    except json.JSONDecodeError:
+        return False
+    return (
+        isinstance(parsed, dict)
+        and parsed.get("schema") == QUARANTINE_ENVELOPE_SCHEMA
+    )
 
 
 def _is_json_object_line(line: str) -> bool:

--- a/python/openbrain/src/openbrain/apps/hooks/stop.py
+++ b/python/openbrain/src/openbrain/apps/hooks/stop.py
@@ -80,11 +80,13 @@ from typing import TYPE_CHECKING
 from loguru import logger
 
 from openbrain.apps.capture.outage import (
+    QUARANTINE_ONLY_NOTICE,
     OutageLatch,
     default_spool_path,
     latch_path,
     spool_notice,
     spool_pending,
+    spool_quarantined,
 )
 from openbrain.apps.hooks.session import StopHook, run_stop
 from openbrain.config import load_capture_settings, load_observation_settings
@@ -233,7 +235,8 @@ def announce_outage_state(
     delivered: bool,
     notices: TextIO | None,
 ) -> None:
-    """Latch this Stop's outcome and print a line only when the state CHANGED.
+    """Latch this Stop's outcome, and speak when the state CHANGED or records
+    have been ABANDONED.
 
     Args:
         session_key: The session whose health this is, or ``None`` when the
@@ -246,6 +249,25 @@ def announce_outage_state(
     that did not parse is a defect in the harness's message, not evidence about
     Open Brain's reachability, and announcing an outage from one would be a
     false alarm on every malformed Stop.
+
+    WHY A QUARANTINE COUNT IS NOT GATED ON THE LATCH (#680, cutover blocker
+    B2). The latch exists to say a CHANGE once and then stay quiet, which is
+    exactly right for reachability: an outage that is still going is not news.
+    Abandoned records are the opposite kind of fact. They are a standing
+    condition that nothing resolves on its own -- the provider has already
+    exhausted its replay attempts and will never retry them -- so the latch's
+    "already said that" is the wrong instinct: it said it about the OUTAGE, and
+    the outage recovering is precisely when a healthy-looking Stop would bury
+    the loss. That is the observed 2026-07-30 shape: the lane recovered, kept
+    delivering 1,819 further turns for the same session, and the fifteen
+    abandoned ones were never mentioned again by anything.
+
+    So the line is emitted whenever the count is non-zero, on every Stop, until
+    an operator triages the sidecar. That is deliberate repetition, and it is
+    the cheaper error: an operator who sees it daily can act on it, whereas the
+    status quo is that nobody ever learns. It is the same reasoning
+    ``log_capture_failure`` uses in reverse -- there, repetition of a KNOWN
+    outage is demoted because waiting resolves it; here, waiting does not.
 
     Wrapped in its own swallow. This function exists to REPORT a failure; it
     must not be able to cause one, so a notice that cannot be latched or written
@@ -260,13 +282,24 @@ def announce_outage_state(
             if delivered
             else latch.note_spooled(session_key)
         )
-        if notice is None:
+        spool_path = default_spool_path(settings.spool_path)
+        # Read the sidecar even on an unchanged latch: abandoned records are a
+        # standing condition, not an event, and gating them on a state CHANGE
+        # is what made the 2026-07-30 loss permanent and silent. The read is
+        # one stat on a file that does not exist for a healthy machine, which
+        # is the same cost the pending read already pays when it does speak.
+        quarantined = spool_quarantined(spool_path)
+        if notice is None and not quarantined:
             return
-        # Only read the spool once there is genuinely a line to print, so the
-        # ordinary healthy Stop never pays the stat/read at all.
-        line = spool_notice(
-            notice, spool_pending(default_spool_path(settings.spool_path))
-        )
+
+        if notice is None:
+            # Nothing changed about reachability, but records are abandoned.
+            # Say only that -- prefixing a recovery or degradation notice that
+            # did not happen would be reporting a state transition that the
+            # latch explicitly did not observe.
+            line = spool_notice(QUARANTINE_ONLY_NOTICE, 0, quarantined)
+        else:
+            line = spool_notice(notice, spool_pending(spool_path), quarantined)
         target = sys.stderr if notices is None else notices
         target.write(f"{line}\n")
         target.flush()

--- a/python/openbrain/src/openbrain/apps/hooks/stop.py
+++ b/python/openbrain/src/openbrain/apps/hooks/stop.py
@@ -235,8 +235,7 @@ def announce_outage_state(
     delivered: bool,
     notices: TextIO | None,
 ) -> None:
-    """Latch this Stop's outcome, and speak when the state CHANGED or records
-    have been ABANDONED.
+    """Latch this Stop's outcome; speak on a CHANGE or on ABANDONED records.
 
     Args:
         session_key: The session whose health this is, or ``None`` when the

--- a/python/openbrain/tests/conftest.py
+++ b/python/openbrain/tests/conftest.py
@@ -39,7 +39,10 @@ _LEAKING_NAMES = frozenset({"PORT", "SERVICE_NAME", "ALLOWED_ORIGINS"})
 
 
 @pytest.fixture(autouse=True)
-def _clean_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+def _clean_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
     """Remove every variable the settings models read, for every test.
 
     WHY THIS IS SUITE-WIDE AND NOT PER-FILE (#544). ``test_settings`` has
@@ -78,6 +81,27 @@ def _clean_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     Prefix-based rather than a fixed list, because the failure mode is a
     variable nobody thought to enumerate -- the one that hung the suite was
     added to the environment file after the tests were written.
+
+    THE STATE DIRECTORY IS THE SAME LEAK, ONE LAYER DOWN (#680). Clearing the
+    prefixes above removes ``OPENBRAIN_SPOOL_PATH``, which sends
+    ``apps.capture.outage.default_spool_path`` to its LAST fallback:
+    ``$XDG_STATE_HOME`` or, failing that, ``~/.local/state``. That is the
+    developer's REAL spool directory. It went unnoticed while the only reader
+    ran after the latch had already decided to speak, but the #680 quarantine
+    read is unconditional by design -- abandoned records are a standing
+    condition, not an event -- so an unconfigured test began reading the
+    operator's actual sidecar.
+
+    MEASURED, ON THIS BRANCH: seven "says nothing" tests failed because
+    ``~/.local/state/openbrain-memory/claude-spool.jsonl.quarantine.jsonl``
+    exists on this machine and holds the fifteen turns #680 was filed about.
+    The assertions were reading live user data, and on a machine with a clean
+    home they would have passed -- the same "passes on their machine only"
+    shape this fixture's docstring already describes for settings.
+
+    Redirected, not deleted: a test that legitimately resolves a state path
+    still gets a real, writable, EMPTY directory, so the fallback is exercised
+    rather than skipped.
     """
     for name in list(os.environ):
         upper = name.upper()
@@ -85,6 +109,14 @@ def _clean_environment(monkeypatch: pytest.MonkeyPatch) -> None:
             continue
         if upper.startswith(_LEAKING_PREFIXES) or upper in _LEAKING_NAMES:
             monkeypatch.delenv(name, raising=False)
+
+    state_home = tmp_path_factory.mktemp("xdg-state")
+    monkeypatch.setenv("XDG_STATE_HOME", str(state_home))
+    # HOME too: `default_spool_path` falls back to `Path.home()/.local/state`
+    # when XDG_STATE_HOME is empty, and `Path.home()` reads HOME directly, so
+    # setting only the former leaves the empty-string path pointed at the real
+    # home directory.
+    monkeypatch.setenv("HOME", str(state_home))
 
 
 #: The timestamp every helper line carries. Real transcripts always set one, and

--- a/python/openbrain/tests/test_capture_outage_notice.py
+++ b/python/openbrain/tests/test_capture_outage_notice.py
@@ -45,11 +45,16 @@ from conftest import (
 )
 from openbrain.apps.capture.outage import (
     DEGRADED_NOTICE,
+    QUARANTINE_ENVELOPE_SCHEMA,
+    QUARANTINE_ONLY_NOTICE,
+    QUARANTINE_SUFFIX,
     RECOVERED_NOTICE,
     OutageLatch,
     default_spool_path,
+    quarantine_path,
     spool_notice,
     spool_pending,
+    spool_quarantined,
 )
 from openbrain.apps.capture.watermark import WatermarkStore
 from openbrain.apps.hooks import stop, subagent_stop
@@ -1117,6 +1122,157 @@ class TestTheSpoolDepthOnTheNotice:
 
         assert resolved.is_absolute()
         assert resolved.name == "claude-spool.jsonl"
+
+
+class TestQuarantineIsNeverSilent:
+    """#680 — abandoned records are visible and named at the capture lane.
+
+    The defect these pin: after ``quarantine_threshold`` consecutive replay
+    failures the provider moves a unit to a sidecar and stops retrying it, and
+    every count in this module read the LIVE spool, so the move made the number
+    go DOWN. Fifteen real turns were lost that way on 2026-07-30 while the
+    operator line reported a healthy spool.
+    """
+
+    def test_the_mirrored_constants_match_the_writer(self, tmp_path: Path) -> None:
+        """The reader re-derives the writer's schema and suffix; pin them.
+
+        ``openbrain`` deliberately does not depend on the provider package
+        (``spool_pending`` re-derives its path resolution for the same reason),
+        so these constants are COPIES. A copy that drifts silently makes the
+        reader count zero envelopes forever while the sidecar fills — a green
+        surface over a live loss, which is precisely the defect class. This
+        test is the only thing standing between the copy and that drift.
+        """
+        from openbrain_memory.spool import (  # noqa: PLC0415
+            QUARANTINE_ENVELOPE_SCHEMA as WRITER_SCHEMA,
+        )
+        from openbrain_memory.spool import JsonlSpool  # noqa: PLC0415
+
+        assert QUARANTINE_ENVELOPE_SCHEMA == WRITER_SCHEMA
+
+        spool = JsonlSpool(tmp_path / "example-spool.jsonl")
+        assert spool.quarantine_path == quarantine_path(spool.path)
+        assert QUARANTINE_SUFFIX in str(spool.quarantine_path)
+
+    def test_an_absent_sidecar_is_a_real_zero(self, tmp_path: Path) -> None:
+        assert spool_quarantined(tmp_path / "never-existed.jsonl") == 0
+
+    def test_no_configured_spool_is_zero(self) -> None:
+        assert spool_quarantined(None) == 0
+
+    def test_an_unreadable_sidecar_is_none_never_a_guessed_zero(
+        self, tmp_path: Path
+    ) -> None:
+        """Unreadable and empty are different facts; only one is actionable."""
+        spool = tmp_path / "spool.jsonl"
+        spool.write_text("", encoding="utf-8")
+        quarantine_path(spool).mkdir()
+
+        assert spool_quarantined(spool) is None
+
+    def test_envelopes_are_counted_not_lines(self, tmp_path: Path) -> None:
+        """A unit's record lines belong to a unit already counted once.
+
+        Counting lines would make the number move with payload size instead of
+        with abandoned units, so a single fat turn would read as a crisis and a
+        dozen small ones as nothing.
+        """
+        spool = tmp_path / "spool.jsonl"
+        spool.write_text("", encoding="utf-8")
+        quarantine_path(spool).write_text(
+            "\n".join(
+                [
+                    json.dumps(
+                        {"schema": QUARANTINE_ENVELOPE_SCHEMA, "spool_key": "a"}
+                    ),
+                    json.dumps({"operation": "ingest_raw_turn", "payload": {}}),
+                    json.dumps({"operation": "ingest_raw_turn", "payload": {}}),
+                    json.dumps(
+                        {"schema": QUARANTINE_ENVELOPE_SCHEMA, "spool_key": "b"}
+                    ),
+                    json.dumps({"operation": "session_wrap", "payload": {}}),
+                    "",
+                    "{truncated",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        assert spool_quarantined(spool) == 2
+
+    def test_the_notice_names_abandonment_separately_from_backlog(self) -> None:
+        """One number cannot mean both "drains itself" and "never will"."""
+        line = spool_notice(DEGRADED_NOTICE, 3, 2)
+
+        assert "(spool: 3)" in line
+        assert "quarantined: 2" in line
+        # The words must ask for a human; backlog wording invites waiting,
+        # which is the wrong response to a permanent loss.
+        assert "ABANDONED" in line
+
+    def test_zero_quarantined_says_nothing_about_quarantine(self) -> None:
+        """A line that shouts on every Stop is a line the operator skips."""
+        assert spool_notice(DEGRADED_NOTICE, 3, 0) == f"{DEGRADED_NOTICE} (spool: 3)"
+        assert spool_notice(RECOVERED_NOTICE, 0, 0) == RECOVERED_NOTICE
+
+    def test_an_unreadable_count_prints_no_count_rather_than_a_guess(self) -> None:
+        assert spool_notice(DEGRADED_NOTICE, 0, None) == DEGRADED_NOTICE
+
+    def test_existing_two_argument_callers_are_unchanged(self) -> None:
+        """The new parameter defaults to 0, so no caller changes behaviour."""
+        assert spool_notice(DEGRADED_NOTICE, 7) == f"{DEGRADED_NOTICE} (spool: 7)"
+        assert spool_notice(DEGRADED_NOTICE, 0) == DEGRADED_NOTICE
+
+    def test_abandoned_records_are_announced_when_the_latch_reports_no_change(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """THE LOAD-BEARING ONE: recovery is when the loss used to get buried.
+
+        The latch speaks only on a state CHANGE, which is right for
+        reachability and wrong for abandoned records. On 2026-07-30 the lane
+        recovered and delivered 1,819 further turns for the same session while
+        the fifteen abandoned ones were never mentioned again by anything. So
+        a healthy, unchanged Stop must still say it.
+        """
+        spool = tmp_path / "spool.jsonl"
+        spool.write_text("", encoding="utf-8")
+        quarantine_path(spool).write_text(
+            json.dumps({"schema": QUARANTINE_ENVELOPE_SCHEMA, "spool_key": "a"}),
+            encoding="utf-8",
+        )
+        settings = CaptureSettings(
+            watermark_path=tmp_path / "marks.sqlite",
+            spool_path=spool,
+        )
+        notices = io.StringIO()
+
+        # An already-healthy session delivering again: the latch returns None.
+        stop.announce_outage_state(
+            "session-a", settings, delivered=True, notices=notices
+        )
+
+        line = notices.getvalue()
+        assert "quarantined: 1" in line
+        assert QUARANTINE_ONLY_NOTICE in line
+        # It must NOT claim an outage that the latch did not observe.
+        assert DEGRADED_NOTICE not in line
+
+    def test_a_clean_healthy_stop_still_says_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        """CONTROL. Without this, "announce on every Stop" passes the test above."""
+        settings = CaptureSettings(
+            watermark_path=tmp_path / "marks.sqlite",
+            spool_path=tmp_path / "spool.jsonl",
+        )
+        notices = io.StringIO()
+
+        stop.announce_outage_state(
+            "session-b", settings, delivered=True, notices=notices
+        )
+
+        assert notices.getvalue() == ""
 
 
 def asyncio_offset(watermark: Path, session_key: str) -> int:

--- a/scripts/done-means/680-quarantine-loud.driver.ts
+++ b/scripts/done-means/680-quarantine-loud.driver.ts
@@ -1,0 +1,334 @@
+/**
+ * DONE-MEANS driver (server half) for #680 — a quarantined unit raises a LOUD
+ * fault in `/health`, and can never be reported as a healthy empty spool.
+ *
+ * ---------------------------------------------------------------------------
+ * THE DEFECT, at this boundary
+ * ---------------------------------------------------------------------------
+ * `server/capture/liveness-observer.ts:264-265` hardcodes `spoolPending: 0,
+ * outageAnnouncements: 0`, and `TransportCaptureHealth`
+ * (`server/transport/health.ts:54-78`) has no quarantine field at all. So on
+ * 2026-07-30, with 15 real turns abandoned in a sidecar, the live `/health`
+ * read `spool_pending:0, reason:"capture lane delivering"` — a green verdict
+ * published over a permanent data loss.
+ *
+ * The module's own docstring argues, correctly for `spool_pending`, that a
+ * SERVER cannot enumerate client-side spool files. That argument does NOT
+ * extend to quarantine: a quarantine count is not something the server must
+ * discover by enumeration, it is something a client REPORTS, exactly as the
+ * capture lane already reports its other counts into this observation. The
+ * delta is therefore a reported input, not an invented server-side reader.
+ *
+ * ---------------------------------------------------------------------------
+ * SUBJECT: the real judge and the real composition
+ * ---------------------------------------------------------------------------
+ * Clauses drive `readCaptureLiveness` — the single judge of record, the same
+ * function `server/application/index.ts:204` calls — and the verdict clauses
+ * bind it to a live HTTP `/health` through the real `createShadowApplication`
+ * composition on an ephemeral 127.0.0.1 port. A check that rebuilds its
+ * subject proves the rebuild (#624 harvest).
+ *
+ * Imports of the NEW field/reader are DYNAMIC. A static import of something
+ * that does not exist at the pre-fix tree dies at module resolution before any
+ * clause prints — a false RED indistinguishable in shape from a real one, and
+ * reached by the ordinary act of writing a check for a capability that does
+ * not exist yet (docs/lane-contract.md round 18).
+ *
+ * No database. No network beyond a kernel-assigned ephemeral port. No
+ * wall-clock verdict (round 5, #632/#634).
+ */
+import express from "express";
+import { Writable } from "node:stream";
+import pino from "pino";
+import type { Logger } from "pino";
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { createShadowApplication } from "../../server/application/index.ts";
+import type { ShadowApplication } from "../../server/application/index.ts";
+import { parseServerConfig } from "../../server/config.ts";
+import type { ServerConfig } from "../../server/config.ts";
+import type { Database, DatabaseHealth } from "../../server/db/pool.ts";
+
+const results: Array<{ clause: string; ok: boolean }> = [];
+
+function clause(name: string, ok: boolean, detail: string): void {
+  results.push({ clause: name, ok });
+  console.log(`${ok ? "PASS" : "FAIL"}  (${name}) ${detail}`);
+}
+
+const CONNECTED: DatabaseHealth = { connected: true, total: 2, idle: 2, waiting: 0 };
+
+function testConfig(): ServerConfig {
+  const result = parseServerConfig({
+    DB_HOST: "db.internal",
+    DB_NAME: "open_brain_test",
+    DB_USER: "open_brain",
+    LOG_FILE: "logs/open-brain.log",
+    OPEN_BRAIN_SERVER_IP: "192.0.2.21",
+  });
+  if (!result.ok) {
+    throw new Error(`invalid driver configuration: ${JSON.stringify(result.issues)}`);
+  }
+  return result.config;
+}
+
+function fakeDatabase(): Database {
+  return {
+    pool: {} as Database["pool"],
+    close: async () => {},
+    health: async () => CONNECTED,
+  } as Database;
+}
+
+function capturingLogger(): { logger: Logger; lines: () => string[] } {
+  const captured: string[] = [];
+  const stream = new Writable({
+    write(chunk: Buffer, _encoding, next) {
+      captured.push(chunk.toString("utf8"));
+      next();
+    },
+  });
+  return {
+    logger: pino({ level: "debug" }, stream),
+    lines: () =>
+      captured
+        .join("")
+        .split("\n")
+        .filter((line) => line.trim().length > 0),
+  };
+}
+
+interface LiveApp {
+  readonly base: string;
+  close(): Promise<void>;
+}
+
+async function listen(
+  overrides: Record<string, unknown>,
+  logger: Logger,
+): Promise<LiveApp> {
+  const application: ShadowApplication = createShadowApplication({
+    config: testConfig(),
+    logger,
+    database: fakeDatabase(),
+    authenticate: ((
+      _request: unknown,
+      _response: unknown,
+      next: () => void,
+    ) => next()) as never,
+    parseRequestBody: express.json(),
+    serverFactory: () => ({ connect: async () => {} }) as never,
+    fetch: (async () => new Response("{}", { status: 200 })) as unknown as typeof fetch,
+    ...(overrides as object),
+  } as never);
+
+  const server: Server = await new Promise((resolve) => {
+    const listener = application.app.listen(0, "127.0.0.1", () => resolve(listener));
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    base: `http://127.0.0.1:${port}`,
+    close: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await application.close();
+    },
+  };
+}
+
+interface HealthBody {
+  readonly capture?: Record<string, unknown>;
+  readonly [key: string]: unknown;
+}
+
+async function getHealth(
+  base: string,
+): Promise<{ status: number; body: HealthBody }> {
+  const response = await fetch(`${base}/health`);
+  return {
+    status: response.status,
+    body: (await response.json()) as HealthBody,
+  };
+}
+
+/**
+ * A healthy delivering observation — the CONTROL baseline every fault clause
+ * mutates one field of. Built as a plain object so a missing quarantine field
+ * at the pre-fix tree is a value-level absence, never an import failure.
+ */
+function deliveringObservation(): Record<string, unknown> {
+  return {
+    sessionsObserved: 4,
+    watermarkBytesAdvanced: 120,
+    spoolPending: 0,
+    outageAnnouncements: 0,
+    turnsByRole: { user: 60, assistant: 60 },
+    silenceSeconds: 5,
+  };
+}
+
+async function main(): Promise<number> {
+  const observer = await import("../../server/capture/liveness-observer.ts");
+  const readCaptureLiveness = observer.readCaptureLiveness as (
+    o: Record<string, unknown> | undefined,
+  ) => Record<string, unknown> | undefined;
+
+  // --------------------------------------------------------------------
+  // (a) THE JUDGE SEES QUARANTINE AT ALL. A quarantined unit reported by
+  // the capture lane must make the reading STALE and must be named in the
+  // reason. At the pre-fix tree the field does not exist in the shape, so
+  // the judge ignores it entirely and returns "capture lane delivering" —
+  // the exact live 2026-07-30 verdict published over 15 lost turns.
+  // --------------------------------------------------------------------
+  const quarantinedReading = readCaptureLiveness({
+    ...deliveringObservation(),
+    spoolQuarantined: 3,
+  });
+  const staleOnQuarantine = quarantinedReading?.stale === true;
+  const reason = String(quarantinedReading?.reason ?? "");
+  clause(
+    "a-quarantine-is-stale",
+    staleOnQuarantine && /quarantin/i.test(reason),
+    `an observation carrying 3 quarantined unit(s) reads stale=${String(
+      quarantinedReading?.stale,
+    )} reason=${JSON.stringify(reason)}`,
+  );
+
+  // --------------------------------------------------------------------
+  // (b) THE COUNT IS PUBLISHED, not merely folded into a boolean. An
+  // operator deciding replay-vs-accept needs the number; a bare "stale"
+  // flag makes them go and read the sidecar to learn the size of the loss.
+  // Asserts the exact value survives to the block, so an implementation
+  // that clamps or booleans it fails.
+  // --------------------------------------------------------------------
+  clause(
+    "b-count-published",
+    quarantinedReading?.quarantined_count === 3,
+    `the block publishes quarantined_count=${JSON.stringify(
+      quarantinedReading?.quarantined_count,
+    )} (expected the reported 3)`,
+  );
+
+  // --------------------------------------------------------------------
+  // (c) CONTROL — a delivering lane with NOTHING quarantined stays GREEN
+  // and still publishes the field as a real zero. Fails any implementation
+  // that shouts on every reading, and any that omits the field when it is
+  // zero (an absent field is unreadable to a monitor that must alert on
+  // it crossing 0 -> 1). PASSES PRE-FIX for the verdict half by design:
+  // a check that fails everywhere proves only that it fails (round 13).
+  // --------------------------------------------------------------------
+  const healthyReading = readCaptureLiveness({
+    ...deliveringObservation(),
+    spoolQuarantined: 0,
+  });
+  clause(
+    "c-control-healthy-green",
+    healthyReading?.stale === false &&
+      healthyReading?.quarantined_count === 0 &&
+      !/quarantin/i.test(String(healthyReading?.reason ?? "")),
+    `a delivering lane with nothing quarantined reads stale=${String(
+      healthyReading?.stale,
+    )} quarantined_count=${JSON.stringify(
+      healthyReading?.quarantined_count,
+    )} reason=${JSON.stringify(String(healthyReading?.reason ?? ""))}`,
+  );
+
+  // --------------------------------------------------------------------
+  // (d) UNOBSERVABLE IS ANNOUNCED, NOT ZEROED. The module already
+  // publishes `observableFaults` so a green block is not misread as "all
+  // faults checked and clear". A vantage point with no quarantine input
+  // must NOT report a confident 0 — that is precisely the shape of the
+  // defect (a hardcoded 0 standing in for an unmeasured quantity). Absent
+  // input reports the field as absent/undefined, never 0.
+  // --------------------------------------------------------------------
+  const unreportedReading = readCaptureLiveness(deliveringObservation());
+  clause(
+    "d-unobserved-is-not-zero",
+    unreportedReading?.stale === false &&
+      unreportedReading?.quarantined_count === undefined,
+    `an observation that reports NO quarantine input publishes quarantined_count=${JSON.stringify(
+      unreportedReading?.quarantined_count,
+    )} (absent, not a fabricated 0)`,
+  );
+
+  // --------------------------------------------------------------------
+  // (e) IT REACHES A LIVE /health, DEGRADED. The judge being right is not
+  // the promise; the promise is that an operator watching the endpoint
+  // sees it. Drives the REAL composition over real HTTP and asserts both
+  // the transport status and the published block.
+  // --------------------------------------------------------------------
+  const { logger } = capturingLogger();
+  const app = await listen(
+    {
+      captureObserver: () => ({
+        ...deliveringObservation(),
+        spoolQuarantined: 3,
+      }),
+    },
+    logger,
+  );
+  try {
+    const health = await getHealth(app.base);
+    const capture = health.body.capture ?? {};
+    clause(
+      "e-live-health-degraded",
+      health.status === 503 &&
+        capture.stale === true &&
+        capture.quarantined_count === 3 &&
+        /quarantin/i.test(String(capture.reason ?? "")),
+      `live GET /health -> ${health.status} with capture.stale=${String(
+        capture.stale,
+      )} capture.quarantined_count=${JSON.stringify(
+        capture.quarantined_count,
+      )} reason=${JSON.stringify(String(capture.reason ?? ""))}`,
+    );
+  } finally {
+    await app.close();
+  }
+
+  // --------------------------------------------------------------------
+  // (f) CONTROL — ABSENCE IS NOT STALENESS survives the change. A
+  // deployment composing no capture observer publishes no block and stays
+  // 200/green. PASSES PRE-FIX by design (rounds 8 and 13): the point is
+  // that this fix does not make an opted-out worker degrade itself.
+  // --------------------------------------------------------------------
+  const { logger: bareLogger } = capturingLogger();
+  const bare = await listen({}, bareLogger);
+  try {
+    const health = await getHealth(bare.base);
+    clause(
+      "f-control-absence-not-staleness",
+      health.status === 200 && health.body.capture === undefined,
+      `a deployment composing no observer -> ${health.status} with no capture block`,
+    );
+  } finally {
+    await bare.close();
+  }
+
+  const failed = results.filter((r) => !r.ok);
+  console.log();
+  if (failed.length > 0) {
+    console.log(
+      `SERVER-HALF FAIL — ${failed.length} clause(s): ${failed
+        .map((r) => r.clause)
+        .join(", ")}`,
+    );
+    return 1;
+  }
+  console.log("SERVER-HALF PASS — a quarantined unit is a loud, counted fault in /health.");
+  return 0;
+}
+
+main()
+  .then((code) => {
+    process.exit(code);
+  })
+  .catch((error: unknown) => {
+    // A top-level await with no .catch exits 0 when it throws — a crashing
+    // subject banking a false GREEN (docs/lane-contract.md round 13).
+    console.error(
+      `SERVER-HALF ERROR — driver crashed: ${
+        error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+      }`,
+    );
+    process.exit(1);
+  });

--- a/scripts/done-means/680-quarantine-loud.sh
+++ b/scripts/done-means/680-quarantine-loud.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #680 — "a spool quarantine is never a SILENT drop".
+#
+#   bash scripts/done-means/680-quarantine-loud.sh
+#
+# ---------------------------------------------------------------------------
+# THE GAP THIS CLOSES (cutover blocker B2, docs/core01-cutover-preflight.md)
+# ---------------------------------------------------------------------------
+# The spool is presented as the durability backstop, but after
+# DEFAULT_QUARANTINE_THRESHOLD=5 consecutive replay failures a unit moves to a
+# `<spool>.quarantine.jsonl` sidecar and is abandoned. On 2026-07-30 that took
+# 15 real turns and ~44 lifecycle events, and every operator surface stayed
+# green:
+#
+#   - `outage.spool_pending` counts object lines in the LIVE spool only, so the
+#     drop makes the counter go DOWN (`outage.py:270-299`).
+#   - `liveness-observer.ts:264-265` hardcodes `spoolPending: 0`, and
+#     `TransportCaptureHealth` has no quarantine field, so /health read
+#     `spool_pending:0, reason:"capture lane delivering"`.
+#   - `SpoolStatus.quarantined_count` (`spool.py:101`) exists and is computed on
+#     every `status()` call — with ZERO consumers outside the spool module.
+#
+# The mechanism was DESIGNED loud: `docs/memory-limits.md:25` promises a
+# `QUARANTINED` receipt in the triggering drain report and lists
+# `quarantined_count` under queue observability. It was BUILT silent at the two
+# surfaces an operator actually watches. This check is about what a READER sees
+# after a drop, never about whether the sidecar file was written.
+#
+# ---------------------------------------------------------------------------
+# THE DONE-MEANS, as the pre-flight doc states it (ordered item 2)
+# ---------------------------------------------------------------------------
+#   "forced 5 failures -> still pending OR fault raised, never a silent
+#    sidecar; quarantined_count surfaced in /health and the observer."
+#
+# The client half FORCES FIVE REAL FAILURES through the shipped `JsonlSpool`
+# and then asks what a reader sees. It does not hand-write a sidecar: a
+# hand-built fixture would prove the fixture.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES — client half (680_quarantine_loud_driver.py)
+# ---------------------------------------------------------------------------
+#   (setup) 5 forced failures really quarantined the unit and emptied the live
+#           spool. Asserted, not assumed: every later clause reasons about it.
+#   (a)     THE DEFECT. After the drop the capture lane's pending count must
+#           not read 0 — that is the exact live symptom.
+#   (b)     LOUD AND SPECIFIC. The count rose AND the operator notice names
+#           quarantine. Both halves in ONE clause (round 17): an outage backlog
+#           drains itself, a quarantined unit never will, so a line that cannot
+#           distinguish them is a line the operator learns to ignore.
+#   (c)     CONTROL — an ordinary held turn stays quiet and says nothing about
+#           quarantine. Fails any "always shout" implementation.
+#   (d)     UNREADABLE IS NOT ZERO — a sidecar that cannot be read reports None,
+#           inheriting `spool_pending`'s existing contract. Guessing 0 would
+#           recreate this defect one directory over.
+#   (e)     ABSENT IS GENUINELY ZERO — the other side of (d); a machine that has
+#           never quarantined anything must not print an unknown-count forever.
+#   (f)     THE RECORDS SURVIVE — the sidecar still holds the envelope with its
+#           consecutive_failures, so the operator's replay-vs-accept decision
+#           (issue #680 item 4) has something to act on.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES — server half (680-quarantine-loud.driver.ts)
+# ---------------------------------------------------------------------------
+#   (a)     The judge (`readCaptureLiveness`) makes a reported quarantine STALE
+#           and names it in the reason.
+#   (b)     The COUNT is published, not folded into a boolean.
+#   (c)     CONTROL — a delivering lane with nothing quarantined stays GREEN and
+#           publishes a real 0 (a monitor must see the 0 -> 1 crossing).
+#   (d)     UNOBSERVED IS NOT ZERO — a vantage point given no quarantine input
+#           publishes the field as ABSENT, never a confident 0. A hardcoded 0
+#           standing in for an unmeasured quantity is the defect's own shape.
+#   (e)     It reaches a LIVE /health over real HTTP through the real
+#           `createShadowApplication` composition, 503 + the count.
+#   (f)     CONTROL — absence-is-not-staleness survives: no observer composed
+#           means no block and 200/green. PASSES PRE-FIX by design.
+#
+# Content-free output: clause names, states, counts. No payloads, no secrets.
+# No database. No network beyond an ephemeral 127.0.0.1 port. No wall-clock
+# verdict (round 5, #632/#634). Never contacts core01.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PY_DRIVER="scripts/done-means/680_quarantine_loud_driver.py"
+TS_DRIVER="scripts/done-means/680-quarantine-loud.driver.ts"
+
+for driver in "$PY_DRIVER" "$TS_DRIVER"; do
+  if [[ ! -f "$driver" ]]; then
+    echo "FAIL  driver missing: $driver"
+    echo "DONE-MEANS #680: FAIL"
+    exit 1
+  fi
+done
+
+echo "INFO  repo:   $REPO_ROOT"
+echo "INFO  client: $PY_DRIVER (real JsonlSpool, 5 forced failures, temp dir)"
+echo "INFO  server: $TS_DRIVER (real readCaptureLiveness + live /health, no DB)"
+echo
+
+# Run from the `openbrain` package env, NOT `openbrain-memory`: the driver
+# imports BOTH the spool (openbrain_memory) and the capture lane's reader
+# (openbrain.apps.capture.outage), and only the openbrain env carries the
+# pydantic/loguru dependencies the latter's package __init__ pulls in. Running
+# from openbrain-memory dies at `import openbrain` with ModuleNotFoundError —
+# a crash upstream of every clause, which is a FALSE RED, not a result
+# (docs/lane-contract.md round 18).
+echo "--- CLIENT HALF -----------------------------------------------------"
+set +e
+(cd python/openbrain && uv run python "$REPO_ROOT/$PY_DRIVER")
+CLIENT_STATUS=$?
+set -e
+
+echo
+echo "--- SERVER HALF -----------------------------------------------------"
+set +e
+bun "$TS_DRIVER"
+SERVER_STATUS=$?
+set -e
+
+echo
+echo "INFO  client half exit=$CLIENT_STATUS  server half exit=$SERVER_STATUS"
+
+if [[ $CLIENT_STATUS -eq 0 && $SERVER_STATUS -eq 0 ]]; then
+  echo "DONE-MEANS #680: PASS — five forced delivery failures leave a LOUD, counted fault at the capture lane and in /health; never a silent sidecar."
+  exit 0
+fi
+
+echo "DONE-MEANS #680: FAIL — a quarantine drop is still invisible to at least one operator surface."
+exit 1

--- a/scripts/done-means/680_quarantine_loud_driver.py
+++ b/scripts/done-means/680_quarantine_loud_driver.py
@@ -111,21 +111,38 @@ def main() -> int:
         )
 
         # ------------------------------------------------------------------
-        # (a) THE DEFECT ITSELF. The capture lane's operator-facing count must
-        # not read 0 while records sit abandoned in the sidecar. This is the
-        # exact live symptom: /health said spool_pending:0 with 15 turns gone.
+        # (a) THE DEFECT ITSELF, as the pre-flight doc states the requirement:
+        # "forced 5 failures -> the turn is STILL PENDING **or** a LOUD fault
+        # is raised — never a silent sidecar". A DISJUNCTION, deliberately.
         #
-        # Asserts the COUNT, not the presence of a function: a reader that
-        # returns 0 here is the shipped defect regardless of what it is named.
+        # The lane's first draft of this clause asserted only the left branch
+        # (`spool_pending > 0`) and it FAILED against the implemented fix, for
+        # a good reason: folding abandoned units into the pending depth would
+        # make one number mean both "will drain itself when the server returns"
+        # and "will never drain, ever". Backlog reads as self-healing and the
+        # operator's correct response to backlog is to WAIT, which is exactly
+        # the wrong response here. Conflating them is the defect's own shape in
+        # a new place, so the implementation took the right branch instead: the
+        # abandoned records get their own count and their own words.
+        #
+        # The clause is corrected to assert the requirement as WRITTEN rather
+        # than the lane's first reading of it (docs/lane-contract.md round 19 —
+        # reject a briefed hypothesis on evidence, in writing, never silently).
+        # What it must never accept is the third state: neither pending nor
+        # loud, which is the 2026-07-30 live symptom.
         # ------------------------------------------------------------------
         from openbrain.apps.capture import outage  # noqa: PLC0415
 
         pending = outage.spool_pending(spool_path)
+        loud = call(resolve(outage, "spool_quarantined"), spool_path)
+        still_pending = pending is not None and pending > 0
+        raised_loud = loud is not _MISSING and loud is not None and loud > 0
         check(
-            "a-pending-not-blind",
-            pending is not None and pending > 0,
-            f"after the drop, the capture lane's pending count reads {pending!r} "
-            "(0 or None means the records are invisible to every operator surface)",
+            "a-pending-or-loud",
+            still_pending or raised_loud,
+            f"after the drop: pending={pending!r} quarantined={loud!r} — the records "
+            "are still pending, or an abandoned count is raised; a silent sidecar "
+            "(pending=0 with no quarantine reader) is the shipped defect",
         )
 
         # ------------------------------------------------------------------

--- a/scripts/done-means/680_quarantine_loud_driver.py
+++ b/scripts/done-means/680_quarantine_loud_driver.py
@@ -1,0 +1,251 @@
+"""DONE-MEANS driver (client half) for #680 — a quarantine drop is never silent.
+
+Drives the REAL ``JsonlSpool`` through five genuine consecutive replay failures
+(the shipped ``DEFAULT_QUARANTINE_THRESHOLD``) and then asks the question the
+pre-flight doc asks: after the drop, does any operator-facing count still know
+the records exist?
+
+WHY THIS SHAPE. The defect is not "quarantine happens" — quarantine is designed
+(``docs/memory-limits.md:25``). The defect is that the capture lane's own
+observability reads the LIVE spool only (``outage.spool_pending``), so the
+quarantine move makes the number go DOWN: 15 real turns became pending=0 on
+2026-07-30 and nothing said a word. So every clause here is about what a READER
+sees after the drop, never about whether the sidecar file was written.
+
+Content-free output: clause names, states, and counts only — never payloads.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "python" / "openbrain-memory" / "src"))
+sys.path.insert(0, str(REPO_ROOT / "python" / "openbrain" / "src"))
+
+from openbrain_memory.spool import (  # noqa: E402
+    DEFAULT_QUARANTINE_THRESHOLD,
+    JsonlSpool,
+)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, ok: bool, detail: str) -> None:
+    print(f"{'PASS' if ok else 'FAIL'}  {name}: {detail}")
+    if not ok:
+        FAILURES.append(name)
+
+
+_MISSING = object()
+
+
+def resolve(module: Any, name: str) -> Any:
+    """Look up a symbol that may not exist yet, WITHOUT crashing the run.
+
+    A bare ``module.new_function(...)`` raises ``AttributeError`` at the
+    pre-fix tree and kills every clause after it — a crash upstream of the
+    measurement, which is a FALSE RED indistinguishable in shape from a real
+    one and reached by the ordinary act of checking for a capability that does
+    not exist yet (``docs/lane-contract.md`` round 18, the Python spelling of
+    the dynamic-import rule). Resolving through a sentinel lets each clause
+    report its own honest FAIL for the defect's own reason.
+    """
+    return getattr(module, name, _MISSING)
+
+
+def call(fn: Any, *args: Any) -> Any:
+    """Call a resolved symbol, or return the sentinel when it is absent."""
+    if fn is _MISSING:
+        return _MISSING
+    return fn(*args)
+
+
+def quarantine_one_unit(spool_path: Path) -> JsonlSpool:
+    """Append one unit and fail its replay exactly ``threshold`` times.
+
+    Returns the spool, with the unit quarantined by the real code path — no
+    hand-written sidecar. A hand-built fixture would prove the fixture.
+    """
+    spool = JsonlSpool(spool_path)
+
+    spool.append(
+        operation="ingest_raw_turn",
+        payload={"turns": [{"turn_uuid": "done-means-680-turn", "role": "user"}]},
+    )
+
+    def always_fails(record: Any) -> Any:
+        raise RuntimeError("done-means forced delivery failure")
+
+    for _ in range(DEFAULT_QUARANTINE_THRESHOLD):
+        spool.replay_with_report(always_fails)
+
+    return spool
+
+
+def main() -> int:
+    print(f"INFO  quarantine threshold under test: {DEFAULT_QUARANTINE_THRESHOLD}")
+
+    with tempfile.TemporaryDirectory(prefix="done-means-680-") as tmp:
+        spool_path = Path(tmp) / "claude-spool.jsonl"
+        spool = quarantine_one_unit(spool_path)
+        status = spool.status()
+
+        # ------------------------------------------------------------------
+        # (setup) The precondition every other clause reasons about: five
+        # forced failures really did quarantine the unit and empty the live
+        # spool. If this is not true the rest of the run proves nothing, so it
+        # is asserted rather than assumed.
+        # ------------------------------------------------------------------
+        check(
+            "setup-quarantined",
+            status.quarantined_count == 1 and status.pending_count == 0,
+            f"{DEFAULT_QUARANTINE_THRESHOLD} forced failures -> "
+            f"quarantined_count={status.quarantined_count} "
+            f"pending_count={status.pending_count} "
+            "(the live spool is empty and the records are in the sidecar)",
+        )
+
+        # ------------------------------------------------------------------
+        # (a) THE DEFECT ITSELF. The capture lane's operator-facing count must
+        # not read 0 while records sit abandoned in the sidecar. This is the
+        # exact live symptom: /health said spool_pending:0 with 15 turns gone.
+        #
+        # Asserts the COUNT, not the presence of a function: a reader that
+        # returns 0 here is the shipped defect regardless of what it is named.
+        # ------------------------------------------------------------------
+        from openbrain.apps.capture import outage  # noqa: PLC0415
+
+        pending = outage.spool_pending(spool_path)
+        check(
+            "a-pending-not-blind",
+            pending is not None and pending > 0,
+            f"after the drop, the capture lane's pending count reads {pending!r} "
+            "(0 or None means the records are invisible to every operator surface)",
+        )
+
+        # ------------------------------------------------------------------
+        # (b) LOUD, AND SPECIFICALLY ABOUT QUARANTINE. A count that merely
+        # went up could be an ordinary outage backlog — indistinguishable from
+        # the healthy "held for replay" case an operator is trained to ignore.
+        # The notice must NAME the abandoned records, because the two states
+        # need different operator actions: an outage backlog drains itself, a
+        # quarantined unit never will.
+        #
+        # Both halves in ONE clause (round 17): a count that rose AND a notice
+        # that says the word. Split, each half passes for the wrong reason.
+        # ------------------------------------------------------------------
+        spool_quarantined = resolve(outage, "spool_quarantined")
+        quarantined = call(spool_quarantined, spool_path)
+        notice = (
+            outage.spool_notice(outage.DEGRADED_NOTICE, pending, quarantined)
+            if quarantined is not _MISSING
+            else "<no quarantine reader exists>"
+        )
+        check(
+            "b-notice-names-quarantine",
+            quarantined == 1 and "quarantin" in notice.lower(),
+            f"quarantined={quarantined!r} and the operator notice names it: {notice!r}",
+        )
+
+        # ------------------------------------------------------------------
+        # (c) CONTROL — HEALTHY STAYS QUIET (round 8: every failure-signal
+        # check needs a control proving the healthy path stays healthy).
+        # A spool with nothing quarantined must produce the ORDINARY notice
+        # with no quarantine wording. Without this, "always shout quarantine"
+        # passes (a) and (b) and trains the operator to ignore the line.
+        # ------------------------------------------------------------------
+        clean_path = Path(tmp) / "clean-spool.jsonl"
+        clean = JsonlSpool(clean_path)
+        clean.append(
+            operation="ingest_raw_turn",
+            payload={"turns": [{"turn_uuid": "done-means-680-healthy", "role": "user"}]},
+        )
+        clean_pending = outage.spool_pending(clean_path)
+        clean_quarantined = call(spool_quarantined, clean_path)
+        clean_notice = (
+            outage.spool_notice(
+                outage.DEGRADED_NOTICE, clean_pending, clean_quarantined
+            )
+            if clean_quarantined is not _MISSING
+            else "<no quarantine reader exists>"
+        )
+        check(
+            "c-control-healthy-quiet",
+            clean_quarantined == 0
+            and clean_pending == 1
+            and "quarantin" not in clean_notice.lower(),
+            f"an ordinary held turn reports quarantined={clean_quarantined} "
+            f"pending={clean_pending} and says nothing about quarantine: {clean_notice!r}",
+        )
+
+        # ------------------------------------------------------------------
+        # (d) UNREADABLE IS NOT ZERO. `spool_pending` already distinguishes
+        # "absent -> 0" from "unreadable -> None" on purpose, because a count
+        # is the one thing on that line an operator acts on. The quarantine
+        # reader inherits that contract: guessing 0 for a sidecar it could not
+        # read would recreate this very defect one directory over.
+        #
+        # Driven by pointing the reader at a DIRECTORY where the sidecar file
+        # is expected — a real OSError from the real code path, not a mock.
+        # ------------------------------------------------------------------
+        unreadable_spool = Path(tmp) / "unreadable-spool.jsonl"
+        unreadable_spool.write_text("", encoding="utf-8")
+        sidecar_dir = Path(str(unreadable_spool) + ".quarantine.jsonl")
+        sidecar_dir.mkdir()
+        unreadable = call(spool_quarantined, unreadable_spool)
+        check(
+            "d-unreadable-is-none",
+            unreadable is None,
+            f"an unreadable quarantine sidecar reads {unreadable!r}, not a guessed 0",
+        )
+
+        # ------------------------------------------------------------------
+        # (e) ABSENT IS GENUINELY ZERO. The other side of (d): no sidecar at
+        # all is a real, knowable zero and must NOT degrade to None, or every
+        # healthy machine on earth prints an unknown-count line forever.
+        # ------------------------------------------------------------------
+        absent = call(spool_quarantined, Path(tmp) / "never-existed.jsonl")
+        check(
+            "e-absent-is-zero",
+            absent == 0,
+            f"a spool with no quarantine sidecar reads {absent!r}",
+        )
+
+        # ------------------------------------------------------------------
+        # (f) THE SIDECAR IS INTACT AND REPLAYABLE. "Never a silent drop" is
+        # only half the promise; the records must still BE there for the
+        # operator's replay decision (issue #680 item 4). Reads the envelope
+        # back and asserts the abandoned unit is identifiable by operation and
+        # spool key — content-free, no payload assertions.
+        # ------------------------------------------------------------------
+        sidecar = Path(str(spool_path) + ".quarantine.jsonl")
+        envelopes = [
+            json.loads(line)
+            for line in sidecar.read_text(encoding="utf-8").splitlines()
+            if line.strip().startswith("{") and '"schema"' in line
+        ]
+        check(
+            "f-sidecar-replayable",
+            len(envelopes) == 1
+            and envelopes[0].get("consecutive_failures") == DEFAULT_QUARANTINE_THRESHOLD,
+            f"the sidecar holds {len(envelopes)} envelope(s) recording "
+            f"consecutive_failures="
+            f"{envelopes[0].get('consecutive_failures') if envelopes else 'n/a'} "
+            "— the records survive for an operator replay decision",
+        )
+
+    print()
+    if FAILURES:
+        print(f"CLIENT-HALF FAIL — {len(FAILURES)} clause(s): {', '.join(FAILURES)}")
+        return 1
+    print("CLIENT-HALF PASS — a quarantine drop is visible and named at the capture lane.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/done-means/sme-per-entry-files.sh
+++ b/scripts/done-means/sme-per-entry-files.sh
@@ -82,7 +82,14 @@ BUILD_SCRIPT="scripts/build-sme-indexes.ts"
 # 226 at migration (PR #617); +1 = the 2026-08-08 no-silent-adjustments entry
 # (operator ruling) — raised in the same commit that adds it, as the gate's
 # own failure text instructs.
-EXPECTED_ENTRY_COUNT=228
+# RECONCILED 2026-08-09 (#680 lane): origin/main carried 231 dated headings
+# against a pin of 227 — four entries landed across earlier merges without the
+# same-commit bump the rule requires, so this clause had been RED on main
+# before this lane touched it. 231 (inherited) + 1 (this lane's entry) = 232.
+# Reported rather than absorbed: the drift is other lanes' missed bumps, and
+# the number is reconciled here because leaving it stale keeps the clause red
+# for everyone downstream.
+EXPECTED_ENTRY_COUNT=232
 
 LANE_FILES=(
   "$SME_DIR/correctness.md"

--- a/scripts/done-means/sme-per-entry-files.sh
+++ b/scripts/done-means/sme-per-entry-files.sh
@@ -82,7 +82,7 @@ BUILD_SCRIPT="scripts/build-sme-indexes.ts"
 # 226 at migration (PR #617); +1 = the 2026-08-08 no-silent-adjustments entry
 # (operator ruling) — raised in the same commit that adds it, as the gate's
 # own failure text instructs.
-EXPECTED_ENTRY_COUNT=227
+EXPECTED_ENTRY_COUNT=228
 
 LANE_FILES=(
   "$SME_DIR/correctness.md"

--- a/scripts/replay-quarantined-spool.py
+++ b/scripts/replay-quarantined-spool.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Inspect, and OPTIONALLY restore, units the spool abandoned into its sidecar.
+
+    # what is in there (default; touches nothing)
+    python3 scripts/replay-quarantined-spool.py
+
+    # restore every abandoned unit to the live spool for normal replay
+    python3 scripts/replay-quarantined-spool.py --restore
+
+WHY THIS EXISTS (#680, cutover blocker B2). After
+``DEFAULT_QUARANTINE_THRESHOLD`` consecutive replay failures the provider moves
+a unit to ``<spool>.quarantine.jsonl`` and never retries it automatically —
+triage is operator-managed by design. Nothing in the tree could triage it,
+because ``quarantined_count`` had no consumer anywhere. This is the triage
+tool; the loudness that makes an operator KNOW to run it is the rest of #680.
+
+WHAT IT WILL NOT DO, ON PURPOSE:
+
+  - It never deletes. ``--restore`` REWRITES the sidecar without the units it
+    moved, after those units are safely appended to the live spool, and it
+    always writes a timestamped backup of the original sidecar first. A unit
+    that fails again re-quarantines through the normal path.
+  - It never decides. Replaying versus accepting the loss is the operator's
+    call. The default run reports and exits.
+  - It never dials the server. Restoring puts units back in the LIVE spool;
+    the provider's ordinary drain delivers them on the next healthy operation.
+    Delivery is the existing path's job, not this script's.
+
+CONTENT-FREE OUTPUT. Operations, counts, keys, and unix times only — never
+payload bodies. The sidecar holds already-redacted records, and this script
+does not widen that exposure by printing them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "python" / "openbrain-memory" / "src"))
+sys.path.insert(0, str(REPO_ROOT / "python" / "openbrain" / "src"))
+
+from openbrain_memory.spool import (  # noqa: E402
+    QUARANTINE_ENVELOPE_SCHEMA,
+    JsonlSpool,
+)
+
+
+def default_spool() -> Path:
+    """The provider spool this machine uses, resolved as the readers resolve it."""
+    from openbrain.apps.capture.outage import default_spool_path  # noqa: PLC0415
+
+    return default_spool_path()
+
+
+def summarize(sidecar: Path) -> tuple[list[dict], Counter, Counter, int]:
+    """Read the sidecar into envelopes plus content-free tallies."""
+    envelopes: list[dict] = []
+    operations: Counter = Counter()
+    records: Counter = Counter()
+    raw_turns = 0
+
+    for line in sidecar.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        if parsed.get("schema") == QUARANTINE_ENVELOPE_SCHEMA:
+            envelopes.append(parsed)
+            operations[str(parsed.get("operation", "unknown"))] += 1
+            continue
+        operation = str(parsed.get("operation", "unknown"))
+        records[operation] += 1
+        if operation == "ingest_raw_turn":
+            turns = parsed.get("payload", {}).get("turns")
+            if isinstance(turns, list):
+                raw_turns += len(turns)
+
+    return envelopes, operations, records, raw_turns
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--spool",
+        type=Path,
+        default=None,
+        help="live spool path (default: this machine's resolved spool)",
+    )
+    parser.add_argument(
+        "--restore",
+        action="store_true",
+        help="move abandoned units back into the live spool (default: report only)",
+    )
+    args = parser.parse_args()
+
+    spool_path = args.spool if args.spool is not None else default_spool()
+    spool = JsonlSpool(spool_path)
+    sidecar = spool.quarantine_path
+
+    print(f"live spool : {spool_path}")
+    print(f"sidecar    : {sidecar}")
+
+    if not sidecar.exists() or sidecar.stat().st_size == 0:
+        print("\nNothing quarantined. No action needed.")
+        return 0
+
+    envelopes, operations, records, raw_turns = summarize(sidecar)
+    failures = [
+        int(e["consecutive_failures"])
+        for e in envelopes
+        if isinstance(e.get("consecutive_failures"), (int, float))
+    ]
+    times = [
+        float(e[key])
+        for e in envelopes
+        for key in ("first_failure_at", "last_failure_at", "quarantined_at")
+        if isinstance(e.get(key), (int, float))
+    ]
+
+    print(f"\nABANDONED UNITS: {len(envelopes)}")
+    for operation, count in sorted(records.items()):
+        print(f"  {operation:24s} {count:5d} record line(s)")
+    if raw_turns:
+        print(f"\n  raw turns inside those records: {raw_turns}")
+    if failures:
+        print(f"  consecutive failures per unit : {sorted(set(failures))}")
+    if times:
+        fmt = "%Y-%m-%d %H:%M:%S"
+        print(f"  failure window                : {time.strftime(fmt, time.localtime(min(times)))}"
+              f" .. {time.strftime(fmt, time.localtime(max(times)))}")
+
+    if not args.restore:
+        print(
+            "\nREPORT ONLY — nothing was changed.\n"
+            "These records are NOT in the database and will never be retried on\n"
+            "their own. Two options, and the choice is the operator's:\n"
+            "  1. Replay:  re-run with --restore, then let the provider drain.\n"
+            "  2. Accept:  leave them. Say so explicitly, so the loss is a\n"
+            "              decision on the record rather than an oversight."
+        )
+        return 0
+
+    backup = sidecar.with_name(
+        f"{sidecar.name}.backup-{time.strftime('%Y%m%dT%H%M%S')}"
+    )
+    shutil.copy2(sidecar, backup)
+    print(f"\nbackup written: {backup}")
+
+    lines = sidecar.read_text(encoding="utf-8").splitlines()
+    restored = 0
+    pending_records: list[tuple[str, dict, str | None]] = []
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        if parsed.get("schema") == QUARANTINE_ENVELOPE_SCHEMA:
+            restored += 1
+            continue
+        pending_records.append(
+            (
+                str(parsed.get("operation", "unknown")),
+                parsed.get("payload", {}),
+                parsed.get("idempotency_key"),
+            )
+        )
+
+    for operation, payload, key in pending_records:
+        spool.append(operation=operation, payload=payload, key=key)
+
+    # Sidecar emptied only AFTER the live spool holds the records. Ordered this
+    # way on purpose: a crash between the two re-delivers (the spool is
+    # at-least-once and consumers dedupe on idempotency_key), where the reverse
+    # order would lose them outright.
+    sidecar.write_text("", encoding="utf-8")
+
+    status = spool.status()
+    print(
+        f"\nRESTORED {restored} unit(s) / {len(pending_records)} record(s) to the live spool.\n"
+        f"  spool pending now   : {status.pending_count}\n"
+        f"  quarantined now     : {status.quarantined_count}\n"
+        f"  original sidecar    : {backup}\n"
+        "\nThe provider drains on its next healthy operation. Verify the turns\n"
+        "landed by querying ob_raw_turns for their turn_uuids; a unit that fails\n"
+        "again will re-quarantine through the normal path and be reported by\n"
+        "/health, which is the whole point of #680."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/capture/liveness-observer.test.ts
+++ b/server/capture/liveness-observer.test.ts
@@ -147,4 +147,90 @@ describe("capture liveness observer", () => {
   it("returns undefined for an absent observation rather than a healthy reading", () => {
     expect(readCaptureLiveness(undefined)).toBeUndefined();
   });
+
+  describe("quarantined units are never a silent drop (#680)", () => {
+    const delivering = {
+      sessionsObserved: 4,
+      watermarkBytesAdvanced: 240,
+      spoolPending: 0,
+      outageAnnouncements: 0,
+      turnsByRole: { user: 120, assistant: 120 },
+      silenceSeconds: 3,
+    } as const;
+
+    it("raises a named fault and publishes the count", () => {
+      const reading = readCaptureLiveness({ ...delivering, spoolQuarantined: 3 });
+
+      expect(reading?.stale).toBe(true);
+      expect(reading?.quarantined_count).toBe(3);
+      expect(reading?.reason).toContain("quarantined");
+      // The words must state the consequence, because "3 quarantined" alone
+      // reads like a queue depth an operator can wait out. These records are
+      // gone until someone replays the sidecar by hand.
+      expect(reading?.reason).toContain("operator");
+    });
+
+    it("reports a real zero when a vantage point looked and found none", () => {
+      const reading = readCaptureLiveness({ ...delivering, spoolQuarantined: 0 });
+
+      expect(reading?.stale).toBe(false);
+      expect(reading?.quarantined_count).toBe(0);
+      expect(reading?.reason).not.toContain("quarantined");
+    });
+
+    it("omits the count entirely when nothing reported one", () => {
+      // The load-bearing distinction. A hardcoded 0 standing in for an
+      // unmeasured quantity is the exact defect: on 2026-07-30 `/health` read
+      // `spool_pending:0, reason:"capture lane delivering"` while fifteen turns
+      // were already gone. "Nobody looked" must not render as "nothing wrong".
+      const reading = readCaptureLiveness(delivering);
+
+      expect(reading?.stale).toBe(false);
+      expect(reading).not.toHaveProperty("quarantined_count");
+    });
+
+    it("fires below the silence quorum, unlike the liveness faults", () => {
+      // Deliberately NOT gated on `active`. The other faults ask "is the lane
+      // working right now?" and are meaningless on a quiet night; this one
+      // reports that data is already lost, which is equally true at 3am. A
+      // deployment that stopped capturing BECAUSE its records were being
+      // abandoned is precisely the case a quorum gate would hide.
+      const reading = readCaptureLiveness({
+        ...delivering,
+        sessionsObserved: MIN_SESSIONS_FOR_SILENCE - 1,
+        spoolQuarantined: 2,
+      });
+
+      expect(reading?.stale).toBe(true);
+      expect(reading?.quarantined_count).toBe(2);
+    });
+
+    it("reports every fault that fired, not just the first", () => {
+      const reading = readCaptureLiveness({
+        ...delivering,
+        turnsByRole: { user: 120, assistant: 0 },
+        spoolQuarantined: 1,
+      });
+
+      expect(reading?.stale).toBe(true);
+      expect(reading?.silent_roles).toEqual(["assistant"]);
+      expect(reading?.reason).toContain("quarantined");
+      expect(reading?.reason).toContain("assistant");
+    });
+
+    it("leaves the gatherer reporting no quarantine count of its own", async () => {
+      // The arrivals query genuinely cannot see a client-side sidecar, so the
+      // gatherer must leave the field undefined rather than pass a confident 0
+      // — the same honesty the module already applies to spool_pending.
+      const observed = observer(
+        poolReturning([
+          { role: "user", turns: "12", sessions: "3", seconds_since_last: "4" },
+        ]),
+      );
+      await observed.refresh();
+
+      expect(observed.observation()).not.toHaveProperty("spoolQuarantined");
+      expect(observed.reading()).not.toHaveProperty("quarantined_count");
+    });
+  });
 });

--- a/server/capture/liveness-observer.ts
+++ b/server/capture/liveness-observer.ts
@@ -42,6 +42,18 @@
  *     fault stays unobservable from here, and reporting it as absent is honest
  *     where reporting it as present would be a fabrication.
  *
+ * WHY QUARANTINE IS DIFFERENT FROM SPOOL DEPTH (#680, cutover blocker B2). The
+ * paragraph above is right about `spool_pending` and does NOT extend to
+ * abandoned units, which is the distinction that let a real data loss stay
+ * invisible. `spoolQuarantined` is an OPTIONAL REPORTED input, not something
+ * this gatherer discovers: a client already computes the count
+ * (`SpoolStatus.quarantined_count`) and can hand it over, so no enumeration
+ * has to be invented. This gatherer does not report it — the arrivals query
+ * genuinely cannot see it — so it leaves the field UNDEFINED and the judge
+ * publishes no count, rather than the hardcoded 0 that used to stand in for an
+ * unmeasured quantity. That hardcoded 0 is exactly what `/health` was showing
+ * on 2026-07-30 while fifteen turns sat abandoned in a sidecar, permanently.
+ *
  * This is announced rather than silent (AGENTS.md, "Nothing is adjusted
  * silently"): `observableFaults` names which of the reader's three faults this
  * vantage point can actually raise, and it travels into the health block.
@@ -114,6 +126,19 @@ export interface CaptureObservation {
   readonly outageAnnouncements: number;
   readonly turnsByRole: Readonly<Record<string, number>>;
   readonly silenceSeconds: number;
+  /**
+   * Units a capture lane ABANDONED after exhausting its replay attempts (#680).
+   *
+   * OPTIONAL, and its absence is not zero. This is a REPORTED input, not
+   * something a server discovers: the module docstring's argument that a
+   * server cannot enumerate client-side spool files is correct for
+   * `spoolPending` and does NOT extend to this, because a quarantine count is
+   * something a client already computes (`SpoolStatus.quarantined_count`) and
+   * can hand over. A vantage point with no reporter leaves it undefined, and
+   * the judge then publishes no count rather than a fabricated 0 — which is
+   * the whole lesson of the field that sits above it.
+   */
+  readonly spoolQuarantined?: number;
 }
 
 interface RoleCountRow {
@@ -153,6 +178,17 @@ export function readCaptureLiveness(
         .sort()
     : [];
 
+  // ABANDONED RECORDS ARE A FAULT WHENEVER THEY EXIST (#680), with no
+  // `active` guard. The other faults ask "is the lane working right now?", so
+  // they are meaningless below quorum — a quiet night is not a dead lane.
+  // This one is not a liveness question at all: it is a report that data is
+  // already gone and stays gone until a human acts. A quarantine count is
+  // equally true on a busy Tuesday and an idle Sunday, so gating it on
+  // sessions observed would hide exactly the deployment that stopped
+  // capturing BECAUSE its records were being abandoned.
+  const quarantined = observation.spoolQuarantined;
+  const quarantineFault = quarantined !== undefined && quarantined > 0;
+
   const faults: string[] = [];
   if (watermarkWedged) {
     faults.push(
@@ -162,6 +198,11 @@ export function readCaptureLiveness(
   if (spoolUnannounced) {
     faults.push(
       `spool holds ${observation.spoolPending} record(s) with no outage announced`,
+    );
+  }
+  if (quarantineFault) {
+    faults.push(
+      `${String(quarantined)} unit(s) quarantined — replay gave up, records are lost until an operator replays the sidecar`,
     );
   }
   if (silentRoles.length > 0) {
@@ -176,6 +217,11 @@ export function readCaptureLiveness(
     sessions_observed: observation.sessionsObserved,
     turns_delivered: turnsDelivered,
     spool_pending: observation.spoolPending,
+    // Present only when something actually reported it. Spreading a
+    // conditional rather than writing `?? 0` is the entire point: an absent
+    // count and a zero count are different facts, and the fabricated zero is
+    // the defect (#680).
+    ...(quarantined === undefined ? {} : { quarantined_count: quarantined }),
     silence_seconds: Math.max(0, observation.silenceSeconds),
     reason: faults.length > 0 ? faults.join("; ") : "capture lane delivering",
   };

--- a/server/transport/health.ts
+++ b/server/transport/health.ts
@@ -71,6 +71,21 @@ export interface TransportCaptureHealth {
   readonly sessions_observed: number;
   readonly turns_delivered: number;
   readonly spool_pending: number;
+  /**
+   * Units the capture lane ABANDONED after exhausting its replay attempts.
+   *
+   * ABSENT, never 0, when no vantage point reported the count (#680). The two
+   * states are genuinely different — "nothing was abandoned" and "nobody
+   * looked" — and collapsing them into a confident zero is the exact defect
+   * this field exists to end: on 2026-07-30 a hardcoded 0 stood in for an
+   * unmeasured quantity while fifteen turns were gone for good, and `/health`
+   * read `spool_pending:0, reason:"capture lane delivering"` over the top of
+   * it.
+   *
+   * A monitor alerts on this crossing 0 -> 1, so a reporting vantage point
+   * publishes a real 0 rather than omitting the field.
+   */
+  readonly quarantined_count?: number;
   /** Reported for an operator; no verdict is derived from it. */
   readonly silence_seconds: number;
   /** Content-free sentence naming which fault fired. */


### PR DESCRIPTION
## Summary

- Closes #680 (cutover blocker B2). A spool quarantine was a permanent SILENT drop: after `DEFAULT_QUARANTINE_THRESHOLD=5` consecutive replay failures a unit moves to a `.quarantine.jsonl` sidecar and is never retried, and every operator-facing count read the LIVE spool — so the drop made the number go DOWN. On 2026-07-30, 15 raw turns and ~44 lifecycle records were abandoned while `/health` read `spool_pending:0, reason:"capture lane delivering"`.
- The mechanism was DESIGNED loud and BUILT silent. `SpoolStatus.quarantined_count` had existed the whole time with ZERO consumers outside the module that computed it. This PR wires it to readers at three owning boundaries; it does not invent a new mechanism.
- **Client** (`apps/capture/outage.py`, `apps/hooks/stop.py`): `spool_quarantined()` counts abandoned ENVELOPES; unreadable reports `None`, never a guessed 0. The notice gives abandonment its OWN clause and words — deliberately NOT folded into the spool depth, because one number meaning both "drains itself" and "never will" is the defect in a new place. The Stop hook reads the sidecar **even when the latch reports no change**: abandoned records are a standing condition, and the outage RECOVERING is exactly when the loss used to get buried.
- **Server** (`liveness-observer.ts`, `transport/health.ts`): `quarantined_count` is published in the capture block and raises a named fault. Optional and ABSENT rather than 0 when nothing reported it — "nothing was abandoned" and "nobody looked" are different facts. The fault is deliberately NOT gated on the liveness quorum, unlike the other three.
- **Operator triage** (`scripts/replay-quarantined-spool.py`): report-only by default, `--restore` to replay. The replay-vs-accept decision for the EXISTING sidecar is the operator's and is stated below, undecided on purpose.

## Verification

- Done-means: scripts/done-means/680-quarantine-loud.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [ ] Live Open Brain smoke passed or is not applicable

**RED (pre-change tree)** — 9 clauses red, 3 controls green:

```
PASS  setup-quarantined: 5 forced failures -> quarantined_count=1 pending_count=0
FAIL  a-pending-or-loud: pending=0 quarantined=<missing>   <- the silent sidecar
FAIL  b-notice-names-quarantine / c-control-healthy-quiet / d / e
PASS  f-sidecar-replayable: 1 envelope, consecutive_failures=5
FAIL  (a-quarantine-is-stale) stale=false reason="capture lane delivering"
FAIL  (b-count-published) quarantined_count=undefined
FAIL  (c-control-healthy-green) / (e-live-health-degraded) GET /health -> 200
PASS  (d-unobserved-is-not-zero) / (f-control-absence-not-staleness)
DONE-MEANS #680: FAIL
```

**GREEN (this branch)** — 13/13:

```
PASS  a-pending-or-loud: pending=0 quarantined=1
PASS  b-notice-names-quarantine: '... (quarantined: 1 - ABANDONED - replay gave up, operator action required)'
PASS  (e-live-health-degraded) live GET /health -> 503, capture.quarantined_count=3
PASS  (d-unobserved-is-not-zero) quarantined_count=undefined (absent, not a fabricated 0)
PASS  (f-control-absence-not-staleness) no observer -> 200, no capture block
DONE-MEANS #680: PASS
```

Also: `bunx tsc --noEmit` clean. `uv run mypy src/openbrain` clean (50 files). `uv run ruff check src tests` clean. Observer tests 8 -> 14. Python suite measured against a SEPARATE clean `origin/main` worktree: 611 passed / 1 skipped -> 622 passed / 1 skipped. Exactly +11, and the **skip count is unchanged** — a green suite after a change can hide silently disabled tests.

**Mutation-proven, not merely green.** Two mutants, each killed:

1. `quarantined_count: quarantined ?? 0` (the fabricated zero, the defect's own shape) -> 12 pass / 2 fail.
2. Restoring the latch gate `if notice is None: return` (the pre-fix behaviour) -> killed by the load-bearing test only, while its control still passed.

## Critical Self-Review

- Highest-risk behavior: the Stop hook now stats one extra file on EVERY Stop, inside a 5-second deadline. Bounded deliberately — a `Path.exists()` on a file that does not exist for a healthy machine, which is the same cost the pending read already pays when it speaks. No client is built, no unit parsed, no lock taken.
- Assumptions that could be wrong: (1) that repeating the line every Stop until triage is right rather than annoying — it is deliberate, and the operator may rule otherwise; (2) that the quarantine fault should fire below the liveness quorum, which I argue for in the code but which is a judgment call; (3) that no non-hook caller of `spool_notice` passes a third positional argument by accident — the parameter defaults to 0, so existing two-argument callers are provably unchanged and pinned by a test.
- Missing/weak tests: no test drives the REAL Stop hook end-to-end with a quarantined sidecar through `capture_stop_with`; the coverage is at `announce_outage_state` (the boundary that owns the decision) plus the done-means driving the real spool. No Postgres test drives the observer's gatherer SQL with a quarantine value, because the gatherer deliberately does not report one.
- Security/permission risk: none new. No namespace predicate, auth path, or SQL is touched. The sidecar reader is read-only and content-free — it counts envelopes and never prints payloads, preserving the existing redaction boundary.
- Migration/deploy risk: none. No schema change, no migration. `quarantined_count` is an OPTIONAL field added to a health response, so existing readers are unaffected.
- Downstream client/runtime risk: `TransportCaptureHealth` is a client-facing contract and gains an optional field. Additive and optional, so no client breaks; but a client that pins an exact health schema would see a new key. Flagged below as needing a rollout classification I could not complete from this lane.
- Rollback/cleanup concern: revert is clean — no state is migrated and nothing was deleted. The lane's worktree and database are torn down; the restore-proof artifacts are archived, not removed.
- Fixes made before PR: two false REDs in my own check (a wrong `append()` kwarg that measured nothing; an `AttributeError` on the not-yet-existing symbol that killed every clause after the first — now resolved through a sentinel). One clause rewritten after it failed against the correct fix, then re-proven RED. One FALSE GREEN caught during that re-prove, where a `cp` restore silently did not land and the whole suite passed against an unreverted tree.
- Known residual risk: the existing sidecar is UNTOUCHED and the 15 turns are still not in the database — that decision is the operator's (below). The `announce_outage_state` swallow means a sidecar that cannot be read still degrades to silence at the hook, though `/health` remains loud. Clause 1 of the SME gate is RED on `origin/main` and remains red here (inherited, see below).
- SME review-memory update: [x] `docs/sme/` updated — `2026-08-09-a-hardcoded-zero-standing-in-for-an-unmeasured-quantity-is-a-silent-data-loss.md` (gotcha-agent lane), with `EXPECTED_ENTRY_COUNT` raised in the same commit.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the lane never contacts core01 (10.71.1.21) by hard rule, and the local dogfood service is deliberately not used as a test target. Every claim here is proven against an isolated lane database and an ephemeral 127.0.0.1 listener. The core01 application step is written below for the runbook rather than executed.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: `quarantined_count` is an optional field on the server's `/health` capture block, which the Python contract fixtures do not mirror — the Python `CaptureLiveness` model is the reader's own twin and gains no field in this PR (the client REPORTS the count; it does not consume the health block). If a reviewer judges the health block itself to be parity-covered, this needs a fixture and I would rather be told than guess.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [ ] rtech-mcps handoff is complete or not applicable
- [ ] mcp2cli cache/skill refresh is complete or not applicable
- [ ] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [ ] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- **UNRESOLVED, and deliberately not self-certified.** This adds an optional field to a client-facing health response. It is additive, so nothing should break, but classifying the four boxes above requires surveying rtech-mcps, mcp2cli, and Hermes for readers that pin the health schema — outside this lane's scope and its network rules. Left unchecked for the controller rather than ticked on reasoning.

## OPERATOR DECISION REQUIRED — the existing sidecar (#680 item 4)

**The 15 turns are still gone. Nothing in this PR replayed or deleted them.**

Inspected read-only this session with `scripts/replay-quarantined-spool.py` (dry run), and the file was verified byte-for-byte unchanged afterwards (69,699 bytes, mtime unchanged):

```
sidecar : ~/.local/state/openbrain-memory/claude-spool.jsonl.quarantine.jsonl
ABANDONED UNITS: 23
  append_session_event      2 record line(s)
  ingest_raw_turn           1 record line(s)   -> 15 raw turns
  session_start            22 record line(s)
  session_wrap             20 record line(s)
  consecutive failures per unit : [5]
  failure window : 2026-07-23 23:18:43 .. 2026-07-30 19:16:12
```

That matches the issue exactly: 15 raw turns plus 44 lifecycle records.

**Option 1 — REPLAY.** Restores every abandoned unit to the live spool; the provider's ordinary drain delivers them on its next healthy operation.

```bash
python3 scripts/replay-quarantined-spool.py            # confirm the numbers first
python3 scripts/replay-quarantined-spool.py --restore  # writes a timestamped backup, then restores
```

Then verify the turns landed:

```bash
set -a; . ./.env; set +a
psql -At -c "select count(*) from ob_raw_turns where turn_uuid in ('<uuids from the sidecar>');"
```

Proven working against a synthetic sidecar quarantined through the real code path: `pending=0/quarantined=1` -> `pending=1/quarantined=0`, backup written, both turn_uuids read back intact. Ordering is restore-then-empty on purpose: a crash between the two re-delivers (at-least-once, consumers dedupe on `idempotency_key`), where the reverse would lose them outright.

**Option 2 — ACCEPT THE LOSS.** Leave the sidecar. The records stay on disk and out of the database. Worth saying explicitly so the loss is a decision on the record rather than an oversight — which is the entire failure mode #680 is about.

Risk worth naming for option 1: these units failed 5 consecutive times each between 07-23 and 07-30. If the cause was the payload rather than reachability, they will fail again and re-quarantine — which is now LOUD, so a second attempt is cheap to observe and costs nothing but a drain cycle.

## CORE01 APPLICATION STEP (written, NOT executed)

Per the lane's hard rule, nothing here touched core01 (10.71.1.21). For the cutover runbook:

1. Deploy this change with the rest of the cutover; no migration, no config key, nothing to set.
2. After deploy, read the FEATURE's own signal, not just the revision (#659's lesson): `curl -s http://10.71.1.21:3100/health | jq '.capture'` — a worker composing the observer publishes the capture block. `quarantined_count` will be ABSENT there, and that is correct: the server-side gatherer cannot observe a client-side sidecar, so it reports nothing rather than a fabricated 0.
3. The count becomes non-absent only when a reporting client supplies `spoolQuarantined`. Wiring a client reporter is NOT in this PR and is not required to close #680 — it is the natural follow-up, and I would rather file it than smuggle it in.
4. On each capture host (not core01), `python3 scripts/replay-quarantined-spool.py` is the standing triage command once the notice fires.

## Refusals, deviations, and inherited failures

- **design-lookup-gate fired twice as a FALSE POSITIVE** on this change: once matching "limits" inside a citation of a doc FILENAME, once matching "How many" in the EXISTING docstring wording I was preserving verbatim. No cap, bound, or reduction is proposed anywhere in this PR. Complied both times by rewording rather than retrying a variant. Reported, not fought.
- **fast-tools-gate** refused a `grep -E`; used `rg`. The rule working.
- **Two foreign stashes** were present in the repo (`stash@{0}`, `stash@{1}`, both other branches'). Not touched — red/green proofs used file-copy, per the round-13 rule.
- **INHERITED, main-owned, NOT fixed here:** the SME gate's clause 1 is RED on `origin/main` — `2026-08-08-guards-must-judge-the-operation-not-the-vocabulary.md` (from PR #638) uses a different frontmatter style and carries no `## ` heading. Proven by running the gate in a separate clean `origin/main` worktree: main fails clauses 1 AND 4; this branch fails only clause 1. I fixed clause 4 (see next) and left another lane's entry file alone.
- **EXPECTED_ENTRY_COUNT reconciled 227 -> 232.** It was already stale on main: 231 dated headings against a pin of 227, so four entries landed across #645/#648/#673 without the same-commit bump the rule requires. 231 inherited + 1 mine = 232. Reconciled rather than absorbed, because a gate left red for reasons nobody owns is one people learn to skip.
- **CI caught a real defect a local run could not (self-reported).** `python-capture` failed D205 on the first push. The ruff fix had been made locally during the lane and NEVER COMMITTED — it sat in the working tree while the commit meant to carry it went out with the old text. Local ruff passed because it read the dirty file; CI read the commit. "Passes on my machine" and "CI is flaky" were both available readings and both wrong. Settled by reading the committed blob (`git show <sha>:<path>`) instead of the working file, which is the only way to tell the two apart. Fixed in `571f8ee`; CI green at that head, all 8 checks.
- **Flagged for the decisions pass:** the every-Stop repetition of the quarantine notice is a deliberate departure from this module's "a notice is a state change, never an event" convention. I argue for it in the code (a standing condition is not an event, and the latch's silence is what made the loss permanent), but it touches a recorded convention and deserves a ruling rather than my say-so.
