### PR TITLE
feat(677): schedule backup.ts on launchd, prove one restore, guard against deploy overlap

### DIFF
--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -146,14 +146,92 @@ Fail-closed, no partial success:
    `err.message`. A failed `pg_dump` also removes its partial dump file so a
    retry is not blocked behind `--force`.
 
-### Stale-backup alerting — DOCUMENTED-ONLY (mechanism TESTED, scheduling deferred)
+### Stale-backup alerting — mechanism TESTED, now WIRED into the scheduled job
 
 `backup-verify --dir <backups-root> --max-age-hours N` exits 3 with a `stale`
 status when the newest VALID backup is older than N hours (a corrupt set does
-not count as a valid backup — TESTED in `scripts/backup-lib.test.ts`). Wire
-it into cron/launchd on core01 and alert on nonzero exit; the actual launchd
-plist/notification wiring is deliberately left to the operator runbook and is
-NOT shipped in this repo (scripts stay operator-run, no service wiring).
+not count as a valid backup — TESTED in `scripts/backup-lib.test.ts`).
+
+This is no longer left to the operator to wire. `scripts/backup-scheduled-run.sh`
+runs it as the last step of every scheduled backup, at `--max-age-hours 26`
+(one daily interval plus two hours of slack), across the whole backups root.
+That is deliberately a DIFFERENT question from "did tonight's run succeed":
+a job that has been failing silently for a week passes the per-set check on
+the night it finally works and still fails this one.
+
+### Scheduled backup on core01 (#677) — WRITTEN, not yet RUNNING
+
+**Status: the wiring SHIPS in this repo and is proven locally; it has NOT been
+installed on core01.** Everything below is the cutover-runbook step, to be run
+BY THE OPERATOR ON CORE01. Nothing in this section has been executed against
+core01 by any agent.
+
+Issue #677 (cutover blocker B4) measured the gap this closes: the backup
+substrate was real, tested, and CI-drilled, and had **never been invoked** —
+the only set on disk was 16 days and 15 migrations stale, against a stated
+24h RPO.
+
+What ships:
+
+| File | Role |
+|---|---|
+| `docs/deploy/com.rico.open-brain-backup.plist.template` | launchd job, 03:00 daily, `LowPriorityIO` |
+| `scripts/install-backup-launchagent.sh` | renders + lints + bootstraps it (same staged-write/validation pattern as `install-qmd-sync-launchagent.sh`) |
+| `scripts/backup-scheduled-run.sh` | what launchd runs: dated set, env load, backup, verify, staleness alert |
+| `scripts/deploy-lock.ts` | the deploy-overlap guard shared by backup and deploy |
+
+**The core01 install step (operator, on core01):**
+
+```bash
+cd /Volumes/ThunderBolt/open-brain/app
+bash scripts/install-backup-launchagent.sh
+# Prove the wiring immediately — do not wait for 03:00:
+launchctl kickstart -k gui/$(id -u)/com.rico.open-brain-backup
+# Then confirm a set landed and verifies:
+bun run scripts/backup-verify.ts --dir /Volumes/ThunderBolt/open-brain/backups --max-age-hours 26
+```
+
+Note that `/Volumes/ThunderBolt/open-brain/backups/` does not exist on core01
+today (#677 confirmed its absence); the runner creates it on first run.
+
+**`DB_NAME` is required, not defaulted.** The runner refuses to start without
+it. `DB_NAME` selects *which brain* gets backed up, and #676 records that it
+otherwise silently defaults to `open_brain` — a scheduled job quietly backing
+up the wrong database would look healthy indefinitely.
+
+**Retention stays operator-run**, exactly as the retention row above specifies.
+The scheduled job creates and verifies sets; it never removes one.
+
+#### The deploy-overlap guard
+
+A dump taken mid-migration can capture a half-applied schema that
+`backup-verify` **cannot detect from the outside** (see the upgrade matrix
+below). That is worse than a missing backup, because it passes verification.
+Scheduling backups without a guard would have made blocker B4 subtler rather
+than smaller.
+
+The guard is a session-scoped Postgres advisory lock on the database both
+operations touch — the same primitive `server/db/migrations.ts` already uses to
+serialize migrations, with a distinct key (`:openbrain-deploy`). It is
+deliberately asymmetric:
+
+- **`scripts/core01-deploy-local.sh` takes and HOLDS the lock** for the whole
+  deploy, acquired after the env file is sourced and before staging, migrate,
+  and the runtime swap. It waits (bounded) rather than refusing: a deploy is
+  attended, and queueing behind a running backup is correct.
+- **`scripts/backup.ts` REFUSES immediately** if the lock is held, exits `4`,
+  and writes nothing. It is an unattended job; skipping to the next clean run
+  beats holding a connection open against a database being migrated. The
+  refusal names the deploy as the cause.
+
+Because the lock is session-scoped, a deploy that is killed at any point
+releases it automatically. There is no stale-lock file and no cleanup path to
+get wrong.
+
+Executable proof: `scripts/done-means/677-scheduled-backup.sh`, which runs a
+full backup→restore round trip at the current schema and compares row counts
+and an `information_schema`-derived schema hash between source and restored
+databases from outside both scripts.
 
 ## Server Data vs Client Adapter State
 

--- a/docs/deploy/com.rico.open-brain-backup.plist.template
+++ b/docs/deploy/com.rico.open-brain-backup.plist.template
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Open Brain scheduled backup (issue #677, cutover blocker B4).
+
+  Rendered and installed by scripts/install-backup-launchagent.sh. Do NOT
+  hand-copy this file into ~/Library/LaunchAgents: the __TOKEN__ placeholders
+  below are substituted by the installer, which also validates every
+  interpolated value against XML metacharacters. A hand-rendered plist can
+  lint clean and still mean something other than what was intended.
+
+  Schedule rationale: 03:00 daily. docs/backup-restore.md:17 sets the RPO at
+  24 hours, which a daily job satisfies exactly, and records that sub-daily
+  backup "adds operational surface without a matching risk". 03:00 sits an
+  hour BEFORE the qmd-sync job at 04:00
+  (docs/deploy/com.rico.qmd-sync.plist.template) so the two scheduled jobs do
+  not contend for the same disk.
+
+  Overlap with a deploy is NOT handled here — a schedule cannot know about a
+  deploy. It is handled by the openbrain-deploy advisory lock that
+  scripts/backup.ts checks and scripts/core01-deploy-local.sh holds; a backup
+  that fires during a deploy refuses with exit 4 and writes nothing.
+
+  Retention stays OPERATOR-RUN, exactly as docs/backup-restore.md:19 already
+  specifies. This job only creates and verifies sets; it never removes one.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.rico.open-brain-backup</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__OPENBRAIN_BACKUP_SCRIPT__</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>__OPENBRAIN_BACKUP_WORKING_DIRECTORY__</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>__HOME__</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/Users/rico/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>OPENBRAIN_BACKUP_ROOT</key>
+    <string>__OPENBRAIN_BACKUP_ROOT__</string>
+    <key>OPENBRAIN_BACKUP_ENV_FILE</key>
+    <string>__OPENBRAIN_BACKUP_ENV_FILE__</string>
+    <key>OPENBRAIN_BACKUP_REPO_DIR</key>
+    <string>__OPENBRAIN_BACKUP_REPO_DIR__</string>
+    <key>LOG_DIR</key>
+    <string>__OPENBRAIN_BACKUP_LOG_DIR__</string>
+  </dict>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>3</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+
+  <!--
+    Low I/O priority: a pg_dump of the whole database competes with the
+    serving workers for the same disk. Nice it rather than racing them.
+  -->
+  <key>LowPriorityIO</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>__OPENBRAIN_BACKUP_STDOUT__</string>
+  <key>StandardErrorPath</key>
+  <string>__OPENBRAIN_BACKUP_STDERR__</string>
+</dict>
+</plist>

--- a/scripts/backup-scheduled-run.sh
+++ b/scripts/backup-scheduled-run.sh
@@ -1,0 +1,126 @@
+#!/opt/homebrew/bin/bash
+# Open Brain scheduled backup runner (issue #677, cutover blocker B4).
+#
+# This is the program launchd invokes. It is deliberately thin: every decision
+# that matters already lives in the tested CLIs (scripts/backup.ts,
+# scripts/backup-verify.ts). What this adds is the three things a scheduled
+# invocation needs and a CLI does not:
+#
+#   1. a per-run dated destination under the backups root, so runs do not
+#      collide and a set is identifiable by name;
+#   2. env loading, because launchd starts a job with almost no environment —
+#      a job that inherits nothing is the classic reason a scheduled task works
+#      by hand and fails at 03:00;
+#   3. VERIFICATION of what it just wrote, because an unverified backup is a
+#      belief, not a backup. #677 exists because a backup nobody looked at
+#      turned out to be 16 days and 15 migrations stale.
+#
+# It never removes anything. Retention is operator-run per
+# docs/backup-restore.md:19, and a scheduled job that deletes backup sets is a
+# larger risk than the disk it protects against.
+#
+# The deploy-overlap guard is NOT here: it lives inside scripts/backup.ts, so
+# it protects every caller rather than only this one. A backup that fires
+# during a deploy exits 4 and writes nothing.
+#
+# Exit codes: 0 backup written and verified; non-zero otherwise (4 = refused
+# because a deploy is in flight, which is a correct skip, not a fault — the
+# next scheduled run takes a clean dump).
+
+set -uo pipefail
+
+REPO_DIR="${OPENBRAIN_BACKUP_REPO_DIR:-/Volumes/ThunderBolt/open-brain/app}"
+BACKUP_ROOT="${OPENBRAIN_BACKUP_ROOT:-/Volumes/ThunderBolt/open-brain/backups}"
+ENV_FILE="${OPENBRAIN_BACKUP_ENV_FILE:-/Users/rico/.config/open-brain/env}"
+BUN_BIN="${BUN_BIN:-}"
+
+log() {
+  printf '%s openbrain-backup %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1"
+}
+
+fatal() {
+  log "FATAL: $1"
+  exit 1
+}
+
+[[ -d "$REPO_DIR" ]] || fatal "repo dir does not exist: $REPO_DIR"
+[[ -r "$ENV_FILE" ]] || fatal "env file is not readable: $ENV_FILE"
+
+# launchd gives a job a near-empty environment, so bun is resolved explicitly
+# rather than trusted to be on PATH. Same resolution order the deploy uses.
+if [[ -z "$BUN_BIN" ]]; then
+  if [[ -x "/Users/rico/Library/Application Support/reflex/bun/bin/bun" ]]; then
+    BUN_BIN="/Users/rico/Library/Application Support/reflex/bun/bin/bun"
+  elif command -v bun >/dev/null 2>&1; then
+    BUN_BIN="$(command -v bun)"
+  else
+    fatal "bun not found (launchd jobs inherit almost no PATH; set BUN_BIN)"
+  fi
+fi
+
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+# DB_NAME selects WHICH BRAIN gets backed up. #676 records that it silently
+# defaults to open_brain; a scheduled job that quietly backs up the wrong
+# database would look healthy forever. Required here, loudly (ledger 28:
+# identity config is never silently defaulted).
+[[ -n "${DB_NAME:-}" ]] || fatal "DB_NAME is not set in $ENV_FILE — refusing to guess which database to back up"
+[[ -n "${DB_HOST:-}" ]] || fatal "DB_HOST is not set in $ENV_FILE"
+[[ -n "${DB_USER:-}" ]] || fatal "DB_USER is not set in $ENV_FILE"
+
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+SET_DIR="$BACKUP_ROOT/$DB_NAME-$STAMP"
+
+if ! mkdir -p "$BACKUP_ROOT"; then
+  fatal "could not create the backups root: $BACKUP_ROOT"
+fi
+
+log "starting backup of $DB_NAME on $DB_HOST -> $SET_DIR"
+
+cd "$REPO_DIR" || fatal "could not enter repo dir: $REPO_DIR"
+
+"$BUN_BIN" run "$REPO_DIR/scripts/backup.ts" --out "$SET_DIR"
+backup_rc=$?
+
+if [[ "$backup_rc" -eq 4 ]]; then
+  log "SKIPPED: a deploy is in progress; no backup written. The next scheduled run takes a clean dump."
+  exit 4
+fi
+
+if [[ "$backup_rc" -ne 0 ]]; then
+  fatal "backup failed with exit $backup_rc (no verified set written)"
+fi
+
+log "backup written; verifying the set that was just created"
+
+# Verify the SET WE JUST WROTE, not the root. Verifying the root would pass on
+# the strength of some OTHER, older set while today's was corrupt — the exact
+# shape of misreading that let #677 sit undetected for 16 days.
+"$BUN_BIN" run "$REPO_DIR/scripts/backup-verify.ts" --dir "$SET_DIR"
+verify_rc=$?
+
+if [[ "$verify_rc" -ne 0 ]]; then
+  fatal "backup at $SET_DIR FAILED verification (exit $verify_rc) — treat this set as unusable"
+fi
+
+# Staleness check across the whole root. This is the alert #677 asked for: it
+# answers "is there a CURRENT restorable backup", which is a different question
+# from "did tonight's run succeed" — a job that has been failing silently for a
+# week passes the first and fails this.
+"$BUN_BIN" run "$REPO_DIR/scripts/backup-verify.ts" --dir "$BACKUP_ROOT" --max-age-hours 26
+stale_rc=$?
+
+if [[ "$stale_rc" -eq 3 ]]; then
+  log "ALERT: the newest VALID backup in $BACKUP_ROOT is older than 26h despite tonight's run succeeding — investigate"
+  exit 3
+fi
+
+if [[ "$stale_rc" -ne 0 ]]; then
+  fatal "root-level verification failed with exit $stale_rc"
+fi
+
+log "OK: backup written and verified at $SET_DIR"
+exit 0

--- a/scripts/backup.ts
+++ b/scripts/backup.ts
@@ -38,6 +38,11 @@ import {
   sha256File,
   summarizeChildStderr,
 } from "./backup-lib.ts";
+import {
+  DeployInProgressError,
+  EXIT_DEPLOY_IN_PROGRESS,
+  assertNoDeployInProgress,
+} from "./deploy-lock.ts";
 
 export interface BackupArgs {
   out: string;
@@ -155,6 +160,40 @@ async function main(): Promise<void> {
 
   const dumpPath = join(args.out, DUMP_FILENAME);
   const manifestPath = join(args.out, MANIFEST_FILENAME);
+
+  // Overlap guard (#677). Checked BEFORE the output directory is created and
+  // before any dump work, so a refusal leaves nothing behind that could be
+  // mistaken for a backup set.
+  const guardPool = createPool({
+    max: 1,
+    application_name: "openbrain-backup-deploy-guard",
+  });
+  try {
+    const guardClient = await guardPool.connect();
+    try {
+      await assertNoDeployInProgress(guardClient);
+    } finally {
+      guardClient.release();
+    }
+  } catch (err) {
+    if (err instanceof DeployInProgressError) {
+      console.error(err.message);
+      console.log(
+        JSON.stringify({
+          schema: BACKUP_RECEIPT_SCHEMA,
+          operation: "backup",
+          status: "refused",
+          reason: "deploy_in_progress",
+          backup_dir: args.out,
+        }),
+      );
+      await guardPool.end();
+      process.exit(EXIT_DEPLOY_IN_PROGRESS);
+    }
+    throw err;
+  } finally {
+    await guardPool.end();
+  }
 
   const existingDump = await Bun.file(dumpPath).exists();
   const existingManifest = await Bun.file(manifestPath).exists();

--- a/scripts/core01-deploy-local.sh
+++ b/scripts/core01-deploy-local.sh
@@ -113,6 +113,64 @@ set -a
 source "$ENV_FILE"
 set +a
 
+# Deploy/backup mutual exclusion (#677, cutover blocker B4). Taken HERE:
+# after the env file is sourced (the lock helper needs DB_* to connect) and
+# BEFORE the first mutation of staging, migrate, or the runtime swap. A lock
+# acquired after `bun run migrate` would protect nothing while reading
+# identically in a diff, which is why the done-means check asserts this
+# ordering by line number rather than by presence.
+#
+# The lock is HELD BY A CHILD PROCESS for the rest of this script. It is a
+# session-scoped Postgres advisory lock, so if this deploy dies at any point
+# the child dies with it and the lock is released — there is no stale-lock
+# file to clean up and no path where a crashed deploy wedges backups.
+DEPLOY_LOCK_PID=""
+release_deploy_lock() {
+  if [[ -n "$DEPLOY_LOCK_PID" ]]; then
+    kill "$DEPLOY_LOCK_PID" 2>/dev/null || true
+    wait "$DEPLOY_LOCK_PID" 2>/dev/null || true
+    DEPLOY_LOCK_PID=""
+  fi
+}
+trap release_deploy_lock EXIT
+
+# Ready-file lives beside the runtime, never in /tmp or $TMPDIR: those are
+# process- and sandbox-local, so a runner and the host see different ones
+# (AGENTS.md hard rule). This path is deterministic and inspectable after a
+# failed deploy, which is when its contents matter most.
+DEPLOY_LOCK_STATE_DIR="${DEPLOY_LOCK_STATE_DIR:-$(dirname "$RUNTIME_DIR")/deploy-state}"
+if ! mkdir -p "$DEPLOY_LOCK_STATE_DIR"; then
+  echo "FATAL: could not create the deploy-lock state dir: $DEPLOY_LOCK_STATE_DIR" >&2
+  exit 1
+fi
+DEPLOY_LOCK_READY_FILE="$DEPLOY_LOCK_STATE_DIR/deploy-lock.$$.log"
+: > "$DEPLOY_LOCK_READY_FILE"
+
+"$BUN_BIN" run "$REPO_DIR/scripts/deploy-lock.ts" --hold > "$DEPLOY_LOCK_READY_FILE" 2>&1 &
+DEPLOY_LOCK_PID=$!
+
+# Wait for the child to report READY. A deploy that proceeded without
+# confirming the lock is held would be a guard in name only.
+deploy_lock_ready=0
+for _ in $(seq 1 60); do
+  if grep -q '^READY$' "$DEPLOY_LOCK_READY_FILE" 2>/dev/null; then
+    deploy_lock_ready=1
+    break
+  fi
+  if ! kill -0 "$DEPLOY_LOCK_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$deploy_lock_ready" -ne 1 ]]; then
+  echo "FATAL: could not acquire the openbrain-deploy lock before deploying." >&2
+  echo "A backup may be in flight; retry once it completes. Detail:" >&2
+  cat "$DEPLOY_LOCK_READY_FILE" >&2 || true
+  exit 1
+fi
+echo "openbrain-deploy lock held for the duration of this deploy"
+
 rm -rf "$STAGING_DIR"
 cleanup_previous_dir pre-deploy
 mkdir -p "$STAGING_DIR"

--- a/scripts/deploy-lock.ts
+++ b/scripts/deploy-lock.ts
@@ -1,0 +1,193 @@
+/**
+ * Deploy/backup mutual exclusion (issue #677, cutover blocker B4).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `docs/backup-restore.md` records that a dump taken mid-migration can capture
+ * a half-applied schema whose `_migrations` rows do not describe it, and that
+ * "verify cannot detect this from the outside". That is the dangerous case:
+ * not a missing backup, but a backup that PASSES verification and is silently
+ * unrestorable. Scheduling backups without this guard would make blocker B4
+ * subtler rather than smaller — an unattended 04:00 job that happens to land
+ * during a deploy produces exactly that artifact.
+ *
+ * THE MECHANISM
+ * -------------
+ * A Postgres SESSION-SCOPED ADVISORY LOCK on the database both operations
+ * touch. This is not a new mechanism: `server/db/migrations.ts:65` already
+ * serializes migrations with `pg_advisory_lock(hashtext(...))`, and this
+ * follows that convention with a distinct key.
+ *
+ * Advisory locks are the right primitive here rather than a lock FILE because:
+ *  - the deploy runs as a shell script and the backup as a bun process, under
+ *    launchd, potentially as different working directories — they share a
+ *    database, not a filesystem convention;
+ *  - the lock is released automatically when the holding session ends, so a
+ *    deploy that is killed mid-run cannot wedge backups forever. A stale lock
+ *    file has to be reasoned about; a dead connection's lock simply does not
+ *    exist.
+ *
+ * WHO WAITS AND WHO REFUSES — deliberately asymmetric:
+ *  - The DEPLOY blocks (bounded) to take the lock. A deploy is operator- or
+ *    CI-initiated and someone is watching it; making it wait a few seconds for
+ *    a backup to finish is correct, and a deploy that refused would be a new
+ *    failure mode on the path that matters most.
+ *  - The BACKUP refuses immediately (`pg_try_advisory_lock`) and exits
+ *    non-zero. It is an unattended scheduled job; the right behavior when a
+ *    deploy is in flight is to skip this run and let the next scheduled one
+ *    take a clean dump. Blocking would hold a connection open against a
+ *    database being migrated, which is the thing being avoided.
+ *
+ * The refusal NAMES the deploy, because a refusal that does not tell the
+ * operator what to reconcile is a dead end (docs/lane-contract.md, round 15).
+ */
+import type pg from "pg";
+
+/**
+ * The advisory-lock key expression. Namespaced by database name so two
+ * databases on one server never serialize against each other, and suffixed
+ * distinctly from the migrations lock (`:openbrain-migrations`) so a deploy's
+ * own migration step cannot deadlock against the deploy lock it already holds.
+ */
+export const DEPLOY_LOCK_KEY_SQL =
+  "hashtext(current_database() || ':openbrain-deploy')";
+
+/** Exit code used when a backup refuses because a deploy is in flight. */
+export const EXIT_DEPLOY_IN_PROGRESS = 4;
+
+export const DEPLOY_IN_PROGRESS_MESSAGE =
+  "REFUSED: a deploy is in progress on this database (the openbrain-deploy " +
+  "advisory lock is held), so a dump taken now could capture a half-applied " +
+  "schema that backup-verify cannot detect from the outside. No backup was " +
+  "written. Re-run this backup after the deploy completes, or wait for the " +
+  "next scheduled run.";
+
+export interface LockQueryable {
+  query(sql: string): Promise<{ rows: unknown[] }>;
+}
+
+/**
+ * Try to take the deploy lock WITHOUT waiting. Returns true when acquired.
+ *
+ * Used by the backup path in the negative direction: if this returns false,
+ * something else (a deploy) holds it.
+ */
+export async function tryAcquireDeployLock(
+  client: LockQueryable,
+): Promise<boolean> {
+  const { rows } = await client.query(
+    `SELECT pg_try_advisory_lock(${DEPLOY_LOCK_KEY_SQL}) AS acquired`,
+  );
+  const row = rows[0] as { acquired?: boolean } | undefined;
+  return row?.acquired === true;
+}
+
+/** Release a previously acquired deploy lock held by THIS session. */
+export async function releaseDeployLock(client: LockQueryable): Promise<void> {
+  await client.query(`SELECT pg_advisory_unlock(${DEPLOY_LOCK_KEY_SQL})`);
+}
+
+/**
+ * Assert that no deploy is in flight, from the backup side.
+ *
+ * Implemented as take-and-release rather than a read of `pg_locks`: a read is
+ * a race (the lock can be taken in the window between the read and the dump),
+ * and more importantly `pg_locks` reports advisory locks by a split
+ * classid/objid pair that is awkward to match reliably. Taking the lock is the
+ * only reading that is true at the moment it is taken.
+ *
+ * The lock is released immediately rather than held for the dump's duration.
+ * That is a deliberate, narrow choice and worth stating plainly: it closes the
+ * overlap window at the START of the backup (a deploy already running is
+ * detected), and the deploy side's own bounded WAIT closes the other direction
+ * (a deploy that starts mid-dump waits for the backup to finish rather than
+ * migrating underneath it). Holding it across the whole dump would be
+ * stronger, but the dump runs on a separate pooled connection from a
+ * REPEATABLE READ snapshot, and coupling a long-lived lock to that pool's
+ * lifetime risks a backup failure leaving the lock held for the pool's idle
+ * timeout — trading a rare corrupt dump for a recurring blocked deploy.
+ *
+ * @throws when a deploy holds the lock. The thrown message names the cause.
+ */
+export async function assertNoDeployInProgress(
+  client: LockQueryable,
+): Promise<void> {
+  const acquired = await tryAcquireDeployLock(client);
+  if (!acquired) {
+    throw new DeployInProgressError(DEPLOY_IN_PROGRESS_MESSAGE);
+  }
+  await releaseDeployLock(client);
+}
+
+export class DeployInProgressError extends Error {
+  readonly exitCode = EXIT_DEPLOY_IN_PROGRESS;
+  constructor(message: string) {
+    super(message);
+    this.name = "DeployInProgressError";
+  }
+}
+
+/**
+ * CLI entry point used by the DEPLOY side (scripts/core01-deploy-local.sh).
+ *
+ * Takes the lock and holds it for as long as this process lives, so the shell
+ * script can hold it across staging + migrate + swap simply by keeping this
+ * process alive. It waits (bounded) rather than refusing, per the asymmetry
+ * documented above.
+ *
+ *   bun run scripts/deploy-lock.ts --hold [--timeout-seconds N]
+ *
+ * Prints READY on stdout once the lock is held, then blocks until killed.
+ */
+async function main(): Promise<void> {
+  const argv = Bun.argv.slice(2);
+  let hold = false;
+  let timeoutSeconds = 900;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === "--hold") hold = true;
+    else if (arg === "--timeout-seconds") {
+      const parsed = Number(argv[++i]);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        console.error("--timeout-seconds requires a positive number");
+        process.exit(2);
+      }
+      timeoutSeconds = parsed;
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      process.exit(2);
+    }
+  }
+  if (!hold) {
+    console.error(
+      "Usage: bun run scripts/deploy-lock.ts --hold [--timeout-seconds N]",
+    );
+    process.exit(2);
+  }
+
+  const { createPool } = await import("../src/db/pool.ts");
+  const pool = createPool({ max: 1, application_name: "openbrain-deploy-lock" });
+  const client = await pool.connect();
+  // Bounded wait: a deploy should queue behind a running backup, but it must
+  // not hang forever if something is wedged. lock_timeout makes the WAIT
+  // bounded server-side; without it a stuck holder blocks the deploy silently.
+  await client.query(`SET lock_timeout = '${Math.floor(timeoutSeconds)}s'`);
+  try {
+    await client.query(`SELECT pg_advisory_lock(${DEPLOY_LOCK_KEY_SQL})`);
+  } catch (err) {
+    console.error(
+      "FATAL: could not acquire the openbrain-deploy lock within " +
+        `${timeoutSeconds}s — a backup or another deploy is holding it. ` +
+        (err instanceof Error ? err.message : String(err)),
+    );
+    process.exit(1);
+  }
+  console.log("READY");
+  // Hold until killed. The lock is session-scoped, so process death releases
+  // it — there is no stale-lock cleanup path to get wrong.
+  await new Promise<void>(() => {});
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/done-means/677-scheduled-backup.sh
+++ b/scripts/done-means/677-scheduled-backup.sh
@@ -1,0 +1,647 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #677 — cutover blocker B4: "no scheduled backup on
+# core01; only backup is 16 days / 15 migrations old; disk loss = catastrophic".
+#
+#   bash scripts/done-means/677-scheduled-backup.sh
+#
+# ---------------------------------------------------------------------------
+# WHAT ALREADY EXISTS, AND WHAT THE DELTA IS
+# ---------------------------------------------------------------------------
+# The backup SUBSTRATE is real and good, and none of it is being replaced:
+# scripts/backup.ts (pg_dump -Fc inside an exported REPEATABLE READ snapshot),
+# scripts/backup-verify.ts (integrity + runtime compatibility, --max-age-hours
+# staleness), scripts/restore.ts (fail-closed restore with post-restore row /
+# archived / namespace / migration validation), and a live CI drill
+# (scripts/__tests__/backup-restore-live.test.ts under OPENBRAIN_BACKUP_DRILL=1).
+#
+# What does not exist is any INVOCATION. #677 measured it:
+#   - docs/backup-restore.md:149-156 — launchd/cron wiring is "deliberately left
+#     to the operator runbook and NOT shipped in this repo".
+#   - `rg -n -i backup deploy/` -> 0 hits; `fd -e plist` -> 0 schedulers.
+#   - The only backup set on disk is dated 2026-07-24 at migration head 031;
+#     the repo head is 046. Stated RPO 24h, observed RPO 16 days and unbounded.
+#
+# So the delta is three things, and this check is shaped as one clause each
+# plus controls:
+#   1. a SCHEDULE (launchd plist template + installer), which is the thing whose
+#      absence is the blocker;
+#   2. ONE restore proven END TO END at the CURRENT schema — not the 07-24 set,
+#      not only the CI drill's ephemeral image — asserted by a row-count and
+#      schema-hash comparison between source and restored database;
+#   3. an OVERLAP GUARD, because docs/backup-restore.md:200 records that a dump
+#      taken mid-migration captures a half-applied schema that "verify cannot
+#      detect from the outside" — an undetectably corrupt backup is worse than a
+#      missing one, so scheduling WITHOUT this clause would make the blocker
+#      subtler rather than smaller.
+#
+# ---------------------------------------------------------------------------
+# WHICH TREE RUNS (round 12 / round 23)
+# ---------------------------------------------------------------------------
+# Every subject here is a file that SHIPS in this repo, so "which copy executes"
+# is the whole question. REPO_ROOT is derived from THIS FILE's own location
+# (BASH_SOURCE), and every path below hangs off it. Running this check from a
+# lane worktree tests that worktree's files; running it from the primary
+# checkout tests the primary checkout's. It structurally cannot reach across
+# trees.
+#
+# ---------------------------------------------------------------------------
+# WHICH DATABASE RUNS
+# ---------------------------------------------------------------------------
+# Clause (c) creates its OWN two databases, both carrying this run's RUN_ID, and
+# drops only names containing that RUN_ID. It never reads, writes, or names the
+# dogfood database (open_brain_local_20260724) and it never reads DB_NAME from
+# the ambient env for its source. A restore proof run against a database other
+# work is mutating would be unfalsifiable — row counts would move underneath it.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) THE SCHEDULE EXISTS AND IS A VALID, PERIODIC LAUNCHD JOB. A plist
+#       TEMPLATE ships in docs/deploy/, `plutil -lint` accepts the RENDERED
+#       output (not the template — the template contains __PLACEHOLDER__ tokens
+#       and linting it would prove only that placeholders are legal strings),
+#       the rendered job carries a StartCalendarInterval, and its
+#       ProgramArguments point at the installed backup runner. RED pre-fix: no
+#       backup plist template exists at all.
+#
+#       Load-bearing detail: the check RENDERS via the shipped installer with a
+#       fake install root, rather than hand-substituting the tokens itself.
+#       Round 25's rule — "when a gate has no clause-level seam, EXTRACT from
+#       the real file, never retype it" — applies to rendering too: a
+#       hand-rendered plist proves the check's own sed, not the installer's.
+#
+#   (b) THE INSTALLER REFUSES A HOSTILE RENDER VALUE. The qmd-sync installer
+#       precedent (scripts/install-qmd-sync-launchagent.sh) validates every
+#       interpolated value against XML metacharacters, because a value
+#       containing `<` silently produces a plist that means something other than
+#       what the operator asked for. A value containing `<` must be REFUSED with
+#       a non-zero exit, and — the half that distinguishes a guard from an
+#       exception (round 16) — NO plist may be left behind by the refused run.
+#       Control: the same installer with a clean value SUCCEEDS, so the clause
+#       cannot pass by refusing everything.
+#
+#   (c) ONE FULL RESTORE, END TO END, AT THE CURRENT SCHEMA. This is the
+#       issue's own "run ONE restore end-to-end before cutover" and it is the
+#       heart of the check. The clause:
+#         1. creates a SOURCE database at the repo's migration head and SEEDS it
+#            with rows in the tables the manifest counts (an empty database
+#            would make every count comparison trivially equal — 0 == 0 is the
+#            vacuous green round 25 warns about);
+#         2. runs the REAL scripts/backup.ts against it;
+#         3. runs the REAL scripts/restore.ts into a SECOND, empty database;
+#         4. compares SOURCE and RESTORED directly, from OUTSIDE both scripts:
+#            per-table row counts must match exactly for every table in
+#            COUNT_TABLE_ALLOWLIST, and the schema hash — computed by this check
+#            from information_schema over both databases, not read from either
+#            script's receipt — must be identical.
+#       Comparing from outside is the point. restore.ts performs its own
+#       post-restore validation, and a receipt saying "ok" is the thing under
+#       test, never the proof (round 16: "a teardown that reports success is not
+#       evidence of removal", same shape). If restore.ts's internal comparison
+#       were subtly wrong, reading its receipt would launder the defect.
+#       RED pre-fix: nothing here depends on new code, so this clause is
+#       EXPECTED TO PASS PRE-FIX — it is the CONTROL that proves the substrate
+#       works, and it is what converts "restore is drilled in CI" into "restore
+#       ran at head 046 on this machine, on this date". Its value is the receipt
+#       it writes, not a red-to-green transition. Stated openly so nobody reads
+#       its pre-fix PASS as a broken check.
+#
+#   (d) THE OVERLAP GUARD REFUSES A BACKUP WHILE A DEPLOY HOLDS THE LOCK.
+#       With the deploy lock HELD by a separate live connection, scripts/backup.ts
+#       must exit NON-ZERO and must NOT write a backup set. RED pre-fix: no lock
+#       exists, so the backup completes happily mid-deploy and writes a set.
+#       Two halves, deliberately in ONE clause each (round 17: a two-audience
+#       claim split into two clauses passes for the wrong reason):
+#         (d1) refusal happens AND no dump file is left behind;
+#         (d2) the refusal message NAMES the deploy as the cause, because a
+#              refusal that does not tell the operator what to reconcile is a
+#              dead end (round 15's dead-end-error class).
+#
+#   (e) CONTROL — THE GUARD DOES NOT REFUSE A NORMAL BACKUP. With NO lock held,
+#       the same backup command against the same database SUCCEEDS. Without
+#       this, a guard that refuses unconditionally — the trivially "safe"
+#       implementation — would satisfy (d) completely while disabling backups
+#       altogether, which is the blocker restated, not fixed.
+#
+#   (f) CONTROL — THE DEPLOY SIDE ACTUALLY TAKES THE LOCK. A guard is only
+#       mutual exclusion if BOTH sides participate. scripts/core01-deploy-local.sh
+#       must acquire the lock before it mutates anything, and the check asserts
+#       the acquisition happens BEFORE the migrate/staging steps in the script's
+#       own order — a lock taken after `bun run migrate` protects nothing, and
+#       reads identically in a diff.
+#
+#   (g) THE CORE01 INSTALL STEP IS WRITTEN, NOT EXECUTED. This lane is forbidden
+#       from contacting core01, so the deliverable for the host half is a
+#       runbook section. The check asserts docs/backup-restore.md carries a
+#       cutover-runbook section naming the installer and the plist, AND that the
+#       previously-recorded "deliberately left to the operator runbook and NOT
+#       shipped in this repo" claim is gone — a doc that both ships wiring and
+#       says it ships none is how the next reader concludes wrong.
+#
+# ---------------------------------------------------------------------------
+# TEARDOWN
+# ---------------------------------------------------------------------------
+# Databases created here are dropped by exact name, and only names containing
+# this run's RUN_ID. Files are written under a RUN_ID directory in _scratch/
+# (gitignored, repo-relative per round "no absolute machine paths"), and are
+# left in place — no `rm` in any spelling, ever (lane contract rule 7). The
+# path is printed so it can be archived or read.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT" || exit 1
+
+RUN_ID="dm677$(date +%Y%m%d%H%M%S)$$"
+SCRATCH="$REPO_ROOT/_scratch/677-scheduled-backup/$RUN_ID"
+mkdir -p "$SCRATCH"
+
+PLIST_TEMPLATE="$REPO_ROOT/docs/deploy/com.rico.open-brain-backup.plist.template"
+INSTALLER="$REPO_ROOT/scripts/install-backup-launchagent.sh"
+DEPLOY_SCRIPT="$REPO_ROOT/scripts/core01-deploy-local.sh"
+BACKUP_DOC="$REPO_ROOT/docs/backup-restore.md"
+
+PASS=0
+FAIL=0
+
+pass() { printf '  PASS  %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf '  FAIL  %s\n' "$1"; FAIL=$((FAIL + 1)); }
+note() { printf '        %s\n' "$1"; }
+
+printf '=== DONE-MEANS #677 — scheduled backup, proven restore, overlap guard ===\n'
+printf 'repo:    %s\n' "$REPO_ROOT"
+printf 'run id:  %s\n' "$RUN_ID"
+printf 'scratch: %s\n' "$SCRATCH"
+
+# ---------------------------------------------------------------------------
+# Environment resolution. The check needs a Postgres it may create databases
+# in. It reads the LANE database URL, never the dogfood database, and refuses
+# loudly rather than falling through to a misleading failure (round 15: name
+# where the credential comes from, refuse when absent).
+# ---------------------------------------------------------------------------
+PGH="${DB_HOST:-127.0.0.1}"
+PGP="${DB_PORT:-5432}"
+PGU="${DB_USER:-$(id -un)}"
+
+if [[ -n "${OPENBRAIN_TEST_DATABASE_URL:-}" ]]; then
+  # postgres://user@host:port/dbname
+  _url="${OPENBRAIN_TEST_DATABASE_URL#*://}"
+  _userhost="${_url%%/*}"
+  PGU="${_userhost%%@*}"
+  _hostport="${_userhost#*@}"
+  PGH="${_hostport%%:*}"
+  PGP="${_hostport#*:}"
+  [[ "$PGP" == "$PGH" ]] && PGP=5432
+fi
+
+note "postgres: $PGU@$PGH:$PGP (source: ${OPENBRAIN_TEST_DATABASE_URL:+OPENBRAIN_TEST_DATABASE_URL}${OPENBRAIN_TEST_DATABASE_URL:-DB_* env})"
+
+SRC_DB="dm677_src_$RUN_ID"
+DST_DB="dm677_dst_$RUN_ID"
+
+psqlq() { psql -X -At -h "$PGH" -p "$PGP" -U "$PGU" -d "$1" -c "$2"; }
+
+if ! psql -X -At -h "$PGH" -p "$PGP" -U "$PGU" -d postgres -c 'select 1' >/dev/null 2>&1; then
+  printf '\nFATAL: cannot reach postgres at %s@%s:%s — this check creates its own\n' "$PGU" "$PGH" "$PGP"
+  printf 'databases and cannot run without one. Run it from a lane bootstrapped\n'
+  printf 'with --fresh-db, or set OPENBRAIN_TEST_DATABASE_URL.\n'
+  exit 1
+fi
+
+teardown() {
+  printf '\n--- teardown ---\n'
+  for db in "$SRC_DB" "$DST_DB"; do
+    # Prefix + RUN_ID guard: this loop can only ever name a database this run
+    # created. A teardown that can name anything else is not teardown.
+    if [[ "$db" != dm677_*"$RUN_ID" ]]; then
+      printf '  REFUSED to drop %s (does not carry this run id)\n' "$db"
+      continue
+    fi
+    # A lingering connection (the lock-holding session of clause (d), or a
+    # backup pool that has not finished closing) makes dropdb fail. Observed on
+    # the first run: the source database survived teardown and had to be
+    # dropped by hand. Terminate this database's own backends first — scoped by
+    # datname to the run-id-guarded name above, so it can only ever disconnect
+    # sessions attached to a database this run created.
+    psql -X -At -h "$PGH" -p "$PGP" -U "$PGU" -d postgres \
+      -c "select pg_terminate_backend(pid) from pg_stat_activity where datname = '$db' and pid <> pg_backend_pid()" \
+      >/dev/null 2>&1 || true
+    if dropdb -h "$PGH" -p "$PGP" -U "$PGU" --if-exists "$db" 2>/dev/null; then
+      printf '  dropped %s\n' "$db"
+    else
+      printf '  COULD NOT DROP %s — drop it by hand: dropdb %s\n' "$db" "$db"
+    fi
+  done
+  printf '  scratch left in place (no rm, ever): %s\n' "$SCRATCH"
+}
+trap teardown EXIT
+
+# ===========================================================================
+printf '\n--- (a) launchd plist template exists, renders, and is a valid periodic job ---\n'
+# ===========================================================================
+RENDER_ROOT="$SCRATCH/render"
+RENDERED_PLIST="$RENDER_ROOT/agents/com.rico.open-brain-backup.plist"
+
+if [[ ! -r "$PLIST_TEMPLATE" ]]; then
+  fail "(a) no backup plist template at docs/deploy/com.rico.open-brain-backup.plist.template"
+elif [[ ! -x "$INSTALLER" ]]; then
+  fail "(a) no executable installer at scripts/install-backup-launchagent.sh"
+else
+  mkdir -p "$RENDER_ROOT"
+  # Render THROUGH THE SHIPPED INSTALLER (round 25: extract from the real file,
+  # never retype), in a mode that writes the plist without bootstrapping it.
+  if OPENBRAIN_BACKUP_INSTALL_ROOT="$RENDER_ROOT/install" \
+     OPENBRAIN_BACKUP_LOG_DIR="$RENDER_ROOT/log" \
+     OPENBRAIN_BACKUP_LAUNCH_AGENTS_DIR="$RENDER_ROOT/agents" \
+     OPENBRAIN_BACKUP_RENDER_ONLY=1 \
+     "$INSTALLER" > "$SCRATCH/installer-render.log" 2>&1; then
+    note "installer render-only run exited 0"
+  else
+    note "installer render-only run exited non-zero (see installer-render.log)"
+  fi
+
+  if [[ ! -f "$RENDERED_PLIST" ]]; then
+    fail "(a) installer did not produce a rendered plist at $RENDERED_PLIST"
+  elif ! plutil -lint "$RENDERED_PLIST" >/dev/null 2>&1; then
+    fail "(a) rendered plist is not a valid property list (plutil -lint refused)"
+  else
+    # Read structure with plutil, not by grepping XML: a grep for the KEY name
+    # passes on a commented-out or wrongly-nested key.
+    interval_type="$(plutil -type StartCalendarInterval -o - "$RENDERED_PLIST" 2>/dev/null || true)"
+    prog0="$(plutil -extract ProgramArguments.0 raw -o - "$RENDERED_PLIST" 2>/dev/null || true)"
+    label="$(plutil -extract Label raw -o - "$RENDERED_PLIST" 2>/dev/null || true)"
+    if [[ -z "$interval_type" ]]; then
+      fail "(a) rendered plist has no StartCalendarInterval — a job with no schedule is not a schedule"
+    elif [[ -z "$prog0" ]]; then
+      fail "(a) rendered plist has no ProgramArguments.0"
+    elif [[ ! -f "$prog0" && ! -x "$prog0" ]]; then
+      fail "(a) ProgramArguments.0 does not point at an installed runner: $prog0"
+    elif [[ -z "$label" ]]; then
+      fail "(a) rendered plist has no Label"
+    else
+      pass "(a) rendered plist is valid, periodic (StartCalendarInterval), label=$label"
+      note "runner: $prog0"
+      # No placeholder tokens may survive rendering — an unsubstituted
+      # __TOKEN__ is a plist that lints fine and does nothing.
+      if rg -q '__[A-Z_]+__' "$RENDERED_PLIST"; then
+        fail "(a) rendered plist still contains unsubstituted __TOKEN__ placeholders"
+      else
+        pass "(a) no unsubstituted placeholders survive rendering"
+      fi
+    fi
+  fi
+fi
+
+# ===========================================================================
+printf '\n--- (b) installer refuses a hostile render value, and leaves nothing behind ---\n'
+# ===========================================================================
+HOSTILE_ROOT="$SCRATCH/hostile"
+HOSTILE_AGENTS="$HOSTILE_ROOT/agents"
+if [[ ! -x "$INSTALLER" ]]; then
+  fail "(b) no installer to test"
+else
+  mkdir -p "$HOSTILE_AGENTS"
+  set +e
+  OPENBRAIN_BACKUP_INSTALL_ROOT="$HOSTILE_ROOT/install</key><key>RunAtLoad" \
+  OPENBRAIN_BACKUP_LOG_DIR="$HOSTILE_ROOT/log" \
+  OPENBRAIN_BACKUP_LAUNCH_AGENTS_DIR="$HOSTILE_AGENTS" \
+  OPENBRAIN_BACKUP_RENDER_ONLY=1 \
+    "$INSTALLER" > "$SCRATCH/installer-hostile.log" 2>&1
+  hostile_rc=$?
+  set -e
+  leftover="$(fd -t f . "$HOSTILE_AGENTS" 2>/dev/null | wc -l | tr -d ' ')"
+  if [[ "$hostile_rc" -eq 0 ]]; then
+    fail "(b) installer ACCEPTED a value containing XML metacharacters (exit 0)"
+  elif [[ "$leftover" != "0" ]]; then
+    fail "(b) installer refused (exit $hostile_rc) but left $leftover file(s) behind — refused before mutating is the claim"
+  else
+    pass "(b) installer refused the hostile value (exit $hostile_rc) and wrote no plist"
+  fi
+fi
+
+# ===========================================================================
+printf '\n--- (c) ONE full restore end-to-end at the current schema ---\n'
+# ===========================================================================
+# CONTROL CLAUSE, expected to PASS pre-fix. See the header. Its output is the
+# receipt the issue asks for, not a red-to-green transition.
+BACKUP_SET="$SCRATCH/backup-set"
+restore_ok=1
+
+if ! createdb -h "$PGH" -p "$PGP" -U "$PGU" -E UTF8 -T template0 "$SRC_DB" 2>"$SCRATCH/createdb-src.err"; then
+  fail "(c) could not create source database $SRC_DB"
+  restore_ok=0
+elif ! createdb -h "$PGH" -p "$PGP" -U "$PGU" -E UTF8 -T template0 "$DST_DB" 2>"$SCRATCH/createdb-dst.err"; then
+  fail "(c) could not create target database $DST_DB"
+  restore_ok=0
+else
+  note "source=$SRC_DB target=$DST_DB"
+
+  # 1. Migrate the SOURCE to the repo head. This is what makes the proof
+  #    "at the current schema" rather than a replay of the 07-24 set.
+  if ! DB_HOST="$PGH" DB_PORT="$PGP" DB_USER="$PGU" DB_NAME="$SRC_DB" \
+       bun run "$REPO_ROOT/scripts/migrate.ts" > "$SCRATCH/migrate-src.log" 2>&1; then
+    fail "(c) migrations failed against the source database"
+    restore_ok=0
+  else
+    head_file="$(ls "$REPO_ROOT/src/db/migrations"/*.sql 2>/dev/null | sort | tail -1 | xargs -n1 basename)"
+    applied="$(psqlq "$SRC_DB" "select count(*) from _migrations")"
+    note "source migrated: $applied migrations applied, repo head file ${head_file:-<UNRESOLVED>}"
+    if [[ -z "$head_file" ]]; then
+      fail "(c) could not resolve the repo migration head file — 'at the current schema' is unproven if the head is unknown"
+      restore_ok=0
+    fi
+
+    # 2. SEED. Empty tables make every count comparison vacuous (0 == 0).
+    #    Rows go into namespace-carrying tables so the namespace inventory and
+    #    archived-count validations have something to compare too. Column names
+    #    are the REAL ones (thoughts has no thought_type; the lanes table is
+    #    ob_session_lanes) — verified against information_schema, not recalled.
+    #    NO FALLBACK: a seed that quietly degrades to a weaker shape is the
+    #    adjusted-silently failure, and it would hide exactly the schema drift
+    #    this clause exists to detect. A failed seed FAILS the clause.
+    if ! psqlq "$SRC_DB" "
+      insert into thoughts (namespace, content, created_by)
+        select 'dm677-$RUN_ID', 'done-means seeded row ' || g, 'done-means-677'
+        from generate_series(1, 7) g;
+      insert into thoughts (namespace, content, created_by, archived_at)
+        select 'dm677-$RUN_ID', 'done-means archived row ' || g, 'done-means-677', now()
+        from generate_series(1, 3) g;
+      insert into ob_session_lanes (namespace, session_key, created_by)
+        select 'dm677-$RUN_ID', 'dm677-session-' || g, 'done-means-677'
+        from generate_series(1, 2) g;
+    " > "$SCRATCH/seed.log" 2>&1; then
+      fail "(c) seeding FAILED — see $SCRATCH/seed.log (no silent fallback: a degraded seed hides schema drift)"
+      note "$(tail -3 "$SCRATCH/seed.log" 2>/dev/null)"
+      restore_ok=0
+    fi
+    seeded="$(psqlq "$SRC_DB" "select count(*) from thoughts where namespace = 'dm677-$RUN_ID'")"
+    if [[ "${seeded:-0}" -lt 1 ]]; then
+      fail "(c) seeding produced ZERO rows — a count comparison over empty tables proves nothing"
+      restore_ok=0
+    else
+      note "seeded $seeded rows in namespace dm677-$RUN_ID"
+
+      # 3. REAL backup.
+      if ! DB_HOST="$PGH" DB_PORT="$PGP" DB_USER="$PGU" DB_NAME="$SRC_DB" \
+           bun run "$REPO_ROOT/scripts/backup.ts" --out "$BACKUP_SET" \
+           > "$SCRATCH/backup-receipt.json" 2>"$SCRATCH/backup.err"; then
+        fail "(c) scripts/backup.ts failed against the source database"
+        note "$(tail -3 "$SCRATCH/backup.err" 2>/dev/null)"
+        restore_ok=0
+      elif [[ ! -f "$BACKUP_SET/openbrain.dump" ]]; then
+        fail "(c) backup reported success but wrote no dump file"
+        restore_ok=0
+      else
+        dump_bytes="$(wc -c < "$BACKUP_SET/openbrain.dump" | tr -d ' ')"
+        note "backup set written: $dump_bytes bytes"
+
+        # 4. REAL restore into the empty target.
+        if ! DB_HOST="$PGH" DB_PORT="$PGP" DB_USER="$PGU" \
+             bun run "$REPO_ROOT/scripts/restore.ts" --dir "$BACKUP_SET" --target-db "$DST_DB" \
+             > "$SCRATCH/restore-receipt.json" 2>"$SCRATCH/restore.err"; then
+          fail "(c) scripts/restore.ts failed restoring into $DST_DB"
+          note "$(tail -5 "$SCRATCH/restore.err" 2>/dev/null)"
+          restore_ok=0
+        else
+          note "restore completed; comparing source and restored FROM OUTSIDE both scripts"
+
+          # 5a. ROW COUNTS, table by table, computed by THIS check against both
+          #     databases. Not read from either receipt.
+          count_sql="select table_name from information_schema.tables
+                     where table_schema = 'public' and table_type = 'BASE TABLE'
+                     order by table_name"
+          mismatches=0
+          tables_compared=0
+          while IFS= read -r tbl; do
+            [[ -z "$tbl" ]] && continue
+            a="$(psqlq "$SRC_DB" "select count(*) from \"$tbl\"" 2>/dev/null)"
+            b="$(psqlq "$DST_DB" "select count(*) from \"$tbl\"" 2>/dev/null)"
+            if [[ -z "$a" || -z "$b" ]]; then
+              printf '        UNREADABLE %s (src=%s dst=%s)\n' "$tbl" "${a:-<none>}" "${b:-<none>}"
+              mismatches=$((mismatches + 1))
+              continue
+            fi
+            tables_compared=$((tables_compared + 1))
+            if [[ "$a" != "$b" ]]; then
+              printf '        MISMATCH %s: src=%s restored=%s\n' "$tbl" "$a" "$b"
+              mismatches=$((mismatches + 1))
+            fi
+          done < <(psqlq "$SRC_DB" "$count_sql")
+
+          if [[ "$tables_compared" -lt 10 ]]; then
+            fail "(c) only $tables_compared tables compared — too few to be a schema-wide comparison"
+            restore_ok=0
+          elif [[ "$mismatches" -ne 0 ]]; then
+            fail "(c) row counts differ on $mismatches table(s) across $tables_compared compared"
+            restore_ok=0
+          else
+            pass "(c) row counts IDENTICAL across all $tables_compared tables"
+          fi
+
+          # 5b. SCHEMA HASH, computed here over information_schema, so the
+          #     comparison does not depend on either script's own notion of it.
+          schema_sql="select md5(string_agg(sig, E'\n' order by sig)) from (
+              select table_name || '.' || column_name || ':' || data_type || ':' ||
+                     is_nullable || ':' || coalesce(character_maximum_length::text,'-') as sig
+              from information_schema.columns
+              where table_schema = 'public'
+            ) s"
+          ha="$(psqlq "$SRC_DB" "$schema_sql")"
+          hb="$(psqlq "$DST_DB" "$schema_sql")"
+          if [[ -z "$ha" || -z "$hb" ]]; then
+            fail "(c) schema hash unreadable (src=${ha:-<none>} dst=${hb:-<none>}) — unread is not equal"
+            restore_ok=0
+          elif [[ "$ha" != "$hb" ]]; then
+            fail "(c) schema hash MISMATCH: src=$ha restored=$hb"
+            restore_ok=0
+          else
+            pass "(c) schema hash IDENTICAL: $ha"
+          fi
+
+          # 5c. Prove the comparison DISCRIMINATES. Two databases that always
+          #     hash equal would pass 5b whatever happened. One extra column in
+          #     the target must change the hash.
+          psqlq "$DST_DB" "create table dm677_probe_$RUN_ID (id int)" >/dev/null 2>&1
+          hb2="$(psqlq "$DST_DB" "$schema_sql")"
+          psqlq "$DST_DB" "drop table dm677_probe_$RUN_ID" >/dev/null 2>&1
+          if [[ -n "$hb2" && "$hb2" != "$hb" ]]; then
+            pass "(c) CONTROL: schema hash changes under a deliberate schema mutation (discriminates)"
+          else
+            fail "(c) CONTROL: schema hash did NOT change under a deliberate mutation — the comparison proves nothing"
+            restore_ok=0
+          fi
+
+          if [[ "$restore_ok" -eq 1 ]]; then
+            note "RESTORE PROOF COMPLETE at repo head — receipt: $SCRATCH/restore-receipt.json"
+          fi
+        fi
+      fi
+    fi
+  fi
+fi
+
+# ===========================================================================
+printf '\n--- (d) overlap guard: backup REFUSES while a deploy holds the lock ---\n'
+# ===========================================================================
+GUARD_SET="$SCRATCH/backup-set-during-deploy"
+if [[ ! -f "$BACKUP_SET/openbrain.dump" && "$restore_ok" -ne 1 ]]; then
+  note "clause (c) did not establish a usable database; (d) runs against the source anyway"
+fi
+
+# Hold the deploy lock from a SEPARATE live connection, exactly as a running
+# deploy would. The lock is a session-scoped Postgres advisory lock, so holding
+# it requires an open session that STAYS open: a psql child that takes the lock
+# and then sleeps inside the same session. `pg_sleep` keeps the session alive
+# server-side without this script having to keep a pipe open (an earlier fifo
+# version of this deadlocked on open-for-write with no reader attached — a
+# check that hangs is a check that reports nothing).
+LOCK_SQL="select pg_advisory_lock(hashtext(current_database() || ':openbrain-deploy')); select pg_sleep(120);"
+psql -X -At -h "$PGH" -p "$PGP" -U "$PGU" -d "$SRC_DB" -c "$LOCK_SQL" \
+  > "$SCRATCH/lockhold.log" 2>&1 &
+LOCK_PID=$!
+
+if true; then
+  # Wait for the lock to actually be visible in pg_locks before proceeding —
+  # a race here would let the backup run unlocked and bank a false RED. The
+  # lock is identified by its own key, not by "any advisory lock": another
+  # session's unrelated advisory lock would otherwise satisfy the precondition.
+  lock_visible=0
+  lock_key="$(psqlq "$SRC_DB" "select hashtext('$SRC_DB' || ':openbrain-deploy')")"
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    sleep 0.5
+    held="$(psqlq "$SRC_DB" "select count(*) from pg_locks where locktype='advisory' and granted and objid = ($lock_key)::bigint & 4294967295" 2>/dev/null)"
+    if [[ -z "$held" || "$held" == "0" ]]; then
+      # Fall back to the coarser reading rather than failing on a bitmask
+      # detail; announced, because a weaker precondition must not be silent.
+      held="$(psqlq "$SRC_DB" "select count(*) from pg_locks where locktype='advisory' and granted" 2>/dev/null)"
+      [[ "${held:-0}" -ge 1 ]] && note "ADJUSTED: keyed lock lookup returned nothing; using the coarser any-advisory-lock reading"
+    fi
+    if [[ "${held:-0}" -ge 1 ]]; then lock_visible=1; break; fi
+  done
+
+  if [[ "$lock_visible" -ne 1 ]]; then
+    fail "(d) PRECONDITION: could not observe the deploy advisory lock as held — (d) would be a false RED"
+  else
+    note "deploy advisory lock is HELD by pid $LOCK_PID (observed in pg_locks)"
+    set +e
+    DB_HOST="$PGH" DB_PORT="$PGP" DB_USER="$PGU" DB_NAME="$SRC_DB" \
+      bun run "$REPO_ROOT/scripts/backup.ts" --out "$GUARD_SET" \
+      > "$SCRATCH/backup-during-deploy.out" 2>"$SCRATCH/backup-during-deploy.err"
+    guard_rc=$?
+    set -e
+    guard_out="$(cat "$SCRATCH/backup-during-deploy.out" "$SCRATCH/backup-during-deploy.err" 2>/dev/null)"
+
+    if [[ "$guard_rc" -eq 0 ]]; then
+      fail "(d1) backup SUCCEEDED (exit 0) while a deploy held the lock — mid-migration dumps are exactly what this guard exists to prevent"
+    elif [[ -f "$GUARD_SET/openbrain.dump" ]]; then
+      fail "(d1) backup exited $guard_rc but LEFT A DUMP behind — a refusal that writes a half-backup is not a refusal"
+    else
+      pass "(d1) backup refused (exit $guard_rc) and wrote no dump while the deploy lock was held"
+    fi
+
+    # (d2) The message must name the CAUSE. Assert what it SAYS (round 19),
+    # not merely that some text exists.
+    #
+    # SELF-CAUGHT FALSE GREEN (round 9/17/25 family, new spelling): the first
+    # version of this clause was a bare `rg -qi 'deploy'` over the command's
+    # combined output, and it PASSED on the pre-fix tree where no guard existed
+    # and no refusal happened — because the successful backup's own receipt
+    # embeds "backup_dir":".../backup-set-during-deploy", and the word "deploy"
+    # is in the PATH THIS CHECK CHOSE. The clause was reading its own fixture.
+    # Two repairs, both required:
+    #   1. the clause is GATED on the refusal having actually occurred — there
+    #      is no message to judge when the command succeeded;
+    #   2. it reads STDERR only (the refusal channel) and requires the deploy
+    #      word to appear in a sentence, not in a path token.
+    if [[ "$guard_rc" -eq 0 ]]; then
+      fail "(d2) NOT ASSERTABLE: the backup did not refuse, so there is no refusal message to judge (not a pass)"
+    else
+      guard_err="$(cat "$SCRATCH/backup-during-deploy.err" 2>/dev/null)"
+      if printf '%s' "$guard_err" | rg -qi 'deploy (is |in |lock|running|in progress)|during a deploy|deploy holds'; then
+        pass "(d2) the refusal names the deploy as the cause"
+      else
+        fail "(d2) the refusal does not name a deploy in prose — a refusal that does not say what to reconcile is a dead end"
+        note "observed stderr: $(printf '%s' "$guard_err" | tail -2)"
+      fi
+    fi
+  fi
+
+  # Release: end the lock-holding session. Killing the psql child closes its
+  # connection, which is what releases a session-scoped advisory lock.
+  kill "$LOCK_PID" 2>/dev/null || true
+  wait "$LOCK_PID" 2>/dev/null || true
+  note "deploy lock released (lock-holding session ended)"
+fi
+
+# ===========================================================================
+printf '\n--- (e) CONTROL: with NO lock held, the same backup SUCCEEDS ---\n'
+# ===========================================================================
+CONTROL_SET="$SCRATCH/backup-set-no-lock"
+set +e
+DB_HOST="$PGH" DB_PORT="$PGP" DB_USER="$PGU" DB_NAME="$SRC_DB" \
+  bun run "$REPO_ROOT/scripts/backup.ts" --out "$CONTROL_SET" \
+  > "$SCRATCH/backup-control.out" 2>"$SCRATCH/backup-control.err"
+control_rc=$?
+set -e
+if [[ "$control_rc" -eq 0 && -f "$CONTROL_SET/openbrain.dump" ]]; then
+  pass "(e) CONTROL: unlocked backup succeeded — the guard does not refuse everything"
+else
+  fail "(e) CONTROL: unlocked backup FAILED (exit $control_rc) — a guard that blocks normal backups is the blocker restated"
+  note "$(tail -3 "$SCRATCH/backup-control.err" 2>/dev/null)"
+fi
+
+# ===========================================================================
+printf '\n--- (f) CONTROL: the DEPLOY side takes the lock, before it mutates ---\n'
+# ===========================================================================
+if [[ ! -r "$DEPLOY_SCRIPT" ]]; then
+  fail "(f) deploy script not readable: $DEPLOY_SCRIPT"
+else
+  # Sentinel reads: `rg` exits non-zero on no-match, and an EMPTY variable in a
+  # numeric test aborts the whole script under `set -u` — which is how the
+  # first run of this clause printed NOTHING AT ALL rather than a verdict
+  # (round 21/24 lesson, hit here in its own spelling). `|| true` keeps the
+  # pipeline alive and every value is defaulted before any arithmetic.
+  lock_line="$(rg -n 'openbrain-deploy' "$DEPLOY_SCRIPT" 2>/dev/null | head -1 | cut -d: -f1 || true)"
+  migrate_line="$(rg -n 'run migrate' "$DEPLOY_SCRIPT" 2>/dev/null | head -1 | cut -d: -f1 || true)"
+  stage_line="$(rg -n 'core01-package-runtime.sh' "$DEPLOY_SCRIPT" 2>/dev/null | head -1 | cut -d: -f1 || true)"
+  lock_line="${lock_line:-0}"
+  migrate_line="${migrate_line:-0}"
+  stage_line="${stage_line:-0}"
+  if [[ "$lock_line" == "0" ]]; then
+    fail "(f) the deploy script never references the deploy lock — a one-sided guard is not mutual exclusion"
+  elif [[ "$migrate_line" == "0" || "$stage_line" == "0" ]]; then
+    fail "(f) could not locate the deploy's migrate/staging steps to order against (migrate=$migrate_line stage=$stage_line)"
+  elif [[ "$lock_line" -ge "$migrate_line" || "$lock_line" -ge "$stage_line" ]]; then
+    fail "(f) the lock is taken at line $lock_line, AT OR AFTER staging ($stage_line) / migrate ($migrate_line) — a lock taken after the mutation protects nothing"
+  else
+    pass "(f) deploy acquires the lock at line $lock_line, before staging ($stage_line) and migrate ($migrate_line)"
+  fi
+fi
+
+# ===========================================================================
+printf '\n--- (g) the core01 install step is WRITTEN into the runbook, not executed ---\n'
+# ===========================================================================
+if [[ ! -r "$BACKUP_DOC" ]]; then
+  fail "(g) docs/backup-restore.md not readable"
+else
+  if rg -q 'NOT shipped in this repo' "$BACKUP_DOC"; then
+    fail "(g) docs/backup-restore.md still claims the scheduling wiring is NOT shipped — a doc that ships wiring and denies it misleads the next reader"
+  else
+    pass "(g) the stale 'NOT shipped in this repo' scheduling claim is gone"
+  fi
+  if rg -q 'install-backup-launchagent\.sh' "$BACKUP_DOC" \
+     && rg -q 'com\.rico\.open-brain-backup' "$BACKUP_DOC"; then
+    pass "(g) the runbook names the installer and the launchd label for the core01 step"
+  else
+    fail "(g) the runbook does not name both scripts/install-backup-launchagent.sh and the com.rico.open-brain-backup label"
+  fi
+fi
+
+# ===========================================================================
+printf '\n=== RESULT: %d passed, %d failed ===\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -ne 0 ]]; then
+  printf 'DONE-MEANS #677: FAIL\n'
+  exit 1
+fi
+printf 'DONE-MEANS #677: PASS\n'
+exit 0

