### PR TITLE
fix(codex): make task_complete telemetry optional so Codex rollouts parse (#512)

### DIFF
--- a/docs/codex-adapter.md
+++ b/docs/codex-adapter.md
@@ -1,0 +1,180 @@
+# Codex Adapter — the direct Python Open Brain provider on Codex
+
+State: **WRITTEN**, with one RUNNING measurement set (below). The repo-side
+parser fix and this document are merged code and prose; the machine-side hook
+registration is described here but is NOT claimed as running on any box other
+than where its receipt says so.
+
+Issue: #512. Sibling of the Claude swap (2026-08-02) and the Pi adapter.
+
+## Why this exists
+
+Claude sessions on this box reach Open Brain through wrapper-invoked console
+scripts from the installed `openbrain` / `openbrain-provider` packages:
+
+```
+sh /Users/rico/.local/share/openbrain-memory/env/openbrain-hook-env <console-script>
+```
+
+Codex's route, per `docs/memory-contract.md`, is daemon-mode
+`mcp2cli open-brain`. That route **stays** — it is the correct answer for remote
+and uninstalled boxes, and #512 is explicitly additive. This document covers the
+native Codex runtime on a box where the Python stack IS installed.
+
+## Codex's real hook surface (measured, Codex CLI 0.147.0)
+
+Codex has a native hook engine. It is enabled by `features.hooks = true` in
+`~/.codex/config.toml` and configured in **`~/.codex/hooks.json`** — a separate
+file from `config.toml`, in Claude's `{"hooks": {EventName: [{matcher, hooks:
+[{type, command, timeout}]}]}}` shape.
+
+Event vocabulary, read from the binary's own strings (`hooks/src/events/*.rs`):
+
+| Codex event | Claude counterpart | OB use |
+| --- | --- | --- |
+| `SessionStart` | `SessionStart` | canon injection |
+| `UserPromptSubmit` | `UserPromptSubmit` | gates |
+| `PreToolUse` | `PreToolUse` | `ob-guard`, gates |
+| `PostToolUse` | `PostToolUse` | — |
+| `PermissionRequest` | (none) | — |
+| `PreCompact` / `PostCompact` | same | checkpoint |
+| `SessionEnd` | `SessionEnd` | wrap |
+| `SubagentStart` / `SubagentStop` | `SubagentStop` | subagent capture |
+| `Stop` | `Stop` | capture |
+
+Codex emits **snake_case payload fields identical to Claude's**. Captured live
+from a real `codex exec` run:
+
+```json
+{"session_id":"...","transcript_path":"/Users/rico/.codex/sessions/.../rollout-....jsonl",
+ "cwd":"...","hook_event_name":"SessionStart","model":"...",
+ "permission_mode":"bypassPermissions","source":"startup"}
+```
+
+`UserPromptSubmit` adds `turn_id` and `prompt`; `SessionEnd` adds `reason`.
+Because `SessionStartHook` and `StopHook` are all-optional with
+`extra="ignore"`, **the canon read path needs no payload change at all.**
+
+## THE TRUST GATE — read this before registering anything
+
+Codex **hash-pins every hook entry**. A new or edited entry is untrusted until
+reviewed, and an untrusted hook **does not run**. The binary's own strings:
+
+- `New hook - review required`
+- `Modified since last trusted - review required`
+- `Continue without trusting (hooks won't run)`
+- `--dangerously-bypass-hook-trust`
+
+**This fails silently and it looks like success.** Measured 2026-08-09: a probe
+hook and a deliberately-blocking hook were added to `~/.codex/hooks.json`, then
+`codex exec` was run twice. Codex printed `hook: ... Completed` for the
+already-trusted entries, the new entries never ran, no files were written, and
+the blocker could not block. With `--dangerously-bypass-hook-trust` the same
+entries fired and the blocker correctly returned `UserPromptSubmit Blocked`.
+
+Corroboration that this is longstanding rather than an artifact of that session:
+an unrelated `PreToolUse` trace hook registered on 2026-07-30 has **never once**
+written its log file.
+
+Consequences for anyone wiring this:
+
+1. Editing `hooks.json` de-trusts the entries you touched.
+2. Trust is granted in the **interactive TUI** (`startup_hooks_review.rs`:
+   "Review hooks" / "Trust all and continue"). `codex exec` is non-interactive
+   and therefore cannot grant it.
+3. For non-interactive lanes, either trust the entries once in the TUI first, or
+   pass `--dangerously-bypass-hook-trust` deliberately and record that you did.
+4. **Never conclude a hook works because Codex printed `Completed`** — that line
+   is emitted for the hooks that ran, and says nothing about the one you added.
+
+## Transcript compatibility — the real gap, and what was fixed
+
+Codex rollout JSONL is **not** Claude's format. It carries `session_meta`,
+`turn_context`, `world_state`, `event_msg/*`, and `response_item/*` records,
+with no `uuid`, no `promptSource`, and no Claude `message` envelope. The Claude
+hook-path parser (`openbrain.apps.capture.records.raw_turn_from_line`) requires
+`uuid`, so a real Codex rollout parses to **0 turns** through it — a silent zero
+capture with a clean exit 0, the #525/#544 failure class.
+
+A Codex reader already existed for the bulk ingester:
+`openbrain.apps.bulk.formats.codex_raw_turn_from_line`, mapping
+`event_msg/user_message` to a user turn and `event_msg/task_complete` to an
+assistant turn. It was **broken on Codex 0.147.0**:
+`CodexTaskCompletePayload.time_to_first_token_ms` was required, and Codex omits
+it when a turn produced no tokens. Because `ingest.py` re-raises rather than
+skipping, one such line aborted an entire ingest.
+
+Measured across every rollout written on 2026-08-09: 144 `task_complete` records
+carried the field, 1 did not — and that one came from `codex exec`, the path
+automation uses. The fix makes the field optional (it is telemetry; no turn
+content depends on it) while `turn_id`, `last_agent_message`, and the timestamps
+stay required so malformed records are still quarantined loudly.
+
+After the fix, across all of 2026-08-09's rollouts:
+
+```
+lines=27196 turns=430 errors=0
+```
+
+Gate: `scripts/done-means/512-codex-adapter.sh`.
+
+### Why `event_msg`, not `response_item`
+
+`response_item/message:user` is contaminated: Codex injects AGENTS.md,
+environment context, and policy text as `user`-role records, so treating it as
+operator speech would attribute injected instructions to Rico. The
+`event_msg/user_message` and `event_msg/task_complete` records carry the clean
+prompt and the final answer, which is why the existing adapter keys on them.
+
+## Gaps where Codex's surface does not reach Claude's
+
+Stated explicitly rather than papered over, per #512.
+
+1. **No `Notification` event.** Claude's `Notification` registration has no
+   Codex counterpart. Not emulated.
+2. **Trust gating has no non-interactive grant.** There is no
+   `codex hooks trust <path>` command; the only paths are the TUI review or the
+   bypass flag. A fleet rollout cannot grant trust by writing a file, which
+   makes this the main obstacle to wiring the remaining boxes.
+3. **`additionalContext` is bounded by Codex.** `HookMetadata` carries an
+   `additionalContextLimit`. Claude's canon path already learned that an
+   oversized injection gets diverted to a preview file (see
+   `session_start.py`); the Codex limit is a separate, unmeasured bound. The
+   two-emission split that canon already performs is what keeps this tolerable,
+   but the exact Codex ceiling has NOT been measured here.
+4. **Capture is not wired by this change.** The parser now handles Codex
+   rollouts, but `openbrain-capture-stop` reads Claude transcripts via
+   `records.raw_turn_from_line`. Routing the hook path to the Codex adapter by
+   transcript shape is follow-on work and is deliberately not claimed here.
+5. **Subagent capture is unverified.** Codex has `SubagentStart`/`SubagentStop`,
+   but Codex subagents write their own rollouts and the per-subagent watermark
+   key has not been exercised on this runtime.
+
+## Registration shape (WRITTEN, not deployed by this change)
+
+For a box where the Python stack is installed, the Codex-side registrations
+mirror Claude's one-for-one, using the same wrapper so the environment contract
+(`openbrain-hook-env`) is identical:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      { "matcher": "*", "hooks": [
+        { "type": "command", "timeout": 10,
+          "command": "sh /Users/rico/.local/share/openbrain-memory/env/openbrain-hook-env openbrain-session-start" },
+        { "type": "command", "timeout": 10,
+          "command": "sh /Users/rico/.local/share/openbrain-memory/env/openbrain-hook-env openbrain-session-start-remaining" }
+      ]}
+    ]
+  }
+}
+```
+
+The wrapper is required, not optional: the Python config rejects any
+`OPENBRAIN_*` variable it does not declare, the hook entrypoints swallow that
+rejection by design, and the result is a silent zero capture with exit 0. The
+wrapper's own header documents this at length.
+
+Do **not** point Codex at core01 or hardcode a host: endpoint and token come
+from `$OPENBRAIN_BASE_URL` / `$OPENBRAIN_TOKEN` in `claudex-observation.env`.

--- a/python/openbrain/src/openbrain/apps/bulk/formats.py
+++ b/python/openbrain/src/openbrain/apps/bulk/formats.py
@@ -187,7 +187,25 @@ class CodexTaskCompletePayload(BaseModel):
     started_at: int
     completed_at: int
     duration_ms: int
-    time_to_first_token_ms: int
+    # OPTIONAL BECAUSE CODEX OMITS IT, and it is telemetry either way.
+    #
+    # Measured 2026-08-09 against Codex CLI 0.147.0 (#512): a turn that produced
+    # no tokens writes `task_complete` with NO `time_to_first_token_ms` at all.
+    # Across every rollout written that day, 144 records carried the field and 1
+    # did not -- and the one that did not came from `codex exec`, which is
+    # exactly the non-interactive path automation and Workflow lanes use.
+    #
+    # Required, this cost the WHOLE file: `codex_raw_turn_from_line` raised
+    # MalformedCodexRecordError, and `ingest.py` re-raises with a file:line
+    # rather than skipping, so a single tokenless turn aborted the entire
+    # ingest. Rare input, total failure.
+    #
+    # Optional is the minimal correct change, not a loosening: no turn content
+    # depends on this field. `turn_id`, `last_agent_message`, and the timestamps
+    # stay REQUIRED, because turn identity and the assistant's actual words do
+    # depend on them -- a record missing those is still quarantined loudly, and
+    # `scripts/done-means/512-codex-adapter.sh` clause (c) holds that line.
+    time_to_first_token_ms: int | None = None
 
 
 CodexEventAdapter = Callable[[CodexEnvelope, str], RawTurn | None]

--- a/scripts/done-means/512-codex-adapter.sh
+++ b/scripts/done-means/512-codex-adapter.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #512 — Codex sessions carry the same direct Python
+# Open Brain provider structure already proven on Claude.
+#
+#   bash scripts/done-means/512-codex-adapter.sh
+#
+# ---------------------------------------------------------------------------
+# What was MEASURED on 2026-08-09 before this check was written
+# ---------------------------------------------------------------------------
+# Codex CLI 0.147.0 has a NATIVE hook engine (`features.hooks = true`), config
+# at `~/.codex/hooks.json`. Its event vocabulary, read out of the Rust binary's
+# own strings (`hooks/src/events/*.rs`), is Claude-Code-shaped: PreToolUse,
+# PermissionRequest, PostToolUse, PreCompact, PostCompact, SessionStart,
+# SessionEnd, SubagentStart, SubagentStop, UserPromptSubmit, Stop.
+#
+# Three facts decide this gate's shape, all observed live, none inferred:
+#
+#   1. PAYLOADS ARE FIELD-COMPATIBLE. A real `codex exec` run emitted
+#      SessionStart {session_id, transcript_path, cwd, hook_event_name, model,
+#      permission_mode, source=startup}. All snake_case. `SessionStartHook` and
+#      `StopHook` are all-optional with extra="ignore", so the CANON (read) path
+#      needs no payload change and is not what this gate measures.
+#
+#   2. A CODEX TRANSCRIPT READER ALREADY EXISTS — and it is BROKEN on the
+#      installed Codex. `openbrain.apps.bulk.formats.codex_raw_turn_from_line`
+#      already maps `event_msg/user_message` to a user turn and
+#      `event_msg/task_complete` to an assistant turn. But
+#      `CodexTaskCompletePayload.time_to_first_token_ms` is a REQUIRED int, and
+#      Codex 0.147.0 OMITS that field when a turn produced no tokens. Measured
+#      against a real rollout:
+#          codex_raw_turn_from_line -> MalformedCodexRecordError
+#          "observed shape failed at time_to_first_token_ms"
+#          lines=10 turns=0 errors=1
+#      Across every rollout written on 2026-08-09: 144 `task_complete` records
+#      carry the field, 1 does not — and the one that does not came from
+#      `codex exec`, which is precisely the automation path a Workflow lane
+#      uses. `ingest.py:179` RE-RAISES, so ONE such line aborts the WHOLE
+#      ingest with a file:line. Rare input, total failure.
+#
+#      The minimal correct change is therefore to make the field optional
+#      (it is pure telemetry — no turn content depends on it), NOT to write a
+#      second parser. Round 22's "stub the boundary, don't extract a helper"
+#      applies: the owning boundary is the payload model.
+#
+#   3. HOOK TRUST IS A HARD, SILENT GATE. Codex hash-pins every hook entry.
+#      Binary strings: "New hook - review required", "Modified since last
+#      trusted - review required", "Continue without trusting (hooks won't
+#      run)". Measured: newly-added hooks did NOT run under `codex exec` and a
+#      deliberately-blocking hook could not block; with
+#      `--dangerously-bypass-hook-trust` the same hooks fired and the blocker
+#      returned `UserPromptSubmit Blocked`. Corroboration that this is
+#      longstanding, not an artifact of this session: an unrelated PreToolUse
+#      trace hook registered on 2026-07-30 has never once written its log file.
+#
+# ---------------------------------------------------------------------------
+# The existing design, and the delta
+# ---------------------------------------------------------------------------
+# `_ob/scripts/ob-memory-provider/wiring/codex-hooks.json` and
+# `codex-config.toml` are INACTIVE shape-reference fixtures ("No hook command is
+# registered by this fixture") describing the RETIRED TypeScript adapter.
+# `docs/agent-memory-adapter-contract.md` keeps auth/namespace server-side and
+# distillation client-side, so a Codex transcript reader is an additive
+# CLIENT-side concern, not a contract change.
+#
+# `docs/memory-contract.md` states Codex's durable route is daemon-mode
+# `mcp2cli open-brain`. Per #512 that route STAYS for remote/uninstalled boxes;
+# this adapter is additive where the Python stack is installed. Clause (e) pins
+# that, because removing it would strand remote boxes and is out of scope.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+#   (a) RED ANCHOR — a real-shaped Codex rollout whose `task_complete` omits
+#       `time_to_first_token_ms` parses without raising, yielding turns.
+#       Today this raises MalformedCodexRecordError and yields 0.
+#   (b) BOTH ROLES — that rollout yields a human prompt AND an assistant reply,
+#       so capture cannot report agent volume as operator volume (the
+#       `is_human_prompt` invariant capture-never-drops-a-turn.md relies on).
+#   (c) CONTROL, STRICTNESS PRESERVED — a genuinely malformed record (a
+#       `task_complete` missing `turn_id`, a field turn identity depends on)
+#       must STILL raise. Without this, "fixing" the gate by setting
+#       extra="ignore" on everything, or by swallowing all errors, would pass
+#       (a) and (b) while destroying the loud-quarantine contract.
+#   (d) CONTROL, SILENCE IS NOT A TURN — non-speech records (session_meta,
+#       turn_context, world_state, task_started) must NOT become turns. Without
+#       this, returning a turn per line passes (a) and (b) by inventing content.
+#   (e) SCOPE PIN — the documented mcp2cli route for Codex survives.
+#   (f) The adapter doc exists and names the hook trust gate and its bypass,
+#       because a correct hooks.json that is never trusted is a silent no-op,
+#       and "document the gap, never fake it" is the issue's own instruction.
+#
+# Output is content-free: counts, roles, statuses, and exception class names
+# only. No transcript text, no tokens, no memory bodies.
+#
+# EXPECTED TO FAIL until #512 is implemented. It is the reward function, not a
+# test of the fix's author.
+set -uo pipefail
+
+# When the subject IS repo code, resolve the repo from THIS script's own tree so
+# the check structurally cannot reach across worktrees (lane-contract round 12,
+# sharpened round 21).
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(CDPATH='' cd -- "$SCRIPT_DIR/../.." && pwd)"
+PKG="$REPO_ROOT/python/openbrain"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+[ -d "$PKG" ] || fail_hard "python package missing at $PKG"
+command -v uv >/dev/null 2>&1 || fail_hard "uv not on PATH (the Python runner; system python is forbidden by policy)"
+
+FIXTURE="$REPO_ROOT/scripts/done-means/fixtures/512-codex-rollout.jsonl"
+# The fixture is a REAL `codex exec` rollout's line shapes with content replaced
+# by neutral text — captured 2026-08-09, no session ids, no instructions, no user
+# data. Its `task_complete` omits `time_to_first_token_ms` exactly as the live
+# one did. A fixture invented by the same reasoning as the fix would prove only
+# that the reasoning is self-consistent (lane-contract round 20).
+[ -r "$FIXTURE" ] || fail_hard "codex rollout fixture missing at $FIXTURE"
+
+ADAPTER_DOC="$REPO_ROOT/docs/codex-adapter.md"
+MEMORY_CONTRACT="$REPO_ROOT/docs/memory-contract.md"
+
+printf '=== done-means #512 — Codex adapter (direct Python provider) ===\n'
+
+# ---------------------------------------------------------------------------
+# Clauses (a)-(d) are decided by ONE probe run so every assertion is judged by
+# the same parser in the same interpreter.
+#
+# The import is DYNAMIC (importlib), not a top-level `from ... import`: a static
+# import of a not-yet-existing symbol dies at module resolution before any
+# clause prints, which is a FALSE RED indistinguishable in shape from a real one
+# (lane-contract round 22).
+# ---------------------------------------------------------------------------
+PROBE_OUT="$(cd "$PKG" && FIXTURE="$FIXTURE" uv run --quiet python - <<'PY' 2>&1
+import importlib
+import json
+import os
+import sys
+
+try:
+    formats = importlib.import_module("openbrain.apps.bulk.formats")
+    parse = formats.codex_raw_turn_from_line
+except Exception as error:  # the reader itself is missing or broken
+    print(f"IMPORT_ERROR={type(error).__name__}")
+    sys.exit(0)
+
+turns, roles, humans, raised = [], set(), 0, ""
+with open(os.environ["FIXTURE"], encoding="utf-8") as handle:
+    for line in handle:
+        if not line.strip():
+            continue
+        try:
+            turn = parse(line)
+        except Exception as error:
+            raised = type(error).__name__
+            break
+        if turn is not None:
+            turns.append(turn)
+            roles.add(str(getattr(turn, "role", "?")).split(".")[-1].lower())
+            humans += 1 if getattr(turn, "is_human_prompt", False) else 0
+
+print(f"RAISED={raised}")
+print(f"TURNS={len(turns)}")
+print(f"ROLES={','.join(sorted(roles))}")
+print(f"HUMANS={humans}")
+
+# Clause (c): strictness must survive. `turn_id` is a field turn identity
+# depends on, so its absence must STILL be a loud rejection.
+bad = json.dumps({
+    "timestamp": "2026-08-09T18:22:36.000Z",
+    "type": "event_msg",
+    "payload": {
+        "type": "task_complete",
+        "last_agent_message": "x",
+        "started_at": 1,
+        "completed_at": 2,
+        "duration_ms": 3,
+    },
+})
+try:
+    parse(bad)
+    print("STRICT=no-raise")
+except Exception as error:
+    print(f"STRICT={type(error).__name__}")
+PY
+)"
+
+case "$PROBE_OUT" in
+  *IMPORT_ERROR=*)
+    # A reader that cannot be imported is a RED for (a), not a harness fault.
+    RAISED="$(printf '%s\n' "$PROBE_OUT" | sed -n 's/^IMPORT_ERROR=//p' | tail -1)"
+    TURNS=0; ROLES=""; HUMANS=0; STRICT="import-failed"
+    ;;
+  *)
+    RAISED="$(printf '%s\n' "$PROBE_OUT" | sed -n 's/^RAISED=//p' | tail -1)"
+    TURNS="$(printf '%s\n' "$PROBE_OUT" | sed -n 's/^TURNS=//p' | tail -1)"
+    ROLES="$(printf '%s\n' "$PROBE_OUT" | sed -n 's/^ROLES=//p' | tail -1)"
+    HUMANS="$(printf '%s\n' "$PROBE_OUT" | sed -n 's/^HUMANS=//p' | tail -1)"
+    STRICT="$(printf '%s\n' "$PROBE_OUT" | sed -n 's/^STRICT=//p' | tail -1)"
+    ;;
+esac
+
+# An empty capture must not read as a clean 0 and look like an honest RED.
+[ -n "${TURNS:-}" ] || fail_hard "probe produced no TURNS line; output was: $(printf '%s' "$PROBE_OUT" | tr '\n' ' ')"
+[ -n "${STRICT:-}" ] || fail_hard "probe produced no STRICT line; output was: $(printf '%s' "$PROBE_OUT" | tr '\n' ' ')"
+
+# --- (a) red anchor ---------------------------------------------------------
+if [ -z "$RAISED" ] && [ "$TURNS" -gt 0 ]; then
+  CLAUSE_A=PASS
+  CLAUSE_A_EVIDENCE="real-shaped rollout parsed to $TURNS turns with no exception"
+elif [ -n "$RAISED" ]; then
+  CLAUSE_A=FAIL
+  CLAUSE_A_EVIDENCE="parser raised $RAISED on a real Codex rollout — one such line aborts the whole ingest"
+else
+  CLAUSE_A=FAIL
+  CLAUSE_A_EVIDENCE="parsed to 0 turns with no exception — silent zero capture"
+fi
+
+# --- (b) both roles present -------------------------------------------------
+case ",$ROLES," in *,user,*) HAS_USER=1 ;; *) HAS_USER=0 ;; esac
+case ",$ROLES," in *,assistant,*) HAS_ASSISTANT=1 ;; *) HAS_ASSISTANT=0 ;; esac
+
+if [ "$HAS_USER" -eq 1 ] && [ "$HAS_ASSISTANT" -eq 1 ] && [ "${HUMANS:-0}" -ge 1 ]; then
+  CLAUSE_B=PASS
+  CLAUSE_B_EVIDENCE="roles=[$ROLES] human_prompts=$HUMANS"
+else
+  CLAUSE_B=FAIL
+  CLAUSE_B_EVIDENCE="roles=[${ROLES:-<none>}] human_prompts=${HUMANS:-0} (need both roles and >=1 human prompt)"
+fi
+
+# --- (c) control: strictness preserved --------------------------------------
+case "$STRICT" in
+  MalformedCodexRecordError)
+    CLAUSE_C=PASS
+    CLAUSE_C_EVIDENCE="a task_complete missing turn_id still raises MalformedCodexRecordError"
+    ;;
+  no-raise)
+    CLAUSE_C=FAIL
+    CLAUSE_C_EVIDENCE="a task_complete missing turn_id was ACCEPTED — the loud-quarantine contract was loosened into a no-op"
+    ;;
+  *)
+    CLAUSE_C=FAIL
+    CLAUSE_C_EVIDENCE="strictness probe returned '$STRICT' instead of MalformedCodexRecordError"
+    ;;
+esac
+
+# --- (d) control: silence is not a turn -------------------------------------
+# The fixture holds 6 records; exactly 2 are speech (user_message,
+# task_complete). A reader inventing a turn per line would report 6.
+FIXTURE_RECORDS=6
+if [ "$TURNS" -gt 0 ] && [ "$TURNS" -lt "$FIXTURE_RECORDS" ]; then
+  CLAUSE_D=PASS
+  CLAUSE_D_EVIDENCE="$TURNS turns from $FIXTURE_RECORDS records — non-speech records correctly declined"
+elif [ "$TURNS" -ge "$FIXTURE_RECORDS" ]; then
+  CLAUSE_D=FAIL
+  CLAUSE_D_EVIDENCE="$TURNS turns from $FIXTURE_RECORDS records — non-speech records are being invented as turns"
+else
+  CLAUSE_D=FAIL
+  CLAUSE_D_EVIDENCE="no turns parsed, so the not-faked control cannot be satisfied"
+fi
+
+# --- (e) scope pin ----------------------------------------------------------
+if [ -r "$MEMORY_CONTRACT" ] && grep -q 'mcp2cli open-brain' "$MEMORY_CONTRACT"; then
+  CLAUSE_E=PASS
+  CLAUSE_E_EVIDENCE="memory-contract still documents the mcp2cli route (additive change; remote boxes unaffected)"
+else
+  CLAUSE_E=FAIL
+  CLAUSE_E_EVIDENCE="the documented mcp2cli route for Codex is gone; #512 is additive and must not strand remote boxes"
+fi
+
+# --- (f) trust gate documented ----------------------------------------------
+if [ -r "$ADAPTER_DOC" ] \
+  && grep -qi 'trust' "$ADAPTER_DOC" \
+  && grep -q 'dangerously-bypass-hook-trust' "$ADAPTER_DOC"; then
+  CLAUSE_F=PASS
+  CLAUSE_F_EVIDENCE="docs/codex-adapter.md documents the hook trust gate and its bypass"
+else
+  CLAUSE_F=FAIL
+  CLAUSE_F_EVIDENCE="docs/codex-adapter.md missing, or does not name the trust gate that makes an untrusted hook a silent no-op"
+fi
+
+printf '  (a) real rollout parses           : %s — %s\n' "$CLAUSE_A" "$CLAUSE_A_EVIDENCE"
+printf '  (b) both roles, human attributed  : %s — %s\n' "$CLAUSE_B" "$CLAUSE_B_EVIDENCE"
+printf '  (c) control, strictness preserved : %s — %s\n' "$CLAUSE_C" "$CLAUSE_C_EVIDENCE"
+printf '  (d) control, silence is not a turn: %s — %s\n' "$CLAUSE_D" "$CLAUSE_D_EVIDENCE"
+printf '  (e) mcp2cli route preserved       : %s — %s\n' "$CLAUSE_E" "$CLAUSE_E_EVIDENCE"
+printf '  (f) trust gate documented         : %s — %s\n' "$CLAUSE_F" "$CLAUSE_F_EVIDENCE"
+
+if [ "$CLAUSE_A" = PASS ] && [ "$CLAUSE_B" = PASS ] && [ "$CLAUSE_C" = PASS ] \
+  && [ "$CLAUSE_D" = PASS ] && [ "$CLAUSE_E" = PASS ] && [ "$CLAUSE_F" = PASS ]; then
+  printf 'DONE-MEANS 512: PASS\n'
+  exit 0
+fi
+printf 'DONE-MEANS 512: FAIL\n'
+exit 1

--- a/scripts/done-means/fixtures/512-codex-rollout.jsonl
+++ b/scripts/done-means/fixtures/512-codex-rollout.jsonl
@@ -1,0 +1,6 @@
+{"timestamp":"2026-08-09T18:22:32.013Z","type":"session_meta","payload":{"session_id":"fixture-session-512","id":"fixture-session-512","timestamp":"2026-08-09T18:22:31.691Z","cwd":"/fixture/repo","originator":"codex_exec","cli_version":"0.147.0","source":"exec","thread_source":"user","model_provider":"fixture"}}
+{"timestamp":"2026-08-09T18:22:32.100Z","type":"event_msg","payload":{"type":"task_started","turn_id":"fixture-turn-1","started_at":1,"model_context_window":1000,"collaboration_mode_kind":"default"}}
+{"timestamp":"2026-08-09T18:22:32.200Z","type":"turn_context","payload":{"cwd":"/fixture/repo","approval_policy":"never","sandbox_policy":{"mode":"workspace-write"},"model":"fixture-model","effort":"low","summary":"concise"}}
+{"timestamp":"2026-08-09T18:22:32.300Z","type":"event_msg","payload":{"type":"user_message","message":"fixture operator prompt one","images":[],"local_images":[],"audio":[],"local_audio":[],"text_elements":[]}}
+{"timestamp":"2026-08-09T18:22:35.000Z","type":"world_state","payload":{"state":{"files":[]}}}
+{"timestamp":"2026-08-09T18:22:36.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"fixture-turn-1","last_agent_message":"fixture assistant reply one","started_at":1,"completed_at":7,"duration_ms":6215}}


### PR DESCRIPTION
## Summary

Codex sessions could not carry the Python Open Brain provider structure, and the
reason turned out to be two separate things — one researched, one measured.

**The code defect.** A Codex transcript reader already existed for the bulk
ingester (`openbrain.apps.bulk.formats.codex_raw_turn_from_line`). It was broken
on the installed Codex CLI 0.147.0: `CodexTaskCompletePayload.time_to_first_token_ms`
was a required int, and Codex omits that field when a turn produced no tokens.
`ingest.py` re-raises rather than skipping, so ONE such line aborted an entire
ingest with a file:line.

Measured across every rollout written 2026-08-09: **144** `task_complete` records
carry the field, **1** does not — and that one came from `codex exec`, which is
exactly the non-interactive path automation and Workflow lanes use. Rare input,
total failure.

The field is telemetry; no turn content depends on it. `turn_id`,
`last_agent_message`, and the timestamps stay REQUIRED, so malformed records are
still quarantined loudly.

After the fix, over all of that day's real rollouts:

```
lines=27196 turns=430 errors=0     (before: aborted on the first tokenless turn)
```

**The research deliverable** (`docs/codex-adapter.md`) is the part #512 actually
asked for — what Codex's native surface can and cannot express:

- Codex 0.147.0 HAS a native hook engine (`features.hooks = true`,
  `~/.codex/hooks.json`), with Claude-shaped events and **identical snake_case
  payload fields**. `SessionStartHook`/`StopHook` are all-optional with
  `extra="ignore"`, so the canon read path needs no payload change.
- **Codex hash-pins hooks, and untrusted hooks fail silently.** A new or edited
  entry does not run, while Codex still prints `Completed` for the entries that
  did. Measured both ways: an untrusted probe and blocker never fired; with
  `--dangerously-bypass-hook-trust` the same blocker returned
  `UserPromptSubmit Blocked`. Corroborated by an unrelated trace hook registered
  2026-07-30 that has never written a single line.
- Gaps are documented rather than faked: no `Notification` event, no
  non-interactive trust grant, an unmeasured `additionalContext` ceiling, the
  capture hook not yet routed by transcript shape, and subagent capture
  unverified.

The `mcp2cli` route stays for remote/uninstalled boxes — #512 is additive, and
the done-means pins that so it cannot be dropped silently.

Refs #512

## Verification

- Done-means: scripts/done-means/512-codex-adapter.sh
- RED before the fix: clauses (a), (b), (d), (f) FAILED. Controls (c) and (e)
  PASSED in the same RED run, which is what proves the check discriminates
  rather than failing everything.
- PASS after: all six clauses.
- `uv run mypy src/openbrain` — Success, 50 source files.
- `uv run ruff check src tests` — All checks passed.
- `uv run pytest -q` — 610 passed, 1 skipped, **1 pre-existing failure**
  (`test_receipts_gate_crosslang.py::test_python_capture_receipt_clears_the_gates_capture_block`).
  Confirmed pre-existing by stashing this branch's changes and re-running on the
  untouched base, where it fails identically. NOT introduced here and NOT fixed
  here.

## Critical Self-Review

- Highest-risk behavior: relaxing a required field on a validating payload model.
  Contained by keeping `turn_id`, `last_agent_message`, and the timestamps
  required, and by done-means clause (c), which feeds a `task_complete` missing
  `turn_id` and asserts it STILL raises `MalformedCodexRecordError`.
- Assumptions that could be wrong: that `time_to_first_token_ms` is purely
  telemetry. Checked against the adapter — no turn content, role, or identity is
  derived from it. If a future consumer wants latency data it now has to handle
  `None`, which is the honest shape of the source.
- Missing/weak tests: the done-means covers the parser end-to-end, but capture is
  NOT wired to the Codex reader by this PR, so nothing here proves a Codex hook
  writes a row. That is stated as a gap in the doc rather than implied to work.
  There is no automated test for the hook trust behaviour — it is a property of
  the Codex binary, evidenced by measurement in the doc, not by CI.
- Security/permission risk: none introduced. No auth, namespace, or SQL path is
  touched; namespace stays token-derived server-side. The doc explicitly forbids
  hardcoding a host and points at `$OPENBRAIN_BASE_URL`/`$OPENBRAIN_TOKEN`.
- Migration/deploy risk: none. Making a field optional is backward compatible —
  every record that parsed before still parses, and the fixtures prove it.
- Downstream client/runtime risk: Codex is a downstream runtime, so
  `docs/downstream-rollout.md` applies. This PR changes no MCP tool, schema, or
  transport contract; it fixes a client-side parser and adds documentation. The
  `mcp2cli` route for Codex is unchanged and done-means clause (e) enforces that.
- Rollback/cleanup concern: revert is a single-field revert. The probe hooks used
  to measure trust behaviour were removed and `~/.codex/hooks.json` was restored
  from a timestamped backup; verified no probe references remain.
- Fixes made before PR: two. (1) The first done-means fixture invented a
  `user_message` shape without the attachment fields — measuring 391 real records
  showed all of them carry `images`/`local_images`/`audio`/`local_audio`/
  `text_elements`, so the FIXTURE was wrong, not the code, and it was corrected to
  the observed shape. (2) The check originally targeted
  `capture.records.raw_turn_from_line`; searching the repo first surfaced the
  existing bulk Codex adapter, so the gate was retargeted to reuse it instead of
  adding a second parser.
- Known residual risk: capture is not routed to the Codex reader by transcript
  shape yet, so a Codex session still does not write turns. The parser is now
  correct and proven over 27k real lines; the routing is follow-on work, named as
  gap 4 in the adapter doc.
- SME review-memory update: [x] not applicable because: the findings here are runtime surface facts and a schema-drift fix, captured in docs/codex-adapter.md where the next agent wiring Codex will read them; no review-lane pattern changed.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this PR changes a transcript parser and adds documentation; it wires no hook and performs no Open Brain read or write. The live measurements that back it are Codex-side and are recorded in docs/codex-adapter.md.
