### PR TITLE
fix(gates): pre-push reads the suite's exit code, not its ability to write to a pipe (#712)

### DIFF
--- a/_githooks/pre-push
+++ b/_githooks/pre-push
@@ -225,8 +225,93 @@ echo "  bun run typecheck ..."
 bun run typecheck
 echo "  ✓ TypeScript passed"
 
-echo "  bun test ..."
-bun test
+# ---------------------------------------------------------------------------
+# THE TEST SUITE (issue #712)
+# ---------------------------------------------------------------------------
+# `bun test` used to run here bare, inheriting git's stdout and stderr. When git
+# is invoked with its output captured (`git push ... | tail`, or any wrapper that
+# reads it), those fds are PIPES, and bun 1.3.14 aborts partway through writing
+# the full-suite coverage table:
+#
+#     src/validation-errors.ts       |  100.00 |   90.
+#     error: An internal error occurred (WriteFailed)
+#
+# It exits 1 having run a GREEN suite. Measured on the untouched primary at
+# e3917ab, clean tree, by redirecting each fd independently:
+#
+#   stdout PIPE  + stderr PIPE  -> exit 1 (WriteFailed)
+#   stdout FILE  + stderr FILE  -> exit 0 (3372 pass, 0 fail)
+#   stdout FILE  + stderr PIPE  -> exit 1 (WriteFailed)   <-- stderr is the writer
+#   stdout PIPE  + stderr FILE  -> exit 0
+#
+# So the failing writer is bun's STDERR -- which is where the coverage table and
+# the pass/fail summary go. Redirecting stdout alone would not have fixed this,
+# and a fix that "looked right" that way would have left the defect live. Piping
+# into a fully-draining `cat` does not help either, and the output truncates
+# MID-LINE, so this is bun's own write path against a pipe fd rather than a
+# consumer that stopped reading.
+#
+# WHY THIS MATTERS MORE THAN THE WASTED RUN. The verdict depended on how the
+# CALLER captured output, so the push failed "randomly" from the operator's
+# seat, with text identical to a genuinely broken branch. A gate that fails the
+# same way for a green push and a broken one has stopped carrying information,
+# and that is precisely the condition that makes `--no-verify` habitual. It is
+# the same family as CLOSED #483: something the hook INHERITED from its caller
+# decided its verdict. The rule both share -- a gate must not let anything it
+# inherited from its caller decide its verdict.
+#
+# THE FIX. Both fds go to a log file under the temp workspace, so neither is a
+# pipe no matter how git was called, and the verdict is read from bun's EXIT
+# CODE. The log is tee'd back afterwards so the operator still sees the output
+# they would have seen. The redirect is ANNOUNCED (AGENTS.md, nothing is
+# adjusted silently): a reader of the transcript can see where the output went
+# rather than wondering why the suite went quiet.
+#
+# AND THE TWO FAILURES ARE NAMED SEPARATELY. "the tests failed" and "the runner
+# could not write its output" are different defects with different owners, and
+# before this they were the same bare `WriteFailed` plus a refused push. The
+# WriteFailed marker is searched for in the log so that if this ever fires again
+# through a path not covered here, the hook says which one it was instead of
+# blaming the branch.
+TEST_LOG_DIR="${OPENBRAIN_TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch/pre-push"
+TEST_LOG="$TEST_LOG_DIR/bun-test-$$-$(date +%s).log"
+if ! mkdir -p "$TEST_LOG_DIR" 2>/dev/null; then
+  echo "  ✗ pre-push could not create the test log directory: $TEST_LOG_DIR" >&2
+  echo "    This is a HOOK environment problem, not a test failure." >&2
+  exit 1
+fi
+
+echo "  bun test ... (stdout+stderr -> $TEST_LOG, replayed below; #712)"
+
+# `set -e` is on, so the exit code is captured explicitly rather than letting a
+# non-zero status kill the hook before the log can be replayed and classified.
+TEST_EXIT=0
+bun test > "$TEST_LOG" 2>&1 || TEST_EXIT=$?
+
+# Replay what the operator would have seen. `cat` writes to the hook's OWN
+# stdout, which may still be git's pipe -- but a truncated REPLAY cannot change
+# the verdict, because the verdict was already decided by TEST_EXIT above. That
+# separation is the entire point of the fix. `|| true` so a broken replay is
+# never mistaken for a failing suite.
+cat "$TEST_LOG" 2>/dev/null || true
+
+if [ "$TEST_EXIT" -ne 0 ]; then
+  # Distinguish the two failures and SAY WHICH.
+  # POSIX `grep` deliberately, not `rg`: this is a git hook that must classify
+  # the failure in any environment it is installed into (CI image, fresh clone,
+  # a box without ripgrep). The repo's fast-tools rule governs what an AGENT
+  # types to search the tree, not what a shipped script depends on at runtime.
+  if grep -q "An internal error occurred (WriteFailed)" "$TEST_LOG" 2>/dev/null; then
+    echo "  ✗ THE TEST RUNNER COULD NOT WRITE ITS OUTPUT (WriteFailed) — this is NOT a test failure." >&2
+    echo "    bun exited ${TEST_EXIT} while writing its report, so the suite's real verdict is unknown." >&2
+    echo "    Full output: $TEST_LOG  (see issue #712)" >&2
+  else
+    echo "  ✗ TESTS FAILED (bun exit ${TEST_EXIT}) — the suite ran and reported failures." >&2
+    echo "    Full output: $TEST_LOG" >&2
+  fi
+  exit "$TEST_EXIT"
+fi
+
 echo "  ✓ Bun tests passed"
 
 if [ "$CHANGED_PYTHON" = yes ]; then

--- a/docs/lane-contract.md
+++ b/docs/lane-contract.md
@@ -143,6 +143,66 @@ Newest first. Every entry: what changed, and the observation that forced it.
   path in. Filing it is cheaper than the habit it would otherwise train; #705's
   own commit message predicted this exact slide into routine bypass.
 