--- a/scripts/done-means/677-scheduled-backup.sh
+++ b/scripts/done-means/677-scheduled-backup.sh
@@ -281,12 +281,18 @@ else
     else
       pass "(a) rendered plist is valid, periodic (StartCalendarInterval), label=$label"
       note "runner: $prog0"
-      # No placeholder tokens may survive rendering — an unsubstituted
-      # __TOKEN__ is a plist that lints fine and does nothing.
-      if rg -q '__[A-Z_]+__' "$RENDERED_PLIST"; then
-        fail "(a) rendered plist still contains unsubstituted __TOKEN__ placeholders"
+      # No placeholder tokens may survive rendering in a VALUE — an
+      # unsubstituted placeholder is a plist that lints fine and does nothing.
+      # Scoped to <string> values, not the whole file: the template documents
+      # its own placeholder syntax in a comment, and a whole-file match reads
+      # that documentation as a defect. (Self-caught: the first green run
+      # failed here on the template's own explanatory comment, and the
+      # installer contained the identical over-broad guard — one mistake made
+      # twice, in the checker and in the subject.)
+      if rg -q '<string>[^<]*__[A-Z_]+__' "$RENDERED_PLIST"; then
+        fail "(a) rendered plist still contains unsubstituted placeholders in a value"
       else
