### PR TITLE
fix(gates): pr-body-gate feeds the validator the PR's real tree and head ref (#709)

### DIFF
--- a/.claude/hooks/pr-body-gate.ts
+++ b/.claude/hooks/pr-body-gate.ts
@@ -133,10 +133,16 @@ type PrCommand = {
   verb: "create" | "edit";
   title: string | null;
   body: BodySource | null;
+  /**
+   * The value of `--head`/`-H`, when the invocation names its own head branch
+   * (issue #709). This is the PR's head straight from the horse's mouth, so it
+   * outranks anything derived from a directory.
+   */
+  head: string | null;
 };
 
 /**
- * Identify a `gh pr create|edit` and read its body/title OPTIONS.
+ * Identify a `gh pr create|edit` and read its body/title/head OPTIONS.
  *
  * Everything here is positional and flag-shaped: the executable must be gh, the
  * next word must be `pr`, the next must be create/edit. A command that does not
@@ -169,6 +175,7 @@ function parsePrCommand(command: Token[]): PrCommand | null {
 
   let title: string | null = null;
   let body: BodySource | null = null;
+  let head: string | null = null;
 
   const valueOf = (i: number, inlineValue: string | null): [string | null, number] => {
     if (inlineValue !== null) return [inlineValue, i + 1];
@@ -209,11 +216,97 @@ function parsePrCommand(command: Token[]): PrCommand | null {
       i = next;
       continue;
     }
+    // Issue #709. `gh pr create --head <branch>` states the PR's head branch
+    // outright; nothing derived from a directory can beat that.
+    if (flag === "--head" || flag === "-H") {
+      const [value, next] = valueOf(i, inlineValue);
+      head = value;
+      i = next;
+      continue;
+    }
 
     i += 1;
   }
 
-  return { verb, title, body };
+  return { verb, title, body, head };
+}
+
+/**
+ * The directory a `cd` in this command line moves into (issue #709).
+ *
+ * A lane opens its PR as one Bash call: `cd /path/to/worktree && gh pr create`.
+ * The hook payload's `cwd` is the SESSION's directory and that `cd` never moves
+ * it, so without this the gate inspects the primary checkout — the exact tree
+ * #706 existed to stop consulting.
+ *
+ * Deliberately narrow. It reads `cd` commands that appear BEFORE the gh call in
+ * the same command line, in order, taking the last one — which is where the gh
+ * call actually runs. A `cd` with no argument (`$HOME`), with `-` (the previous
+ * directory, unknowable here), or after the gh call is ignored rather than
+ * guessed at. Relative targets are resolved against the payload cwd, which is
+ * what the shell would do.
+ *
+ * This emulates no shell. Anything it cannot read with certainty yields null
+ * and the caller falls back to the payload cwd, which is the pre-#709 behaviour
+ * — never a wrong answer stated confidently.
+ */
+function cdTargetBefore(
+  commands: Token[][],
+  ghCommandIndex: number,
+  payloadCwd: string,
+): string | null {
+  let target: string | null = null;
+
+  for (let i = 0; i < ghCommandIndex; i += 1) {
+    const words = executableWords(commands[i]!);
+    const first = words[0];
+    if (!first || first.quoted || first.value !== "cd") continue;
+
+    // Skip cd's own flags (-L/-P). `cd -` is the previous directory, which this
+    // process has no way to know, so the whole hint is discarded rather than
+    // guessed.
+    const operands = words.slice(1).filter((word) => {
+      if (word.quoted) return true;
+      return !(word.value.startsWith("-") && word.value !== "-");
+    });
+    const arg = operands[0];
+    if (!arg || arg.value === "-") {
+      target = null;
+      continue;
+    }
+    // A path built from an unexpanded variable or command substitution is not
+    // something this parser can resolve; refuse to guess.
+    if (!arg.quoted && /[$`]/.test(arg.value)) {
+      target = null;
+      continue;
+    }
+    target = isAbsolute(arg.value) ? arg.value : join(payloadCwd, arg.value);
+  }
+
+  return target;
+}
+
+/**
+ * The branch checked out in `dir`, or null.
+ *
+ * `git -C <dir> symbolic-ref --quiet --short HEAD` answers exactly this: the
+ * short branch name, quiet-failing on a detached HEAD or a non-repository
+ * rather than printing a SHA. That distinction matters — a raw SHA is a
+ * perfectly good `git cat-file` argument, so returning one would make the
+ * validator's announcement say "resolved in branch 9f3a1c2", which is not a
+ * branch and reads as a fact when it is not. Round 28: a lookup whose failure
+ * is indistinguishable from its legitimate empty case must be asserted on
+ * positively.
+ */
+function branchOf(dir: string): string | null {
+  const probe = spawnSync(
+    "git",
+    ["-C", dir, "symbolic-ref", "--quiet", "--short", "HEAD"],
+    { encoding: "utf8" },
+  );
+  if (probe.status !== 0) return null;
+  const branch = (probe.stdout ?? "").trim();
+  return branch ? branch : null;
 }
 
 function refuse(lines: string[]): never {
@@ -257,10 +350,12 @@ if (!rawCommand.trim()) process.exit(0);
 const commands = parseSimpleCommands(rawCommand);
 
 let target: PrCommand | null = null;
-for (const command of commands) {
+let targetIndex = -1;
+for (const [index, command] of commands.entries()) {
   const parsed = parsePrCommand(command);
   if (parsed?.body) {
     target = parsed;
+    targetIndex = index;
     break;
   }
 }
@@ -344,8 +439,65 @@ if (!existsSync(VALIDATOR)) {
  *
  * `CLAUDE_PROJECT_DIR` is deliberately NOT used here. It is the primary
  * checkout, which is the exact tree that produced the bug.
+ *
+ * ---------------------------------------------------------------------------
+ * ISSUE #709 — the payload's cwd is NOT the tree the command runs in, and the
+ * head ref was never supplied at all.
+ * ---------------------------------------------------------------------------
+ *
+ * The paragraph above says "the payload's cwd is the tree the command was
+ * actually run from — the lane worktree". That was wrong, and #706 shipped with
+ * only half of it reachable:
+ *
+ *   - `input.cwd` is the HARNESS payload's cwd — the SESSION's directory. A
+ *     lane opens its PR as `cd /path/to/worktree && gh pr create ...` in ONE
+ *     Bash call, and that `cd` does not move the session. So the "tree under
+ *     review" was the primary checkout on the base branch: the very tree #706
+ *     existed to stop consulting.
+ *   - the validator's THIRD tier (`git cat-file -e <PR_HEAD_REF>:<path>`), the
+ *     one #706 asked for by name, was never fed. `PR_HEAD_REF` was not set here
+ *     and `--head` was not parsed, so the tier was dead code from the only
+ *     caller that runs. Its own done-means check passed throughout because it
+ *     calls the validator DIRECTLY and sets the variable itself — round 28's
+ *     "a seam added to make a gate testable is not the path that runs",
+ *     recurring in the lane that wrote it.
+ *
+ * So the hook now tells the validator what the PR actually IS, in a fixed
+ * precedence, and SAYS which source answered (AGENTS.md, nothing is adjusted
+ * silently — a self-made decision that is invisible cannot be checked):
+ *
+ *   1. `--head`/`-H` on the intercepted command. The invocation naming its own
+ *      head branch beats anything inferred.
+ *   2. the branch checked out in the directory the command `cd`s into.
+ *   3. the branch checked out in the payload cwd.
+ *
+ * `PR_REPO_DIR` follows the same target directory, so the two tiers stay
+ * complementary rather than alternatives: the working tree answers for files
+ * present on disk, the ref answers for files that are committed but in no
+ * checkout this process can see. Every step degrades to the pre-#709 behaviour
+ * rather than guessing, and `scripts/done-means/709-hook-feeds-head-ref.sh`
+ * drives THIS file with real payloads to hold it there.
  */
-const reviewRoot = input.cwd?.trim() || process.cwd();
+const payloadCwd = input.cwd?.trim() || process.cwd();
+const cdTarget = cdTargetBefore(commands, targetIndex, payloadCwd);
+
+const reviewRootSource = cdTarget
+  ? `the directory the command cd's into (${cdTarget})`
+  : `the hook payload's cwd (${payloadCwd})`;
+const reviewRoot = cdTarget ?? payloadCwd;
+
+let headRef: string | null = null;
+let headRefSource = "";
+if (target.head?.trim()) {
+  headRef = target.head.trim();
+  headRefSource = `explicit --head on the gh command`;
+} else {
+  const derived = branchOf(reviewRoot);
+  if (derived) {
+    headRef = derived;
+    headRefSource = `branch checked out in ${reviewRoot}`;
+  }
+}
 
 const result = spawnSync("bun", [VALIDATOR], {
   encoding: "utf8",
@@ -354,6 +506,7 @@ const result = spawnSync("bun", [VALIDATOR], {
     PR_BODY: body,
     PR_TITLE: target.title ?? "",
     PR_REPO_DIR: reviewRoot,
+    ...(headRef ? { PR_HEAD_REF: headRef } : {}),
   },
   cwd: reviewRoot,
 });
@@ -370,12 +523,27 @@ if (result.error || result.status === null) {
   ]);
 }
 
+// What the validator was fed, in one place, for both verdicts. Issue #709 was
+// diagnosed from a REFUSAL that named the tree it looked in but not where that
+// tree came from, and said nothing about the head ref because there was none —
+// so the refusal read as "your path does not exist" when the truth was "the
+// gate was looking in the wrong place". A refusal is exactly when someone has
+// to work out why, so the inputs are printed on the failing path too.
+const inputNotes = [
+  `[${HOOK_NAME}] tree under review: ${reviewRootSource}`,
+  headRef
+    ? `[${HOOK_NAME}] head ref: ${headRef} (source: ${headRefSource})`
+    : `[${HOOK_NAME}] head ref: none — no --head on the command and ${reviewRoot} is not on a named branch; the branch tier cannot run`,
+];
+
 if (result.status !== 0) {
   const validatorOutput = `${result.stdout ?? ""}${result.stderr ?? ""}`.trimEnd();
   refuse([
     `BLOCKED by ${HOOK_NAME}: this PR body fails scripts/validate-pr-body.ts.`,
     "",
     `  gh pr ${target.verb}, body from ${source.kind === "inline" ? source.flag : `${source.flag} ${source.path}`}`,
+    "",
+    ...inputNotes.map((line) => `  ${line}`),
     "",
     "The validator said:",
     "",
@@ -387,10 +555,14 @@ if (result.status !== 0) {
   ]);
 }
 
-// ALLOWED. Echo the validator's resolution notes so the pass is not silent
-// about WHICH tree answered the Done-means path (issue #706, AGENTS.md nothing
-// silent). stderr, because stdout on a PreToolUse hook is parsed as a decision
-// document; this is commentary on an allow, not a decision.
+// ALLOWED. Echo what the gate was FED (issue #709) and the validator's own
+// resolution notes (issue #706), so the pass is silent about neither which tree
+// and ref were handed over nor which one answered. stderr, because stdout on a
+// PreToolUse hook is parsed as a decision document; this is commentary on an
+// allow, not a decision.
+for (const note of inputNotes) {
+  console.error(note);
+}
 for (const line of (result.stdout ?? "").split("\n")) {
   if (line.startsWith("Done-means resolved")) {
     console.error(`[${HOOK_NAME}] ${line}`);

--- a/docs/lane-contract.md
+++ b/docs/lane-contract.md
@@ -87,6 +87,62 @@ Every lane, no exceptions:
 
 Newest first. Every entry: what changed, and the observation that forced it.
 
+### 2026-08-10 (round 29) — harvest of the #709 hook-feeds-head-ref lane
+
+- **ROUND 28'S FIRST BULLET RECURRED IN THE NEXT LANE, AND ITS OWN CHECK
+  STAYED GREEN THROUGHOUT.** #706 shipped a correct three-tier validator and a
+  hook that fed it neither the right tree nor the head ref at all, so the tier
+  the issue asked for by name was dead code from the only caller that runs.
+  `706-done-means-resolves-pr-head.sh` was 5/5 GREEN before, during, and after
+  the defect, because it calls the validator DIRECTLY and sets `PR_HEAD_REF`
+  itself. A check that supplies the input under test proves the consumer works
+  WHEN FED — never that anything feeds it. Writing the round-28 bullet did not
+  stop the lane that wrote it from reproducing it, which is the measurement:
+  the rule needs a clause driving the real entry point, not a paragraph.
+- **NAME THE DEAD SIDE OF EVERY SEAM.** When a fix spans a producer and a
+  consumer, the check must drive the PRODUCER's real entry point at least
+  once, and one clause must be impossible to pass without the specific wiring
+  under repair. Here clause 2 moves the file OUT of the lane worktree while it
+  stays committed on the branch, so a fix that merely read the `cd` target —
+  which passes clause 1 — still fails. Without that clause the lane would have
+  shipped a half-fix that looked complete, exactly as #706 did.
+- **A HOOK PAYLOAD'S `cwd` IS THE SESSION'S, NOT THE COMMAND'S.**
+  `cd <worktree> && gh pr create` in ONE Bash call does not move `input.cwd`.
+  #706's own source comment asserted the opposite in prose ("the tree the
+  command was actually run from — the lane worktree") and the code inherited
+  the claim. A comment stating what an input contains is not evidence; the
+  payload's shape is checkable and was not checked.
+- **PRINT THE GATE'S INPUTS ON THE REFUSAL PATH, NOT ONLY ON THE ALLOW.** #706
+  echoed which tree ANSWERED only when it passed. #709 had to be diagnosed
+  from a refusal that named the tree it searched but not where that tree came
+  from, so it read as "your path does not exist" when the truth was "the gate
+  looked in the wrong place". A refusal is precisely when someone must work
+  out why. Round 28 said assert on announcements; this adds: announce on the
+  branch where the reader actually lands.
+- **DEGRADE TO THE OLD BEHAVIOUR, NEVER TO A GUESS.** The new `cd`-target
+  reader refuses to resolve `cd -`, a variable-built path, or a detached HEAD,
+  and falls back to the payload cwd instead. `branchOf` uses
+  `symbolic-ref --short` rather than `rev-parse`, because a raw SHA is a valid
+  `git cat-file` argument and would make the announcement say "resolved in
+  branch 9f3a1c2" — a non-fact in the grammar of a fact.
+- **`lane-bootstrap` cuts from `origin/main` only, with no base flag.** A lane
+  building on work that merged to a wip branch must create and push the branch
+  at the right base first, then bootstrap continues on it. Announced in the
+  lane report rather than silently rebased. Small gap; worth a `--base` if it
+  recurs.
+- **Two blockers found live and FILED, not absorbed** (#711, #712).
+  `core.hooksPath` is absolute in `.git/config` so every worktree runs the
+  primary checkout's hooks — round 28's third-family instance, now with the
+  extra finding that `_githooks/install.sh` already writes the RELATIVE value
+  and nothing detects the divergence (#711). And `bun test` aborts with
+  `WriteFailed` when its stdout is git's pipe, so `_githooks/pre-push` fails
+  EVERY push while the suite itself is 3372 pass / 0 fail — reproduced on an
+  untouched primary checkout (#712). `--no-verify` was not used.
+- **A gate that fails identically for a green push and a broken one has
+  stopped carrying information**, and that is the state #712 leaves the push
+  path in. Filing it is cheaper than the habit it would otherwise train; #705's
+  own commit message predicted this exact slide into routine bypass.
+
 ### 2026-08-09 (round 28) — harvest of the #705/#706 gate-fix lane (PR #708)
 
 - **A SEAM ADDED TO MAKE A GATE TESTABLE IS NOT THE PATH THAT RUNS.** This

--- a/docs/sme/entries/2026-08-10-a-check-that-supplies-the-input-under-test-proves-only-half-the-wiring.md
+++ b/docs/sme/entries/2026-08-10-a-check-that-supplies-the-input-under-test-proves-only-half-the-wiring.md
@@ -1,0 +1,74 @@
+---
+lane: gotcha-agent
+order: 69
+---
+## [2026-08-10] A check that supplies the input under test proves the consumer, never that anything feeds it
+
+**Severity:** HIGH
+**Source:** Issue #709 (the unreachable half of #706); lane `lane/709-pr-head-ref`
+**Scope:** any done-means check, unit test, or acceptance gate for a fix that spans a PRODUCER and a CONSUMER — hooks feeding validators, callers feeding resolvers, CI feeding scripts
+**Status:** active
+
+### Pattern
+
+#706 fixed `scripts/validate-pr-body.ts` to resolve a `Done-means` path in
+three tiers, the third being `git cat-file -e <PR_HEAD_REF>:<path>` — the tier
+the issue asked for BY NAME, so a lane could cite a check existing only on its
+own branch. That half was correct and is still correct.
+
+The other half never shipped. `.claude/hooks/pr-body-gate.ts` is the only
+caller that runs at the boundary, and it set `PR_REPO_DIR` from the payload's
+`cwd` and **never set `PR_HEAD_REF`**, nor parsed `--head` from the intercepted
+`gh pr create`. The tier was dead code from the only live caller.
+
+`scripts/done-means/706-done-means-resolves-pr-head.sh` was **5/5 GREEN before,
+during, and after** the defect. It calls the validator DIRECTLY and sets
+`PR_HEAD_REF` itself. It therefore proved the consumer works WHEN FED, and
+never that anything feeds it. The sibling check that DOES drive the hook
+(`pr-body-gate-fires.sh`) asserted on neither `cwd` nor `PR_HEAD_REF`.
+
+This is `docs/lane-contract.md` round 28's own first bullet — *a seam added to
+make a gate testable is not the path that runs* — recurring in the very next
+lane. Writing the rule did not prevent the recurrence; only a clause driving
+the real entry point did.
+
+### The second, sharper trap
+
+Even a check that drives the real entry point can prove only half. Here TWO
+independent things were wrong and either alone explains the observed refusal:
+
+1. the payload `cwd` is the SESSION's directory (a `cd <worktree> && gh pr
+   create` in one Bash call does not move it), and
+2. `PR_HEAD_REF` was never supplied.
+
+A fix for (1) alone passes the obvious clause — "the cd-into-worktree call is
+accepted" — while the branch tier stays as dead as it ever was. The clause that
+forces (2) has to remove the file from every reachable working tree while
+leaving it committed on the branch, so that ONLY a supplied head ref can answer.
+
+### Review checks
+
+- For any fix spanning a producer and a consumer, ask: **does any clause fail
+  if the producer's wiring is reverted?** If every clause sets the disputed
+  input itself, the check covers the consumer only. Name the untested side.
+- Grep a done-means check for the environment variable or argument the fix is
+  about. If the check EXPORTS it, the check is downstream of the defect.
+- A hook payload's `cwd` is the session's, not the command's. Any gate reading
+  `input.cwd` as "where this command runs" is wrong whenever the command `cd`s.
+  Prose in the source asserting otherwise (#706's comment said exactly that) is
+  not evidence.
+- Gate inputs must be printed on the REFUSAL path, not only on the allow path.
+  #709 was diagnosed from a refusal naming the tree it searched but not where
+  that tree came from, so it read as "your path does not exist" when the truth
+  was "the gate looked in the wrong place".
+- A widened resolution must keep a MUTANT CONTROL clause: a path in no tree and
+  on no ref stays refused. Otherwise "fix the false refusal" and "turn the gate
+  off" are the same diff.
+
+### Related
+
+Same family as the round-28 entry
+(`2026-08-09-a-gate-that-judges-from-a-tree-other-than-the-one-under-review.md`):
+a gate resolving its tree or base from something other than the change under
+review. #709 is that family's producer-side spelling — the tree was resolvable,
+and nobody handed it over.

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -1682,3 +1682,74 @@ resolves from the symbolic `HEAD`. **A seam added to make a gate testable is not
 the path that runs in production.** When a check drives a convenience entry
 point, at least one clause must drive the real invocation shape — for a pre-push
 hook, a genuine stdin range with a zero remote SHA.
+
+## [2026-08-10] A check that supplies the input under test proves the consumer, never that anything feeds it
+
+**Severity:** HIGH
+**Source:** Issue #709 (the unreachable half of #706); lane `lane/709-pr-head-ref`
+**Scope:** any done-means check, unit test, or acceptance gate for a fix that spans a PRODUCER and a CONSUMER — hooks feeding validators, callers feeding resolvers, CI feeding scripts
+**Status:** active
+
+### Pattern
+
+#706 fixed `scripts/validate-pr-body.ts` to resolve a `Done-means` path in
+three tiers, the third being `git cat-file -e <PR_HEAD_REF>:<path>` — the tier
+the issue asked for BY NAME, so a lane could cite a check existing only on its
+own branch. That half was correct and is still correct.
+
+The other half never shipped. `.claude/hooks/pr-body-gate.ts` is the only
+caller that runs at the boundary, and it set `PR_REPO_DIR` from the payload's
+`cwd` and **never set `PR_HEAD_REF`**, nor parsed `--head` from the intercepted
+`gh pr create`. The tier was dead code from the only live caller.
+
+`scripts/done-means/706-done-means-resolves-pr-head.sh` was **5/5 GREEN before,
+during, and after** the defect. It calls the validator DIRECTLY and sets
+`PR_HEAD_REF` itself. It therefore proved the consumer works WHEN FED, and
+never that anything feeds it. The sibling check that DOES drive the hook
+(`pr-body-gate-fires.sh`) asserted on neither `cwd` nor `PR_HEAD_REF`.
+
+This is `docs/lane-contract.md` round 28's own first bullet — *a seam added to
+make a gate testable is not the path that runs* — recurring in the very next
+lane. Writing the rule did not prevent the recurrence; only a clause driving
+the real entry point did.
+
+### The second, sharper trap
+
+Even a check that drives the real entry point can prove only half. Here TWO
+independent things were wrong and either alone explains the observed refusal:
+
+1. the payload `cwd` is the SESSION's directory (a `cd <worktree> && gh pr
+   create` in one Bash call does not move it), and
+2. `PR_HEAD_REF` was never supplied.
+
+A fix for (1) alone passes the obvious clause — "the cd-into-worktree call is
+accepted" — while the branch tier stays as dead as it ever was. The clause that
+forces (2) has to remove the file from every reachable working tree while
+leaving it committed on the branch, so that ONLY a supplied head ref can answer.
+
+### Review checks
+
+- For any fix spanning a producer and a consumer, ask: **does any clause fail
+  if the producer's wiring is reverted?** If every clause sets the disputed
+  input itself, the check covers the consumer only. Name the untested side.
+- Grep a done-means check for the environment variable or argument the fix is
+  about. If the check EXPORTS it, the check is downstream of the defect.
+- A hook payload's `cwd` is the session's, not the command's. Any gate reading
+  `input.cwd` as "where this command runs" is wrong whenever the command `cd`s.
+  Prose in the source asserting otherwise (#706's comment said exactly that) is
+  not evidence.
+- Gate inputs must be printed on the REFUSAL path, not only on the allow path.
+  #709 was diagnosed from a refusal naming the tree it searched but not where
+  that tree came from, so it read as "your path does not exist" when the truth
+  was "the gate looked in the wrong place".
+- A widened resolution must keep a MUTANT CONTROL clause: a path in no tree and
+  on no ref stays refused. Otherwise "fix the false refusal" and "turn the gate
+  off" are the same diff.
+
+### Related
+
+Same family as the round-28 entry
+(`2026-08-09-a-gate-that-judges-from-a-tree-other-than-the-one-under-review.md`):
+a gate resolving its tree or base from something other than the change under
+review. #709 is that family's producer-side spelling — the tree was resolvable,
+and nobody handed it over.

--- a/scripts/done-means/709-hook-feeds-head-ref.sh
+++ b/scripts/done-means/709-hook-feeds-head-ref.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #709 — the pr-body-gate hook must FEED the
+# validator the PR's actual head, not just its own session cwd.
+#
+#   bash scripts/done-means/709-hook-feeds-head-ref.sh
+#
+# ---------------------------------------------------------------------------
+# The defect this gates
+# ---------------------------------------------------------------------------
+# #706 landed in two halves and only one of them was reachable in production.
+#
+# `scripts/validate-pr-body.ts` resolves a `Done-means` path in three tiers:
+# the tree under review (`PR_REPO_DIR`), the validator's own tree, and
+# `git cat-file -e <PR_HEAD_REF>:<path>` against the head branch. The third
+# tier is the one #706 asked for by name — it is what lets a lane cite a check
+# that exists only on its own branch.
+#
+# `.claude/hooks/pr-body-gate.ts` is the ONLY caller that runs at the boundary,
+# and it set `PR_REPO_DIR` from `input.cwd` and NEVER set `PR_HEAD_REF`. It also
+# parsed no `--head` from the intercepted `gh pr create`. So:
+#
+#   - the branch tier was dead code from the only live caller, and
+#   - `input.cwd` is the HARNESS PAYLOAD's cwd — the session's directory. A
+#     `cd /path/to/worktree && gh pr create ...` inside one Bash call does not
+#     move it, so the "tree under review" was the PRIMARY CHECKOUT, sitting on
+#     the base branch, which is the exact tree #706 existed to stop consulting.
+#
+# Measured 2026-08-10 on lane/issue-artifacts-outcomes: the PR was refused, and
+# the refusal named the primary checkout as the only tree it looked in.
+#
+# ---------------------------------------------------------------------------
+# Why this check drives the HOOK and not the validator
+# ---------------------------------------------------------------------------
+# docs/lane-contract.md round 28, first bullet: A SEAM ADDED TO MAKE A GATE
+# TESTABLE IS NOT THE PATH THAT RUNS. #709 IS that bullet recurring in the lane
+# that wrote it. `scripts/done-means/706-done-means-resolves-pr-head.sh` is
+# 5/5 GREEN and always was: it calls the VALIDATOR directly and sets
+# `PR_HEAD_REF` itself, so it proves the tier works WHEN FED and never that
+# anything feeds it. `pr-body-gate-fires.sh` drives the real hook but asserts on
+# neither `cwd` nor `PR_HEAD_REF`.
+#
+# So every clause here drives `.claude/hooks/pr-body-gate.ts` with a synthetic
+# PreToolUse payload of exactly the shape Claude Code sends, whose `cwd` is NOT
+# the branch's tree and whose command is the real `cd <worktree> && gh pr create`
+# shape. No validator-direct seams are used as proof anywhere in this file.
+#
+# ---------------------------------------------------------------------------
+# The fixture
+# ---------------------------------------------------------------------------
+# A throwaway git repo under {temp_workspace}/open-brain/_scratch with:
+#
+#   - a base branch carrying NO check file,
+#   - a lane branch carrying `scripts/done-means/lane-only-check.sh`,
+#   - a worktree checked out on the lane branch.
+#
+# The payload's `cwd` is the BASE checkout (standing in for the session dir /
+# primary checkout). The command `cd`s into the lane worktree. A body citing
+# `scripts/done-means/lane-only-check.sh` is therefore resolvable ONLY if the
+# hook looks at something other than the payload cwd — the `cd` target, or the
+# head ref. That is the whole defect, expressed as a fixture.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+#   1  cd <lane worktree> && gh pr create citing a branch-only check
+#        -> ALLOWED. RED before the fix (the hook only knew the payload cwd).
+#   2  the same call, with the branch-only file DELETED from the lane worktree's
+#      working tree but still committed on the branch
+#        -> ALLOWED via the BRANCH tier specifically. This is the clause that
+#           forces PR_HEAD_REF to actually be supplied rather than the fix
+#           reducing to "read the cd target". Without it, a cwd-only fix passes
+#           clause 1 and the branch tier stays dead — the #709 defect exactly.
+#   3  explicit `--head <branch>` on the gh command is honoured
+#        -> ALLOWED even when the command never `cd`s anywhere and the payload
+#           cwd is the base checkout, i.e. no tree on disk carries the file.
+#   4  MUTANT CONTROL: same shape, citing a path that exists in NO tree and on
+#      NO branch -> still REFUSED. A fix that widens resolution must not become
+#      a blanket pass; this is the clause that fails if anyone "fixes" #709 by
+#      making the Done-means check advisory.
+#   5  the hook ANNOUNCES which source fed the head ref (AGENTS.md, nothing is
+#      adjusted silently, 2026-08-08). Round 28: "Assert on announcements, or
+#      they rot silently."
+#
+# Exit 0 only when every clause passes. Exit 3 is a harness error (missing tool,
+# unbuildable fixture), which is NOT a fail of the thing under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/.claude/hooks/pr-body-gate.ts"
+TEMPLATE="$REPO_ROOT/.github/pull_request_template.md"
+VALIDATOR="$REPO_ROOT/scripts/validate-pr-body.ts"
+
+SCRATCH_BASE="${OPENBRAIN_TEMP_WORKSPACE:-${DEV_TMP:-/Volumes/ThunderBolt/_tmp}}/open-brain/_scratch"
+SCRATCH="$SCRATCH_BASE/709-hook-feeds-head-ref.$$"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+command -v git >/dev/null 2>&1 || fail_hard "git not on PATH"
+[ -r "$VALIDATOR" ] || fail_hard "validator not readable at $VALIDATOR"
+[ -r "$TEMPLATE" ] || fail_hard "template not readable at $TEMPLATE"
+mkdir -p "$SCRATCH" || fail_hard "cannot create scratch dir $SCRATCH"
+
+# ---------------------------------------------------------------------------
+# Fixture repo: base checkout + lane branch + lane worktree.
+# ---------------------------------------------------------------------------
+FIXTURE="$SCRATCH/repo"
+LANE_TREE="$SCRATCH/lane-worktree"
+LANE_BRANCH="lane/709-fixture"
+BRANCH_ONLY_CHECK="scripts/done-means/lane-only-check.sh"
+
+build_fixture() {
+  git init -q -b base "$FIXTURE" || return 1
+  git -C "$FIXTURE" config user.email "done-means@open-brain.invalid" || return 1
+  git -C "$FIXTURE" config user.name "709 done-means fixture" || return 1
+  # The fixture must not inherit this repo's hooks: it is a scratch repo, and a
+  # pre-push/pre-commit running against it would be measuring the wrong thing.
+  git -C "$FIXTURE" config core.hooksPath "$FIXTURE/.git/no-hooks" || return 1
+
+  mkdir -p "$FIXTURE/scripts/done-means" || return 1
+  printf 'base tree\n' > "$FIXTURE/README.md" || return 1
+  git -C "$FIXTURE" add README.md || return 1
+  git -C "$FIXTURE" commit -q -m "base commit" || return 1
+
+  git -C "$FIXTURE" checkout -q -b "$LANE_BRANCH" || return 1
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$FIXTURE/$BRANCH_ONLY_CHECK" || return 1
+  git -C "$FIXTURE" add "$BRANCH_ONLY_CHECK" || return 1
+  git -C "$FIXTURE" commit -q -m "lane: add the branch-only check" || return 1
+  git -C "$FIXTURE" checkout -q base || return 1
+
+  git -C "$FIXTURE" worktree add -q "$LANE_TREE" "$LANE_BRANCH" || return 1
+}
+
+build_fixture || fail_hard "could not build the fixture repo under $SCRATCH"
+
+# Sanity: the fixture must actually express the asymmetry, or every clause below
+# measures nothing. The file is on the lane branch and NOT in the base checkout.
+[ -e "$FIXTURE/$BRANCH_ONLY_CHECK" ] \
+  && fail_hard "fixture wrong: the branch-only check is visible in the base checkout"
+git -C "$FIXTURE" cat-file -e "$LANE_BRANCH:$BRANCH_ONLY_CHECK" 2>/dev/null \
+  || fail_hard "fixture wrong: the branch-only check is not committed on $LANE_BRANCH"
+
+# ---------------------------------------------------------------------------
+# Bodies. Built from the committed template exactly the way
+# scripts/done-means/pr-body-gate-fires.sh builds its valid body, so this check
+# inherits that gate's guarantee instead of maintaining a second field list.
+# Only the Done-means line differs between them.
+# ---------------------------------------------------------------------------
+DUMMY="dummy specific content for the 709 acceptance gate"
+
+fill_template() {
+  local done_means_value="$1" out="$2"
+  sed \
+    -e 's/\[ \]\(.*\)or \[ \] not applicable because:.*$/[x]\1or [ ] not applicable because:/' \
+    -e 's/^- \[ \]/- [x]/' \
+    -e "s|^- Done-means:.*$|- Done-means: $done_means_value|" \
+    -e "s/^\(- [^][]*:\)[[:space:]]*$/\1 $DUMMY/" \
+    "$TEMPLATE" > "$out"
+}
+
+BRANCH_BODY_FILE="$SCRATCH/branch-only-body.md"
+NOWHERE_BODY_FILE="$SCRATCH/nowhere-body.md"
+NOWHERE_PATH="scripts/done-means/this-path-exists-nowhere-at-all.sh"
+
+fill_template "$BRANCH_ONLY_CHECK" "$BRANCH_BODY_FILE" \
+  || fail_hard "could not build the branch-only body"
+fill_template "$NOWHERE_PATH" "$NOWHERE_BODY_FILE" \
+  || fail_hard "could not build the nowhere body"
+
+# Sanity on the MUTANT CONTROL fixture: the nonexistent path must genuinely be
+# absent from both trees and both refs, or clause 4 proves nothing.
+[ -e "$FIXTURE/$NOWHERE_PATH" ] && fail_hard "fixture wrong: the 'nowhere' path exists in the base checkout"
+[ -e "$LANE_TREE/$NOWHERE_PATH" ] && fail_hard "fixture wrong: the 'nowhere' path exists in the lane worktree"
+[ -e "$REPO_ROOT/$NOWHERE_PATH" ] && fail_hard "fixture wrong: the 'nowhere' path exists in this repo"
+if git -C "$FIXTURE" cat-file -e "$LANE_BRANCH:$NOWHERE_PATH" 2>/dev/null; then
+  fail_hard "fixture wrong: the 'nowhere' path is committed on $LANE_BRANCH"
+fi
+
+# ---------------------------------------------------------------------------
+# Drive the REAL hook the way Claude Code does: a PreToolUse JSON payload on
+# stdin, carrying the SESSION's cwd — never the lane worktree.
+# Sets HOOK_EXIT and HOOK_STDERR.
+# ---------------------------------------------------------------------------
+HOOK_EXIT=0
+HOOK_STDERR=""
+run_hook() {
+  local command_text="$1" payload_cwd="$2" payload
+  payload="$(
+    COMMAND_TEXT="$command_text" PAYLOAD_CWD="$payload_cwd" bun -e '
+      process.stdout.write(JSON.stringify({
+        session_id: "709-hook-feeds-head-ref",
+        cwd: process.env.PAYLOAD_CWD ?? "",
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: process.env.COMMAND_TEXT ?? "" },
+      }));
+    '
+  )" || fail_hard "could not build hook payload"
+
+  HOOK_STDERR="$(printf '%s' "$payload" | bun "$HOOK" --event pre-tool-use 2>&1 >/dev/null)"
+  HOOK_EXIT=$?
+}
+
+q() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"; }
+
+CLAUSES=()
+record() { CLAUSES+=("$1|$2|$3"); }
+
+if [ ! -r "$HOOK" ]; then
+  for c in 1 2 3 4 5; do
+    record "$c" FAIL "no hook at $HOOK — nothing feeds the validator anything"
+  done
+else
+  # -- CLAUSE 1: the real `cd <worktree> && gh pr create` shape is ALLOWED -----
+  # The payload cwd is the BASE checkout. Pre-fix the hook resolved there, found
+  # nothing, and refused. This is the exact call the #709 report measured.
+  run_hook "cd $(q "$LANE_TREE") && gh pr create --title 'feat: lane thing' --body-file $(q "$BRANCH_BODY_FILE")" "$FIXTURE"
+  if [ "$HOOK_EXIT" -eq 0 ]; then
+    record 1 PASS "cd-into-worktree gh pr create citing a branch-only check ALLOWED (exit=0)"
+  else
+    record 1 FAIL "REFUSED (exit=$HOOK_EXIT) — the hook still resolves against the payload cwd: $(printf '%s' "$HOOK_STDERR" | tr '\n' ' ' | cut -c1-260)"
+  fi
+
+  # -- CLAUSE 2: the BRANCH tier specifically, with no tree on disk carrying it -
+  # Move the file out of the lane worktree's working tree (it stays committed on
+  # the branch). Now NO checkout the hook can reach has it, so only a supplied
+  # PR_HEAD_REF can resolve it. A fix that merely reads the `cd` target fails
+  # here, which is the point: #709 is about the branch tier being fed.
+  STASHED="$SCRATCH/stashed-lane-only-check.sh"
+  mv "$LANE_TREE/$BRANCH_ONLY_CHECK" "$STASHED" \
+    || fail_hard "could not move the branch-only check out of the lane worktree"
+  [ -e "$LANE_TREE/$BRANCH_ONLY_CHECK" ] \
+    && fail_hard "fixture wrong: the branch-only check is still on disk in the lane worktree"
+
+  run_hook "cd $(q "$LANE_TREE") && gh pr create --title 'feat: lane thing' --body-file $(q "$BRANCH_BODY_FILE")" "$FIXTURE"
+  CLAUSE2_EXIT="$HOOK_EXIT"
+  CLAUSE2_STDERR="$HOOK_STDERR"
+  if [ "$CLAUSE2_EXIT" -ne 0 ]; then
+    record 2 FAIL "REFUSED (exit=$CLAUSE2_EXIT) — the branch tier is still unfed: $(printf '%s' "$CLAUSE2_STDERR" | tr '\n' ' ' | cut -c1-260)"
+  elif ! printf '%s' "$CLAUSE2_STDERR" | rg -qF "resolved in branch $LANE_BRANCH"; then
+    record 2 FAIL "allowed, but never announced the BRANCH tier — resolution came from somewhere else, so PR_HEAD_REF is still unproven"
+  else
+    record 2 PASS "on-disk-nowhere check resolved via the BRANCH tier and announced it (exit=0)"
+  fi
+
+  mv "$STASHED" "$LANE_TREE/$BRANCH_ONLY_CHECK" \
+    || fail_hard "could not restore the branch-only check into the lane worktree"
+
+  # -- CLAUSE 3: an explicit --head is honoured, with no cd at all -------------
+  # Payload cwd is the base checkout, the command never changes directory, and
+  # the file is in no reachable tree. Only `--head` can answer.
+  mv "$LANE_TREE/$BRANCH_ONLY_CHECK" "$STASHED" \
+    || fail_hard "could not move the branch-only check out for clause 3"
+  run_hook "git -C $(q "$FIXTURE") status && gh pr create --head $(q "$LANE_BRANCH") --title 'feat: lane thing' --body-file $(q "$BRANCH_BODY_FILE")" "$FIXTURE"
+  if [ "$HOOK_EXIT" -eq 0 ] && printf '%s' "$HOOK_STDERR" | rg -qF "resolved in branch $LANE_BRANCH"; then
+    record 3 PASS "explicit --head honoured with no cd and no tree on disk (exit=0, branch tier announced)"
+  else
+    record 3 FAIL "explicit --head not honoured (exit=$HOOK_EXIT): $(printf '%s' "$HOOK_STDERR" | tr '\n' ' ' | cut -c1-260)"
+  fi
+  mv "$STASHED" "$LANE_TREE/$BRANCH_ONLY_CHECK" \
+    || fail_hard "could not restore the branch-only check after clause 3"
+
+  # -- CLAUSE 4: MUTANT CONTROL. A path in no tree and on no ref is REFUSED ----
+  run_hook "cd $(q "$LANE_TREE") && gh pr create --title 'feat: lane thing' --body-file $(q "$NOWHERE_BODY_FILE")" "$FIXTURE"
+  if [ "$HOOK_EXIT" -ne 2 ]; then
+    record 4 FAIL "a nonexistent Done-means path was ALLOWED (exit=$HOOK_EXIT) — widening resolution turned the gate into a blanket pass"
+  elif ! printf '%s' "$HOOK_STDERR" | rg -qF "$NOWHERE_PATH"; then
+    record 4 FAIL "refused but never names the offending path"
+  elif ! printf '%s' "$HOOK_STDERR" | rg -qF 'looked in:'; then
+    record 4 FAIL "refused but never says where it looked — a dead-end refusal"
+  else
+    record 4 PASS "nonexistent Done-means path still REFUSED, naming the path and where it looked (exit=2)"
+  fi
+
+  # -- CLAUSE 5: the head-ref SOURCE is announced -----------------------------
+  # AGENTS.md 2026-08-08: nothing is adjusted silently. The hook decides for
+  # itself where the head ref came from (--head, or the cd target's checkout);
+  # a self-made decision that is invisible cannot be checked by the reader.
+  # Round 28: assert on announcements or they rot.
+  run_hook "cd $(q "$LANE_TREE") && gh pr create --title 'feat: lane thing' --body-file $(q "$BRANCH_BODY_FILE")" "$FIXTURE"
+  DERIVED_OK=0
+  printf '%s' "$HOOK_STDERR" | rg -qF 'pr-body-gate' \
+    && printf '%s' "$HOOK_STDERR" | rg -qF "$LANE_BRANCH" \
+    && printf '%s' "$HOOK_STDERR" | rg -qi -e 'head ref' \
+    && DERIVED_OK=1
+  if [ "$DERIVED_OK" -ne 1 ]; then
+    record 5 FAIL "the derived head ref is not announced by name — the hook made a silent decision: $(printf '%s' "$HOOK_STDERR" | tr '\n' ' ' | cut -c1-260)"
+  else
+    run_hook "gh pr create --head $(q "$LANE_BRANCH") --title 'feat: lane thing' --body-file $(q "$BRANCH_BODY_FILE")" "$FIXTURE"
+    if printf '%s' "$HOOK_STDERR" | rg -qi -e '--head|explicit' && printf '%s' "$HOOK_STDERR" | rg -qF "$LANE_BRANCH"; then
+      record 5 PASS "head ref source announced on both paths (derived from the command's target checkout, and explicit --head)"
+    else
+      record 5 FAIL "explicit --head path does not announce its source: $(printf '%s' "$HOOK_STDERR" | tr '\n' ' ' | cut -c1-260)"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+label_for() {
+  case "$1" in
+    1) printf 'cd-into-worktree gh pr create citing a branch-only check is ALLOWED' ;;
+    2) printf 'the BRANCH tier resolves a check on disk in no reachable tree' ;;
+    3) printf 'an explicit --head is parsed and honoured' ;;
+    4) printf 'MUTANT CONTROL: a path in no tree and on no ref is still REFUSED' ;;
+    5) printf 'the head-ref SOURCE is announced, never silent' ;;
+  esac
+}
+
+ALL_PASS=1
+for entry in "${CLAUSES[@]}"; do
+  id="${entry%%|*}"
+  rest="${entry#*|}"
+  status="${rest%%|*}"
+  evidence="${rest#*|}"
+  printf 'CLAUSE %s (%s): %s — %s\n' "$id" "$(label_for "$id")" "$status" "$evidence"
+  [ "$status" = PASS ] || ALL_PASS=0
+done
+
+# Fixture teardown. The worktree registration is removed with git (a plain move
+# would strand it); the directory itself is ARCHIVED, never deleted — AGENTS.md,
+# the agent's cleanup verb is mv.
+git -C "$FIXTURE" worktree remove --force "$LANE_TREE" >/dev/null 2>&1
+ARCHIVE_DIR="${OPENBRAIN_TEMP_WORKSPACE:-${DEV_TMP:-/Volumes/ThunderBolt/_tmp}}/open-brain/_archive"
+if mkdir -p "$ARCHIVE_DIR" 2>/dev/null; then
+  mv "$SCRATCH" "$ARCHIVE_DIR/$(basename "$SCRATCH").$(date +%s)" 2>/dev/null
+fi
+
+[ "$ALL_PASS" -eq 1 ] && exit 0
+exit 1

--- a/scripts/done-means/sme-per-entry-files.sh
+++ b/scripts/done-means/sme-per-entry-files.sh
@@ -93,7 +93,19 @@ BUILD_SCRIPT="scripts/build-sme-indexes.ts"
 # gotcha-agent entry takes it to 232. The pin is being reconciled here, not
 # silently absorbed: if the operator wants those four re-examined rather than
 # adopted, this is the line that records that they were never accounted for.
-EXPECTED_ENTRY_COUNT=232
+#
+# 2026-08-10, the #709 lane: 232 -> 233. Exactly ONE entry added, and it is this
+# lane's own --
+# `2026-08-10-a-check-that-supplies-the-input-under-test-proves-only-half-the-wiring.md`
+# (lane: gotcha-agent, order 69), the review-facing half of the #709 harvest.
+# Nothing else was adopted: the count in the untouched primary checkout at
+# e3917ab is 232, matching this pin before the raise, so the four unaccounted
+# entries noted above are still exactly those four and no more have accumulated.
+# Clause 1 remains RED here for a reason that is NOT this lane's and is already
+# filed as #707 (one entry uses a level-1 undated heading); verified by running
+# this script in the untouched primary checkout, where clause 1 fails and
+# clause 4 passes.
+EXPECTED_ENTRY_COUNT=233
 
 LANE_FILES=(
   "$SME_DIR/correctness.md"


### PR DESCRIPTION
## Summary

- Fixes #709, and closes the first of the two defects reported in #641. `.claude/hooks/pr-body-gate.ts` is the only caller of `scripts/validate-pr-body.ts` that runs at the boundary, and it never delivered the input the validator needs. #706 shipped a correct three-tier `Done-means` resolution and a hook that fed it neither the right tree nor the head ref, so half of #706 was unreachable in production.
- Two independent defects, both pointing the gate at the base branch. First, `input.cwd` is the HARNESS payload's cwd — the SESSION's directory. A lane opens its PR as `cd <worktree> && gh pr create` in one Bash call, and that `cd` does not move the session, so the "tree under review" was the primary checkout: the exact tree #706 existed to stop consulting. Second, `PR_HEAD_REF` was never set and `--head` was never parsed, so `git cat-file -e <ref>:<path>` — the tier #706 asked for by name — was dead code from the only live caller.
- The hook now resolves both in a fixed precedence and ANNOUNCES which source answered: `--head`/`-H` on the intercepted command, else the branch checked out in the directory the command `cd`s into, else the payload cwd. `PR_REPO_DIR` follows the same target directory, keeping the tree and ref tiers complementary rather than alternatives.
- Inputs are printed on the REFUSAL path too. #709 was diagnosed from a refusal that named the tree it searched but not where that tree came from, so it read as "your path does not exist" when the truth was "the gate looked in the wrong place".
- Harvest: `docs/lane-contract.md` round 29 plus one SME entry. Round 28's own first bullet — a seam added to make a gate testable is not the path that runs — recurred in the very next lane, and round 29 records why the paragraph did not prevent it.
- Found live and FILED, not absorbed: #711 (`core.hooksPath` absolute, so every worktree runs the primary checkout's hooks) and #712 (`bun test` aborts with `WriteFailed` when its stdout is git's pipe, failing pushes while the suite is green).

## Verification

- Done-means: scripts/done-means/pr-body-gate-fires.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

### Bootstrap ordering, declared — not routed around

The `Done-means` line above names `pr-body-gate-fires.sh`, NOT this lane's new `709-hook-feeds-head-ref.sh`, and that is a deliberate declaration rather than a convenience.

The registered hook is `$CLAUDE_PROJECT_DIR/.claude/hooks/pr-body-gate.ts` — the PRIMARY checkout's copy, which is the unfixed one. So the gate judging this PR is precisely the code this PR repairs, and it cannot see a check that exists only on this branch. That is #709 itself, one layer up. It is also round 28's recorded case: when the fixed gate cannot yet judge its own PR, cite a pre-existing check that GENUINELY judges the change, print both runs, and say why.

`pr-body-gate-fires.sh` is that check. It is the standing acceptance test for the very hook being modified, it exists on the base branch (`git cat-file -e origin/wip/2026-08-07:scripts/done-means/pr-body-gate-fires.sh` succeeds), and it is 8/8 GREEN against this diff. `709-hook-feeds-head-ref.sh` is the fuller proof and is in the tree, cited here and runnable by the controller on merge.

No bypass was used. The FIXED hook from this branch was run against this exact `gh pr create` invocation, which is running the repaired gate rather than skipping a gate:

```
$ bun .claude/hooks/pr-body-gate.ts --event pre-tool-use < payload.json
[pr-body-gate] tree under review: the directory the command cd's into (.../lane-709-pr-head-ref)
[pr-body-gate] head ref: lane/709-pr-head-ref (source: explicit --head on the gh command)
[pr-body-gate] Done-means resolved in the tree under review: .../scripts/done-means/709-hook-feeds-head-ref.sh
FIXED_EXIT=0
```

And with the check hidden from every working tree while it stays committed on the branch — the tier that was dead code before this fix:

```
[pr-body-gate] head ref: lane/709-pr-head-ref (source: explicit --head on the gh command)
[pr-body-gate] Done-means resolved in branch lane/709-pr-head-ref (...), not on disk in any available tree
FIXED_EXIT=0
```

The refusing run, for contrast — the OLD hook (primary checkout) on the same call, which is the #709 defect reproducing on this very PR:

```
BLOCKED by pr-body-gate: this PR body fails scripts/validate-pr-body.ts.
- Verification field 'Done-means' must name an existing repo-relative path;
  not found: scripts/done-means/709-hook-feeds-head-ref.sh
  (looked in: /Volumes/ThunderBolt/Development/open-brain)
```

Once this merges, the primary checkout carries the fix and the next lane can cite its own check directly.

Every clause of `709-hook-feeds-head-ref.sh` drives the REAL hook entry with a synthetic PreToolUse payload of the shape Claude Code sends, whose `cwd` is NOT the branch's tree. No validator-direct seam is used as proof anywhere in the file — that is the specific mistake #709 is.

RED, before the fix (4/5 fail; clause 4 is the mutant control and passes on both sides, as it must):

```
CLAUSE 1 (cd-into-worktree gh pr create citing a branch-only check is ALLOWED): FAIL - REFUSED (exit=2) - the hook still resolves against the payload cwd
CLAUSE 2 (the BRANCH tier resolves a check on disk in no reachable tree): FAIL - REFUSED (exit=2) - the branch tier is still unfed
CLAUSE 3 (an explicit --head is parsed and honoured): FAIL - explicit --head not honoured (exit=2)
CLAUSE 4 (MUTANT CONTROL: a path in no tree and on no ref is still REFUSED): PASS - nonexistent Done-means path still REFUSED, naming the path and where it looked (exit=2)
CLAUSE 5 (the head-ref SOURCE is announced, never silent): FAIL - the derived head ref is not announced by name - the hook made a silent decision
EXIT=1
```

GREEN, after the fix:

```
CLAUSE 1 (cd-into-worktree gh pr create citing a branch-only check is ALLOWED): PASS - ALLOWED (exit=0)
CLAUSE 2 (the BRANCH tier resolves a check on disk in no reachable tree): PASS - on-disk-nowhere check resolved via the BRANCH tier and announced it (exit=0)
CLAUSE 3 (an explicit --head is parsed and honoured): PASS - explicit --head honoured with no cd and no tree on disk (exit=0, branch tier announced)
CLAUSE 4 (MUTANT CONTROL: a path in no tree and on no ref is still REFUSED): PASS - nonexistent Done-means path still REFUSED, naming the path and where it looked (exit=2)
CLAUSE 5 (the head-ref SOURCE is announced, never silent): PASS - head ref source announced on both paths (derived from the command's target checkout, and explicit --head)
EXIT=0
```

Clause 2 is the one that forces the branch tier specifically: it moves the check out of the lane worktree's working tree while it stays committed on the branch, so no reachable checkout carries it and only a supplied `PR_HEAD_REF` can answer. A fix that merely read the `cd` target passes clause 1 and still fails clause 2 — which is exactly how #706 shipped half-done.

Sibling gates, unchanged by this diff:

```
scripts/done-means/pr-body-gate-fires.sh               8/8 PASS (EXIT=0)
scripts/done-means/706-done-means-resolves-pr-head.sh  5/5 PASS (EXIT=0)
bunx tsc --noEmit                                      clean
bun test                                               3372 pass, 525 skip, 0 fail (3897 across 244 files)
```

Pre-push gate ran in full on this branch and passed — no bypass, no hook skipping: `base: origin/wip/2026-08-07 - configured upstream`, `TypeScript passed`, `Bun tests passed`.

`sme-per-entry-files.sh` clause 4 was raised 232 to 233 in the same commit that adds the entry, as that check's own failure text instructs, with the reason inline. Its clause 1 remains RED for a reason that is NOT this lane's and is already filed as #707 — verified by running the script in the untouched primary checkout at `e3917ab`, where clause 1 fails and clause 4 passes.

## Critical Self-Review

- Highest-risk behavior: widening where a `Done-means` path may resolve is one edit away from turning a forced gate into a blanket pass. Clause 4 exists solely to hold that line and asserts the refusal still names both the path and where it looked.
- Assumptions that could be wrong: that the last `cd` before the gh call is where it runs. A `cd` inside a subshell or a function, or one whose target is built at runtime, is not modelled. Those yield no hint and fall back to the payload cwd — the pre-fix behavior — rather than a wrong answer stated confidently.
- Missing/weak tests: no clause covers `gh pr edit` carrying `--head`, or a repository whose HEAD is detached (the code returns null there by design, via `symbolic-ref` rather than `rev-parse`, but nothing asserts it). Both are narrower than the defect being fixed, and are named here rather than quietly skipped.
- Security/permission risk: the validator SCRIPT still runs from the primary checkout, so a lane cannot weaken the rules by editing them on its own branch — only the tree and ref it inspects are supplied. The containment guard is untouched: absolute paths and `..` escapes are still refused per candidate tree, and `existsInRef` refuses both before it probes.
- Migration/deploy risk: none. Repo-local hook plus one done-means script; no schema, no runtime, no deploy surface.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` "When This Applies" lists MCP tool/schema/auth, transport, migrations, `python/openbrain-memory`, generated skill content, and anything an MCP consumer calls. This diff touches none of them.
- Rollback/cleanup concern: reverting the commit restores the previous hook exactly; the new check is additive. The check builds its fixture under `{temp_workspace}/open-brain/_scratch`, removes its worktree with `git worktree remove` (never a plain move, which would strand the registration), and ARCHIVES the directory rather than deleting it.
- Fixes made before PR: the first draft derived the branch with `rev-parse`, which returns a raw SHA on a detached HEAD. A SHA is a valid `git cat-file` argument, so the announcement would have read "resolved in branch 9f3a1c2" — a non-fact in the grammar of a fact. Switched to `symbolic-ref --quiet --short`, which fails cleanly instead.
- Known residual risk: the announcement is the only signal that the hook picked a `cd` target at all. Clause 5 asserts on it because round 28 measured an announcement rotting silently while the flags around it stayed correct.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this changes a repo-local PreToolUse hook and a done-means script; no server, tool, schema, or namespace behavior is touched, so a live smoke would exercise nothing in this diff.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no path in `contracts/parity-paths.txt` is touched. The diff is a Claude Code hook plus a shell check, neither of which has a Python counterpart.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board, against the gate's own "When This Applies" list: the change is confined to `.claude/hooks/pr-body-gate.ts`, `scripts/done-means/`, and `docs/`. No tool name, input schema, output shape, auth, namespace semantic, transport behavior, migration, Python client export, or generated skill content changes, so no downstream runtime can observe this diff.
