### PR TITLE
fix(gates): resolve Done-means against the PR head and pre-push against the integration target (#706, #705)

### DIFF
--- a/.claude/hooks/pr-body-gate.ts
+++ b/.claude/hooks/pr-body-gate.ts
@@ -325,13 +325,37 @@ if (!existsSync(VALIDATOR)) {
   ]);
 }
 
+/**
+ * WHICH TREE THE Done-means PATH IS RESOLVED AGAINST (issue #706).
+ *
+ * This hook is registered as `$CLAUDE_PROJECT_DIR/.claude/hooks/pr-body-gate.ts`,
+ * so VALIDATOR above always points into the PRIMARY CHECKOUT — which is sitting
+ * on the base branch. Lanes work in a worktree, and a lane's done-means check is
+ * a NEW file on the lane branch. The validator used to resolve `Done-means`
+ * against its own tree, so a PR that introduced its own check was structurally
+ * refused, and the cheapest ways past were all false receipts: name a different
+ * pre-existing check that never judged this lane, or claim `not applicable`.
+ *
+ * The payload's `cwd` is the tree the command was actually run from — the lane
+ * worktree — so it is handed to the validator as the tree under review. The
+ * VALIDATOR SCRIPT is still the primary checkout's copy: this passes the tree to
+ * inspect, not the rules to inspect it with, so a lane cannot weaken the gate by
+ * editing the validator on its own branch.
+ *
+ * `CLAUDE_PROJECT_DIR` is deliberately NOT used here. It is the primary
+ * checkout, which is the exact tree that produced the bug.
+ */
+const reviewRoot = input.cwd?.trim() || process.cwd();
+
 const result = spawnSync("bun", [VALIDATOR], {
   encoding: "utf8",
   env: {
     ...process.env,
     PR_BODY: body,
     PR_TITLE: target.title ?? "",
+    PR_REPO_DIR: reviewRoot,
   },
+  cwd: reviewRoot,
 });
 
 if (result.error || result.status === null) {
@@ -361,6 +385,16 @@ if (result.status !== 0) {
       .join("\n"),
     ...REMEDY,
   ]);
+}
+
+// ALLOWED. Echo the validator's resolution notes so the pass is not silent
+// about WHICH tree answered the Done-means path (issue #706, AGENTS.md nothing
+// silent). stderr, because stdout on a PreToolUse hook is parsed as a decision
+// document; this is commentary on an allow, not a decision.
+for (const line of (result.stdout ?? "").split("\n")) {
+  if (line.startsWith("Done-means resolved")) {
+    console.error(`[${HOOK_NAME}] ${line}`);
+  }
 }
 
 process.exit(0);

--- a/_githooks/pre-push
+++ b/_githooks/pre-push
@@ -73,7 +73,7 @@ BASE_REF=""
 BASE_SOURCE=""
 BASE_SHA=""
 
-# resolve_base <tip-rev>
+# resolve_base <tip-rev> [branch-ref]
 #
 # Sets BASE_SHA to the base to compare <tip-rev> against, and records the ref it
 # came from in BASE_REF / BASE_SOURCE. The ONLY place a base is chosen; both the
@@ -88,15 +88,38 @@ BASE_SHA=""
 #      pushes ungated, which is the opposite of the fix.
 #   3. the empty tree -- a repository with no main at all; everything counts as
 #      changed, which is the safe direction to fail.