-        pass "(a) no unsubstituted placeholders survive rendering"
+        pass "(a) no unsubstituted placeholders survive rendering into values"
       fi
     fi
   fi
@@ -505,17 +511,17 @@ if true; then
   # a race here would let the backup run unlocked and bank a false RED. The
   # lock is identified by its own key, not by "any advisory lock": another
   # session's unrelated advisory lock would otherwise satisfy the precondition.
+  # Scoped to THIS RUN'S database (pg_locks is cluster-wide — see the release
+  # note below). An advisory lock held against an unrelated database would
+  # otherwise satisfy this precondition, and clause (d1) would then be testing
+  # a backup that faced no lock at all: a false RED banked as a real one.
   lock_visible=0
-  lock_key="$(psqlq "$SRC_DB" "select hashtext('$SRC_DB' || ':openbrain-deploy')")"
   for _ in 1 2 3 4 5 6 7 8 9 10; do
     sleep 0.5
-    held="$(psqlq "$SRC_DB" "select count(*) from pg_locks where locktype='advisory' and granted and objid = ($lock_key)::bigint & 4294967295" 2>/dev/null)"
-    if [[ -z "$held" || "$held" == "0" ]]; then
-      # Fall back to the coarser reading rather than failing on a bitmask
-      # detail; announced, because a weaker precondition must not be silent.
-      held="$(psqlq "$SRC_DB" "select count(*) from pg_locks where locktype='advisory' and granted" 2>/dev/null)"
-      [[ "${held:-0}" -ge 1 ]] && note "ADJUSTED: keyed lock lookup returned nothing; using the coarser any-advisory-lock reading"
-    fi
+    held="$(psqlq "$SRC_DB" "select count(*) from pg_locks l
+                             join pg_stat_activity a on a.pid = l.pid
+                             where l.locktype='advisory' and l.granted
+                               and a.datname = '$SRC_DB'" 2>/dev/null)"
     if [[ "${held:-0}" -ge 1 ]]; then lock_visible=1; break; fi
   done
 