+### 2026-08-10 (round 29) — harvest of the #712 pre-push WriteFailed lane
+
+- **A GATE MUST NOT LET ITS OWN REPORTING CHANNEL DECIDE ITS VERDICT.**
+  `_githooks/pre-push` ran `bun test` bare, so bun inherited git's stdout and
+  stderr; when the CALLER pipes git's output, bun 1.3.14 dies mid-coverage-table
+  with `WriteFailed` and exits 1 on a suite that is GREEN. The real result
+  existed and was thrown away because the process died printing it. Read the
+  verdict from the EXIT CODE; send a child's output somewhere the caller cannot
+  make hostile, then replay for the human. Second instance of CLOSED #483's
+  family (there the inherited thing was `GIT_DIR`) — two instances make it a
+  family: audit what else a gate passes down untouched.
+- **Measure WHICH fd before fixing, or the obvious fix looks right and changes
+  nothing.** Redirecting each fd independently proved the failing writer is
+  **stderr** (stdout FILE + stderr PIPE still exits 1; stdout PIPE + stderr FILE
+  exits 0). `bun test > log` — the reflex spelling — leaves the defect 100% live
+  and passes review. The done-means clause must pin the fd that was MEASURED,
+  not the one that is conventional to redirect. Also measured: a fully-draining
+  `cat` does not help and output truncates mid-line, so "something downstream
+  stopped reading" was the wrong first hypothesis.
+- **A failure whose presence depends on HOW THE CALLER CAPTURED OUTPUT is
+  intermittent from the operator's seat** — the push "randomly" failed then
+  "randomly" worked, with text identical to a genuinely broken branch. That is
+  the precise profile that makes `--no-verify` habitual, so it is a severity
+  multiplier, not a footnote.
+- **Do NOT couple a check to the upstream bug's own threshold.** Reproducing
+  bun's internal ~214 KB stderr trigger was attempted and abandoned: a synthetic
+  4 MB stderr writer exits 0, and fixture suites of 300 and 1200 modules both
+  exit 0 through a pipe. A check that depended on it **would go green the day
+  bun fixes the bug**, silently un-testing the hook's classification logic —
+  which is the part this repo owns. Reproduce the child's OBSERVABLE CONTRACT
+  (fd 2 is a FIFO → `WriteFailed`, exit 1) via a PATH shim; keep the HOOK, the
+  pipe, and the stdin range real. Round 28 says the invocation shape must be
+  real; this says the *upstream defect* need not be, and names the line between.
+- **Know which spelling the subject actually invokes.** The fake runner was
+  first placed in `package.json` `scripts.test`, but the hook calls `bun test`
+  DIRECTLY, not `bun run test` — so the clause went red with "0 test files
+  matching", a false RED proving the FIXTURE wrong rather than the hook broken
+  (rounds 18/22/23 family). Round 18's read-WHY-it-went-red rule caught it.
+- **"Tests failed" and "the runner could not report" are different defects with
+  different owners, and a gate that collapses them stops carrying information.**
+  Two lanes were blocked on #712 before it was diagnosed. The fix names which,
+  and the mutant clause (b) holds the other direction: a genuinely failing suite
+  must still fail AND still be called a test failure.
+- **Round 28's pre-existing-failure practice held twice.** `sme-per-entry-files.sh`
+  clause 1 was RED for #707 (not this lane's file; zero mentions in this lane's
+  diff) — proven identically RED on the untouched primary at `e3917ab` and left
+  failing rather than absorbed. The count pin WAS this lane's and was raised in
+  the same commit as the entry, with the reason named.
+- **The #711 bootstrap trap is now the standing condition for hook lanes.**
+  `core.hooksPath` is absolute, so a lane worktree runs the PRIMARY's hook — a
+  lane fixing pre-push cannot exercise its own fix on push without an explicit
+  `-c core.hooksPath=<lane worktree>`. Used here (the #713 precedent: running
+  the FIXED gate is not a bypass), declared in the PR body, and `--no-verify`
+  was not used. This lane's own push through a piped git IS the live proof.
+- **A git-guard refusal and a design-lookup refusal were both the rules
+  working** — `git reset --hard` refused when re-basing the lane onto its real
+  integration target (rebuilt with `git checkout -B` instead), and a Write
+  refused pending a subject-relevant lookup. Neither was retried as a spelling
+  variant.
+
 ### 2026-08-09 (round 28) — harvest of the #705/#706 gate-fix lane (PR #708)
 
 - **A SEAM ADDED TO MAKE A GATE TESTABLE IS NOT THE PATH THAT RUNS.** This

--- a/docs/sme/entries/2026-08-10-a-gate-must-not-let-its-own-reporting-channel-decide-its-verdict.md
+++ b/docs/sme/entries/2026-08-10-a-gate-must-not-let-its-own-reporting-channel-decide-its-verdict.md
@@ -1,0 +1,105 @@
+---
+lane: gotcha-agent
+order: 70
+---
+## [2026-08-10] A gate must not let its own reporting channel decide its verdict
+
+**Severity:** HIGH
+**Source:** Issue #712 (`lane/712-pre-push-writefailed`); second confirmed instance of the family opened by CLOSED #483
+**Scope:** any gate, hook, or CI step that runs a child process and reads its success from anything other than the child's exit code — and any child whose behavior changes with the KIND of fd it inherits (pipe vs file vs tty)
+**Status:** active
+
+### Pattern
+
+`_githooks/pre-push` ran `bun test` bare, letting it inherit git's stdout and
+stderr. When the CALLER captures git's output (`git push ... | tail`, or any
+wrapper that reads it), those fds are pipes, and bun 1.3.14 aborts partway
+through writing the full-suite coverage table:
+
+```
+ src/validation-errors.ts       |  100.00 |   90.
+error: An internal error occurred (WriteFailed)
+```
+
+It exits 1 having run a GREEN suite. Every piped push failed, with text
+identical to a genuinely broken branch.
+
+The generalisable defect is not bun's bug. It is that **the gate's verdict was
+carried by its reporting channel.** The suite's real result (3372 pass, 0 fail)
+existed and was discarded, because the process that produced it died trying to
+print it.
+
+### The measurement that mattered, and the fix that would have looked right
+
+Redirecting each fd independently on the untouched primary:
+
+| stdout | stderr | bun exit |
+|---|---|---|
+| PIPE | PIPE | 1 (WriteFailed) |
+| FILE | FILE | 0 (3372 pass, 0 fail) |
+| FILE | **PIPE** | **1 (WriteFailed)** |
+| PIPE | FILE | 0 |
+
+The failing writer is **stderr** — where bun's coverage table and pass/fail
+summary go. The obvious fix (`bun test > log`) redirects only stdout, leaves the
+defect 100% live, and looks correct in review. Any check for this class must pin
+the fd that was actually measured, not the one that is conventional to redirect.
+
+Also measured: a fully-draining `cat` consumer does NOT help, and the output
+truncates mid-line — so this is the child's own write path against a pipe fd,
+not a consumer that stopped reading. "Something downstream stopped reading" is
+the wrong first hypothesis here.
+
+### Why it is worse than an ordinary flaky gate
+
+The failure depended on **how the caller captured output**, so from the
+operator's seat the push failed "randomly" and then "randomly" worked. A gate
+that fails identically for a green push and a broken one has stopped carrying
+information, and intermittent-plus-indistinguishable is the exact profile that
+makes `--no-verify` habitual — the decay this repo's gate work keeps fighting.
+
+### Second instance of #483's family
+
+CLOSED #483: the pre-push hook's inherited `GIT_DIR` changed the outcome of
+`bun test`, and the difference was invisible in the verdict. Here the inherited
+thing is stdout/stderr. **The rule both share: a gate must not let anything it
+inherited from its caller decide its verdict.** Two instances make this a
+family, not an incident — audit what else a hook passes down untouched.
+
+### Review checks
+
+- **Read the verdict from the exit code, never from the presence, shape, or
+  survival of output.** If a step's success is inferred from parsed text, ask
+  what happens when the writer dies mid-write.
+- **A child process's output destination is part of its environment.** When a
+  gate runs a child, send that child's stdout AND stderr somewhere the caller
+  cannot make hostile (a log file), then replay for the human. A truncated
+  replay must not be able to change the verdict.
+- **Announce the redirect and name the log** (`nothing is adjusted silently`).
+  Moving output is a self-made decision; a reader of the transcript should not
+  have to wonder why the suite went quiet.
+- **"The tests failed" and "the runner could not report" are different defects
+  with different owners — the gate must say WHICH.** Collapsing them is what
+  made #712 undiagnosable for two lanes: both presented as one bare
+  `WriteFailed` plus a refused push.
+- When a gate is fixed this way, keep a **mutant control**: a genuinely failing
+  suite must still fail AND still be named a test failure. A fix that stops
+  reading the exit code passes the happy-path clause and destroys the gate.
+
+### Check-design lesson that came with it
+
+The done-means check must drive **the real hook through a genuine pipe**
+(round 28). But it should NOT couple itself to bun's internal ~214 KB stderr
+threshold: a synthetic 4 MB stderr writer exits 0, and fixture suites of 300 and
+1200 modules both exit 0 through a pipe, so the trigger is internal to bun's
+reporter at real-suite scale. A check that depended on it **would go green the
+day bun fixes the bug** — silently un-testing the hook's classification logic,
+which is the part the repo actually owns. Reproduce the child's *observable
+contract* (fd 2 is a FIFO → `WriteFailed`, exit 1) via a PATH shim, and keep the
+HOOK, the pipe, and the stdin range real.
+
+One false RED was caught doing this: the runner was first placed in
+`package.json` `scripts.test`, but the hook invokes `bun test` DIRECTLY, not
+`bun run test`, so the clause went red with "0 test files matching" — proving
+the fixture wrong rather than the hook broken. **When a check goes red, read WHY
+before believing it.**

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -1753,3 +1753,105 @@ Same family as the round-28 entry
 a gate resolving its tree or base from something other than the change under
 review. #709 is that family's producer-side spelling — the tree was resolvable,
 and nobody handed it over.
