### PR TITLE
fix(271): heal the get_contract tripwire by acknowledging #691's tool-contract bump

### DIFF
--- a/docs/lane-contract.md
+++ b/docs/lane-contract.md
@@ -59,6 +59,68 @@ Every lane, no exceptions:
 
 Newest first. Every entry: what changed, and the observation that forced it.
 
+> **Note on this file's history, recorded 2026-08-09 by the #271 tripwire
+> lane.** Rounds 8 through 26 are committed on the unmerged `wip/2026-08-07`
+> branch and are NOT on the upstream default branch: main's copy is 211 lines
+> and jumps from round 7 to the founding round, while the wip copy is 945
+> lines. Lanes read this file from their own worktree (round 3, PR #631), so a
+> lane bootstrapped from main has been briefed from a contract missing
+> nineteen rounds of ratchet. The ratchet only ratchets where it is merged.
+> Flagged for the decisions pass rather than fixed here — landing nineteen
+> rounds of someone else's harvest inside a test-heal PR would be the silent
+> scope adjustment the contract forbids. The round 27 entry below is written
+> into main's lineage so this lane's own harvest is not lost to the same gap.
+
+### 2026-08-09 (round 27) — harvest of the #271 tripwire heal (PR #701), a CONTROLLER merge defect
+
+- **A failing assertion turns off every clause after it in the same test, and
+  for a TRIPWIRE that is a hole rather than an inconvenience.** The #271
+  block's later clauses — the exact top-level key-set assertion and the
+  push/injection negative filter — are the ones that enforce the boundary,
+  and the stale version literal aborted the body before either ran (37
+  expect() calls red vs 44 healed). For the window main stayed red, a
+  push-shaped hot-memory key could have landed and the tripwire would have
+  failed for the OLD reason, looking like the same known redness. **A red
+  tripwire and a disabled tripwire are indistinguishable in test output**,
+  and known redness is a strong anaesthetic. Never leave a guard red on the
+  upstream default branch; heal it or revert what broke it.
+- **Prove a guard test by its executed-assertion COUNT, not by its exit
+  code.** A floor on expect() calls is the only clause that can express "the
+  body ran to the end"; green/red structurally cannot. Pin a floor, not an
+  equality, so adding assertions does not fail the gate.
+- **A PR that moves a pinned value must re-run the OTHER assertions of that
+  value, including in files its diff never touches.** #691 bumped the tool
+  contract 2 -> 3 with all its own gates green; the pin-holder was a test in
+  an untouched file, so the branch was green and the merge was red. This is
+  the controller's defect, not the lane's — the cross-file pin check belongs
+  in the merge pass.
+- **A mutation clause written against an ALREADY-RED subject banks the
+  pre-existing failure as a kill.** Clause c passed on the pre-fix tree in its
+  first form — a survived mutant reported as a discriminating check. Gate
+  mutation clauses on a proven-green baseline and report INCONCLUSIVE
+  otherwise. Found by reading WHY each RED clause failed rather than accepting
+  a satisfying 4/4 red.
+- **Exit 127 can masquerade as a gate verdict.** Five CI failures asserted
+  `toBe(1)` for a refusal and received 127 — the shell's command-not-found,
+  meaning the script under test never ran. "Did not execute" and "refused
+  correctly" were distinguishable only by the number's luck. Any clause
+  asserting a specific nonzero exit should reject 127 explicitly. Filed as
+  #702 rather than absorbed.
+- **The two-runs-same-SHA comparison settled a red CI check again:** identical
+  f0e135c passed on `push` and failed on `pull_request`. Corroborated by
+  running both failing clusters locally on clean origin/main AND on the branch
+  in separate worktrees — 29 pass / 0 fail on both — before concluding
+  environment-owned. A same-SHA disagreement is the signal; the local
+  differential is the proof.
+- **PIPESTATUS printed empty when read outside the pipeline's shell**, reading
+  as exit 0 at a glance. Every verdict in this lane re-read the exit code
+  directly from the command instead.
+- **Pin collisions between concurrent branches are a merge-order hazard the
+  pin cannot see.** PR #701 and PR #687 each legitimately re-measured
+  EXPECTED_ENTRY_COUNT as 235 on their own trees; whichever merges second is
+  silently stale. Re-measure the pin AFTER integrating main, never carry a
+  branch's own derivation across a merge — and never sum.
+
 ### 2026-08-08 (round 7) — harvest of the #636 continuation lane (inherited a dead lane's worktree)
 
 - **Inherited work is PROPOSED, and auditing it is the first task, not a

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -2020,3 +2020,32 @@ Note the near-miss that makes this hard to catch: `src/contract.test.ts` pinned 
 - Mirrors need a parity assertion in BOTH directions. A key in the source but not the mirror under-advertises; a key in the mirror but not the source advertises a parameter the strict schema will REJECT, which is the worse client experience because the manifest itself is lying.
 - When more than one tree can serve (this repo has `src/index.ts` and `server/main.ts`), a mirror reconciled against one tree while the other drifted is accurate and still wrong on whichever surface is running. Pin every reachable tree.
 - Bumping a hash and re-pinning its consumers are ONE change, never two. A bumped server with stale client pins converts a blind receipt into a hard downstream refusal — check the pin sites in the same diff.
+
+## [2026-08-09] A failing assertion turns off every clause after it in the same test
+
+**Severity:** HIGH
+**Source:** #691 merge defect; `src/tools/__tests__/get-contract.test.ts` (the #271 boundary tripwire), healed by the #271 tripwire lane
+**Scope key:** tripwires, boundary guards, and any single test whose later assertions enforce a security or contract decision; PRs that move a pinned version, hash, or count
+**Status:** active
+
+### Pattern
+
+`expect()` throws on first failure, so every assertion after the first failing one in the same `it()` block never executes. For an ordinary test that is fine — it is red either way. For a TRIPWIRE it is a hole, because the test's job is not to be green; it is to REFUSE a specific class of change.
+
+Concretely: the #271 tripwire pins two independently-versioned surfaces and then, further down the same block, asserts the exact top-level key set of the served contract and applies a negative filter rejecting any new key matching `/(hot|inject|push|bundle|_meta)/i`. Those last two clauses are the ones that actually enforce the boundary. #691 bumped `tool_contracts.agent_context_pack.version` 2 -> 3 and left the tripwire's stale literal in place, so the block aborted at the version line and the two enforcing clauses stopped running — measurable as 37 `expect()` calls on the red tree versus 44 on the healed one.
+
+For the window the default branch stayed red, a PR could have advertised a push-shaped hot-memory key and the tripwire would not have refused it. It would have failed for the old reason and looked like the same known redness.
+
+That is the trap worth naming: **a red tripwire and a disabled tripwire are indistinguishable in the test output.** Both show one failing test with a familiar message. Known redness is a strong anaesthetic — the second failure hides behind the first, and the longer the branch stays red the more normal the message looks.
+
+The enabling defect is separate and mundane: a PR moved a pinned number and did not re-run the OTHER assertions of that number, because they lived in a file the diff did not touch. The PR's own gates were green.
+
+### Review checks
+
+- **When a PR moves a pinned value — a version, a hash, a count, a schema literal — grep for every other assertion of that value before merging, including in files the diff does not touch.** The pin-holders are by definition somewhere else; a green branch proves the branch's own tests, not the pins.
+- On any test whose later assertions enforce a boundary, ask **what happens to the clauses BELOW an early failure.** If the answer is "they do not run," the enforcement is conditional on the rest of the file being green, and that is a property nobody is tracking.
+- Prefer proving execution by **assertion count** over greenness for guard tests. A floor on `expect()` calls catches a silently truncated body; an exit code cannot express it. Pin a floor, not an equality, so adding assertions does not fail the gate.
+- Splitting a multi-clause tripwire into separate `it()` blocks is the structural fix and is usually right; where a single block is deliberate (the clauses share expensive setup), the count assertion is the compensating control.
+- **Never let a tripwire sit red on the default branch.** Its failure message stops carrying information the moment it becomes expected, and the whole value of a tripwire is that its redness is surprising. Heal it or revert what broke it; "known failure" is not a state a guard can survive in.
+- When healing a red tripwire, the review question is never "what value makes it green." It is "does the thing that moved stay on the correct side of the decision this tripwire encodes" — answered from source, with the reasoning written next to the number so the next reader inherits it. A bumped literal with no rationale is indistinguishable from a silenced guard.
+- A mutation clause written for a subject that is ALREADY red will pass off the pre-existing failure and report a survived mutant as a kill. Gate mutation clauses on a proven-green baseline.

--- a/docs/sme/entries/2026-08-09-a-failing-assertion-turns-off-every-clause-after-it-in-the-same-test.md
+++ b/docs/sme/entries/2026-08-09-a-failing-assertion-turns-off-every-clause-after-it-in-the-same-test.md
@@ -1,0 +1,32 @@
+---
+lane: correctness
+order: 69
+---
+## [2026-08-09] A failing assertion turns off every clause after it in the same test
+
+**Severity:** HIGH
+**Source:** #691 merge defect; `src/tools/__tests__/get-contract.test.ts` (the #271 boundary tripwire), healed by the #271 tripwire lane
+**Scope key:** tripwires, boundary guards, and any single test whose later assertions enforce a security or contract decision; PRs that move a pinned version, hash, or count
+**Status:** active
+
+### Pattern
+
+`expect()` throws on first failure, so every assertion after the first failing one in the same `it()` block never executes. For an ordinary test that is fine — it is red either way. For a TRIPWIRE it is a hole, because the test's job is not to be green; it is to REFUSE a specific class of change.
+
+Concretely: the #271 tripwire pins two independently-versioned surfaces and then, further down the same block, asserts the exact top-level key set of the served contract and applies a negative filter rejecting any new key matching `/(hot|inject|push|bundle|_meta)/i`. Those last two clauses are the ones that actually enforce the boundary. #691 bumped `tool_contracts.agent_context_pack.version` 2 -> 3 and left the tripwire's stale literal in place, so the block aborted at the version line and the two enforcing clauses stopped running — measurable as 37 `expect()` calls on the red tree versus 44 on the healed one.
+
+For the window the default branch stayed red, a PR could have advertised a push-shaped hot-memory key and the tripwire would not have refused it. It would have failed for the old reason and looked like the same known redness.
+
+That is the trap worth naming: **a red tripwire and a disabled tripwire are indistinguishable in the test output.** Both show one failing test with a familiar message. Known redness is a strong anaesthetic — the second failure hides behind the first, and the longer the branch stays red the more normal the message looks.
+
+The enabling defect is separate and mundane: a PR moved a pinned number and did not re-run the OTHER assertions of that number, because they lived in a file the diff did not touch. The PR's own gates were green.
+
+### Review checks
+
+- **When a PR moves a pinned value — a version, a hash, a count, a schema literal — grep for every other assertion of that value before merging, including in files the diff does not touch.** The pin-holders are by definition somewhere else; a green branch proves the branch's own tests, not the pins.
+- On any test whose later assertions enforce a boundary, ask **what happens to the clauses BELOW an early failure.** If the answer is "they do not run," the enforcement is conditional on the rest of the file being green, and that is a property nobody is tracking.
+- Prefer proving execution by **assertion count** over greenness for guard tests. A floor on `expect()` calls catches a silently truncated body; an exit code cannot express it. Pin a floor, not an equality, so adding assertions does not fail the gate.
+- Splitting a multi-clause tripwire into separate `it()` blocks is the structural fix and is usually right; where a single block is deliberate (the clauses share expensive setup), the count assertion is the compensating control.
+- **Never let a tripwire sit red on the default branch.** Its failure message stops carrying information the moment it becomes expected, and the whole value of a tripwire is that its redness is surprising. Heal it or revert what broke it; "known failure" is not a state a guard can survive in.
+- When healing a red tripwire, the review question is never "what value makes it green." It is "does the thing that moved stay on the correct side of the decision this tripwire encodes" — answered from source, with the reasoning written next to the number so the next reader inherits it. A bumped literal with no rationale is indistinguishable from a silenced guard.
+- A mutation clause written for a subject that is ALREADY red will pass off the pre-existing failure and report a survived mutant as a kill. Gate mutation clauses on a proven-green baseline.

--- a/scripts/done-means/271-tripwire-acknowledges-contract-moves.sh
+++ b/scripts/done-means/271-tripwire-acknowledges-contract-moves.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for the #271 get_contract tripwire heal (Refs #271, #691).
+#
+#   bash scripts/done-means/271-tripwire-acknowledges-contract-moves.sh
+#
+# WHAT THIS GATES, AND WHY IT IS NOT JUST "RUN THE TEST"
+#
+# src/tools/__tests__/get-contract.test.ts carries the #271 boundary tripwire:
+# hot memory is advertised ONLY through the client-pulled agent_context_pack,
+# and any new advertised surface must be consciously acknowledged before it
+# lands. #691 bumped tool_contracts.agent_context_pack.version 2 -> 3 without
+# touching the tripwire, so the upstream default branch went red and STAYED
+# red — which is the failure this gate exists to make impossible to repeat.
+#
+# The subtle half is why a red tripwire is worse than a failing test. Bun's
+# expect() throws on first failure, so every assertion AFTER the stale literal
+# stopped executing: the exact-key-set assertion and the push/injection
+# negative filter — the two clauses that actually enforce #271 — were dark
+# while the file "merely" failed. Measured: 37 expect() calls on the red tree,
+# 44 on the healed one. A tripwire whose later clauses do not run is not a
+# weakened tripwire; it is an absent one that still shows up in the test list.
+#
+# So this gate asserts THREE things a bare `bun test` does not:
+#   - the tripwire passes (clause a),
+#   - the two enforcing clauses actually EXECUTE, proven by the expect() count
+#     rather than by the file being green (clause b),
+#   - the tripwire still discriminates — it is not green because someone
+#     loosened it (clause c, a mutation).
+#
+# Clause z is a control: it must PASS on both sides of the fix, so a red z
+# means the harness broke, not that the boundary moved.
+#
+# RED PROOF (pre-fix tree, origin/main @ 123cc63): clause a FAILS with
+# "Expected: 2 / Received: 3" on the test named
+# "advertises hot memory only through the agent_context_pack pull boundary
+# (#271)"; clause b FAILS at 37 expect() calls against the required floor.
+# Clause z PASSES pre-fix, as a control must.
+#
+# Output is content-free: counts, names, and pass/fail states only.
+
+set -uo pipefail
+
+# Resolve the repo from THIS script's own location (lane-contract round 23:
+# when the subject is in-tree, the check must structurally be unable to reach
+# across trees — verify-lane runs it from a fresh worktree at the PR head).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}" || exit 1
+
+TEST_FILE="src/tools/__tests__/get-contract.test.ts"
+TRIPWIRE_NAME="advertises hot memory only through the agent_context_pack pull boundary (#271)"
+
+# Scratch is gitignored; a run leaves the working tree clean.
+WORK_DIR="${REPO_ROOT}/_scratch/271"
+mkdir -p "${WORK_DIR}"
+
+# The expect() floor. 44 on the healed tree; 37 when the stale literal aborts
+# the body. Anything at or below the pre-fix count means the enforcing clauses
+# did not run. Pinned as a floor, not an equality, so ADDING assertions to the
+# tripwire does not fail this gate — only losing them does.
+MIN_EXPECT_CALLS=44
+PREFIX_EXPECT_CALLS=37
+
+fail_count=0
+pass_count=0
+
+pass() { printf '  PASS  %s\n' "$1"; pass_count=$((pass_count + 1)); }
+fail() { printf '  FAIL  %s\n' "$1"; fail_count=$((fail_count + 1)); }
+
+printf 'done-means: #271 tripwire acknowledges contract moves\n'
+printf '  repo: %s\n\n' "${REPO_ROOT}"
+
+if [[ ! -f "${TEST_FILE}" ]]; then
+  printf 'FATAL: %s not found — wrong tree or the file was renamed.\n' "${TEST_FILE}"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# clause a — the tripwire passes, by name
+# ---------------------------------------------------------------------------
+# Asserted by NAME rather than by the file's overall exit code: a green file
+# whose tripwire was renamed or skipped would otherwise satisfy this.
+A_LOG="${WORK_DIR}/clause-a.log"
+bun test "${TEST_FILE}" > "${A_LOG}" 2>&1
+a_status=$?
+
+if [[ ${a_status} -ne 0 ]]; then
+  fail "a: ${TEST_FILE} is RED (exit ${a_status}) — see ${A_LOG}"
+  # Surface the assertion cause, not the coverage table.
+  rg -e 'Expected:|Received:|✗' "${A_LOG}" 2>/dev/null | head -5 | sed 's/^/        | /'
+else
+  # A passing file is not yet proof the tripwire itself ran. Bun names tests
+  # only on FAILURE (lane-contract, #613), so a name grep cannot prove
+  # execution on a green run — clause b carries that burden via the count.
+  if rg -qF -e "${TRIPWIRE_NAME}" "${TEST_FILE}"; then
+    pass "a: ${TEST_FILE} green and the #271 tripwire is present by name"
+  else
+    fail "a: the file is green but the #271 tripwire NAME is gone — renamed or deleted"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# clause b — the enforcing clauses EXECUTED (expect() count, not greenness)
+# ---------------------------------------------------------------------------
+# The whole reason this gate exists beyond `bun test`. A first-failure abort
+# silently skips the exact-key-set assertion and the push/injection negative
+# filter while the suite still reports the test.
+expect_calls="$(rg -o -e '([0-9]+) expect\(\) calls' -r '$1' "${A_LOG}" 2>/dev/null | tail -1)"
+
+if [[ -z "${expect_calls:-}" ]]; then
+  fail "b: could not read an expect() count from the run — did-not-run, not zero"
+elif (( expect_calls >= MIN_EXPECT_CALLS )); then
+  pass "b: ${expect_calls} expect() calls executed (floor ${MIN_EXPECT_CALLS}; pre-fix tree ran ${PREFIX_EXPECT_CALLS})"
+else
+  fail "b: only ${expect_calls} expect() calls executed (floor ${MIN_EXPECT_CALLS}) — clauses after the first failure are dark"
+fi
+
+# ---------------------------------------------------------------------------
+# clause c — the tripwire still DISCRIMINATES (mutation)
+# ---------------------------------------------------------------------------
+# A green clause is not evidence until it has been seen to fail
+# (lane-contract round 9). The mutation adds a push-shaped top-level key to
+# the served contract; the tripwire must go red. If it does not, the tripwire
+# is decoration and the heal made it green by loosening it.
+#
+# The mutation is applied to a COPY-BACK backup and restored in an EXIT trap
+# via `mv` — no delete path anywhere in this script.
+MUT_TARGET="src/contract.ts"
+MUT_BACKUP="${WORK_DIR}/contract.ts.orig"
+restore_mutation() {
+  if [[ -f "${MUT_BACKUP}" ]]; then
+    mv -f "${MUT_BACKUP}" "${MUT_TARGET}"
+  fi
+}
+trap restore_mutation EXIT
+
+cp "${MUT_TARGET}" "${MUT_BACKUP}"
+
+# Insert a push-shaped top-level key into the returned contract object. The
+# tripwire's key-set assertion AND its /(hot|inject|push|...)/i negative
+# filter should both reject it.
+MUT_LOG="${WORK_DIR}/clause-c.log"
+#
+# A KILL IS ONLY A KILL IF THE BASELINE WAS ALIVE. On a tree where the
+# tripwire is ALREADY red (the pre-fix world), "red under mutation" is
+# satisfied by the failure that was there all along — a survived mutant
+# reported as a kill, which is the false-GREEN family this contract's rounds
+# 9/17/24 keep catching. So clause c is gated on clause a's baseline: with a
+# red baseline it reports INCONCLUSIVE and fails, rather than banking a free
+# pass off someone else's failure.
+if [[ ${a_status} -ne 0 ]]; then
+  restore_mutation
+  fail "c: INCONCLUSIVE — the baseline is already RED, so 'red under mutation' proves nothing"
+elif bun --eval '
+  const fs = require("fs");
+  const p = "'"${MUT_TARGET}"'";
+  const src = fs.readFileSync(p, "utf8");
+  const needle = "  agent_context_pack: {";
+  const at = src.indexOf(needle);
+  if (at < 0) { console.error("MUTATION-TARGET-NOT-FOUND"); process.exit(3); }
+  const injected = "  hot_memory_push: { status: \"mutation-probe\" as const },\n";
+  fs.writeFileSync(p, src.slice(0, at) + injected + src.slice(at));
+' >> "${MUT_LOG}" 2>&1; then
+  bun test "${TEST_FILE}" >> "${MUT_LOG}" 2>&1
+  mut_status=$?
+  restore_mutation
+
+  if [[ ${mut_status} -ne 0 ]]; then
+    pass "c: green baseline + mutation (push-shaped top-level key) goes RED — it discriminates"
+  else
+    fail "c: mutation SURVIVED — the tripwire passes with a push-shaped key advertised; it is decoration"
+  fi
+else
+  restore_mutation
+  fail "c: could not apply the mutation (target string not found) — clause measured nothing"
+fi
+
+# ---------------------------------------------------------------------------
+# clause z — CONTROL: the two versions are pinned SEPARATELY and still differ
+# ---------------------------------------------------------------------------
+# This must PASS on both sides of the fix. The capability entry stayed at 2
+# while the tool contract moved to 3; that they are allowed to differ is the
+# point of pinning them separately, and a heal that "fixed" the red by making
+# them equal would have destroyed the distinction. A red z means the harness
+# or the tree is wrong, not that the boundary moved.
+cap_version="$(rg -A2 -e 'name: "agent_context_pack"' src/contract.ts 2>/dev/null | rg -o -e 'version: ([0-9]+)' -r '$1' | head -1)"
+tool_version="$(rg -A8 -e '^  agent_context_pack: \{' src/contract-schemas.ts 2>/dev/null | rg -o -e 'version: ([0-9]+)' -r '$1' | head -1)"
+
+if [[ -z "${cap_version:-}" || -z "${tool_version:-}" ]]; then
+  fail "z: could not read both versions (capability='${cap_version:-}' tool='${tool_version:-}') — did-not-run, not agreement"
+elif rg -qF -e "expect(parsed.tool_contracts.agent_context_pack.version).toBe(${tool_version})" "${TEST_FILE}" &&
+     rg -qF -e ").toBe(${cap_version});" "${TEST_FILE}"; then
+  pass "z: both surfaces pinned in the tripwire and read from source (capability=${cap_version}, tool_contract=${tool_version})"
+else
+  fail "z: the tripwire's pinned versions do not match source (capability=${cap_version}, tool_contract=${tool_version})"
+fi
+
+# ---------------------------------------------------------------------------
+printf '\n  passed: %d   failed: %d\n' "${pass_count}" "${fail_count}"
+
+if (( fail_count > 0 )); then
+  printf '  VERDICT: FAIL\n'
+  exit 1
+fi
+
+printf '  VERDICT: PASS\n'
+exit 0

--- a/scripts/done-means/sme-per-entry-files.sh
+++ b/scripts/done-means/sme-per-entry-files.sh
@@ -105,7 +105,20 @@ BUILD_SCRIPT="scripts/build-sme-indexes.ts"
 #
 # The count-DOWN half of the clause is untouched and still fires if entry text is
 # ever lost.
-EXPECTED_ENTRY_COUNT=234
+#
+# 2026-08-09, the #271 tripwire lane: 234 -> 235. ONE entry added
+# (docs/sme/entries/2026-08-09-a-failing-assertion-turns-off-every-clause-after-it-in-the-same-test.md,
+# lane correctness, order 69 — the enforcing clauses below a failed assertion
+# stop executing, so a red tripwire and a disabled one look identical).
+#
+# The number was RE-MEASURED on this tree, not arithmetic on the previous pin:
+# `rg -c '^## \[20' docs/sme/entries/*.md | wc -l` returns 235. Main measured
+# 234 against a pin of 234 before this branch, so measured and expected agree
+# on both sides of the change. Announced here rather than adjusted quietly,
+# per the nothing-is-adjusted-silently rule — and the derivation is stated
+# because a summed pin cannot tell a legitimate addition from a lost entry
+# plus two new ones.
+EXPECTED_ENTRY_COUNT=235
 
 LANE_FILES=(
   "$SME_DIR/correctness.md"

--- a/src/tools/__tests__/get-contract.test.ts
+++ b/src/tools/__tests__/get-contract.test.ts
@@ -199,7 +199,12 @@ describe("get_contract", () => {
           (item: { name: string }) => item.name === "append_session_event",
         ).version,
       ).toBe(8);
-      expect(parsed.tool_contracts.agent_context_pack.version).toBe(2);
+      // 2 -> 3 acknowledged 2026-08-09 (#691): the tool-contract bump adds
+      // continue_from, a bounded-recall CONTINUATION of the client-pulled
+      // pack -- it stays on the #271 pull side of the boundary; no
+      // push/injection surface was added. The capability entry above stays
+      // at 2 deliberately: #691 moved the tool contract, not the capability.
+      expect(parsed.tool_contracts.agent_context_pack.version).toBe(3);
       expect(parsed.tool_contracts.append_session_event.version).toBe(8);
 
       // Positive shape: the top-level contract surface is exactly this key


### PR DESCRIPTION
## Summary

- The upstream default branch has been RED on `src/tools/__tests__/get-contract.test.ts` since 123cc63 (#691) merged. This heals it by doing the exact thing the #271 tripwire exists to force: consciously acknowledging a contract move against the boundary decision, in the test, with the reasoning written beside the number.
- #691 reconciled the hand-maintained contract mirror with the live Zod schema and bumped `tool_contracts.agent_context_pack.version` 2 -> 3 (`src/contract-schemas.ts:126`). It did not touch `capabilities[name=agent_context_pack].version`, which is still 2 (`src/contract.ts:448`). The tripwire pins both, so it failed with `Expected: 2 / Received: 3`.
- **The acknowledgement, verified in source rather than assumed:** the three keys #691 added — `repo`, `prior_context`, `continue_from` — are INPUT parameters of the client-pulled tool, present in both reachable serving trees (`src/tools/agent-context-pack.ts:188`, `server/tools/context-pack-args.ts:158`). `continue_from` is a resume cursor, "a delivery position, never a filter" (`src/contract-schemas.ts:267-279`): the client passes back the `next` object to pull the following burst of the same ranked recall. No server-initiated surface was added, so the move stays on the #271 pull side and the correct resolution is to acknowledge it, not to revert it.
- The capability entry stays at 2 deliberately and is untouched: #691 moved the tool contract only. The two numbers being allowed to differ is the point of pinning them separately.
- **A red tripwire is worse than a failing test.** `expect()` throws on first failure, so the two clauses that actually enforce #271 — the exact top-level key-set assertion and the `/(hot|inject|push|bundle|_meta)/i` negative filter — stopped executing while the file still appeared in the test list. 37 `expect()` calls on the red tree, 44 on the healed one. The second commit adds a done-means check that gates on that execution count rather than on greenness, because a green/red signal structurally cannot express this.

## Verification

- Done-means: scripts/done-means/271-tripwire-acknowledges-contract-moves.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

**Done-means RED (pre-fix tree, `git show 123cc63:<test>`), check in its current form:** 0 passed / 4 failed.

```
FAIL  a: get-contract.test.ts is RED (exit 1)
      | Expected: 2   Received: 3
      | ✗ advertises hot memory only through the agent_context_pack pull boundary (#271)
FAIL  b: only 37 expect() calls executed (floor 44) — clauses after the first failure are dark
FAIL  c: INCONCLUSIVE — the baseline is already RED, so 'red under mutation' proves nothing
FAIL  z: the tripwire's pinned versions do not match source (capability=2, tool_contract=3)
VERDICT: FAIL   (exit 1)
```

**Done-means GREEN (this branch):** 4 passed / 0 failed.

```
PASS  a: get-contract.test.ts green and the #271 tripwire is present by name
PASS  b: 44 expect() calls executed (floor 44; pre-fix tree ran 37)
PASS  c: green baseline + mutation (push-shaped top-level key) goes RED — it discriminates
PASS  z: both surfaces pinned in the tripwire and read from source (capability=2, tool_contract=3)
VERDICT: PASS   (exit 0)
```

**Direct test evidence, both directions on an otherwise identical tree:**

- Pre-fix: 4 pass / 1 fail, 37 `expect()` calls, failing test named by the #271 boundary.
- Healed: 5 pass / 0 fail, 44 `expect()` calls.
- Bisection: passes at 78b740b, fails at 123cc63.

**Other gates:**

- `bunx tsc --noEmit`: exit 0, zero output.
- Sibling contract surface (`src/contract.test.ts`, `src/contract-schema-parity.test.ts`, `server/contracts/declaration.test.ts`): 26 pass / 0 fail.
- `clients/ts/tests/contract-fixtures.test.ts` + this file: 18 pass / 0 fail.
- Full suite via the pre-push hook on this branch: **3379 pass / 0 fail / 525 skip**, 3904 tests across 245 files.
- Swept every remaining assertion of the literal (`rg 'tool_contracts\.agent_context_pack|agent_context_pack.*version'` across tests and fixtures): this tripwire was the only stale one, so the heal is complete rather than the first of a series.

## Critical Self-Review

- Highest-risk behavior: changing a security-boundary tripwire's expected value. The risk is not the number — it is normalising "the tripwire went red, bump it." Mitigated by verifying in source that what moved is pull-side input parameters, by leaving the capability entry untouched, and by clause c, which fails if the tripwire ever stops rejecting a push-shaped key.
- Assumptions that could be wrong: that `continue_from`/`prior_context`/`repo` add no push surface. Checked against both serving trees and the mirror's own description rather than the PR prose. If a future key genuinely crosses the boundary, this same tripwire is what must refuse it — which is why clause b exists to keep its later clauses executing.
- Missing/weak tests: clause b's floor is pinned to 44 and will need a deliberate bump if the tripwire gains assertions. That is the same pinned-count friction the SME entry count carries, kept on purpose: a silent drop in executed assertions is exactly the defect being gated. Per-field BOUNDS parity remains unenforced (named in #691, not this PR's scope).
- Security/permission risk: none added. No auth, namespace, or predicate code is touched; the diff is one test file and one new check script. The #271 enforcement is strictly stronger after this PR than before, because the enforcing clauses now execute.
- Migration/deploy risk: none. No schema, migration, or served behavior changes — the served contract is exactly what #691 already merged.
- Downstream client/runtime risk: none from this PR. #691 already moved the version, hash, and every downstream pin together; this only teaches the test about it. No new contract surface, so no rtech-mcps/mcp2cli/Hermes action is created by this change.
- Rollback/cleanup concern: revert restores a red default branch, so rollback is not a safe default here. The check's mutation is restored via an `mv` EXIT trap and the working tree was verified clean after runs; artifacts land in gitignored `_scratch/271/`. No delete path in the script.
- Fixes made before PR: clause c initially PASSED on the pre-fix tree — it was inheriting the pre-existing redness and reporting a survived mutant as a kill. Gated it on clause a's baseline (INCONCLUSIVE on a red baseline) and re-proved RED in the edited form, per the rewritten-clause rule.
- Known residual risk: this heal was authored and verified by the same session that merged #691, so it is not an independent review of #691's contract judgement — it verifies the boundary claim from source, which is a weaker guarantee than a fresh reviewer. Named rather than implied.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no served behavior changes — the diff is one test file plus a new done-means script, and the contract this PR acknowledges was already merged and deployed by #691.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: #691 already moved every fixture, pin, and receipt triple together; this PR changes no served value, so parity fixtures are correct as-is and were re-run green (26 pass) as evidence rather than edited.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board, for one reason stated once: this PR changes no client-facing value. `docs/downstream-rollout.md:112` names `schema_hash` the authoritative drift receipt; it does not move here, because `src/contract.ts` and `src/contract-schemas.ts` are untouched by this PR. The rollout obligation for the 2->3 bump belonged to #691, which re-pinned the Python client, the TS client, both receipt triples, the parity fixtures, and the compatibility matrix in the same commit.

## Incident context, owned

This is a merge defect I own as the controller of the #691 merge, not a lane's. #691's own gates were green on its branch; the tripwire lives in a file the PR did not touch, and nothing in the merge pass re-ran the pin-holders against the merge result before pushing to the upstream default branch. The generalisable lesson — a PR that moves a pinned number must re-run the OTHER assertions of that number even when they are outside its diff — is filed as a Tightenings candidate for the harvest.