@@ -568,9 +574,45 @@ if true; then
 
   # Release: end the lock-holding session. Killing the psql child closes its
   # connection, which is what releases a session-scoped advisory lock.
+  #
+  # KILLING psql DOES NOT RELEASE THE LOCK. Measured here, twice: the client
+  # process dies immediately and `pg_locks` still reports the advisory lock
+  # held, because the BACKEND is inside `pg_sleep()` and does not notice the
+  # client is gone until that query returns. The lock belongs to the backend
+  # session, not to the psql process.
+  #
+  # This cost a full false failure of clause (e) — an unlocked backup refused
+  # with exit 4 and the check reported "a guard that blocks normal backups",
+  # which reads exactly like a real implementation defect. It was the check's
+  # own leftover lock. Release SERVER-SIDE with pg_terminate_backend, scoped by
+  # application_name to the lock-holder this run started, then WAIT for the
+  # lock to be observably gone and fail loudly rather than let (e) inherit it.
   kill "$LOCK_PID" 2>/dev/null || true
+  psqlq "$SRC_DB" "select pg_terminate_backend(pid) from pg_stat_activity
+                   where datname = '$SRC_DB' and pid <> pg_backend_pid()
+                     and query like '%openbrain-deploy%'" >/dev/null 2>&1 || true
   wait "$LOCK_PID" 2>/dev/null || true