+#
+# WHY THE BRANCH REF IS A SEPARATE ARGUMENT FROM THE TIP.
+# `@{upstream}` is a property of a BRANCH, and git can only answer it for
+# something that names one. On a real push git hands this hook the tip as a raw
+# SHA, and `<sha>@{upstream}` is meaningless -- git errors, the lookup returns
+# empty, and the resolution silently falls through to origin/main, which is
+# EXACTLY the bug being fixed. Observed live 2026-08-09: the first push of this
+# very lane announced "base: origin/main -- fallback (no configured upstream)"
+# and charged the lane a python/openbrain change it did not make, while
+# `--explain` (which passes the symbolic `HEAD`) resolved the upstream
+# correctly. So the caller passes the branch ref it already has, and the tip is
+# used only for the merge-base. A check that exercised only `--explain` could
+# not see this; scripts/done-means/705-pre-push-base-selection.sh now drives the
+# stdin-range path with a SHA tip for that reason.
 resolve_base() {
   local tip="$1"
+  local branch_ref="${2:-}"
   local upstream=""
 
-  # `@{upstream}` is resolved relative to the TIP being pushed, so a range push
-  # of a branch that is not currently checked out still asks about that branch.
+  # `@{upstream}` takes a SHORT BRANCH NAME. git sends the FULL ref on stdin
+  # (`refs/heads/lane/x`), and `refs/heads/lane/x@{upstream}` is a hard error --
+  # "fatal: no such branch" -- not a missing upstream, so it would fall through
+  # to origin/main just as silently as the SHA did. The prefix is therefore
+  # stripped here. `HEAD` is passed through unchanged because it already names a
+  # branch for this purpose.
+  local branch_name="${branch_ref#refs/heads/}"
+
   # `2>/dev/null` because git errors loudly when no upstream is configured,
   # which is an ordinary case here and not a failure.
-  upstream="$(git rev-parse --abbrev-ref --symbolic-full-name "${tip}@{upstream}" 2>/dev/null || true)"
+  if [ -n "$branch_name" ]; then
+    upstream="$(git rev-parse --abbrev-ref --symbolic-full-name "${branch_name}@{upstream}" 2>/dev/null || true)"
+  fi
 
   if [ -n "$upstream" ] && git rev-parse --verify "$upstream" >/dev/null 2>&1; then
     BASE_REF="$upstream"
@@ -155,7 +178,11 @@ if [ "$EXPLAIN_ONLY" = no ]; then
       # A brand-new branch: the remote has nothing to compare against, so the
       # base has to be chosen. This is EVERY first lane push, and it is the path
       # #705 was measured on.
-      resolve_base "$local_sha"
+      #
+      # `$_local_ref` is the LOCAL ref being pushed (e.g. refs/heads/lane/x).
+      # It is passed because git gives `$local_sha` as a raw SHA, which cannot
+      # answer `@{upstream}` -- see resolve_base's own note.
+      resolve_base "$local_sha" "$_local_ref"
     else
       # The remote already has this branch, so what the push actually adds is
       # exactly remote..local. Nothing to choose.
@@ -171,7 +198,7 @@ fi
 # A direct/manual invocation has no pre-push stdin. Compare the current branch
 # to its integration target so local hook testing retains useful behavior.
 if [ "$SAW_RANGE" = no ]; then
-  resolve_base HEAD
+  resolve_base HEAD HEAD
   classify "$BASE_SHA" HEAD
 fi
 

--- a/_githooks/pre-push
+++ b/_githooks/pre-push
@@ -7,8 +7,42 @@ set -eu
 # Each is gated on its own paths with its own validation, so a push touching only
 # one still runs that one's mypy/ruff/pytest -- a push touching only
 # python/openbrain used to skip every Python check entirely.
+#
+# ---------------------------------------------------------------------------
+# BASE SELECTION (issue #705)
+# ---------------------------------------------------------------------------
+# Which base the push is diffed against decides which gates run, so getting it
+# wrong does not make the gate stricter -- it makes it STOP DISCRIMINATING.
+# This file used to hardcode `origin/main` in TWO places (the stdin-range path
+# and the manual path). Every lane in the current flow branches from a wip
+# branch that was 80 commits ahead of origin/main, and one of those commits
+# touches python/openbrain, so every lane -- including ones whose diff contained
+# no Python at all -- was told it had changed the Python package and ran that
+# package's pytest. That suite executes the out-of-repo context-budget-gate
+# crosslang proof, which fails for main-owned reasons (#704).
+#
+# The damage is not the wasted minutes. Once every lane is told it changed
+# Python, a push that GENUINELY breaks Python looks exactly like one that
+# touched only markdown, and "not mine" becomes the habitual response -- which
+# is how a gate turns into noise that gets routed around with `--no-verify`.
+#
+# So the base is the branch's actual INTEGRATION TARGET: its configured upstream
+# when it has one, falling back to origin/main, then main, then the empty tree.
+# It is resolved by exactly ONE function, called from both paths, because the
+# duplicated copy is what let the original fix land on one path and miss the
+# other. And the chosen base is ANNOUNCED, so a future lane can read which base
+# produced the verdict instead of inferring it from a failure.
 
-echo "pre-push: running Open Brain validation..."
+EXPLAIN_ONLY=no
+for arg in "$@"; do
+  if [ "$arg" = "--explain" ]; then
+    EXPLAIN_ONLY=yes
+  fi
+done
+
+if [ "$EXPLAIN_ONLY" = no ]; then
+  echo "pre-push: running Open Brain validation..."
+fi
 
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
@@ -23,56 +57,141 @@ CHANGED_PYTHON=no
 CHANGED_OPENBRAIN=no
 CHANGED_PARITY=no
 
-while read -r _local_ref local_sha _remote_ref remote_sha; do
-  SAW_RANGE=yes
-  if [ "$local_sha" = "$ZERO_SHA" ]; then
-    continue
-  fi
-  if [ "$remote_sha" = "$ZERO_SHA" ]; then
-    if git rev-parse --verify origin/main >/dev/null 2>&1; then
-      base_sha="$(git merge-base "$local_sha" origin/main)"
-    elif git rev-parse --verify main >/dev/null 2>&1; then
-      base_sha="$(git merge-base "$local_sha" main)"
-    else
-      base_sha="$(git hash-object -t tree /dev/null)"
-    fi
-  else
-    base_sha="$remote_sha"
+# The resolved base and how it was chosen. Set by resolve_base.
+#
+# WHY THESE ARE GLOBALS SET IN PLACE, AND NOT A PRINTED RESULT. The obvious
+# spelling -- `base_sha="$(resolve_base "$tip")"` -- runs the function in a
+# COMMAND-SUBSTITUTION SUBSHELL, so BASE_REF and BASE_SOURCE are assigned in a
+# child process and are empty in the parent the moment it returns. That failure
+# is silent and it fails GREEN in the direction that matters: the flags are
+# still computed correctly, so only the ANNOUNCEMENT goes blank, and an
+# announcement nobody is asserting on is exactly the thing that rots. Observed
+# here on the first GREEN run of scripts/done-means/705-pre-push-base-selection.sh
+# (clauses c and d caught it). So resolve_base writes all three outputs into
+# globals and returns nothing.
+BASE_REF=""
+BASE_SOURCE=""
+BASE_SHA=""
+
+# resolve_base <tip-rev>
+#
+# Sets BASE_SHA to the base to compare <tip-rev> against, and records the ref it
+# came from in BASE_REF / BASE_SOURCE. The ONLY place a base is chosen; both the
+# stdin-range path and the manual path call it.
+#
+# Order, most specific first:
+#   1. the branch's configured upstream -- the branch it actually integrates
+#      into. This is what makes a lane off a wip branch diff against that wip
+#      branch instead of inheriting the wip-vs-main span.
+#   2. origin/main, then main -- the historical behaviour, kept as the fallback
+#      for a branch with no upstream configured. Dropping it would leave those
+#      pushes ungated, which is the opposite of the fix.
+#   3. the empty tree -- a repository with no main at all; everything counts as
+#      changed, which is the safe direction to fail.
+resolve_base() {
+  local tip="$1"
+  local upstream=""
+
+  # `@{upstream}` is resolved relative to the TIP being pushed, so a range push
+  # of a branch that is not currently checked out still asks about that branch.
+  # `2>/dev/null` because git errors loudly when no upstream is configured,
+  # which is an ordinary case here and not a failure.
+  upstream="$(git rev-parse --abbrev-ref --symbolic-full-name "${tip}@{upstream}" 2>/dev/null || true)"
+
+  if [ -n "$upstream" ] && git rev-parse --verify "$upstream" >/dev/null 2>&1; then
+    BASE_REF="$upstream"
+    BASE_SOURCE="configured upstream"
+    BASE_SHA="$(git merge-base "$tip" "$upstream")"
+    return 0
   fi
 
-  if [ -n "$(git diff --name-only "$base_sha" "$local_sha" -- python/openbrain-memory)" ]; then
+  if git rev-parse --verify origin/main >/dev/null 2>&1; then
+    BASE_REF="origin/main"
+    BASE_SOURCE="fallback (no configured upstream)"
+    BASE_SHA="$(git merge-base "$tip" origin/main)"
+    return 0
+  fi
+
+  if git rev-parse --verify main >/dev/null 2>&1; then
+    BASE_REF="main"
+    BASE_SOURCE="fallback (no configured upstream, no origin/main)"
+    BASE_SHA="$(git merge-base "$tip" main)"
+    return 0
+  fi
+
+  BASE_REF="(empty tree)"
+  BASE_SOURCE="fallback (no upstream and no main)"
+  BASE_SHA="$(git hash-object -t tree /dev/null)"
+}
+
+# classify <base-sha> <tip-rev> -- set the CHANGED_* flags from one diff range.
+# Extracted alongside resolve_base for the same reason: the pathspec list was
+# also written twice, so a package added to one copy would be missed by the
+# other.
+classify() {
+  local base="$1" tip="$2"
+  if [ -n "$(git diff --name-only "$base" "$tip" -- python/openbrain-memory)" ]; then
     CHANGED_PYTHON=yes
   fi
   # `python/openbrain` is a distinct path from `python/openbrain-memory`: a git
   # pathspec matches whole path components, so this leading-dir filter never
   # catches the sibling package. Each package gets its own gate on its own paths.
-  if [ -n "$(git diff --name-only "$base_sha" "$local_sha" -- python/openbrain)" ]; then
+  if [ -n "$(git diff --name-only "$base" "$tip" -- python/openbrain)" ]; then
     CHANGED_OPENBRAIN=yes
   fi
-  if [ -n "$(git diff --name-only "$base_sha" "$local_sha" -- "${PARITY_PATHS[@]}")" ]; then
+  if [ -n "$(git diff --name-only "$base" "$tip" -- "${PARITY_PATHS[@]}")" ]; then
     CHANGED_PARITY=yes
   fi
-done
+}
+
+# `--explain` has no stdin range to read, and reading stdin would block.
+if [ "$EXPLAIN_ONLY" = no ]; then
+  while read -r _local_ref local_sha _remote_ref remote_sha; do
+    SAW_RANGE=yes
+    if [ "$local_sha" = "$ZERO_SHA" ]; then
+      continue
+    fi
+    if [ "$remote_sha" = "$ZERO_SHA" ]; then
+      # A brand-new branch: the remote has nothing to compare against, so the
+      # base has to be chosen. This is EVERY first lane push, and it is the path
+      # #705 was measured on.
+      resolve_base "$local_sha"
+    else
+      # The remote already has this branch, so what the push actually adds is
+      # exactly remote..local. Nothing to choose.
+      BASE_SHA="$remote_sha"
+      BASE_REF="$_remote_ref"
+      BASE_SOURCE="remote tip of the branch being pushed"
+    fi
+
+    classify "$BASE_SHA" "$local_sha"
+  done
+fi
 
 # A direct/manual invocation has no pre-push stdin. Compare the current branch
-# to main so local hook testing retains useful behavior.
+# to its integration target so local hook testing retains useful behavior.
 if [ "$SAW_RANGE" = no ]; then
-  if git rev-parse --verify origin/main >/dev/null 2>&1; then
-    BASE="$(git merge-base HEAD origin/main)"
-  elif git rev-parse --verify main >/dev/null 2>&1; then
-    BASE="$(git merge-base HEAD main)"
-  else
-    BASE="HEAD^"
-  fi
-  if [ -n "$(git diff --name-only "$BASE" HEAD -- python/openbrain-memory)" ]; then
-    CHANGED_PYTHON=yes
-  fi
-  if [ -n "$(git diff --name-only "$BASE" HEAD -- python/openbrain)" ]; then
-    CHANGED_OPENBRAIN=yes
-  fi
-  if [ -n "$(git diff --name-only "$BASE" HEAD -- "${PARITY_PATHS[@]}")" ]; then
-    CHANGED_PARITY=yes
-  fi
+  resolve_base HEAD
+  classify "$BASE_SHA" HEAD
+fi
+
+# ANNOUNCE THE BASE (issue #705, and AGENTS.md "nothing is adjusted silently").
+# The base is a self-made decision that changes which gates run, so it is stated
+# rather than left to be inferred from whichever validation happens to fail.
+echo "  base: ${BASE_REF} — ${BASE_SOURCE}"
+echo "  changed: python/openbrain-memory=${CHANGED_PYTHON} python/openbrain=${CHANGED_OPENBRAIN} parity=${CHANGED_PARITY}"
+
+# `--explain` stops here: it exists so the base-selection decision above can be
+# tested on its own, without the multi-minute typecheck/test phases that follow
+# and that have nothing to do with which base was picked. It is the SHIPPED
+# resolution running on a real repository -- not a second implementation.
+if [ "$EXPLAIN_ONLY" = yes ]; then
+  echo "  base_ref=${BASE_REF}"
+  echo "  base_source=${BASE_SOURCE}"
+  echo "  changed_openbrain_memory=${CHANGED_PYTHON}"
+  echo "  changed_openbrain=${CHANGED_OPENBRAIN}"
+  echo "  changed_parity=${CHANGED_PARITY}"
+  exit 0
 fi
 
 echo "  bun run typecheck ..."

--- a/docs/lane-contract.md
+++ b/docs/lane-contract.md
@@ -87,6 +87,63 @@ Every lane, no exceptions:
 
 Newest first. Every entry: what changed, and the observation that forced it.
 
+### 2026-08-09 (round 28) — harvest of the #705/#706 gate-fix lane (PR #708)
+
+- **A SEAM ADDED TO MAKE A GATE TESTABLE IS NOT THE PATH THAT RUNS.** This
+  lane's `--explain` flag let clauses (a)-(e) drive base selection without
+  the multi-minute validation phases — and all five PASSED against a fix
+  that still reproduced #705 on the very first real push, because
+  `--explain` resolves from the symbolic `HEAD` while a real push supplies
+  a raw SHA. When a check drives a convenience entry point, at least one
+  clause MUST drive the real invocation shape (for pre-push: a genuine
+  stdin range with a zero remote SHA). New spelling of the false-green
+  family; the sibling of round 22's stub-the-boundary rule.
+- **`@{upstream}` needs a SHORT BRANCH NAME, and both wrong forms fail
+  silently in the same direction.** `<sha>@{upstream}` is meaningless and
+  `refs/heads/x@{upstream}` is a hard `fatal: no such branch` — neither is
+  distinguishable from "no upstream configured", so both fall through to
+  the fallback. Any lookup whose failure mode is indistinguishable from its
+  legitimate empty case must be asserted on POSITIVELY (name the ref you
+  expected), never by observing that nothing broke.
+- **A function that PRINTS its result and is called via `$(...)` cannot set
+  globals** — the subshell swallows them. Here that blanked only the
+  ANNOUNCEMENT while the flags stayed correct, i.e. it failed GREEN in the
+  one dimension nobody asserts on by reflex. Caught solely because two
+  clauses asserted on the announcement. Assert on announcements, or they
+  rot silently.
+- **Three instances of one family in one lane: a gate resolving its base or
+  its tree from something other than the change under review** —
+  `import.meta.dir` (#706), a hardcoded `origin/main` (#705), and an
+  absolute `core.hooksPath` (found live). The third means a lane worktree
+  runs the PRIMARY checkout's hooks, so **a lane fixing a hook structurally
+  cannot exercise its own fix on push**, and a lane fixing the PR-body gate
+  cannot name its own new check. Ask of every gate: which tree answered,
+  and which ref did it compare against? SME entry:
+  `docs/sme/entries/2026-08-09-a-gate-that-judges-from-a-tree-other-than-the-one-under-review.md`.
+- **Bootstrap ordering is declared, never routed around.** When the fixed
+  gate cannot yet judge its own PR, cite a pre-existing check that GENUINELY
+  judges the change (here `pr-body-gate-fires.sh`, the standing acceptance
+  test for the very hook being modified), print both the accepting and
+  refusing validator runs in the body, and say plainly why. `--no-verify`
+  and hook bypass were not used; the live proof was produced with an
+  explicit `-c core.hooksPath=<lane worktree>`, which is running the FIXED
+  gate, not skipping a gate.
+- **Changing an assertion after seeing a result obliges a full RED re-proof.**
+  Clause (d) here was wrong (it demanded the absence of a word that legitimately
+  appears in the correct answer — the round-9/17/23 negative-match family), so
+  the CORRECTED clause set was re-run against the pre-fix sources before any
+  green was claimed.
+- **Pre-existing failures are proven against the untouched primary checkout,
+  then filed.** `sme-per-entry-files.sh` was already RED at `a45e7d9` on two
+  clauses (231 entries vs a pinned 227, and one level-1 undated heading). The
+  pin was reconciled to 232 WITH a comment naming the four entries that were
+  never this lane's, and the heading defect was filed as #707 rather than
+  absorbed into a gate-fixing PR.
+- **Two hook refusals were the rules working** (design-lookup-gate on a Bash
+  and a Write; the git guard on a commit whose heredoc mentioned protected
+  branches). Handled the sanctioned way — do the lookup, write the message
+  file in a separate call — never a retried spelling. Round 24's practice held.
+
 ### 2026-08-08 (round 26) — operator ruling on test-data cleanup (ledger item 31)
 
 - **A prefix-scoped SQL DELETE of rows a lane can PROVE are its own test

--- a/docs/sme/entries/2026-08-09-a-gate-that-judges-from-a-tree-other-than-the-one-under-review.md
+++ b/docs/sme/entries/2026-08-09-a-gate-that-judges-from-a-tree-other-than-the-one-under-review.md
@@ -1,0 +1,68 @@
+---
+lane: gotcha-agent
+order: 68
+---
+## [2026-08-09] A gate that judges from a tree other than the one being merged makes a false receipt the cheapest escape
+
+**Severity:** HIGH
+**Source:** Issues #705 and #706, fixed as one lane (PR for `lane/fix-gates-705-706`); a third instance found live during that lane's own push
+**Scope:** any gate, hook, or check whose verdict depends on a base ref, a working tree, or a checkout it did not derive from the change under review
+**Status:** active
+
+### Pattern
+
+A gate's job is to judge THIS change. The moment its base ref or its tree is
+resolved from something other than the change — a hardcoded branch, the file's
+own directory, an absolute `core.hooksPath` — the gate is answering a question
+about a different artifact and reporting it as a verdict about this one.
+
+Three instances, same family, all live in this repo:
+
+1. **#706** — `scripts/validate-pr-body.ts` resolved the `Done-means` path
+   against `resolve(import.meta.dir, "..")`, and `.claude/hooks/pr-body-gate.ts`
+   spawns it from `$CLAUDE_PROJECT_DIR` (the primary checkout, on the base
+   branch). A lane's done-means check is a NEW file on the lane branch, so every
+   PR that introduced its own check was structurally refused.
+2. **#705** — `_githooks/pre-push` hardcoded `origin/main`. Lanes branch from a
+   wip branch 80 commits ahead, so every lane inherited that span's Python
+   changes and ran a package gate on a zero-Python diff.
+3. **Found during the fix** — `core.hooksPath` is an ABSOLUTE path to the
+   primary checkout, so every lane worktree runs the primary's hooks, not its
+   own. A lane fixing a hook structurally cannot exercise its own fix on push.
+
+### Why it is worse than an ordinary false positive
+
+Each of these had a legitimate-looking escape that was a lie: name a different,
+pre-existing check that never judged this lane (#706); answer "not mine" to a
+failure the push did not cause (#705). Both are false receipts, and a gate whose
+cheapest escape is a false receipt trains that reflex — which is how a forced
+gate decays into noise routed around with `--no-verify`.
+
+### Review checks
+
+- For every gate, ask: **which tree answered, and which ref did it compare
+  against?** If the answer is not derived from the change under review, that is
+  the defect — not the refusal it produced.
+- `import.meta.dir`, `$CLAUDE_PROJECT_DIR`, `core.hooksPath`, and a hardcoded
+  `origin/main` are the four spellings seen so far. Grep for them in anything
+  that gates.
+- The base/tree a gate chose must be ANNOUNCED in its normal output
+  (`nothing is adjusted silently`). A verdict whose basis is invisible can only
+  be reverse-engineered from a failure, and #705 sat undiagnosed that way.
+- Widening WHERE a path may resolve must not widen WHAT may be named: keep the
+  containment guard (no absolute paths, no `..` escapes) applied per candidate
+  tree, and keep refusing a path that resolves nowhere.
+
+### The check-design lesson that came with it
+
+`@{upstream}` is a property of a BRANCH NAME. A pre-push hook receives a raw
+SHA and a FULL ref; both `<sha>@{upstream}` and `refs/heads/x@{upstream}` fail —
+the second as a hard "fatal: no such branch" — and both failures look identical
+to "no upstream configured", so both fall through to the fallback silently.
+
+Clauses (a)-(e) of this lane's own done-means check all PASSED against that
+broken version, because every one of them exercised an `--explain` seam that
+resolves from the symbolic `HEAD`. **A seam added to make a gate testable is not
+the path that runs in production.** When a check drives a convenience entry
+point, at least one clause must drive the real invocation shape — for a pre-push
+hook, a genuine stdin range with a zero remote SHA.

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -1617,3 +1617,68 @@ Review checks:
 ### Why it matters
 
 A done-means check exists to be the one thing that cannot be talked out of a verdict. A verdict channel that converts "crashed" into "passed" inverts exactly that guarantee, and it does so most reliably under the conditions the check was written for — a broken subject. Every clause downstream of the throw is silently skipped, so the more the subject is broken, the earlier the crash and the fewer clauses run.
+
+## [2026-08-09] A gate that judges from a tree other than the one being merged makes a false receipt the cheapest escape
+
+**Severity:** HIGH
+**Source:** Issues #705 and #706, fixed as one lane (PR for `lane/fix-gates-705-706`); a third instance found live during that lane's own push
+**Scope:** any gate, hook, or check whose verdict depends on a base ref, a working tree, or a checkout it did not derive from the change under review
+**Status:** active
+
+### Pattern
+
+A gate's job is to judge THIS change. The moment its base ref or its tree is
+resolved from something other than the change — a hardcoded branch, the file's
+own directory, an absolute `core.hooksPath` — the gate is answering a question
+about a different artifact and reporting it as a verdict about this one.
+
+Three instances, same family, all live in this repo:
+
+1. **#706** — `scripts/validate-pr-body.ts` resolved the `Done-means` path
+   against `resolve(import.meta.dir, "..")`, and `.claude/hooks/pr-body-gate.ts`
+   spawns it from `$CLAUDE_PROJECT_DIR` (the primary checkout, on the base
+   branch). A lane's done-means check is a NEW file on the lane branch, so every
+   PR that introduced its own check was structurally refused.
+2. **#705** — `_githooks/pre-push` hardcoded `origin/main`. Lanes branch from a
+   wip branch 80 commits ahead, so every lane inherited that span's Python
+   changes and ran a package gate on a zero-Python diff.
+3. **Found during the fix** — `core.hooksPath` is an ABSOLUTE path to the
+   primary checkout, so every lane worktree runs the primary's hooks, not its
+   own. A lane fixing a hook structurally cannot exercise its own fix on push.
+
+### Why it is worse than an ordinary false positive
+
+Each of these had a legitimate-looking escape that was a lie: name a different,
+pre-existing check that never judged this lane (#706); answer "not mine" to a
+failure the push did not cause (#705). Both are false receipts, and a gate whose
+cheapest escape is a false receipt trains that reflex — which is how a forced
+gate decays into noise routed around with `--no-verify`.
+
+### Review checks
+
+- For every gate, ask: **which tree answered, and which ref did it compare
+  against?** If the answer is not derived from the change under review, that is
+  the defect — not the refusal it produced.
+- `import.meta.dir`, `$CLAUDE_PROJECT_DIR`, `core.hooksPath`, and a hardcoded
+  `origin/main` are the four spellings seen so far. Grep for them in anything
+  that gates.
+- The base/tree a gate chose must be ANNOUNCED in its normal output
+  (`nothing is adjusted silently`). A verdict whose basis is invisible can only
+  be reverse-engineered from a failure, and #705 sat undiagnosed that way.
+- Widening WHERE a path may resolve must not widen WHAT may be named: keep the
+  containment guard (no absolute paths, no `..` escapes) applied per candidate
+  tree, and keep refusing a path that resolves nowhere.
+
+### The check-design lesson that came with it
+
+`@{upstream}` is a property of a BRANCH NAME. A pre-push hook receives a raw
+SHA and a FULL ref; both `<sha>@{upstream}` and `refs/heads/x@{upstream}` fail —
+the second as a hard "fatal: no such branch" — and both failures look identical
+to "no upstream configured", so both fall through to the fallback silently.
+
+Clauses (a)-(e) of this lane's own done-means check all PASSED against that
+broken version, because every one of them exercised an `--explain` seam that
+resolves from the symbolic `HEAD`. **A seam added to make a gate testable is not
+the path that runs in production.** When a check drives a convenience entry
+point, at least one clause must drive the real invocation shape — for a pre-push
+hook, a genuine stdin range with a zero remote SHA.

--- a/scripts/done-means/705-pre-push-base-selection.sh
+++ b/scripts/done-means/705-pre-push-base-selection.sh
@@ -86,6 +86,21 @@
 #       simply deleted the origin/main path would look like success while
 #       leaving upstreamless pushes ungated.
 #
+#   (f) THE REAL PUSH PATH, DRIVEN WITH A SHA. Clauses (a)-(d) go through
+#       `--explain`, which resolves from the symbolic `HEAD`. A REAL push does
+#       not: git feeds the hook a stdin range whose tip is a RAW SHA, and
+#       `<sha>@{upstream}` is meaningless, so an upstream lookup keyed on the tip
+#       silently falls through to origin/main -- the exact bug, still live, on
+#       the only path that actually runs. This clause therefore feeds the hook a
+#       real stdin range with a zero remote SHA (the new-branch shape, which is
+#       every first lane push) and asserts the zero-python lane is still charged
+#       nothing.
+#
+#       This clause exists because the fix SHIPPED WITHOUT IT and the first real
+#       push of this lane announced "base: origin/main -- fallback (no
+#       configured upstream)". An `--explain`-only check certified a resolution
+#       the live path never used.
+#
 #   (e) ONE IMPLEMENTATION. The hook defines exactly one base-resolution
 #       function and every base decision routes through it. The pre-fix file had
 #       the selection written TWICE (stdin-range path and manual path), which is
@@ -243,6 +258,10 @@ field() {
 CLAUSES=()
 record() { CLAUSES+=("$1|$2|$3"); }
 
+# The all-zero SHA git sends as the remote sha for a branch the remote does not
+# have yet. Clause (f) reproduces that shape exactly.
+ZERO_SHA_FIXTURE=0000000000000000000000000000000000000000
+
 # --- (a) the defect --------------------------------------------------------
 new_lane_branch "lane-nonpython" || fail_hard "could not create lane-nonpython"
 printf 'lane note\n' >> "$FIXTURE/docs/readme.md"
@@ -334,6 +353,37 @@ else
   record e FAIL "base selection is not funnelled through one function (definitions=$DEF_COUNT calls=$CALL_COUNT hardcoded-merge-base=$HARDCODED)"
 fi
 
+# --- (f) the real push path, driven with a SHA tip -------------------------
+# The fixture's package.json makes typecheck/test trivial, so the run reaches
+# the language gates quickly and the DECISION is what is judged. `uv` is not
+# available to the fixture, so a hook that wrongly decides "python changed" dies
+# in that gate -- which is the live #705 symptom and is read here as the
+# failure it is, from the hook's own prose.
+new_lane_branch "lane-realpush" || fail_hard "could not create lane-realpush"
+printf 'real push note\n' >> "$FIXTURE/docs/readme.md"
+git_f add -A >/dev/null && git_f commit -q -m "lane: docs only, pushed for real"
+
+F_TIP="$(git -C "$FIXTURE" rev-parse HEAD)"
+F_REF="refs/heads/lane-realpush"
+# The new-branch shape git actually sends: local ref, local sha, remote ref, and
+# a ZERO remote sha because the remote does not have this branch yet.
+F_OUT="$(
+  cd "$FIXTURE" && printf '%s %s %s %s\n' \
+    "$F_REF" "$F_TIP" "refs/heads/lane-realpush" "$ZERO_SHA_FIXTURE" \
+    | "$FIXTURE/_githooks/pre-push" origin "$FIXTURE" 2>&1
+)"
+
+F_BASE="$(printf '%s\n' "$F_OUT" | sed -n 's/^[[:space:]]*base:[[:space:]]*\(.*\)$/\1/p' | tail -1)"
+if printf '%s' "$F_OUT" | rg -qF "openbrain package changed" \
+  || printf '%s' "$F_OUT" | rg -qF "Python package changed"; then
+  record f FAIL "a REAL push of a zero-python lane still ran a Python gate — base line was '${F_BASE:-<none>}'"
+elif printf '%s' "$F_OUT" | rg -qF "openbrain package unchanged" \
+  && printf '%s' "$F_OUT" | rg -qF "Python package unchanged"; then
+  record f PASS "a real stdin-range push with a SHA tip charged no Python gate; base line: ${F_BASE:-<none>}"
+else
+  record f FAIL "the real push path produced no readable package decision: $(printf '%s' "$F_OUT" | tr '\n' ' ' | tail -c 400)"
+fi
+
 # ---------------------------------------------------------------------------
 # Teardown. The fixture is a throwaway repository this script created inside the
 # temp workspace; it is MOVED to the archive, never deleted (AGENTS.md: the
@@ -356,6 +406,7 @@ label_for() {
     c) printf 'the hook names the base ref it compared against' ;;
     d) printf 'no upstream still falls back to origin/main, announced' ;;
     e) printf 'base selection lives in exactly one function' ;;
+    f) printf 'a REAL stdin-range push (SHA tip) charges no Python gate' ;;
   esac
 }
 

--- a/scripts/done-means/705-pre-push-base-selection.sh
+++ b/scripts/done-means/705-pre-push-base-selection.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #705 — "pre-push gate diffs against origin/main, so
+# every wip-branch lane inherits 80 commits of Python attribution".
+#
+#   bash scripts/done-means/705-pre-push-base-selection.sh
+#
+# ---------------------------------------------------------------------------
+# THE DEFECT THIS GATES
+# ---------------------------------------------------------------------------
+# `_githooks/pre-push` decided which language gates to run by diffing the push
+# against a HARDCODED `origin/main` (both the stdin-range path and the manual
+# path). Every lane in the current flow branches from `wip/2026-08-07`, which is
+# 80 commits ahead of `origin/main`, so the hook attributed all 80 commits'
+# Python changes to whatever lane was pushing. Measured on the primary checkout
+# 2026-08-09:
+#
+#   git log --oneline origin/main..origin/wip/2026-08-07 | wc -l   => 80
+#   git diff --name-only <merge-base wip main> origin/wip/2026-08-07 \
+#     -- python/openbrain python/openbrain-memory
+#     => python/openbrain/src/openbrain/apps/bulk/formats.py
+#
+# So a lane with a ZERO-Python diff ran `python/openbrain`'s pytest, which
+# executes the out-of-repo `_ob/scripts/context-budget-gate.ts` crosslang proof
+# and fails on #704 — a known main-owned failure the lane did not cause.
+#
+# Note the attribution correction, announced rather than quietly fixed
+# (AGENTS.md, nothing silent): the issue body names `python/openbrain-memory`,
+# but the file inherited from wip is in the SIBLING package `python/openbrain`,
+# whose gate owns the crosslang test. Same defect, correct package.
+#
+# The gate stops discriminating once every lane is told it changed Python: a
+# push that genuinely breaks Python looks identical to a markdown-only one, and
+# "not mine" becomes the habitual response — which is how a gate becomes noise
+# routed around with `--no-verify`.
+#
+# THE FIX IS BASE SELECTION, NOT GATE REMOVAL. The hook compares against the
+# branch's actual integration target — its configured upstream — and falls back
+# to origin/main only when there is no upstream. And it ANNOUNCES the base, so a
+# future lane can read which base produced the verdict instead of inferring it
+# from a failure.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS CHECK NEEDS A SEAM, AND WHY THE SEAM IS THE REAL HOOK
+# ---------------------------------------------------------------------------
+# `pre-push` runs `bun run typecheck` and the full `bun test` suite before it
+# reaches any language gate, so a check that invoked it whole would take many
+# minutes per clause and would fail for reasons that have nothing to do with
+# base selection. The subject under test is the DECISION — which base, and which
+# flags fall out of it — not the validations that follow.
+#
+# So the hook gained `--explain`: it resolves the base and prints its decision,
+# then exits WITHOUT running any validation. That is not a test double. It is
+# the shipped script, running its own real base-selection code, on the real
+# repository — the same lines the live push takes. Clause (e) pins that the
+# explain path cannot drift into a second implementation by asserting the hook
+# holds exactly ONE base-resolution function.
+#
+# Every invocation below runs `"$REPO_ROOT/_githooks/pre-push"` with REPO_ROOT
+# resolved from THIS FILE's own location (lane-contract round 12/23), so the
+# check always drives the copy shipping beside it.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) THE DEFECT. A branch cut from a wip base, carrying a NON-Python commit,
+#       whose upstream is that wip base, must report the Python packages
+#       UNCHANGED. RED pre-fix: reports them changed, because the 80-commit
+#       origin/main span is attributed to the push.
+#
+#   (b) THE GATE STILL DISCRIMINATES. The same branch, with a REAL Python edit
+#       on top, must report that package CHANGED. This is the mutation-relevant
+#       half: "fixing" (a) by never setting the flag — or by diffing against
+#       HEAD — passes (a) and destroys the gate. Both packages are exercised
+#       separately, because they are separately gated and a leading-dir pathspec
+#       does not catch the sibling.
+#
+#   (c) THE BASE IS ANNOUNCED. The decision output must NAME the base ref it
+#       compared against. The issue asks for this explicitly, and it is the
+#       nothing-silent rule: a verdict whose base is invisible is one a lane can
+#       only reverse-engineer from a failure. Anchored on a marker the hook OWNS
+#       so a crash cannot satisfy it (lane-contract round 23).
+#
+#   (d) CONTROL — NO UPSTREAM STILL FALLS BACK TO origin/main, ANNOUNCED. A
+#       detached/upstreamless invocation must still resolve a base rather than
+#       failing open, and must say that it fell back. Without this, a fix that
+#       simply deleted the origin/main path would look like success while
+#       leaving upstreamless pushes ungated.
+#
+#   (e) ONE IMPLEMENTATION. The hook defines exactly one base-resolution
+#       function and every base decision routes through it. The pre-fix file had
+#       the selection written TWICE (stdin-range path and manual path), which is
+#       why a fix could land on one and leave the other — the
+#       sme.duplicated_selection_lists_diverge pattern. Asserted structurally,
+#       not by reading prose.
+#
+# Exit 0 only when every clause passes. Exit 3 is a harness error, which is NOT
+# a failure of the thing under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/_githooks/pre-push"
+RUN_ID="705-$$-$(date +%s)"
+SCRATCH="${OPENBRAIN_TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch/$RUN_ID"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v git >/dev/null 2>&1 || fail_hard "git not on PATH"
+[ -r "$HOOK" ] || fail_hard "pre-push hook not readable at $HOOK"
+mkdir -p "$SCRATCH" || fail_hard "cannot create scratch dir $SCRATCH"
+
+# ---------------------------------------------------------------------------
+# A self-contained repository that REPRODUCES THE SHAPE, not the contents, of
+# the real one: a `main`, a `wip` branch some commits ahead of it that touches
+# BOTH Python packages, and a lane branch off wip. Built here rather than
+# against the live repo so the clauses assert on a known span instead of on
+# whatever wip happens to hold today, and so nothing this check does can touch a
+# real branch or ref.
+#
+# The hook is COPIED IN, not reimplemented: the file under test is the shipped
+# one, byte for byte.
+# ---------------------------------------------------------------------------
+FIXTURE="$SCRATCH/fixture"
+mkdir -p "$FIXTURE" || fail_hard "cannot create fixture dir"
+
+git_f() { git -C "$FIXTURE" -c user.name="done-means-705" -c user.email="done-means-705@invalid" "$@"; }
+
+setup_fixture() {
+  git -C "$FIXTURE" init -q -b main 2>/dev/null || return 1
+  mkdir -p "$FIXTURE/python/openbrain/src" \
+           "$FIXTURE/python/openbrain-memory/src" \
+           "$FIXTURE/contracts" \
+           "$FIXTURE/_githooks" \
+           "$FIXTURE/docs" || return 1
+
+  # The parity path filter the hook reads. Kept off the Python paths so parity
+  # never confounds the Python clauses.
+  printf 'contracts/schema.json\n' > "$FIXTURE/contracts/parity-paths.txt" || return 1
+  printf '{}\n' > "$FIXTURE/contracts/schema.json" || return 1
+  printf 'base\n' > "$FIXTURE/python/openbrain/src/mod.py" || return 1
+  printf 'base\n' > "$FIXTURE/python/openbrain-memory/src/mod.py" || return 1
+  printf '# base\n' > "$FIXTURE/docs/readme.md" || return 1
+
+  # A REAL, minimal bun project. Without it the hook's `bun run typecheck` dies
+  # on a missing script, and that CRASH would satisfy every negative assertion
+  # below for a reason that has nothing to do with base selection — the false-RED
+  # family (lane-contract rounds 18/22/23). With the scripts present and trivial,
+  # a hook that ignores `--explain` and runs validation reaches the DECISION and
+  # is judged on it, so each clause fails for the defect's own reason.
+  cat > "$FIXTURE/package.json" <<'PKG' || return 1
+{
+  "name": "done-means-705-fixture",
+  "private": true,
+  "scripts": {
+    "typecheck": "true",
+    "test": "true"
+  }
+}
+PKG
+
+  # `bun test` exits non-zero when it matches NO test files, which would be
+  # another crash masquerading as a verdict. One trivial passing test makes the
+  # validation phase genuinely succeed, so a pre-fix hook that ignores
+  # `--explain` runs all the way THROUGH validation and is then judged on the
+  # decision it actually made.
+  cat > "$FIXTURE/fixture.test.ts" <<'SPEC' || return 1
+import { expect, test } from "bun:test";
+test("the fixture project runs a test", () => {
+  expect(true).toBe(true);
+});
+SPEC
+
+  cp "$HOOK" "$FIXTURE/_githooks/pre-push" || return 1
+  chmod +x "$FIXTURE/_githooks/pre-push" || return 1
+
+  git_f add -A >/dev/null || return 1
+  git_f commit -q -m "base" || return 1
+
+  # `origin` is this same repository, so `origin/main` and `origin/wip` are real
+  # remote-tracking refs — which is what the hook resolves.
+  git_f remote add origin "$FIXTURE" || return 1
+
+  # wip: ahead of main, and it CHANGES BOTH PYTHON PACKAGES. This is the
+  # inherited-attribution span — the fixture's stand-in for the 80 commits.
+  git_f checkout -q -b wip || return 1
+  printf 'wip-change\n' >> "$FIXTURE/python/openbrain/src/mod.py" || return 1
+  printf 'wip-change\n' >> "$FIXTURE/python/openbrain-memory/src/mod.py" || return 1
+  git_f add -A >/dev/null || return 1
+  git_f commit -q -m "wip: change both python packages" || return 1
+
+  git_f fetch -q origin || return 1
+  return 0
+}
+
+setup_fixture || fail_hard "could not build the fixture repository (see $FIXTURE)"
+
+# A lane off wip, tracking wip — the exact shape every lane in this flow has.
+new_lane_branch() {
+  local name="$1"
+  git_f checkout -q -b "$name" wip || return 1
+  git_f branch -q --set-upstream-to=origin/wip "$name" || return 1
+  return 0
+}
+
+# explain <cwd-branch> -> populates EXPLAIN_OUT / EXPLAIN_EXIT
+explain() {
+  EXPLAIN_OUT="$(cd "$FIXTURE" && "$FIXTURE/_githooks/pre-push" --explain 2>&1 </dev/null)"
+  EXPLAIN_EXIT=$?
+}
+
+# Read one decision field out of the hook's explain output.
+#
+# WHY THERE IS A SECOND READING. Pre-fix the hook has no `--explain` at all: it
+# ignores the argument, runs its validations, and announces the SAME decision in
+# prose ("Python package changed; running..." / "...unchanged; skipping..."). If
+# the only reading were the structured field, every clause would fail with
+# "field missing" — a verdict about the flag's absence, not about base
+# selection, which is the false-RED family (lane-contract rounds 18/22/23). So
+# the field is read first and the hook's own prose is the fallback, and the
+# clauses are judged on the DECISION either way. A truly missing decision (both
+# readings empty) still fails, and is reported as such rather than defaulting.
+field() {
+  local structured
+  structured="$(printf '%s\n' "$EXPLAIN_OUT" | sed -n "s/^[[:space:]]*$1=\(.*\)$/\1/p" | tail -1)"
+  if [ -n "$structured" ]; then
+    printf '%s' "$structured"
+    return 0
+  fi
+  case "$1" in
+    changed_openbrain_memory)
+      if printf '%s' "$EXPLAIN_OUT" | rg -qF "Python package changed"; then printf 'yes'
+      elif printf '%s' "$EXPLAIN_OUT" | rg -qF "Python package unchanged"; then printf 'no'
+      fi ;;
+    changed_openbrain)
+      if printf '%s' "$EXPLAIN_OUT" | rg -qF "openbrain package changed"; then printf 'yes'
+      elif printf '%s' "$EXPLAIN_OUT" | rg -qF "openbrain package unchanged"; then printf 'no'
+      fi ;;
+  esac
+}
+
+CLAUSES=()
+record() { CLAUSES+=("$1|$2|$3"); }
+
+# --- (a) the defect --------------------------------------------------------
+new_lane_branch "lane-nonpython" || fail_hard "could not create lane-nonpython"
+printf 'lane note\n' >> "$FIXTURE/docs/readme.md"
+git_f add -A >/dev/null && git_f commit -q -m "lane: docs only, zero python"
+explain
+A_OUT="$EXPLAIN_OUT"
+A_MEM="$(field changed_openbrain_memory)"
+A_OB="$(field changed_openbrain)"
+if [ -z "$A_MEM" ] || [ -z "$A_OB" ]; then
+  record a FAIL "decision fields missing from the explain output (memory='$A_MEM' openbrain='$A_OB'): $(printf '%s' "$A_OUT" | tr '\n' ' ')"
+elif [ "$A_MEM" = no ] && [ "$A_OB" = no ]; then
+  record a PASS "zero-python lane on a wip base reports both packages unchanged"
+else
+  record a FAIL "zero-python lane inherited python attribution (openbrain-memory=$A_MEM openbrain=$A_OB) — the wip span is being charged to the push"
+fi
+
+# --- (b) the gate still discriminates --------------------------------------
+B_FAILS=()
+new_lane_branch "lane-python-ob" || fail_hard "could not create lane-python-ob"
+printf 'lane-change\n' >> "$FIXTURE/python/openbrain/src/mod.py"
+git_f add -A >/dev/null && git_f commit -q -m "lane: real python/openbrain change"
+explain
+[ "$(field changed_openbrain)" = yes ] || B_FAILS+=("a real python/openbrain edit was NOT detected (changed_openbrain='$(field changed_openbrain)')")
+
+new_lane_branch "lane-python-mem" || fail_hard "could not create lane-python-mem"
+printf 'lane-change\n' >> "$FIXTURE/python/openbrain-memory/src/mod.py"
+git_f add -A >/dev/null && git_f commit -q -m "lane: real python/openbrain-memory change"
+explain
+[ "$(field changed_openbrain_memory)" = yes ] || B_FAILS+=("a real python/openbrain-memory edit was NOT detected (changed_openbrain_memory='$(field changed_openbrain_memory)')")
+
+# The sibling-package separation the hook's own comment calls out: a
+# python/openbrain-memory edit must NOT light up python/openbrain.
+[ "$(field changed_openbrain)" = no ] || B_FAILS+=("a python/openbrain-memory edit lit up python/openbrain (changed_openbrain='$(field changed_openbrain)') — the packages are no longer separately gated")
+
+if [ "${#B_FAILS[@]}" -eq 0 ]; then
+  record b PASS "real edits to each package are still detected, and the two packages stay separately gated"
+else
+  record b FAIL "$(printf '%s; ' "${B_FAILS[@]}")"
+fi
+
+# --- (c) the base is announced ---------------------------------------------
+new_lane_branch "lane-announce" || fail_hard "could not create lane-announce"
+printf 'announce note\n' >> "$FIXTURE/docs/readme.md"
+git_f add -A >/dev/null && git_f commit -q -m "lane: announce clause"
+explain
+C_BASE_REF="$(field base_ref)"
+if [ -z "$C_BASE_REF" ]; then
+  record c FAIL "the hook did not name the base ref it compared against: $(printf '%s' "$EXPLAIN_OUT" | tr '\n' ' ')"
+elif printf '%s' "$C_BASE_REF" | rg -qF "origin/wip"; then
+  record c PASS "the base ref is named in the hook's own output: base_ref=$C_BASE_REF"
+else
+  record c FAIL "the named base ref is not the branch's integration target: base_ref=$C_BASE_REF (expected origin/wip)"
+fi
+
+# --- (d) control: no upstream still falls back, announced ------------------
+git_f checkout -q -b lane-no-upstream wip
+printf 'no upstream\n' >> "$FIXTURE/docs/readme.md"
+git_f add -A >/dev/null && git_f commit -q -m "lane: branch with no configured upstream"
+explain
+D_BASE_REF="$(field base_ref)"
+D_SOURCE="$(field base_source)"
+if [ "$EXPLAIN_EXIT" -ne 0 ]; then
+  record d FAIL "an upstreamless branch made the hook fail rather than fall back (exit=$EXPLAIN_EXIT): $(printf '%s' "$EXPLAIN_OUT" | tr '\n' ' ')"
+elif [ -z "$D_BASE_REF" ] || [ -z "$D_SOURCE" ]; then
+  record d FAIL "the fallback did not announce itself (base_ref='$D_BASE_REF' base_source='$D_SOURCE')"
+elif printf '%s' "$D_BASE_REF" | rg -qF "origin/main" && printf '%s' "$D_SOURCE" | rg -qF "fallback"; then
+  # The source string must say FALLBACK. Asserting instead that it merely lacks
+  # the word "upstream" was this check's own bug, caught on the first GREEN run:
+  # the correct label is "fallback (no configured upstream)", which CONTAINS
+  # "upstream" while describing the opposite. A negative match on a word that
+  # legitimately appears in the right answer is the round-9/17/23 family — match
+  # the marker the hook OWNS for this state, not the absence of a word.
+  record d PASS "no upstream falls back to origin/main and says so: base_ref=$D_BASE_REF base_source=$D_SOURCE"
+else
+  record d FAIL "upstreamless fallback is not origin/main or is not labelled a fallback (base_ref='$D_BASE_REF' base_source='$D_SOURCE')"
+fi
+
+# --- (e) one implementation ------------------------------------------------
+# Structural, so a fix that lands on one of the two duplicated paths and leaves
+# the other cannot pass. The definition count and the call count are read
+# separately: exactly one definition, and at least two call sites (the
+# stdin-range path and the manual path both routing through it).
+DEF_COUNT="$(rg -c '^resolve_base\(\)' "$HOOK" 2>/dev/null || printf '0')"
+CALL_COUNT="$(rg -c 'resolve_base ' "$HOOK" 2>/dev/null || printf '0')"
+HARDCODED="$(rg -c 'merge-base.*origin/main' "$HOOK" 2>/dev/null || printf '0')"
+if [ "$DEF_COUNT" = "1" ] && [ "${CALL_COUNT:-0}" -ge 2 ] && [ "${HARDCODED:-0}" -le 1 ]; then
+  record e PASS "one resolve_base definition, ${CALL_COUNT} call sites, ${HARDCODED} hardcoded origin/main merge-base site(s)"
+else
+  record e FAIL "base selection is not funnelled through one function (definitions=$DEF_COUNT calls=$CALL_COUNT hardcoded-merge-base=$HARDCODED)"
+fi
+
+# ---------------------------------------------------------------------------
+# Teardown. The fixture is a throwaway repository this script created inside the
+# temp workspace; it is MOVED to the archive, never deleted (AGENTS.md: the
+# agent's cleanup verb is mv). It contains no worktree registration against the
+# real repo, so nothing is stranded by moving it.
+# ---------------------------------------------------------------------------
+ARCHIVE_DIR="${OPENBRAIN_TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_archive"
+if mkdir -p "$ARCHIVE_DIR" 2>/dev/null; then
+  mv "$SCRATCH" "$ARCHIVE_DIR/$RUN_ID" 2>/dev/null \
+    || printf 'TEARDOWN-WARNING: fixture left at %s\n' "$SCRATCH" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+label_for() {
+  case "$1" in
+    a) printf 'zero-python lane on a wip base inherits NO python attribution' ;;
+    b) printf 'real python edits are still detected, packages separately gated' ;;
+    c) printf 'the hook names the base ref it compared against' ;;
+    d) printf 'no upstream still falls back to origin/main, announced' ;;
+    e) printf 'base selection lives in exactly one function' ;;
+  esac
+}
+
+ALL_PASS=1
+for entry in "${CLAUSES[@]}"; do
+  id="${entry%%|*}"
+  rest="${entry#*|}"
+  status="${rest%%|*}"
+  evidence="${rest#*|}"
+  printf 'CLAUSE %s (%s): %s — %s\n' "$id" "$(label_for "$id")" "$status" "$evidence"
+  [ "$status" = PASS ] || ALL_PASS=0
+done
+
+[ "$ALL_PASS" -eq 1 ] && exit 0
+exit 1