+
+## [2026-08-10] A gate must not let its own reporting channel decide its verdict
+
+**Severity:** HIGH
+**Source:** Issue #712 (`lane/712-pre-push-writefailed`); second confirmed instance of the family opened by CLOSED #483
+**Scope:** any gate, hook, or CI step that runs a child process and reads its success from anything other than the child's exit code — and any child whose behavior changes with the KIND of fd it inherits (pipe vs file vs tty)
+**Status:** active
+
+### Pattern
+
+`_githooks/pre-push` ran `bun test` bare, letting it inherit git's stdout and
+stderr. When the CALLER captures git's output (`git push ... | tail`, or any
+wrapper that reads it), those fds are pipes, and bun 1.3.14 aborts partway
+through writing the full-suite coverage table:
+
+```
+ src/validation-errors.ts       |  100.00 |   90.
+error: An internal error occurred (WriteFailed)
+```
+
+It exits 1 having run a GREEN suite. Every piped push failed, with text
+identical to a genuinely broken branch.
+
+The generalisable defect is not bun's bug. It is that **the gate's verdict was
+carried by its reporting channel.** The suite's real result (3372 pass, 0 fail)
+existed and was discarded, because the process that produced it died trying to
+print it.
+
+### The measurement that mattered, and the fix that would have looked right
+
+Redirecting each fd independently on the untouched primary:
+
+| stdout | stderr | bun exit |
+|---|---|---|
+| PIPE | PIPE | 1 (WriteFailed) |
+| FILE | FILE | 0 (3372 pass, 0 fail) |
+| FILE | **PIPE** | **1 (WriteFailed)** |
+| PIPE | FILE | 0 |
+
+The failing writer is **stderr** — where bun's coverage table and pass/fail
+summary go. The obvious fix (`bun test > log`) redirects only stdout, leaves the
+defect 100% live, and looks correct in review. Any check for this class must pin
+the fd that was actually measured, not the one that is conventional to redirect.
+
+Also measured: a fully-draining `cat` consumer does NOT help, and the output
+truncates mid-line — so this is the child's own write path against a pipe fd,
+not a consumer that stopped reading. "Something downstream stopped reading" is
+the wrong first hypothesis here.
+
+### Why it is worse than an ordinary flaky gate
+
+The failure depended on **how the caller captured output**, so from the
+operator's seat the push failed "randomly" and then "randomly" worked. A gate
+that fails identically for a green push and a broken one has stopped carrying
+information, and intermittent-plus-indistinguishable is the exact profile that
+makes `--no-verify` habitual — the decay this repo's gate work keeps fighting.
+
+### Second instance of #483's family
+
+CLOSED #483: the pre-push hook's inherited `GIT_DIR` changed the outcome of
+`bun test`, and the difference was invisible in the verdict. Here the inherited
+thing is stdout/stderr. **The rule both share: a gate must not let anything it
+inherited from its caller decide its verdict.** Two instances make this a
+family, not an incident — audit what else a hook passes down untouched.
+
+### Review checks
+
+- **Read the verdict from the exit code, never from the presence, shape, or
+  survival of output.** If a step's success is inferred from parsed text, ask
+  what happens when the writer dies mid-write.
+- **A child process's output destination is part of its environment.** When a
+  gate runs a child, send that child's stdout AND stderr somewhere the caller
+  cannot make hostile (a log file), then replay for the human. A truncated
+  replay must not be able to change the verdict.
+- **Announce the redirect and name the log** (`nothing is adjusted silently`).
+  Moving output is a self-made decision; a reader of the transcript should not
+  have to wonder why the suite went quiet.
+- **"The tests failed" and "the runner could not report" are different defects
+  with different owners — the gate must say WHICH.** Collapsing them is what
+  made #712 undiagnosable for two lanes: both presented as one bare
+  `WriteFailed` plus a refused push.
+- When a gate is fixed this way, keep a **mutant control**: a genuinely failing
+  suite must still fail AND still be named a test failure. A fix that stops
+  reading the exit code passes the happy-path clause and destroys the gate.
+
+### Check-design lesson that came with it
+
+The done-means check must drive **the real hook through a genuine pipe**
+(round 28). But it should NOT couple itself to bun's internal ~214 KB stderr
+threshold: a synthetic 4 MB stderr writer exits 0, and fixture suites of 300 and
+1200 modules both exit 0 through a pipe, so the trigger is internal to bun's
+reporter at real-suite scale. A check that depended on it **would go green the
+day bun fixes the bug** — silently un-testing the hook's classification logic,
+which is the part the repo actually owns. Reproduce the child's *observable
+contract* (fd 2 is a FIFO → `WriteFailed`, exit 1) via a PATH shim, and keep the
+HOOK, the pipe, and the stdin range real.
+
+One false RED was caught doing this: the runner was first placed in
+`package.json` `scripts.test`, but the hook invokes `bun test` DIRECTLY, not
+`bun run test`, so the clause went red with "0 test files matching" — proving
+the fixture wrong rather than the hook broken. **When a check goes red, read WHY
+before believing it.**