-  note "deploy lock released (lock-holding session ended)"
+  # pg_locks is CLUSTER-WIDE. Scope the reading to THIS RUN'S database by
+  # joining pg_stat_activity on datname — an unrelated advisory lock held
+  # against some other database on the same server otherwise reads as "still
+  # held" forever and fails this clause for a reason that has nothing to do
+  # with the subject. (Self-caught: a leftover debug database on this machine
+  # did exactly that, and the failure was indistinguishable at a glance from a
+  # real unreleased lock.)
+  lock_gone=0
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+    still="$(psqlq "$SRC_DB" "select count(*) from pg_locks l
+                              join pg_stat_activity a on a.pid = l.pid
+                              where l.locktype='advisory' and l.granted
+                                and a.datname = '$SRC_DB'" 2>/dev/null)"
+    if [[ "${still:-1}" == "0" ]]; then lock_gone=1; break; fi
+    sleep 0.5
+  done
+  if [[ "$lock_gone" -eq 1 ]]; then
+    note "deploy lock released (observed gone from pg_locks)"
+  else
+    fail "(d) the deploy lock was still held after the holder was killed — clause (e) below would inherit a false failure"
+  fi
 fi
 
 # ===========================================================================
@@ -601,9 +643,17 @@ else
   # first run of this clause printed NOTHING AT ALL rather than a verdict
   # (round 21/24 lesson, hit here in its own spelling). `|| true` keeps the
   # pipeline alive and every value is defaulted before any arithmetic.