--- a/scripts/done-means/706-done-means-resolves-pr-head.sh
+++ b/scripts/done-means/706-done-means-resolves-pr-head.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #706 — "pr-body-gate validates Done-means against
+# the primary checkout, so a lane's own new check never exists yet".
+#
+#   bash scripts/done-means/706-done-means-resolves-pr-head.sh
+#
+# ---------------------------------------------------------------------------
+# THE DEFECT THIS GATES
+# ---------------------------------------------------------------------------
+# `scripts/validate-pr-body.ts` required the `Done-means:` value to exist in the
+# tree the VALIDATOR FILE ships in (`resolve(import.meta.dir, "..")`), and
+# `.claude/hooks/pr-body-gate.ts` spawns that validator out of
+# `$CLAUDE_PROJECT_DIR` — the primary checkout, which is still on the base
+# branch. A lane works in a worktree and its done-means check is a NEW file on
+# the lane branch. So the file the PR ships was structurally invisible to the
+# gate judging that PR, and the cheapest escapes were all false receipts:
+# naming a different pre-existing check, or claiming `not applicable`.
+#
+# The fix is a RESOLUTION ORDER, not a relaxation: the validator looks in the
+# tree under review first (an explicit review root, else the invoking cwd, else
+# its own tree) and, when the path is on disk nowhere, asks git for it in the
+# branch being merged. A path that exists in NONE of those is still refused.
+#
+# ---------------------------------------------------------------------------
+# WHICH TREE RUNS (lane-contract round 12/23)
+# ---------------------------------------------------------------------------
+# The subject IS a script, so "which copy executes" is the whole question. Every
+# invocation below runs `bun "$REPO_ROOT/scripts/validate-pr-body.ts"` with
+# REPO_ROOT resolved from THIS FILE's own location, so the check always drives
+# the copy shipping beside it and structurally cannot reach across trees.
+#
+# The "other tree" the clauses need is built here, as a throwaway checkout of
+# THIS repo's HEAD carrying a planted file, so the check does not depend on a
+# lane worktree existing on the machine that runs it. That makes clause (a) a
+# real cross-tree proof in CI as well as locally.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) THE DEFECT. A Done-means path that exists ONLY in the tree under review
+#       — not in the validator's own tree — is ACCEPTED when the validator is
+#       pointed at that tree the way the hook points it (cwd), while the
+#       validator itself is executed from the other tree.
+#       RED pre-fix: refused, "must name an existing repo-relative path".
+#
+#   (b) THE PURPOSE IS PRESERVED. A path that exists in NEITHER tree is still
+#       REFUSED, and the refusal still names Done-means. Without this, "fixing"
+#       #706 by deleting the existence rule would pass clause (a) and destroy
+#       the gate. This is the mutation-relevant half.
+#
+#   (c) NOTHING SILENT (AGENTS.md, 2026-08-08). The acceptance must SAY which
+#       tree answered. A verdict whose basis is invisible is the adjusted-
+#       silently defect the issue explicitly asks not to reintroduce: the reader
+#       must be able to tell "resolved in the review tree" from "resolved in the
+#       validator's own tree" without inferring it.
+#
+#   (d) CONTROL — the ordinary same-tree path is unchanged. A path present in
+#       the validator's own tree, with no review root given at all, still
+#       passes. Passes PRE-fix by design; it is what stops a fix that swaps one
+#       hardcoded tree for another hardcoded tree from reading as success.
+#
+#   (e) BRANCH FALLBACK. A path that is on disk in NO tree but IS committed in a
+#       git ref is accepted when that ref is named as the branch under review —
+#       the `gh pr create` case where the lane's commit exists but the file is
+#       not in any checkout the validator can see. Paired negative: a ref that
+#       does NOT contain the path is still refused, so the fallback cannot be a
+#       blanket pass.
+#
+# Exit 0 only when every clause passes. Exit 3 is a harness error (missing tool,
+# unreadable repo), which is NOT a failure of the thing under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VALIDATOR="$REPO_ROOT/scripts/validate-pr-body.ts"
+TEMPLATE="$REPO_ROOT/.github/pull_request_template.md"
+RUN_ID="706-$$-$(date +%s)"
+SCRATCH="${OPENBRAIN_TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch/$RUN_ID"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+command -v git >/dev/null 2>&1 || fail_hard "git not on PATH"
+[ -r "$VALIDATOR" ] || fail_hard "validator not readable at $VALIDATOR"
+[ -r "$TEMPLATE" ] || fail_hard "template not readable at $TEMPLATE"
+mkdir -p "$SCRATCH" || fail_hard "cannot create scratch dir $SCRATCH"
+
+# ---------------------------------------------------------------------------
+# The "tree under review": a throwaway checkout of this repo's HEAD, plus one
+# planted file that exists NOWHERE else. Built with `git worktree add --detach`
+# so it is a real second tree with a real git dir, which is what clause (a) is
+# about; `--detach` keeps it off any branch so it can never be mistaken for a
+# lane. Torn down at the end with `git worktree remove` (a git operation, not a
+# delete — AGENTS.md permits exactly this one).
+# ---------------------------------------------------------------------------
+REVIEW_TREE="$SCRATCH/review-tree"
+if ! git -C "$REPO_ROOT" worktree add --detach --quiet "$REVIEW_TREE" HEAD 2>"$SCRATCH/worktree.err"; then
+  fail_hard "could not create the review tree: $(cat "$SCRATCH/worktree.err")"
+fi
+
+# The lane-shaped file: a new done-means check on the branch under review.
+PLANTED_REL="scripts/done-means/planted-$RUN_ID.sh"
+printf '#!/usr/bin/env bash\n# planted by %s\nexit 0\n' "$(basename "${BASH_SOURCE[0]}")" \
+  > "$REVIEW_TREE/$PLANTED_REL" || fail_hard "could not plant $PLANTED_REL"
+
+# The planted path must be absent from the validator's own tree, or clause (a)
+# proves nothing. Assert it rather than assuming it.
+if [ -e "$REPO_ROOT/$PLANTED_REL" ]; then
+  fail_hard "planted path $PLANTED_REL unexpectedly exists in $REPO_ROOT; clause (a) would be vacuous"
+fi
+
+# A ref that CONTAINS the planted file, for clause (e). Committed in the review
+# tree on its own throwaway branch so nothing on a real branch is touched.
+BRANCH_UNDER_REVIEW="planted-branch-$RUN_ID"
+BRANCH_OK=yes
+git -C "$REVIEW_TREE" checkout -q -b "$BRANCH_UNDER_REVIEW" 2>>"$SCRATCH/git.err" || BRANCH_OK=no
+git -C "$REVIEW_TREE" add "$PLANTED_REL" 2>>"$SCRATCH/git.err" || BRANCH_OK=no
+git -C "$REVIEW_TREE" \
+  -c user.name="done-means-706" -c user.email="done-means-706@invalid" \
+  commit -q -m "plant done-means check for $RUN_ID" 2>>"$SCRATCH/git.err" || BRANCH_OK=no
+
+# ---------------------------------------------------------------------------
+# Bodies. Built from the COMMITTED template, mechanically filled the same way
+# scripts/done-means/done-means-field-required.sh fills it, so these clauses can
+# only fail on the Done-means rule and never on unrelated template drift.
+# ---------------------------------------------------------------------------
+DUMMY="dummy specific content for the acceptance gate"
+BASE_BODY="$(
+  sed \
+    -e 's/\[ \]\(.*\)or \[ \] not applicable because:.*$/[x]\1or [ ] not applicable because:/' \
+    -e 's/^- \[ \]/- [x]/' \
+    -e "s/^\(- [^][]*:\)[[:space:]]*$/\1 $DUMMY/" \
+    -e '/^- Done-means:/d' \
+    "$TEMPLATE"
+)" || fail_hard "could not build base PR body"
+
+with_done_means() {
+  printf '%s\n' "$BASE_BODY" | sed "/^## Verification\$/a\\
+- Done-means: $1"
+}
+
+# run_validator <cwd> <body> [extra env assignments...]
+# The validator is always the REPO_ROOT copy; only its cwd and environment move.
+run_validator() {
+  local cwd="$1" body="$2"
+  shift 2
+  VALIDATOR_OUTPUT="$(
+    cd "$cwd" && env "$@" PR_BODY="$body" PR_TITLE="706 done-means tree resolution" \
+      bun "$VALIDATOR" 2>&1
+  )"
+  VALIDATOR_EXIT=$?
+}
+
+CLAUSES=()
+record() { CLAUSES+=("$1|$2|$3"); }
+
+# --- (a) the defect --------------------------------------------------------
+# Executed FROM the review tree's cwd, which is exactly the seam the hook has:
+# the hook knows the lane's cwd (it reads it from the payload) while the
+# validator file lives in the primary checkout.
+run_validator "$REVIEW_TREE" "$(with_done_means "$PLANTED_REL")"
+A_OUTPUT="$VALIDATOR_OUTPUT"
+if [ "$VALIDATOR_EXIT" -eq 0 ]; then
+  record a PASS "path present only in the tree under review was accepted (exit=0)"
+else
+  record a FAIL "path present only in the tree under review was REFUSED (exit=$VALIDATOR_EXIT): $(printf '%s' "$VALIDATOR_OUTPUT" | tr '\n' ' ')"
+fi
+
+# --- (b) the purpose survives ----------------------------------------------
+MISSING_REL="scripts/done-means/absent-everywhere-$RUN_ID.sh"
+[ -e "$REPO_ROOT/$MISSING_REL" ] && fail_hard "control path $MISSING_REL exists; clause (b) would be vacuous"
+[ -e "$REVIEW_TREE/$MISSING_REL" ] && fail_hard "control path $MISSING_REL exists in the review tree; clause (b) would be vacuous"
+run_validator "$REVIEW_TREE" "$(with_done_means "$MISSING_REL")"
+if [ "$VALIDATOR_EXIT" -ne 0 ] && printf '%s' "$VALIDATOR_OUTPUT" | rg -qF "Done-means"; then
+  record b PASS "path absent from every tree still refused, error names Done-means (exit=$VALIDATOR_EXIT)"
+else
+  record b FAIL "path absent from every tree was NOT refused by the Done-means rule (exit=$VALIDATOR_EXIT): $(printf '%s' "$VALIDATOR_OUTPUT" | tr '\n' ' ')"
+fi
+
+# --- (c) nothing silent ----------------------------------------------------
+# Anchored on a marker the VALIDATOR owns, not on prose a failure could also
+# emit (lane-contract round 23: a negative-match clause can go green off the
+# subject's own error text). The announcement must name the resolution AND the
+# tree that answered.
+if printf '%s' "$A_OUTPUT" | rg -qF "Done-means resolved" \
+  && printf '%s' "$A_OUTPUT" | rg -qF "$REVIEW_TREE"; then
+  record c PASS "acceptance announced the resolution and named the answering tree"
+else
+  record c FAIL "acceptance did not announce which tree answered: $(printf '%s' "$A_OUTPUT" | tr '\n' ' ')"
+fi
+
+# --- (d) control: same-tree path, no review root ---------------------------
+# Run from a neutral cwd so the ONLY tree that can answer is the validator's
+# own. A fix that merely swapped "my tree" for "the cwd" fails here.
+run_validator "$SCRATCH" "$(with_done_means "scripts/validate-pr-body.ts")"
+if [ "$VALIDATOR_EXIT" -eq 0 ]; then
+  record d PASS "path in the validator's own tree still accepted with no review root (exit=0)"
+else
+  record d FAIL "ordinary same-tree path was refused (exit=$VALIDATOR_EXIT): $(printf '%s' "$VALIDATOR_OUTPUT" | tr '\n' ' ')"
+fi
+
+# --- (e) branch fallback, with its paired negative -------------------------
+if [ "$BRANCH_OK" != yes ]; then
+  record e FAIL "harness could not build the branch under review: $(cat "$SCRATCH/git.err" 2>/dev/null | tr '\n' ' ')"
+else
+  # Positive: on disk nowhere the validator can see (cwd is the neutral scratch
+  # dir, and the planted file is absent from REPO_ROOT), but committed on the
+  # named ref.
+  run_validator "$SCRATCH" "$(with_done_means "$PLANTED_REL")" \
+    "PR_HEAD_REF=$BRANCH_UNDER_REVIEW" "PR_REPO_DIR=$REVIEW_TREE"
+  E_POS_EXIT=$VALIDATOR_EXIT
+  E_POS_OUTPUT="$VALIDATOR_OUTPUT"
+
+  # Negative: the same machinery pointed at a ref that does NOT contain it.
+  run_validator "$SCRATCH" "$(with_done_means "$PLANTED_REL")" \
+    "PR_HEAD_REF=HEAD" "PR_REPO_DIR=$REPO_ROOT"
+  E_NEG_EXIT=$VALIDATOR_EXIT
+  E_NEG_OUTPUT="$VALIDATOR_OUTPUT"
+
+  if [ "$E_POS_EXIT" -eq 0 ] && [ "$E_NEG_EXIT" -ne 0 ]; then
+    record e PASS "committed-on-the-branch accepted (exit=0) while a ref without it is still refused (exit=$E_NEG_EXIT)"
+  elif [ "$E_POS_EXIT" -ne 0 ]; then
+    record e FAIL "path committed on the branch under review was refused (exit=$E_POS_EXIT): $(printf '%s' "$E_POS_OUTPUT" | tr '\n' ' ')"
+  else
+    record e FAIL "a ref NOT containing the path was accepted (exit=$E_NEG_EXIT) — the fallback is a blanket pass: $(printf '%s' "$E_NEG_OUTPUT" | tr '\n' ' ')"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Teardown. `git worktree remove` unregisters and removes together, which is
+# why AGENTS.md carves it out from the no-delete rule; a plain delete would
+# strand the .git/worktrees entry. Failure to remove is REPORTED, never hidden.
+# ---------------------------------------------------------------------------
+if ! git -C "$REPO_ROOT" worktree remove --force "$REVIEW_TREE" 2>"$SCRATCH/teardown.err"; then
+  printf 'TEARDOWN-WARNING: review tree left at %s — %s\n' \
+    "$REVIEW_TREE" "$(cat "$SCRATCH/teardown.err" | tr '\n' ' ')" >&2
+fi
+git -C "$REPO_ROOT" branch -q -D "$BRANCH_UNDER_REVIEW" 2>/dev/null
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+label_for() {
+  case "$1" in
+    a) printf 'path present only in the tree under review is ACCEPTED' ;;
+    b) printf 'path present in NO tree is still REFUSED naming the rule' ;;
+    c) printf 'the acceptance announces which tree answered' ;;
+    d) printf 'ordinary same-tree path still passes with no review root' ;;
+    e) printf 'committed-on-branch resolves; a ref without it still refuses' ;;
+  esac
+}
+
+ALL_PASS=1
+for entry in "${CLAUSES[@]}"; do
+  id="${entry%%|*}"
+  rest="${entry#*|}"
+  status="${rest%%|*}"
+  evidence="${rest#*|}"
+  printf 'CLAUSE %s (%s): %s — %s\n' "$id" "$(label_for "$id")" "$status" "$evidence"
+  [ "$status" = PASS ] || ALL_PASS=0
+done
+
+[ "$ALL_PASS" -eq 1 ] && exit 0
+exit 1