--- a/scripts/done-means/712-pre-push-pipe-safe.sh
+++ b/scripts/done-means/712-pre-push-pipe-safe.sh
@@ -1,0 +1,435 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #712 — "pre-push fails every push: bun test aborts
+# with WriteFailed when its stdout is git's pipe (tests are green)".
+#
+#   bash scripts/done-means/712-pre-push-pipe-safe.sh
+#
+# ---------------------------------------------------------------------------
+# THE DEFECT THIS GATES
+# ---------------------------------------------------------------------------
+# `_githooks/pre-push` ran `bun test` bare, inheriting git's stdout and stderr.
+# When git's own output is CAPTURED by the caller (`git push ... | tail`, or any
+# wrapper reading it), those fds are pipes, and bun 1.3.14 aborts partway
+# through the full-suite coverage table with
+#
+#     error: An internal error occurred (WriteFailed)
+#
+# exiting 1 on a suite that is GREEN. Measured on the untouched primary at
+# e3917ab by redirecting each fd independently:
+#
+#   stdout PIPE + stderr PIPE -> exit 1 (WriteFailed)
+#   stdout FILE + stderr FILE -> exit 0 (3372 pass, 0 fail)
+#   stdout FILE + stderr PIPE -> exit 1 (WriteFailed)   <-- stderr is the writer
+#   stdout PIPE + stderr FILE -> exit 0
+#
+# The failing writer is bun's STDERR (where the coverage table and the summary
+# go), which is why clause (a) below asserts on stderr specifically: a "fix"
+# that redirected only stdout would leave the defect fully live while looking
+# correct, and this check must fail against that fix. Same family as CLOSED
+# #483 — something the hook INHERITED from its caller decided its verdict.
+#
+# ---------------------------------------------------------------------------
+# WHY THE FIXTURE'S EMITTER IS PIPE-SENSITIVE RATHER THAN A REAL FULL SUITE
+# ---------------------------------------------------------------------------
+# Lane-contract round 28: a seam that avoids the real invocation shape proves
+# nothing. The shape that MUST be real here is the one the defect lives in —
+# THE HOOK, run through a genuine pipe, with its verdict read from the pipe.
+# Every clause below runs the SHIPPED `_githooks/pre-push`, copied byte for
+# byte, with its stdout and stderr attached to a real pipe.
+#
+# What is NOT reproduced literally is bun's internal 214 KB-of-stderr timing
+# threshold. That was attempted first and is recorded here so the next lane does
+# not repeat it: a synthetic 4 MB stderr writer exits 0, and fixture suites of
+# 300 and then 1200 modules (138 KB of coverage table) both exit 0 through a
+# pipe. The trigger is internal to bun's test reporter at real-suite scale, and
+# a check that depended on it would be a multi-minute, version-coupled coin
+# flip — it would go green the day bun fixes the bug, silently un-testing the
+# hook's own classification logic, which is what this check actually owns.
+#
+# So the fixture's test command is a deterministic stand-in with the SAME
+# OBSERVABLE CONTRACT as bun 1.3.14: it inspects fd 2, and when fd 2 is a FIFO
+# it prints the exact `An internal error occurred (WriteFailed)` text and exits
+# 1; otherwise it prints a passing summary and exits 0. Verified against the
+# real thing before being used (probe transcripts in the PR body). The subject
+# under test is the HOOK's handling of a runner whose write fails, and that
+# contract is exactly what the hook must survive.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) THE DEFECT. The real hook, driven through a genuine PIPE with a
+#       pipe-hostile test runner, must PASS — because a green suite is green
+#       regardless of how the caller captured output. RED pre-fix: the hook
+#       inherits the pipe, the runner dies with WriteFailed, the push fails.
+#       Asserted on the hook's OWN success marker, and the runner is proven to
+#       have been genuinely pipe-hostile in the same run, so a hook that passed
+#       by never running the suite cannot satisfy it.
+#
+#   (b) MUTANT CONTROL — A GENUINELY FAILING SUITE STILL FAILS, AND IS NAMED
+#       "TESTS FAILED". This is the half that stops (a) being "fixed" by
+#       ignoring the exit code. A runner that exits non-zero WITHOUT a
+#       WriteFailed marker must fail the hook AND be classified as a test
+#       failure, never masked as a write error.
+#
+#   (c) THE TWO FAILURES ARE DISTINGUISHED, AND IT SAYS WHICH. A runner that
+#       fails WITH the WriteFailed marker must fail the hook and be reported as
+#       a RUNNER/WRITE problem — explicitly NOT a test failure. Before the fix
+#       both worlds presented as one bare `WriteFailed` plus a refused push,
+#       which is the "gate has stopped carrying information" state the issue
+#       names.
+#
+#   (d) THE REDIRECT IS ANNOUNCED (AGENTS.md, nothing is adjusted silently).
+#       The hook moves its runner's output to a log file — a self-made decision
+#       — so it must SAY so and name the log. Anchored on a marker the hook owns.
+#
+#   (e) THE OUTPUT IS STILL REPLAYED. Redirecting to a file must not cost the
+#       operator the output they came for; the suite's text must still reach
+#       the caller. Without this clause, "redirect to a file" passes (a)-(d) by
+#       swallowing the run entirely.
+#
+#   (f) STDERR SPECIFICALLY IS OFF THE PIPE. The measured root cause. A fix
+#       redirecting only stdout passes a naive reading of (a) on a runner that
+#       fails on stdout, so this clause drives a runner that is hostile to
+#       STDERR ONLY — the real bun shape — and pins that the hook survives it.
+#
+# Exit 0 only when every clause passes. Exit 3 is a harness error, which is NOT
+# a failure of the thing under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/_githooks/pre-push"
+RUN_ID="712-$$-$(date +%s)"
+SCRATCH="${OPENBRAIN_TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch/$RUN_ID"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v git >/dev/null 2>&1 || fail_hard "git not on PATH"
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+[ -r "$HOOK" ] || fail_hard "pre-push hook not readable at $HOOK"
+mkdir -p "$SCRATCH" || fail_hard "cannot create scratch dir $SCRATCH"
+
+FIXTURE="$SCRATCH/fixture"
+mkdir -p "$FIXTURE" || fail_hard "cannot create fixture dir"
+
+git_f() { git -C "$FIXTURE" -c user.name="done-means-712" -c user.email="done-means-712@invalid" "$@"; }
+
+# ---------------------------------------------------------------------------
+# The pipe-sensitive runner: bun 1.3.14's observable contract, deterministically.
+#
+# MODE is read from the environment so one fixture serves every clause:
+#   writefail-stderr : fd 2 is a FIFO -> WriteFailed on stderr, exit 1  (the real shape)
+#   writefail-stdout : fd 1 is a FIFO -> WriteFailed on stdout, exit 1  (clause f's foil)
+#   testfail         : always exit 1, NO WriteFailed marker             (the mutant)
+#   pass             : always exit 0
+# ---------------------------------------------------------------------------
+write_runner() {
+  cat > "$FIXTURE/fake-bun-test.ts" <<'RUNNER'
+import { fstatSync } from "node:fs";
+
+const mode = process.env.DM712_MODE ?? "writefail-stderr";
+const isFIFO = (fd: number): boolean => {
+  try {
+    return (fstatSync(fd).mode & 0o170000) === 0o010000;
+  } catch {
+    return false;
+  }
+};
+
+// Suite-shaped output first, so a hook that replays the log has something real
+// to replay and clause (e) is asserting on genuine runner output.
+process.stderr.write("bun test v1.3.14 (fixture)\n");
+for (let i = 0; i < 200; i++) {
+  process.stderr.write(` src/mod${i}.ts       |  100.00 |   90.00 |\n`);
+}
+
+if (mode === "testfail") {
+  process.stderr.write("DM712-RUNNER-RAN\n");
+  process.stderr.write(" 1 fail\n");
+  process.stderr.write("error: 1 test failed\n");
+  process.exit(1);
+}
+
+const hostileFd = mode === "writefail-stdout" ? 1 : 2;
+if (mode.startsWith("writefail") && isFIFO(hostileFd)) {
+  // The exact text bun 1.3.14 emits, on the same fd it emits it on.
+  const out = hostileFd === 1 ? process.stdout : process.stderr;
+  out.write("error: An internal error occurred (WriteFailed)\n");
+  process.exit(1);
+}
+
+// Not hostile -> the suite genuinely passed. The marker proves the runner
+// actually executed, so a hook that skipped the suite cannot fake a green.
+process.stderr.write("DM712-RUNNER-RAN\n");
+process.stderr.write(" 3372 pass\n 0 fail\n");
+process.exit(0);
+RUNNER
+}
+
+setup_fixture() {
+  git -C "$FIXTURE" init -q -b main 2>/dev/null || return 1
+  mkdir -p "$FIXTURE/contracts" "$FIXTURE/_githooks" "$FIXTURE/docs" || return 1
+
+  printf 'contracts/schema.json\n' > "$FIXTURE/contracts/parity-paths.txt" || return 1
+  printf '{}\n' > "$FIXTURE/contracts/schema.json" || return 1
+  printf '# base\n' > "$FIXTURE/docs/readme.md" || return 1
+
+  write_runner || return 1
+
+  # `typecheck` is trivially green so the run reaches the test phase and is
+  # judged there. Python/parity gates never arm: the fixture has no python/
+  # paths and parity is pinned to a file no commit here touches, so nothing but
+  # the test phase can decide these clauses.
+  #
+  # NOTE the hook invokes `bun test` DIRECTLY, not `bun run test`, so a `test`
+  # script here would never be consulted — the first draft of this check put the
+  # runner there and clause (a) went red with "0 test files matching", a false
+  # RED that proved the fixture wrong rather than the hook broken (lane-contract
+  # rounds 18/22/23). The runner is therefore interposed on PATH below, which is
+  # what makes `bun test` itself resolve to it.
+  cat > "$FIXTURE/package.json" <<'PKG' || return 1
+{
+  "name": "done-means-712-fixture",
+  "private": true,
+  "scripts": {
+    "typecheck": "true"
+  }
+}
+PKG
+
+  # A `bun` shim earlier on PATH than the real one. `bun test` -> the
+  # pipe-sensitive runner; every other subcommand (`bun run typecheck`, and the
+  # runner's own `bun`) is delegated to the REAL bun, so the hook is otherwise
+  # running unmodified. This is how the hook's genuine `bun test` line is driven
+  # without depending on bun's own version-coupled WriteFailed threshold.
+  mkdir -p "$FIXTURE/.shim" || return 1
+  REAL_BUN="$(command -v bun)" || return 1
+  cat > "$FIXTURE/.shim/bun" <<SHIM || return 1
+#!/usr/bin/env bash
+if [ "\${1:-}" = "test" ]; then
+  exec "$REAL_BUN" run "$FIXTURE/fake-bun-test.ts"
+fi
+exec "$REAL_BUN" "\$@"
+SHIM
+  chmod +x "$FIXTURE/.shim/bun" || return 1
+
+  cp "$HOOK" "$FIXTURE/_githooks/pre-push" || return 1
+  chmod +x "$FIXTURE/_githooks/pre-push" || return 1
+
+  git_f add -A >/dev/null || return 1
+  git_f commit -q -m "base" || return 1
+  git_f remote add origin "$FIXTURE" || return 1
+  git_f checkout -q -b wip || return 1
+  printf 'wip\n' >> "$FIXTURE/docs/readme.md" || return 1
+  git_f add -A >/dev/null || return 1
+  git_f commit -q -m "wip" || return 1
+  git_f fetch -q origin || return 1
+  return 0
+}
+
+setup_fixture || fail_hard "could not build the fixture repository (see $FIXTURE)"
+
+ZERO_SHA_FIXTURE=0000000000000000000000000000000000000000
+
+# ---------------------------------------------------------------------------
+# run_hook_through_pipe <mode> -- drive the REAL hook on the REAL push path with
+# BOTH fds attached to a genuine pipe, and capture what the pipe carried.
+#
+# This is the round-28 clause: a real stdin range with a zero remote SHA (the
+# new-branch shape, every first lane push), and the hook's own output travelling
+# down a pipe exactly as it does under `git push ... | tail`. HOOK_EXIT is
+# recovered through the pipe rather than via PIPESTATUS because the whole point
+# is that the pipe is the channel under suspicion.
+# ---------------------------------------------------------------------------
+HOOK_OUT=""
+HOOK_EXIT=0
+run_hook_through_pipe() {
+  local mode="$1"
+  local tip ref out
+
+  tip="$(git -C "$FIXTURE" rev-parse HEAD)"
+  ref="refs/heads/$(git -C "$FIXTURE" rev-parse --abbrev-ref HEAD)"
+
+  # The subshell's stdout AND stderr go into the pipe feeding `cat`. The
+  # sentinel carries the hook's real exit code back out.
+  out="$(
+    cd "$FIXTURE" && {
+      (
+        DM712_MODE="$mode" \
+        OPENBRAIN_TEMP_WORKSPACE="$SCRATCH/ws" \
+        PATH="$FIXTURE/.shim:$PATH" \
+          "$FIXTURE/_githooks/pre-push" origin "$FIXTURE" \
+          < <(printf '%s %s %s %s\n' "$ref" "$tip" "$ref" "$ZERO_SHA_FIXTURE")
+        printf 'DM712_HOOK_EXIT=%s\n' "$?"
+      ) 2>&1 | cat
+    }
+  )"
+
+  HOOK_OUT="$out"
+  HOOK_EXIT="$(printf '%s\n' "$out" | sed -n 's/^DM712_HOOK_EXIT=\([0-9]*\)$/\1/p' | tail -1)"
+  [ -n "$HOOK_EXIT" ] || HOOK_EXIT=missing
+}
+
+# Proof that the pipe really is a pipe and the runner really is hostile to it —
+# otherwise clause (a) could go green because the environment quietly handed the
+# hook a non-pipe, certifying nothing. Runs the SAME runner, same mode, with the
+# fds attached the way the BROKEN hook attached them.
+PRECHECK_EXIT=0
+precheck_pipe_is_hostile() {
+  local mode="$1"
+  # Driven through the SAME `bun test` spelling the hook uses, via the shim, so
+  # the hostility proven here is the hostility the hook will meet.
+  ( cd "$FIXTURE" && PATH="$FIXTURE/.shim:$PATH" DM712_MODE="$mode" bun test >/dev/null 2>&1 ) >/dev/null 2>&1
+  local direct=$?
+  local piped
+  piped="$(
+    cd "$FIXTURE" && {
+      ( PATH="$FIXTURE/.shim:$PATH" DM712_MODE="$mode" bun test; printf 'E=%s\n' "$?" ) 2>&1 | sed -n 's/^E=\([0-9]*\)$/\1/p' | tail -1
+    }
+  )"
+  PRECHECK_EXIT="${piped:-missing}"
+  # hostile means: fine when not piped, non-zero when piped.
+  [ "$direct" -eq 0 ] && [ "$PRECHECK_EXIT" != "0" ] && [ "$PRECHECK_EXIT" != "missing" ]
+}
+
+CLAUSES=()
+record() { CLAUSES+=("$1|$2|$3"); }
+
+# --- (a) the defect --------------------------------------------------------
+if precheck_pipe_is_hostile "writefail-stderr"; then
+  run_hook_through_pipe "writefail-stderr"
+  A_OUT="$HOOK_OUT"
+  A_EXIT="$HOOK_EXIT"
+  if [ "$A_EXIT" = "0" ] \
+    && printf '%s' "$A_OUT" | grep -qF "pre-push: all checks passed" \
+    && printf '%s' "$A_OUT" | grep -qF "DM712-RUNNER-RAN"; then
+    record a PASS "the real hook, through a genuine pipe, with a runner that cannot write to a pipe (proven hostile: piped exit=$PRECHECK_EXIT): exit 0, suite genuinely ran"
+  else
+    record a FAIL "a GREEN suite through a pipe still failed the hook (exit=$A_EXIT): $(printf '%s' "$A_OUT" | tr '\n' ' ' | tail -c 400)"
+  fi
+else
+  record a FAIL "harness could not establish a pipe-hostile runner (piped exit=$PRECHECK_EXIT) — clause (a) would prove nothing"
+fi
+
+# --- (b) mutant control: a real test failure still fails, and says so -------
+run_hook_through_pipe "testfail"
+B_OUT="$HOOK_OUT"
+B_EXIT="$HOOK_EXIT"
+B_FAILS=()
+[ "$B_EXIT" != "0" ] || B_FAILS+=("a genuinely failing suite PASSED the hook (exit=$B_EXIT) — the exit code is not being gated on")
+printf '%s' "$B_OUT" | grep -qiF "TESTS FAILED" \
+  || B_FAILS+=("a genuine test failure was not reported as a test failure")
+if printf '%s' "$B_OUT" | grep -qiF "could not write its output"; then
+  B_FAILS+=("a genuine test failure was MASKED as a write/runner error — the two worlds are crossed")
+fi
+if [ "${#B_FAILS[@]}" -eq 0 ]; then
+  record b PASS "a genuinely failing suite still fails the hook (exit=$B_EXIT) and is named a TEST failure, not a write error"
+else
+  record b FAIL "$(printf '%s; ' "${B_FAILS[@]}")"
+fi
+
+# --- (c) the two failures are distinguished --------------------------------
+# A runner that fails WITH the WriteFailed marker even when its fds are files:
+# the hook must still fail (it cannot claim a verdict it never got) but must say
+# RUNNER/WRITE problem, explicitly not a test failure.
+cat > "$FIXTURE/fake-bun-test.ts" <<'RUNNER2'
+process.stderr.write("bun test v1.3.14 (fixture)\n");
+process.stderr.write("error: An internal error occurred (WriteFailed)\n");
+process.exit(1);
+RUNNER2
+git_f add -A >/dev/null && git_f commit -q -m "clause c runner"
+run_hook_through_pipe "writefail-stderr"
+C_OUT="$HOOK_OUT"
+C_EXIT="$HOOK_EXIT"
+C_FAILS=()
+[ "$C_EXIT" != "0" ] || C_FAILS+=("a runner that could not write its output was reported as a PASS (exit=$C_EXIT)")
+printf '%s' "$C_OUT" | grep -qiF "could not write its output" \
+  || C_FAILS+=("the write/runner failure was not named as one")
+printf '%s' "$C_OUT" | grep -qiF "NOT a test failure" \
+  || C_FAILS+=("the hook did not state that this is NOT a test failure")
+if printf '%s' "$C_OUT" | grep -qiF "TESTS FAILED"; then
+  C_FAILS+=("a write/runner failure was blamed on the tests")
+fi
+if [ "${#C_FAILS[@]}" -eq 0 ]; then
+  record c PASS "a runner that cannot write its output fails the hook and is named a WRITE/RUNNER problem, explicitly not a test failure"
+else
+  record c FAIL "$(printf '%s; ' "${C_FAILS[@]}")"
+fi
+write_runner
+git_f add -A >/dev/null && git_f commit -q -m "restore runner"
+
+# --- (d) the redirect is announced -----------------------------------------
+run_hook_through_pipe "writefail-stderr"
+D_OUT="$HOOK_OUT"
+if printf '%s' "$D_OUT" | grep -qF "bun test ..." \
+  && printf '%s' "$D_OUT" | grep -qF "$SCRATCH/ws"; then
+  record d PASS "the hook announces that it redirected the runner's output, and names the log path"
+else
+  record d FAIL "the redirect was silent — no announcement naming the log: $(printf '%s' "$D_OUT" | tr '\n' ' ' | tail -c 300)"
+fi
+
+# --- (e) the output is still replayed --------------------------------------
+# Read from the same run as (d). The runner's own coverage-shaped lines must
+# reach the caller, or the hook bought its verdict by swallowing the output.
+if printf '%s' "$D_OUT" | grep -qF "DM712-RUNNER-RAN" \
+  && printf '%s' "$D_OUT" | grep -qF "src/mod100.ts"; then
+  record e PASS "the runner's output still reaches the caller — the redirect did not cost the operator the transcript"
+else
+  record e FAIL "the runner's output never reached the caller; the redirect swallowed the run: $(printf '%s' "$D_OUT" | tr '\n' ' ' | tail -c 300)"
+fi
+
+# --- (f) stderr specifically is off the pipe -------------------------------
+# The measured root cause. A fix that redirected only stdout leaves this live.
+if precheck_pipe_is_hostile "writefail-stderr"; then
+  run_hook_through_pipe "writefail-stderr"
+  F_EXIT="$HOOK_EXIT"
+  F_OUT="$HOOK_OUT"
+  if [ "$F_EXIT" = "0" ] && printf '%s' "$F_OUT" | grep -qF "DM712-RUNNER-RAN"; then
+    record f PASS "a runner hostile to STDERR ONLY (the measured bun shape) survives — stderr is genuinely off the pipe, not just stdout"
+  else
+    record f FAIL "the runner's STDERR is still attached to a pipe (exit=$F_EXIT) — redirecting stdout alone does not fix #712"
+  fi
+else
+  record f FAIL "harness could not establish a stderr-hostile runner (piped exit=$PRECHECK_EXIT)"
+fi
+
+# ---------------------------------------------------------------------------
+# Teardown. The fixture is a throwaway repository this script created inside the
+# temp workspace; it is MOVED to the archive, never deleted (AGENTS.md: the
+# agent's cleanup verb is mv). No worktree is registered against the real repo,
+# so nothing is stranded by moving it.
+# ---------------------------------------------------------------------------
+ARCHIVE_DIR="${OPENBRAIN_TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_archive"
+if mkdir -p "$ARCHIVE_DIR" 2>/dev/null; then
+  mv "$SCRATCH" "$ARCHIVE_DIR/$RUN_ID" 2>/dev/null \
+    || printf 'TEARDOWN-WARNING: fixture left at %s\n' "$SCRATCH" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+label_for() {
+  case "$1" in
+    a) printf 'a green suite through a genuine pipe passes the hook' ;;
+    b) printf 'MUTANT: a genuinely failing suite still fails, named TESTS FAILED' ;;
+    c) printf 'a write/runner failure is named as one, not as a test failure' ;;
+    d) printf 'the redirect is announced and the log is named' ;;
+    e) printf "the runner's output is still replayed to the caller" ;;
+    f) printf 'STDERR specifically is off the pipe (the measured root cause)' ;;
+  esac
+}
+
+ALL_PASS=1
+for entry in "${CLAUSES[@]}"; do
+  id="${entry%%|*}"
+  rest="${entry#*|}"
+  status="${rest%%|*}"
+  evidence="${rest#*|}"
+  printf 'CLAUSE %s (%s): %s — %s\n' "$id" "$(label_for "$id")" "$status" "$evidence"
+  [ "$status" = PASS ] || ALL_PASS=0
+done
+
+[ "$ALL_PASS" -eq 1 ] && exit 0
+exit 1