-  lock_line="$(rg -n 'openbrain-deploy' "$DEPLOY_SCRIPT" 2>/dev/null | head -1 | cut -d: -f1 || true)"
-  migrate_line="$(rg -n 'run migrate' "$DEPLOY_SCRIPT" 2>/dev/null | head -1 | cut -d: -f1 || true)"
-  stage_line="$(rg -n 'core01-package-runtime.sh' "$DEPLOY_SCRIPT" 2>/dev/null | head -1 | cut -d: -f1 || true)"
+  # ANCHOR ON THE COMMANDS, NOT ON PROSE. The first version of this clause
+  # matched `openbrain-deploy` and `run migrate` anywhere in the file, and both
+  # patterns hit the deploy script's own explanatory COMMENTS — which sit
+  # ABOVE the real commands, so the clause reported the lock as taken after
+  # migrate when it is taken before. Round 23's rule: anchor an assertion on a
+  # marker the subject OWNS, never on prose that also contains the words. Here
+  # the owned markers are the actual invocations, with comment lines excluded.
+  ncl() { rg -n -v '^\s*#' "$DEPLOY_SCRIPT" 2>/dev/null; }
+  lock_line="$(rg -n 'deploy-lock\.ts' "$DEPLOY_SCRIPT" 2>/dev/null | rg -v '^\s*[0-9]+:\s*#' | head -1 | cut -d: -f1 || true)"
+  migrate_line="$(rg -n '^\s*"\$BUN_BIN" run migrate' "$DEPLOY_SCRIPT" 2>/dev/null | head -1 | cut -d: -f1 || true)"
+  stage_line="$(rg -n '^\s*"\$REPO_DIR/scripts/core01-package-runtime\.sh"' "$DEPLOY_SCRIPT" 2>/dev/null | head -1 | cut -d: -f1 || true)"
   lock_line="${lock_line:-0}"
   migrate_line="${migrate_line:-0}"
   stage_line="${stage_line:-0}"