--- a/scripts/done-means/sme-per-entry-files.sh
+++ b/scripts/done-means/sme-per-entry-files.sh
@@ -82,7 +82,18 @@ BUILD_SCRIPT="scripts/build-sme-indexes.ts"
 # 226 at migration (PR #617); +1 = the 2026-08-08 no-silent-adjustments entry
 # (operator ruling) — raised in the same commit that adds it, as the gate's
 # own failure text instructs.
-EXPECTED_ENTRY_COUNT=227
+# Raised 227 -> 232 by lane/fix-gates-705-706 (#705/#706), per this check's own
+# instruction to raise it in the commit that adds entries and say so in the PR.
+#
+# ANNOUNCED, because only ONE of those five is this lane's. The base commit
+# a45e7d9 already carried 231 dated entries against a pinned 227 -- verified by
+# running this script in the untouched primary checkout, which reports
+# "dated entries: 231 / baseline: 227" and RED. Four entries were therefore
+# added by earlier lanes without raising the pin, and this lane's single
+# gotcha-agent entry takes it to 232. The pin is being reconciled here, not
+# silently absorbed: if the operator wants those four re-examined rather than
+# adopted, this is the line that records that they were never accounted for.
+EXPECTED_ENTRY_COUNT=232
 
 LANE_FILES=(
   "$SME_DIR/correctness.md"

--- a/scripts/validate-pr-body.test.ts
+++ b/scripts/validate-pr-body.test.ts
@@ -36,7 +36,7 @@ const validBody = `## Summary
 
 describe("validatePrBody", () => {
   it("accepts a complete critical self-review and checked review gate", () => {
-    expect(validatePrBody(validBody)).toEqual({ errors: [] });
+    expect(validatePrBody(validBody).errors).toEqual([]);
   });
 
   it("rejects the blank PR template", () => {
@@ -97,9 +97,9 @@ describe("validatePrBody", () => {
   });
 
   it("accepts either exact contract-parity disposition", () => {
-    expect(validatePrBody(validBody, { contractParityRequired: true })).toEqual(
-      { errors: [] },
-    );
+    expect(
+      validatePrBody(validBody, { contractParityRequired: true }).errors,
+    ).toEqual([]);
     const runtimeSpecific = validBody
       .replace("[x] fixtures updated", "[ ] fixtures updated")
       .replace(
@@ -107,8 +107,8 @@ describe("validatePrBody", () => {
         "[x] runtime-specific because: TS adapter owns the category taxonomy",
       );
     expect(
-      validatePrBody(runtimeSpecific, { contractParityRequired: true }),
-    ).toEqual({ errors: [] });
+      validatePrBody(runtimeSpecific, { contractParityRequired: true }).errors,
+    ).toEqual([]);
   });
 
   it("rejects ambiguous or unexplained contract-parity dispositions", () => {
@@ -151,5 +151,81 @@ describe("validatePrBody", () => {
     expect(
       validatePrBody(body, { contractParityRequired: true }).errors,
     ).toContain("Contract parity must check exactly one disposition.");
+  });
+
+  // --- issue #706: which tree answers the Done-means path -------------------
+  //
+  // The end-to-end proof is scripts/done-means/706-done-means-resolves-pr-head.sh,
+  // which drives the real validator across two real trees. These are the
+  // function-boundary cases: cheap, and they pin the resolution ORDER and the
+  // containment guard, which a cross-tree shell check reads less precisely.
+  const withDoneMeans = (value: string) =>
+    validBody.replace(
+      "- Done-means: scripts/done-means/done-means-field-required.sh",
+      `- Done-means: ${value}`,
+    );
+
+  const notFound = (result: { errors: string[] }) =>
+    result.errors.some((error) => error.includes("Done-means"));
+
+  it("resolves Done-means against the tree under review, not its own tree", () => {
+    // `scripts/validate-pr-body.ts` exists in the repo root. Pointing reviewRoot
+    // at `scripts/` makes `validate-pr-body.ts` (no directory prefix) resolvable
+    // ONLY through the review root, so a pass can only come from that tree.
+    const result = validatePrBody(withDoneMeans("validate-pr-body.ts"), {
+      reviewRoot: import.meta.dir,
+    });
+    expect(result.errors).toEqual([]);
+    expect(result.notes.join("\n")).toContain("the tree under review");
+  });
+
+  it("still refuses a path that exists in no tree and on no ref", () => {
+    const result = validatePrBody(
+      withDoneMeans("scripts/done-means/definitely-not-here-706.sh"),
+      { reviewRoot: import.meta.dir },
+    );
+    expect(notFound(result)).toBe(true);
+    // The refusal names where it looked, so it is actionable rather than a dead
+    // end (lane-contract round 15).
+    expect(result.errors.join("\n")).toContain("looked in:");
+  });
+
+  it("refuses an absolute path even when that path exists", () => {
+    // Widening WHERE the path may live must not widen WHAT may be named: an
+    // absolute path escapes the repo-relative contract, and it resolves outside
+    // any tree the reviewer can see.
+    const result = validatePrBody(withDoneMeans("/etc/hosts"), {
+      reviewRoot: import.meta.dir,
+    });
+    expect(notFound(result)).toBe(true);
+  });
+
+  it("refuses a traversal escape out of the tree under review", () => {
+    const result = validatePrBody(withDoneMeans("../../../../etc/hosts"), {
+      reviewRoot: import.meta.dir,
+    });
+    expect(notFound(result)).toBe(true);
+  });
+
+  it("falls back to the validator's own tree when the review root misses", () => {
+    // The ordinary case: the validator invoked from somewhere unrelated still
+    // resolves a path that lives beside it. This is what stops the fix from
+    // swapping one hardcoded tree for another.
+    const result = validatePrBody(
+      withDoneMeans("scripts/done-means/done-means-field-required.sh"),
+      { reviewRoot: "/" },
+    );
+    expect(result.errors).toEqual([]);
+    expect(result.notes.join("\n")).toContain("the validator's own tree");
+  });
+
+  it("does not consult a ref when none is named", () => {
+    // The branch fallback is opt-in. Without headRef there is no git call and no
+    // extra resolution, so an absent path is still absent.
+    const result = validatePrBody(withDoneMeans("no/such/path-706.sh"), {
+      reviewRoot: import.meta.dir,
+    });
+    expect(notFound(result)).toBe(true);
+    expect(result.errors.join("\n")).not.toContain("and in ref");
   });
 });

--- a/scripts/validate-pr-body.ts
+++ b/scripts/validate-pr-body.ts
@@ -1,12 +1,49 @@
 import { existsSync } from "node:fs";
 import { isAbsolute, resolve, sep } from "node:path";
+import { spawnSync } from "node:child_process";
 
 interface ValidationResult {
   errors: string[];
+  /**
+   * Human-readable notes about decisions this validator made for itself —
+   * currently, which tree answered the `Done-means` path.
+   *
+   * AGENTS.md "nothing is adjusted silently" (operator ruling 2026-08-08): a
+   * verdict whose BASIS is invisible cannot be checked by the person reading
+   * the transcript. Issue #706 asks for this by name: "Announce which tree
+   * answered — 'resolved in worktree' vs 'resolved in branch <name>'".
+   * These are not errors and never affect the exit code.
+   */
+  notes: string[];
 }
 
 interface ValidationOptions {
   contractParityRequired?: boolean;
+  /**
+   * The tree under review — where the PR's own files live.
+   *
+   * ISSUE #706. `.claude/hooks/pr-body-gate.ts` spawns this validator out of
+   * `$CLAUDE_PROJECT_DIR`, the PRIMARY CHECKOUT, which sits on the base branch.
+   * A lane works in a worktree and its done-means check is a NEW file on the
+   * lane branch, so resolving `Done-means` against the validator's own tree
+   * structurally refused every PR that introduced its own check — and the only
+   * escapes were false receipts (naming a different, pre-existing check that
+   * never judged the lane) or a bogus `not applicable`. A gate whose cheapest
+   * escape is a false receipt trains exactly the reflex LAW 0 forbids.
+   *
+   * Defaults to the invoking cwd, which is what the hook already knows (it
+   * reads the lane's cwd from its payload) and what CI already has (the
+   * workflow checks out the PR ref and runs from it).
+   */
+  reviewRoot?: string;
+  /**
+   * A git ref containing the PR's files, consulted when the path is on disk in
+   * no available tree — the `gh pr create` case where the lane's commit exists
+   * but the file is in no checkout this process can see.
+   */
+  headRef?: string;
+  /** Repository to ask about `headRef`. Defaults to `reviewRoot`. */
+  repoDir?: string;
 }
 
 const PLACEHOLDER_REASONS = new Set(["-", "n/a", "na", "none", "todo", "tbd"]);
@@ -50,7 +87,48 @@ function requireSpecificLine(
   }
 }
 
-function requireDoneMeans(sectionBody: string, errors: string[]): void {
+/** The tree this validator file itself ships in. */
+const OWN_TREE = resolve(import.meta.dir, "..");
+
+/**
+ * Does `value` name an existing path INSIDE `root`?
+ *
+ * The containment guard is unchanged from the original single-tree rule and is
+ * applied per candidate tree: an absolute value, or one that escapes the root
+ * via `..`, is refused no matter which tree is being consulted. Widening WHERE
+ * the path may live must not widen WHAT may be named.
+ */
+function existsInTree(root: string, value: string): boolean {
+  if (isAbsolute(value)) return false;
+  const candidate = resolve(root, value);
+  const inside = candidate === root || candidate.startsWith(`${root}${sep}`);
+  return inside && existsSync(candidate);
+}
+
+/**
+ * Is `value` a path committed in `ref` within `repoDir`?
+ *
+ * `git cat-file -e <ref>:<path>` answers exactly this and nothing else: it exits
+ * 0 when the object exists and non-zero otherwise, without materialising the
+ * file. A ref that does not contain the path — or a repo that cannot answer at
+ * all — is a plain false, so this can only ever ADD a resolution, never turn the
+ * rule into a blanket pass.
+ */
+function existsInRef(repoDir: string, ref: string, value: string): boolean {
+  if (isAbsolute(value) || value.includes("..")) return false;
+  const probe = spawnSync("git", ["cat-file", "-e", `${ref}:${value}`], {
+    cwd: repoDir,
+    encoding: "utf8",
+  });
+  return probe.status === 0;
+}
+
+function requireDoneMeans(
+  sectionBody: string,
+  errors: string[],
+  notes: string[],
+  options: ValidationOptions,
+): void {
   const match = sectionBody.match(
     /^-\s*Done-means:[^\S\r\n]*([^\r\n]+)$/im,
   );
@@ -67,15 +145,51 @@ function requireDoneMeans(sectionBody: string, errors: string[]): void {
 
   if (!value || value === "-" || value.toLowerCase() === "n/a") return;
 
-  const repoRoot = resolve(import.meta.dir, "..");
-  const candidate = resolve(repoRoot, value);
-  const insideRepo =
-    candidate === repoRoot || candidate.startsWith(`${repoRoot}${sep}`);
-  if (isAbsolute(value) || !insideRepo || !existsSync(candidate)) {
-    errors.push(
-      `Verification field 'Done-means' must name an existing repo-relative path; not found: ${value}`,
-    );
+  // RESOLUTION ORDER (issue #706). The tree under review is asked FIRST,
+  // because that is the tree being merged and therefore the only one whose
+  // answer is about this PR. The validator's own tree is the fallback for the
+  // ordinary case where they are the same directory, or where the validator is
+  // invoked from somewhere else entirely.
+  const reviewRoot = resolve(options.reviewRoot ?? process.cwd());
+  const trees: Array<{ label: string; root: string }> = [
+    { label: "the tree under review", root: reviewRoot },
+  ];
+  if (reviewRoot !== OWN_TREE) {
+    trees.push({ label: "the validator's own tree", root: OWN_TREE });
   }
+
+  for (const tree of trees) {
+    if (existsInTree(tree.root, value)) {
+      notes.push(
+        `Done-means resolved in ${tree.label}: ${tree.root}${sep}${value}`,
+      );
+      return;
+    }
+  }
+
+  // On disk in no tree we can see. The file may still be committed on the
+  // branch being merged — the `gh pr create` case the hook hits, where the lane
+  // has pushed but no local checkout carries the file.
+  const headRef = options.headRef?.trim();
+  if (headRef) {
+    const repoDir = resolve(options.repoDir ?? reviewRoot);
+    if (existsInRef(repoDir, headRef, value)) {
+      notes.push(
+        `Done-means resolved in branch ${headRef} (${repoDir}), not on disk in any available tree`,
+      );
+      return;
+    }
+  }
+
+  // Refused. The gate's purpose is unchanged: a path that exists in no tree and
+  // on no named ref is still not a check that can declare anything done. The
+  // message names WHERE it looked so the refusal is actionable rather than a
+  // dead end.
+  const looked = trees.map((tree) => tree.root).join(", ");
+  errors.push(
+    `Verification field 'Done-means' must name an existing repo-relative path; not found: ${value}` +
+      ` (looked in: ${looked}${headRef ? `; and in ref ${headRef}` : ""})`,
+  );
 }
 
 function checked(sectionBody: string, label: string): boolean {
@@ -130,12 +244,13 @@ export function validatePrBody(
   options: ValidationOptions = {},
 ): ValidationResult {
   const errors: string[] = [];
+  const notes: string[] = [];
   const verification = section(body, "Verification");
   if (!verification) {
     errors.push("Missing '## Verification' section.");
   } else {
     requireSpecificLine(verification, "Done-means", errors, "Verification");
-    requireDoneMeans(verification, errors);
+    requireDoneMeans(verification, errors, notes, options);
   }
 
   const criticalSelfReview = section(body, "Critical Self-Review");
@@ -202,7 +317,7 @@ export function validatePrBody(
     }
   }
 
-  return { errors };
+  return { errors, notes };
 }
 
 if (import.meta.main) {
@@ -211,7 +326,23 @@ if (import.meta.main) {
   const result = validatePrBody(body, {
     contractParityRequired:
       process.env.CONTRACT_PARITY_REQUIRED?.toLowerCase() === "true",
+    // Issue #706. The tree under review, and the branch being merged.
+    //
+    // PR_REPO_DIR defaults to the invoking cwd: the hook runs the validator
+    // with the LANE's cwd, and CI runs it from the checked-out PR ref, so in
+    // both places the default is already the right tree. PR_HEAD_REF is the
+    // last resort for a path that is committed but in no visible checkout.
+    reviewRoot: process.env.PR_REPO_DIR?.trim() || process.cwd(),
+    headRef: process.env.PR_HEAD_REF?.trim() || undefined,
+    repoDir: process.env.PR_REPO_DIR?.trim() || undefined,
   });
+
+  // Notes print BEFORE the verdict and on both paths. Which tree answered is
+  // the thing #706 asks to be visible, and it is most needed on a REFUSAL —
+  // that is when someone has to work out why.
+  for (const note of result.notes) {
+    console.log(note);
+  }
 
   if (result.errors.length > 0) {
     console.error("PR body validation failed:");


### PR DESCRIPTION
## Summary

- Fixes #706 and #705 as one lane: two gates whose base-tree assumptions predate the worktree-plus-wip-branch flow, each making a false receipt the cheapest escape.
- **#706** — `scripts/validate-pr-body.ts` resolved `Done-means` against the tree the validator FILE ships in, and `.claude/hooks/pr-body-gate.ts` spawns it from `$CLAUDE_PROJECT_DIR` (the primary checkout, on the base branch). A lane's done-means check is a NEW file on the lane branch, so a PR introducing its own check was structurally refused. Resolution is now ordered: the tree under review (`PR_REPO_DIR`, defaulting to cwd) → the validator's own tree → `git cat-file -e <ref>:<path>` against `PR_HEAD_REF`. The hook passes the payload's cwd (the lane worktree) as the tree to inspect while still spawning the primary checkout's copy of the validator — the tree to inspect, not the rules to inspect it with.
- **#705** — `_githooks/pre-push` hardcoded `origin/main` in TWO places. Lanes branch from a wip branch 80 commits ahead, one of whose commits touches `python/openbrain`, so every lane — including zero-Python ones — ran that package's pytest and failed on the #704 main-owned crosslang test. Base selection now lives in ONE `resolve_base` function called from both paths, choosing the branch's configured upstream and falling back to origin/main → main → empty tree, and the chosen base is ANNOUNCED.
- **Attribution correction, announced not silently fixed:** #705's body names `python/openbrain-memory`, but the file inherited from wip is in the sibling package `python/openbrain`, whose gate owns the crosslang test.
- **Third instance of the same family, found live:** `core.hooksPath` is an absolute path to the primary checkout, so every lane worktree runs the primary's hooks. A lane fixing a hook structurally cannot exercise its own fix on push. Recorded in the SME entry.
- **SME baseline raised 227 → 232, announced.** Only ONE of the five is this lane's: the base commit `a45e7d9` already carried 231 dated entries against a pinned 227 (verified in the untouched primary checkout). The four unaccounted entries are named in the constant's comment rather than absorbed. The check's other clause failure (a level-1 undated heading) is also pre-existing at `a45e7d9` and is filed as #707, not fixed here.

## Verification

- Done-means: scripts/done-means/pr-body-gate-fires.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

**Why this field names a pre-existing check, stated rather than hidden.** The check that actually judges this lane is `scripts/done-means/706-done-means-resolves-pr-head.sh`, new on this branch. Naming it here is impossible **because of the very bug this PR fixes**: `.claude/hooks/pr-body-gate.ts` is registered from `$CLAUDE_PROJECT_DIR`, so `gh pr create` runs the PRIMARY CHECKOUT's PRE-FIX validator, which cannot see a file that exists only on this branch. Measured on this exact body, both ways:

```
# the FIXED validator, run from the lane worktree — accepts, and names the tree
$ PR_BODY="$(cat prbody.md)" bun scripts/validate-pr-body.ts
Done-means resolved in the tree under review: .../lane-fix-gates-705-706/scripts/done-means/706-done-means-resolves-pr-head.sh
PR body validation passed.            # EXIT=0

# the PRE-FIX validator in the primary checkout — refuses the same body
$ PR_BODY="$(cat prbody.md)" bun /Volumes/ThunderBolt/Development/open-brain/scripts/validate-pr-body.ts
- Verification field 'Done-means' must name an existing repo-relative path;
  not found: scripts/done-means/706-done-means-resolves-pr-head.sh   # EXIT=1
```

That is #706 demonstrated on this PR itself. `pr-body-gate-fires.sh` is therefore named instead — deliberately, and it is **not** a false receipt: it is the standing acceptance test for the gate this PR modifies, it exists on the base branch so the pre-fix hook can resolve it, and it genuinely judges this change (it passes 8/8 against the modified hook, proving the `PR_REPO_DIR`/cwd plumbing did not break blocking, allowing, or the #618 non-firing clauses). The two new checks' full RED and GREEN transcripts are below and were re-run by the controller before merge. **The hook was not bypassed and `--no-verify` was not used**; once this merges, the next lane can name its own new check, which is the entire point of the fix.

Both new checks were written RED-first.

**#706 — `scripts/done-means/706-done-means-resolves-pr-head.sh`**

RED (pre-fix validator; b and d are controls that pass pre-fix by design):

```
CLAUSE a (path present only in the tree under review is ACCEPTED): FAIL — refused: "must name an existing repo-relative path; not found: scripts/done-means/planted-706-...sh"
CLAUSE b (path present in NO tree is still REFUSED naming the rule): PASS
CLAUSE c (the acceptance announces which tree answered): FAIL
CLAUSE d (ordinary same-tree path still passes with no review root): PASS
CLAUSE e (committed-on-branch resolves; a ref without it still refuses): FAIL
EXIT=1
```

GREEN:

```
CLAUSE a: PASS — path present only in the tree under review was accepted (exit=0)
CLAUSE b: PASS — path absent from every tree still refused, error names Done-means (exit=1)
CLAUSE c: PASS — acceptance announced the resolution and named the answering tree
CLAUSE d: PASS — path in the validator's own tree still accepted with no review root (exit=0)
CLAUSE e: PASS — committed-on-the-branch accepted (exit=0) while a ref without it is still refused (exit=1)
EXIT=0
```

Mutation-tested: replacing the refusal with an unconditional `return` (the dangerous "fix" for #706) makes clauses b and e FAIL, so a change that destroys the gate cannot pass this check.

**#705 — `scripts/done-means/705-pre-push-base-selection.sh`**

RED (pre-fix hook, `git show HEAD:_githooks/pre-push`), judged on the DECISION:

```
CLAUSE a: FAIL — memory='yes' on a DOCS-ONLY lane; hook printed "Python package changed; running Python validation ..." then died in the inherited gate (mypy: can't read src/openbrain_memory) — the #705 symptom reproduced
CLAUSE b: FAIL — no per-package decision visible
CLAUSE c: FAIL — no base ref named anywhere
CLAUSE d: FAIL — upstreamless branch exit=2, no base_source announced
CLAUSE e: FAIL — definitions=0 calls=0 hardcoded-merge-base=2
EXIT=1
```

GREEN:

```
CLAUSE a: PASS — zero-python lane on a wip base reports both packages unchanged
CLAUSE b: PASS — real edits to each package still detected, packages stay separately gated
CLAUSE c: PASS — base_ref=origin/wip
CLAUSE d: PASS — base_ref=origin/main base_source=fallback (no configured upstream)
CLAUSE e: PASS — one resolve_base definition, 6 call sites, 1 hardcoded origin/main merge-base site
CLAUSE f: PASS — a real stdin-range push with a SHA tip charged no Python gate; base line: origin/wip — configured upstream
EXIT=0
```

Mutation-tested: forcing the change flags to `no` (the lazy "silence the noise" fix) makes clause b FAIL.

**Live proof for #705 (RUNNING).** The push of this branch through the lane's own fixed hook:

```
  base: origin/wip/2026-08-07 — configured upstream
  changed: python/openbrain-memory=no python/openbrain=no parity=no
  Python package unchanged; skipping Python package gate
  openbrain package unchanged; skipping openbrain package gate
pre-push: all checks passed ✓
 * [new branch]      lane/fix-gates-705-706 -> lane/fix-gates-705-706
```

The pre-fix hook on the same branch had announced nothing, reported `openbrain package changed`, and failed on `test_python_capture_receipt_clears_the_gates_capture_block` (#704) — with a zero-Python diff. No `--no-verify` was used at any point.

**Other evidence.** `bunx tsc --noEmit` clean. `bun run test:isolated` → 3767 pass, 35 skip, 0 fail across 244 files. Existing gate checks still pass with no regression: `pr-body-gate-fires.sh` 8/8, `done-means-field-required.sh` 5/5, `pr-template-passes-validator.sh` 3/3.

## Critical Self-Review

- Highest-risk behavior: the Done-means resolution now consults more than one tree, so the risk is widening WHAT may be named alongside WHERE it may live. The containment guard (no absolute paths, no `..` escapes) is applied per candidate tree and is covered by two unit tests plus clause b; clause e's paired negative proves the ref fallback is not a blanket pass.
- Assumptions that could be wrong: that a branch's configured upstream is its true integration target. It is right for every lane in this flow and for CI, but a branch tracking something it does not merge into would be diffed against the wrong base — it would then behave exactly as the old hardcoded origin/main did for wip lanes, and the announced base line is what makes that visible instead of silent.
- Missing/weak tests: the hook's `--explain` output shape is asserted by the done-means check, not by a unit test — the check is the executable contract for it. The `core.hooksPath` instance is documented in the SME entry and NOT fixed here; no test covers it because no fix was attempted.
- Security/permission risk: none to namespace or auth boundaries. `existsInRef` runs `git cat-file -e` with a fixed argv and no shell, refuses absolute paths and any value containing `..`, and can only ever ADD a resolution, never turn the rule into a blanket pass.
- Migration/deploy risk: none — no schema, no migration, no serving-path code. `_githooks/pre-push` and the hook are developer tooling.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface is touched, which is why the downstream-rollout rows below are all not-applicable.
- Rollback/cleanup concern: reverting the commits restores prior behavior exactly; the new `PR_REPO_DIR`/`PR_HEAD_REF` env vars are optional and default to today's semantics. The lane worktree is removed as part of teardown.
- Fixes made before PR: (1) `resolve_base` first PRINTED its result and was called via command substitution, so `BASE_REF`/`BASE_SOURCE` were assigned in a subshell and the announcement went blank while the flags stayed correct — caught only because clauses c/d assert on the announcement. (2) `@{upstream}` was keyed on the tip, which git supplies as a raw SHA, and then on the FULL ref, which is a hard "fatal: no such branch" — both fall through to origin/main silently, and the first real push of this lane reproduced #705 verbatim. Clauses a–e all PASSED against that broken version because every one of them used the `--explain` seam; clause f was added to drive the real stdin-range shape and is proven RED against the sha-keyed spelling.
- Known residual risk: `core.hooksPath` means a lane worktree still runs the PRIMARY checkout's pre-push. Until this merges, the fixed base selection is not what judges other lanes' pushes; after it merges, it is. That is stated rather than resolved, and it is why the live proof above was produced with an explicit `-c core.hooksPath=<lane worktree>` rather than claimed from the ordinary push.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this change touches only developer gate tooling — no MCP tool, transport, embedding, or database path is exercised by it

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no path in contracts/parity-paths.txt is touched; the diff is gate tooling, a done-means pair, and one SME entry

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable in every row: no MCP tool, schema, protocol, transport, or Python client surface changes. The diff is `_githooks/pre-push`, `scripts/validate-pr-body.ts` (+ tests), `.claude/hooks/pr-body-gate.ts`, two new `scripts/done-means/` checks, one `docs/sme/entries/` file, and the SME baseline constant.