--- a/scripts/done-means/sme-per-entry-files.sh
+++ b/scripts/done-means/sme-per-entry-files.sh
@@ -105,7 +105,19 @@ BUILD_SCRIPT="scripts/build-sme-indexes.ts"
 # filed as #707 (one entry uses a level-1 undated heading); verified by running
 # this script in the untouched primary checkout, where clause 1 fails and
 # clause 4 passes.
-EXPECTED_ENTRY_COUNT=233
+#
+# 2026-08-10, the #712 lane: 233 -> 234. Exactly ONE entry added, and it is this
+# lane's own --
+# `2026-08-10-a-gate-must-not-let-its-own-reporting-channel-decide-its-verdict.md`
+# (lane: gotcha-agent, order 70), the review-facing half of the #712 harvest.
+# Nothing else was adopted. Clause 1 is STILL RED here for the same reason it was
+# red for the #709 lane and for the same file
+# (`2026-08-08-guards-must-judge-the-operation-not-the-vocabulary.md`, a level-1
+# undated heading) -- already filed as #707, present unchanged at this lane's
+# base `origin/wip/2026-08-07`, and untouched by this lane's diff (verified:
+# `git diff origin/wip/2026-08-07..HEAD` names that file zero times). It is left
+# failing rather than absorbed into a gate-fixing PR, per lane-contract round 28.
+EXPECTED_ENTRY_COUNT=234
 
 LANE_FILES=(
   "$SME_DIR/correctness.md"


### PR DESCRIPTION
## Summary

- Fixes #712. `_githooks/pre-push` ran `bun test` bare, inheriting git's stdout and stderr. When git's own output is captured by the caller (`git push ... | tail`, or any wrapper reading it), those fds are pipes, and bun 1.3.14 aborts partway through the full-suite coverage table with `error: An internal error occurred (WriteFailed)`, exiting 1 on a suite that is green — so every piped push failed with text identical to a genuinely broken branch.
- Root cause isolated by redirecting each fd independently on the UNTOUCHED primary at `e3917ab` (clean tree). The failing writer is bun's **stderr**, where the coverage table and pass/fail summary go:

| stdout | stderr | bun exit |
|---|---|---|
| PIPE | PIPE | 1 (WriteFailed) |
| FILE | FILE | 0 (3372 pass, 0 fail) |
| FILE | **PIPE** | **1 (WriteFailed)** |
| PIPE | FILE | 0 |

  A fix redirecting only stdout would have looked right and left the defect fully live, which is why clause (f) pins stderr specifically. Piping into a fully-draining `cat` does not help and the output truncates mid-line, so this is bun's own write path against a pipe fd, not a consumer that stopped reading.
- The fix sends both fds to a log under `{temp_workspace}/open-brain/_scratch/pre-push/`, so neither is a pipe however git was called, and reads the verdict from bun's **exit code**. The log is replayed afterwards so the operator still sees the output; a truncated replay cannot change the verdict because the verdict was already decided.
- The redirect is **announced** and the log named (AGENTS.md, nothing is adjusted silently), and the hook now distinguishes `TESTS FAILED` from `THE TEST RUNNER COULD NOT WRITE ITS OUTPUT` and says which. Before, both were one bare `WriteFailed` plus a refused push.
- Same family as CLOSED #483: a gate must not let anything it inherited from its caller decide its verdict. There the inherited thing was `GIT_DIR`; here it is stdout/stderr.
- **Scope, announced:** `bun run typecheck` does NOT share the failure mode — verified through a pipe, exit 0, tiny output — so it is left unchanged per minimal-correct-change.

## Verification

- Done-means: scripts/done-means/712-pre-push-pipe-safe.sh

6 clauses, written red-first.

**RED (pre-fix hook from `origin/wip/2026-08-07` swapped in) — 6/6 FAIL**, each on a genuine `WriteFailed` abort mid-coverage-table:

```
CLAUSE a (a green suite through a genuine pipe passes the hook): FAIL — a GREEN suite through a pipe still failed the hook (exit=1): ... src/mod199.ts | 100.00 | 90.00 | error: An internal error occurred (WriteFailed) DM712_HOOK_EXIT=1
CLAUSE b (MUTANT: a genuinely failing suite still fails, named TESTS FAILED): FAIL — a genuine test failure was not reported as a test failure
CLAUSE c (a write/runner failure is named as one, not as a test failure): FAIL — the write/runner failure was not named as one; the hook did not state that this is NOT a test failure
CLAUSE d (the redirect is announced and the log is named): FAIL — the redirect was silent — no announcement naming the log
CLAUSE e (the runner's output is still replayed to the caller): FAIL — the runner's output never reached the caller
CLAUSE f (STDERR specifically is off the pipe (the measured root cause)): FAIL — the runner's STDERR is still attached to a pipe (exit=1) — redirecting stdout alone does not fix #712
```

**GREEN (fixed hook) — 6/6 PASS, exit 0:**

```
CLAUSE a: PASS — the real hook, through a genuine pipe, with a runner that cannot write to a pipe (proven hostile: piped exit=1): exit 0, suite genuinely ran
CLAUSE b: PASS — a genuinely failing suite still fails the hook (exit=1) and is named a TEST failure, not a write error
CLAUSE c: PASS — a runner that cannot write its output fails the hook and is named a WRITE/RUNNER problem, explicitly not a test failure
CLAUSE d: PASS — the hook announces that it redirected the runner's output, and names the log path
CLAUSE e: PASS — the runner's output still reaches the caller — the redirect did not cost the operator the transcript
CLAUSE f: PASS — a runner hostile to STDERR ONLY (the measured bun shape) survives — stderr is genuinely off the pipe, not just stdout
TRUE_GREEN_EXIT=0
```

**Clause (b) is the mutant control:** a genuinely failing suite must still fail AND be named a test failure, never masked as a write error. Without it, clause (a) could be "fixed" by ignoring the exit code entirely.

**Live proof — the real hook, the real 3897-test suite, a genuine pipe** (the exact shape that failed at session start):

```
  base: origin/wip/2026-08-07 — configured upstream
  ✓ TypeScript passed
  bun test ... (stdout+stderr -> .../_scratch/pre-push/bun-test-10974-1786329603.log, replayed below; #712)
  ✓ Bun tests passed
HOOK_EXIT=0
```

Log tail proves the suite genuinely ran, not skipped: ` 3372 pass / 525 skip / 0 fail / 11819 expect() calls / Ran 3897 tests across 244 files. [31.42s]`

**And this PR's own push is the proof in production:** `ea1436d` was pushed through a piped git invocation running the fixed hook, and it succeeded. No `--no-verify`, no hook bypass.

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

### Round-28 compliance, and what is deliberately NOT reproduced

The shape that MUST be real is the one the defect lives in — **the hook, through a genuine pipe**. Every clause drives the shipped `_githooks/pre-push` (copied byte for byte) on the real stdin-range push path with a zero remote SHA and both fds on a real pipe.

Not reproduced literally: bun's internal ~214 KB stderr threshold. Recorded so the next lane does not repeat the attempts that failed — a synthetic 4 MB stderr writer exits 0; fixture bun suites of 300 and of 1200 modules (138 KB coverage table) both exit 0 through a pipe. The trigger is internal to bun's test reporter at real-suite scale, and a check coupled to it would be a multi-minute version-coupled coin flip that **goes green the day bun fixes the bug**, silently un-testing the hook's classification logic — which is what this check actually owns. The fixture therefore interposes a `bun` PATH shim whose `bun test` carries the same observable contract as bun 1.3.14 (fd 2 is a FIFO → `WriteFailed`, exit 1), verified against the real thing first.

### Install path (#711)

`core.hooksPath` is `/Volumes/ThunderBolt/Development/open-brain/_githooks` — an **absolute** path to the primary's copy, so the tracked `_githooks/pre-push` in this PR **is** the file git executes for the primary once merged; there is no separate install/copy step. `_githooks/install.sh` sets the value to the relative `_githooks`, and the absolute value currently configured is the #711 defect, untouched by this PR.

Consequence, stated plainly: a lane worktree inherits that absolute path and therefore runs the PRIMARY's (unfixed) hook. This PR's push was made with an explicit `-c core.hooksPath=<this lane's _githooks>`, which is running the **fixed** gate rather than skipping a gate — the #713 precedent, and lane-contract round 28's "bootstrap ordering is declared, never routed around."

## Critical Self-Review

- Highest-risk behavior: the hook's verdict for the entire test suite. A wrong exit-code path here either blocks every push or, far worse, passes a broken branch. Clause (b) exists specifically to hold the second direction, and it is asserted on both the exit code and the classification text.
- Assumptions that could be wrong: (1) that bun's WriteFailed always carries that exact string — if bun changes the wording, the hook falls back to reporting "TESTS FAILED" for a write error, which is the SAFE direction (it blocks the push and names a real log) but would misattribute; the log path is printed either way. (2) That the temp workspace is writable — handled explicitly: a failed `mkdir` exits 1 and says it is a hook environment problem, not a test failure.
- Missing/weak tests: the check does not reproduce bun's real byte/timing threshold (reasoned above, with the failed attempts recorded). It also does not cover a log directory that exists but is unwritable — the `mkdir -p` guard covers creation, not permission loss between creation and write.
- Security/permission risk: none new. No auth, namespace, or SQL surface is touched. The log lands under the temp workspace, which already holds test output; test logs can contain env-derived values, so they stay in temp and out of git.
- Migration/deploy risk: none. No schema, no service code, no runtime path — this is a developer-machine git hook.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classified: no MCP tool/schema/protocol/client-facing change, so rtech-mcps, mcp2cli, and Hermes are not applicable.
- Rollback/cleanup concern: revert of one file restores prior behavior exactly. The hook writes one log per run under `{temp_workspace}/open-brain/_scratch/pre-push/` and does not prune them; they are small and live in temp, but they do accumulate — named here rather than silently added.
- Fixes made before PR: the check's first draft put the fake runner in `package.json` `scripts.test`, but the hook invokes `bun test` DIRECTLY, not `bun run test`, so clause (a) went red with "0 test files matching" — a false RED proving the fixture wrong rather than the hook broken. Replaced with the PATH shim and the RED re-run before any green was claimed.
- Known residual risk: the log directory grows unbounded; and #711 (absolute `core.hooksPath`) still means lane worktrees run the primary's hook, so until that is fixed a lane cannot exercise its own hook change on push without the explicit `-c` used here.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this is a local git hook; it touches no service, schema, or client contract.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, schema, or client-facing surface is touched — the change is confined to a developer-machine git hook and its done-means check.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable on every downstream row: no MCP tool, schema, transport, or Python client surface is touched. The diff is `_githooks/pre-push` plus one new `scripts/done-means/` check.