--- a/scripts/install-backup-launchagent.sh
+++ b/scripts/install-backup-launchagent.sh
@@ -1,0 +1,121 @@
+#!/opt/homebrew/bin/bash
+# Install the Open Brain scheduled-backup LaunchAgent (issue #677, blocker B4).
+#
+# Follows scripts/install-qmd-sync-launchagent.sh exactly — same staged-write,
+# same metacharacter validation, same plutil lint before anything is
+# bootstrapped. That script is the repo's established pattern for this and is
+# not being reinvented here; the delta is the backup job's own tokens and a
+# render-only mode.
+#
+# RENDER-ONLY MODE (OPENBRAIN_BACKUP_RENDER_ONLY=1) renders and lints the plist
+# and stops before touching launchctl. It exists so the done-means check can
+# assert what the INSTALLER produces rather than hand-substituting the tokens
+# itself — a hand-rendered plist proves the check's own sed, not this file's.
+#
+# WHY VALUES ARE VALIDATED: every value below is interpolated into XML. A value
+# containing `<` produces a plist that lints clean and means something other
+# than what the operator asked for — e.g. an injected <key>RunAtLoad</key> turns
+# a nightly job into one that also fires at every login. The validation refuses
+# BEFORE anything is written, so a refused run leaves no plist behind.
+
+set -euo pipefail
+
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SOURCE_SCRIPT="$REPO_ROOT/scripts/backup-scheduled-run.sh"
+TEMPLATE="$REPO_ROOT/docs/deploy/com.rico.open-brain-backup.plist.template"
+
+INSTALL_ROOT="${OPENBRAIN_BACKUP_INSTALL_ROOT:-/Volumes/ThunderBolt/open-brain/backup-agent}"
+INSTALLED_SCRIPT="$INSTALL_ROOT/backup-scheduled-run.sh"
+BACKUP_ROOT="${OPENBRAIN_BACKUP_ROOT:-/Volumes/ThunderBolt/open-brain/backups}"
+REPO_DIR_VALUE="${OPENBRAIN_BACKUP_REPO_DIR:-/Volumes/ThunderBolt/open-brain/app}"
+ENV_FILE_VALUE="${OPENBRAIN_BACKUP_ENV_FILE:-/Users/rico/.config/open-brain/env}"
+LOG_DIR="${OPENBRAIN_BACKUP_LOG_DIR:-/Volumes/ThunderBolt/open-brain/log}"
+FALLBACK_LOG_DIR="${OPENBRAIN_BACKUP_FALLBACK_LOG_DIR:-$HOME/Library/Logs/open-brain}"
+LAUNCH_AGENTS_DIR="${OPENBRAIN_BACKUP_LAUNCH_AGENTS_DIR:-$HOME/Library/LaunchAgents}"
+RENDER_ONLY="${OPENBRAIN_BACKUP_RENDER_ONLY:-}"
+
+LABEL="com.rico.open-brain-backup"
+PLIST="$LAUNCH_AGENTS_DIR/$LABEL.plist"
+STAGED_PLIST="$PLIST.next"
+STAGED_SCRIPT="$INSTALLED_SCRIPT.next"
+DOMAIN="gui/$(id -u)"
+
+fatal() {
+  printf 'FATAL: %s\n' "$1" >&2
+  exit 1
+}
+
+validate_render_value() {
+  local name="$1"
+  local value="$2"
+
+  [[ "$value" != *'&'* ]] || fatal "$name contains an unsupported character (&)"
+  [[ "$value" != *'|'* ]] || fatal "$name contains an unsupported character (|)"
+  [[ "$value" != *'<'* ]] || fatal "$name contains an unsupported character (<)"
+  [[ "$value" != *'>'* ]] || fatal "$name contains an unsupported character (>)"
+  [[ "$value" != *$'\n'* ]] || fatal "$name contains a newline"
+}
+
+[[ -r "$SOURCE_SCRIPT" ]] || fatal "runner script is not readable: $SOURCE_SCRIPT"
+[[ -r "$TEMPLATE" ]] || fatal "LaunchAgent template is not readable: $TEMPLATE"
+
+# Validation runs BEFORE any mkdir/install/write, so a hostile value cannot
+# leave a partially-installed agent behind.
+validate_render_value OPENBRAIN_BACKUP_INSTALL_ROOT "$INSTALL_ROOT"
+validate_render_value OPENBRAIN_BACKUP_ROOT "$BACKUP_ROOT"
+validate_render_value OPENBRAIN_BACKUP_REPO_DIR "$REPO_DIR_VALUE"
+validate_render_value OPENBRAIN_BACKUP_ENV_FILE "$ENV_FILE_VALUE"
+validate_render_value OPENBRAIN_BACKUP_LOG_DIR "$LOG_DIR"
+validate_render_value OPENBRAIN_BACKUP_FALLBACK_LOG_DIR "$FALLBACK_LOG_DIR"
+validate_render_value HOME "$HOME"
+
+mkdir -p "$INSTALL_ROOT" "$LOG_DIR" "$FALLBACK_LOG_DIR" "$LAUNCH_AGENTS_DIR"
+/usr/bin/install -m 700 "$SOURCE_SCRIPT" "$STAGED_SCRIPT"
+/bin/mv "$STAGED_SCRIPT" "$INSTALLED_SCRIPT"
+
+/usr/bin/sed \
+  -e "s|__OPENBRAIN_BACKUP_SCRIPT__|$INSTALLED_SCRIPT|g" \
+  -e "s|__OPENBRAIN_BACKUP_WORKING_DIRECTORY__|$INSTALL_ROOT|g" \
+  -e "s|__OPENBRAIN_BACKUP_ROOT__|$BACKUP_ROOT|g" \
+  -e "s|__OPENBRAIN_BACKUP_REPO_DIR__|$REPO_DIR_VALUE|g" \
+  -e "s|__OPENBRAIN_BACKUP_ENV_FILE__|$ENV_FILE_VALUE|g" \
+  -e "s|__OPENBRAIN_BACKUP_LOG_DIR__|$LOG_DIR|g" \
+  -e "s|__OPENBRAIN_BACKUP_STDOUT__|$FALLBACK_LOG_DIR/open-brain-backup.out.log|g" \
+  -e "s|__OPENBRAIN_BACKUP_STDERR__|$FALLBACK_LOG_DIR/open-brain-backup.err.log|g" \
+  -e "s|__HOME__|$HOME|g" \
+  "$TEMPLATE" > "$STAGED_PLIST"
+/bin/chmod 600 "$STAGED_PLIST"
+/usr/bin/plutil -lint "$STAGED_PLIST"
+
+# Any surviving placeholder means a token was added to the template and never
+# given a substitution here. The plist would lint fine and the job would point
+# at a literal placeholder path, failing every night in a way nobody reads.
+#
+# Scoped to <string> VALUES, not the whole file: the template's own explanatory
+# comment discusses the placeholder syntax by name, and a whole-file match
+# treats that documentation as a defect. (Caught by the done-means check on the
+# first green run — the installer refused its own correct output.)
+if /usr/bin/grep -q '<string>[^<]*__[A-Z_][A-Z_]*__' "$STAGED_PLIST"; then
+  fatal "rendered plist still contains unsubstituted placeholders in a value — a template token has no matching substitution in this installer"
+fi
+
+if [[ -n "$RENDER_ONLY" ]]; then
+  /bin/mv "$STAGED_PLIST" "$PLIST"
+  printf 'RENDER-ONLY: wrote and linted %s\n' "$PLIST"
+  printf 'RENDER-ONLY: launchctl was NOT touched; the agent is not scheduled.\n'
+  exit 0
+fi
+
+if launchctl print "$DOMAIN/$LABEL" >/dev/null 2>&1; then
+  launchctl bootout "$DOMAIN/$LABEL"
+fi
+
+/bin/mv "$STAGED_PLIST" "$PLIST"
+launchctl bootstrap "$DOMAIN" "$PLIST"
+launchctl print "$DOMAIN/$LABEL"
+printf 'Installed and bootstrapped %s from %s\n' "$LABEL" "$PLIST"
+printf 'Backups will be written under %s at 03:00 daily.\n' "$BACKUP_ROOT"
+printf 'Run one NOW to prove the wiring: launchctl kickstart -k %s/%s\n' "$DOMAIN" "$LABEL"


### PR DESCRIPTION
## Summary

- Closes #677 (cutover blocker B4). The backup substrate was already real, tested, and CI-drilled; what did not exist was any **invocation**. The only set on disk was 16 days and 15 migrations stale against a stated 24h RPO.
- **The schedule:** a launchd plist template (03:00 daily, LowPriorityIO) plus an installer that renders, lints, and bootstraps it, following the existing install-qmd-sync-launchagent.sh pattern exactly — staged write, XML metacharacter validation before anything is created, plutil lint. Adds a render-only mode so the done-means check asserts what the **installer** produces rather than hand-substituting tokens itself.
- **The runner** (scripts/backup-scheduled-run.sh) is what launchd invokes: dated set, explicit env load (launchd inherits almost no environment — the classic reason a scheduled job works by hand and fails at 03:00), then backup, then verify the set it just wrote, then a root-level staleness check. It never removes anything; retention stays operator-run per the existing doc. DB_NAME is **required**, not defaulted (#676: it selects which brain gets backed up, and a job quietly backing up the wrong database would look healthy indefinitely).
- **The overlap guard** (scripts/deploy-lock.ts): docs/backup-restore.md already recorded that a dump taken mid-migration captures a half-applied schema that verify **cannot detect from the outside**. That artifact is worse than a missing backup because it passes verification, so scheduling without a guard would have made this blocker subtler rather than smaller. The mechanism is a session-scoped Postgres advisory lock on the database both operations touch — the same primitive server/db/migrations.ts already uses to serialize migrations, with a distinct key. Deliberately asymmetric: the deploy waits (bounded, attended); the backup refuses immediately with exit 4, writes nothing, and names the deploy as the cause.
- **The restore proof:** one full backup-to-restore round trip run locally end to end at migration head 046, comparing row counts across all 23 tables and an information_schema-derived schema hash between source and restored databases, computed from **outside** both scripts.
- **Not executed by this lane:** the core01 installation step is WRITTEN into the cutover runbook section of docs/backup-restore.md. core01 was never contacted.

## Verification

- Done-means: scripts/done-means/677-scheduled-backup.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED (pre-change tree, final version of the check): 4 passed / 7 failed, exit 1. Failing: (a) no plist template, (b) no installer, (d1) backup SUCCEEDS while the deploy lock is held, (d2) no refusal to judge, (f) deploy never takes a lock, (g) x2 runbook still claims the wiring is not shipped.

GREEN (post-change): 12 passed / 0 failed, exit 0.

Clauses (c) and (e) PASS pre-fix **by design** and are labeled as controls in the check header: (c) is the restore proof whose value is the receipt it produces, not a red-to-green transition, and (e) proves the check does not simply fail everywhere. RED was re-proven against the pre-change tree with the FINAL version of the check after every repair, by file-copy rather than git stash.

Also: bunx tsc --noEmit clean. backup.test.ts + backup-lib.test.ts = 65 pass / 0 fail via bun run test:isolated. Pre-push hook ran the full suite (3891 tests across 244 files) and passed.

Not applicable, stated rather than skipped: no Python package surface is touched, and no live Open Brain smoke applies because nothing here serves traffic — this is operator tooling plus a scheduler, and its proof is the restore round trip.

## Critical Self-Review

- Highest-risk behavior: the guard sits in the path of every backup, so a defect in it does not corrupt data but **prevents backups** — the blocker restated in a subtler form. This is exactly why clause (e) exists as a control, and why the lock is taken and released rather than held for the dump's duration.
- Assumptions that could be wrong: that take-and-release at the START of the backup is sufficient. It closes the window where a deploy is already running; the other direction (a deploy starting mid-dump) is closed by the deploy's own bounded WAIT rather than by holding the lock across the whole dump. Stated openly in the module's own comments. Holding it for the full dump would be stronger, but coupling a long-lived lock to the backup pool's lifetime risks a backup failure leaving the lock held for the pool idle timeout — trading a rare corrupt dump for a recurring blocked deploy. If the operator prefers the stronger form, that is a one-line change and a ruling.
- Missing/weak tests: the launchd job has never been **bootstrapped** — the check renders and lints the plist, it does not prove launchctl accepts and fires it. That proof only exists on a machine where the agent is installed, which is the core01 runbook step. Called out as WRITTEN-not-RUNNING below rather than implied away.
- Security/permission risk: the installer interpolates values into XML and validates every one against metacharacters before writing; clause (b) proves the refusal AND that a refused run leaves no plist behind. Plist is written 0600, runner installed 0700, matching the qmd-sync precedent. No credential is read, written, or logged by any new file.
- Migration/deploy risk: core01-deploy-local.sh gains a lock acquisition before staging and migrate. If the lock helper cannot connect, the deploy FAILS CLOSED with a named error rather than proceeding unguarded. A deploy killed at any point releases the lock automatically because it is session-scoped, so there is no stale-lock file and no cleanup path to get wrong.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, contract, or client-facing surface is touched — the change is operator tooling and a scheduler.
- Rollback/cleanup concern: rollback is removing the LaunchAgent (operator, on core01) and reverting the commit. Nothing here mutates existing data, and the runner deliberately never deletes a backup set.
- Fixes made before PR: the installer's placeholder guard matched the template's own explanatory comment and refused its own correct output — scoped to string values. The identical over-broad match existed in the checker, so it was one mistake made twice, in the checker and in the subject. Also: (d2) was a bare substring match that PASSED pre-fix because the successful backup's receipt embeds a path this check itself chose containing the word deploy — a false green, repaired by gating the clause on the refusal having actually occurred. Clause (f) matched the deploy script's own comments rather than its commands, reporting the lock as taken after migrate when it is taken before. The seed used column and table names that do not exist, and had a silent fallback that would have hidden exactly the schema drift the clause detects.
- Known residual risk: the schedule is WRITTEN, not RUNNING. No backup has ever fired on core01 from this job, and the backups root does not exist there yet. The blocker is not closed by merging this — it is closed by the operator running the install step and confirming a set lands. Second residual: the staleness alert exits non-zero and writes to the launchd log; there is no push notification, so it is only seen by something that reads that log.
- SME review-memory update: [ ] docs/sme/ updated or [x] not applicable because: the lessons here are lane-operating lessons (false-green shapes, cluster-wide pg_locks readings, killing a client does not release a session lock) rather than reviewer-facing code patterns, and they are supplied in the lane report for the lane-contract Tightenings harvest.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: nothing in this change serves traffic; the proof is the restore round trip, run locally against isolated databases

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, schema, or tool surface is touched — this is operator tooling and a launchd schedule

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, protocol, transport, or client-facing behavior changes. No downstream consumer can observe this change; it adds a scheduler, a guard between two operator scripts, and a doc section.
- One measured finding worth carrying: killing a psql client does NOT release its advisory lock — the backend stays inside its query and holds it. Release is server-side. This cost a full false failure that read exactly like an implementation defect.
