### PR TITLE
fix(hooks): detect core.hooksPath drift so worktrees run their own hooks (#711)

### DIFF
--- a/_githooks/install.sh
+++ b/_githooks/install.sh
@@ -36,6 +36,24 @@ else
   git -C "$repo_root" config --local core.hooksPath "$target"
   if [[ -n "$current" ]]; then
     printf 'core.hooksPath changed: %s -> %s\n' "$current" "$target"
+    # Name the specific damage when the value we just corrected was ABSOLUTE
+    # (issue #711). This clone held /Volumes/.../open-brain/_githooks for long
+    # enough that a family of lane failures (#705-#714) traced back to it, and
+    # the reason it survived is that a corrected value looks the same in the
+    # output whether it was a harmless typo or this. .git/config is SHARED by
+    # every linked worktree, so an absolute value silently makes every lane
+    # worktree run the primary checkout's hooks -- a lane fixing a hook cannot
+    # exercise its own fix, and a lane breaking one pushes green.
+    if [[ "$current" == /* ]]; then
+      printf '\n'
+      printf 'NOTE: the previous value was an ABSOLUTE path.\n'
+      printf '  .git/config is shared by every linked worktree, so that value made\n'
+      printf '  EVERY worktree run the hooks in:\n'
+      printf '      %s\n' "$current"
+      printf '  instead of its own. If lanes in worktrees have been passing or failing\n'
+      printf '  pre-push for reasons that did not match their own diff, that is why.\n'
+      printf '  (issue #711)\n'
+    fi
   else
     printf 'core.hooksPath set to %s\n' "$target"
   fi

--- a/_githooks/pre-push
+++ b/_githooks/pre-push
@@ -47,6 +47,57 @@ fi
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
+# ---------------------------------------------------------------------------
+# WHICH HOOKS DIRECTORY IS THIS (issue #711)
+# ---------------------------------------------------------------------------
+# `.git/config` is SHARED BY EVERY LINKED WORKTREE. So an ABSOLUTE
+# `core.hooksPath` -- `/Volumes/.../open-brain/_githooks` -- points every lane
+# worktree at the PRIMARY CHECKOUT's hooks: the copy on the base branch, not the
+# copy the lane is changing. A RELATIVE value resolves against each worktree's
+# own root, which is why `_githooks/install.sh` writes `_githooks` and says so
+# in a comment written against this exact trap.
+#
+# Measured live before this assertion existed (throwaway worktree, a distinct
+# marker line in each tree's copy of this file, `git hook run pre-push`):
+#
+#   absolute config, from the worktree -> MARKER: PRIMARY-COPY
+#   relative config, from the worktree -> MARKER: WORKTREE-COPY
+#
+# THIS CHECK IS IN THE HOOK, NOT ONLY IN A DONE-MEANS SCRIPT, BECAUSE THE HOOK
+# IS THE THING THAT RUNS. The config had already diverged from its own installer
+# and nothing noticed: the installer is idempotent and reports "already set"
+# only on an exact match, and no check asserted the value. A drift that only a
+# check nobody runs would catch is a drift nobody catches.
+#
+# WHY THIS FAILS THE PUSH RATHER THAN WARNING. When this is wrong, the verdict
+# this hook is about to produce is about THE WRONG TREE -- a lane fixing a hook
+# cannot exercise its fix, and a lane BREAKING one pushes green. A gate that
+# knows its own answer is untrustworthy and returns it anyway is worse than one
+# that stops, so it stops, and it prints the one command that fixes it.
+#
+# The unset case is deliberately NOT an error here: a clone that never ran the
+# installer has no value and git falls back to `.git/hooks`, in which case this
+# file is not running at all and cannot be the thing complaining. If it IS set,
+# it must match.
+HOOKS_PATH="$(git config --get core.hooksPath 2>/dev/null || true)"
+EXPECTED_HOOKS_PATH="_githooks"
+if [ -n "$HOOKS_PATH" ] && [ "$HOOKS_PATH" != "$EXPECTED_HOOKS_PATH" ]; then
+  echo "  ✗ core.hooksPath does not match what _githooks/install.sh writes." >&2
+  echo "      configured: $HOOKS_PATH" >&2
+  echo "      expected:   $EXPECTED_HOOKS_PATH" >&2
+  echo "" >&2
+  echo "    .git/config is shared by every linked worktree, so a non-relative value" >&2
+  echo "    makes EVERY worktree run the primary checkout's hooks -- including this" >&2
+  echo "    one. The verdict this gate is about to give would be about a tree other" >&2
+  echo "    than the one being pushed, so it is refusing instead of guessing." >&2
+  echo "" >&2
+  echo "    Fix it by running, from the repo root:" >&2
+  echo "        ./_githooks/install.sh" >&2
+  echo "" >&2
+  echo "    (issue #711)" >&2
+  exit 1
+fi
+
 # Single source of truth for the parity path filter; CI and the PR-body
 # workflow read the same file, and check-parity.ts asserts it is non-empty.
 PARITY_PATHS=("${(f)$(cat "$ROOT/contracts/parity-paths.txt")}")

--- a/_plans/worklog/fix-711-2026-08-10.md
+++ b/_plans/worklog/fix-711-2026-08-10.md
@@ -1,0 +1,121 @@
+# fix-711 — core.hooksPath was absolute, so every worktree ran the primary's hooks
+
+**Status: MERGED-pending — written and locally proven; see the PR for the
+verify-lane receipt.** Lane branch `lane/711-hookspath-relative`, merge target
+`wip/2026-08-07`.
+
+Issue: #711. Done-means: `scripts/done-means/711-hookspath-relative.sh`.
+
+## What was wrong
+
+This clone's `.git/config` held
+
+    core.hooksPath = /Volumes/ThunderBolt/Development/open-brain/_githooks
+
+while `_githooks/install.sh:24` writes the RELATIVE `_githooks`, under a comment
+written against this exact trap. The config had diverged from its own installer
+and **nothing detected it**: the installer is idempotent and reports "already
+set" only on an exact match, and no check asserted the value.
+
+`.git/config` is shared by every linked worktree, so an absolute value points
+every lane worktree at the PRIMARY CHECKOUT's hooks — the copy on the base
+branch, not the copy the lane is changing.
+
+## The proof (done-means red/green)
+
+Before writing any fix, a throwaway worktree with a distinct marker line planted
+in each tree's `_githooks/pre-push`, driven with `git hook run pre-push` (the
+shipped resolution, not a reimplementation):
+
+| config | run from | hook that executed |
+|---|---|---|
+| absolute | worktree | `MARKER: PRIMARY-COPY` ← the defect |
+| relative `_githooks` | worktree | `MARKER: WORKTREE-COPY` ← the fix |
+| relative `_githooks` | primary | `MARKER: PRIMARY-COPY` ← control, unchanged |
+
+So yes — a relative `core.hooksPath` **does** resolve per-worktree. That answers
+the question the task posed rather than assuming it, and clause (a) of the
+done-means check reproduces it hermetically (its own throwaway repo) so it also
+holds in CI and would go red if git ever changed that behaviour.
+
+RED run (before the fix): (a) PASS, (b) FAIL, (c) FAIL, (d) PASS, (e) FAIL.
+GREEN run (after): 5/5 PASS, exit 0.
+
+(b)/(c) failing while (a)/(d) passed is the shape that matters — (d) is the
+mutation control, so an "assertion" that refused everything could not have
+passed by accident.
+
+## Why this is the root of the #705–#714 family
+
+`docs/lane-contract.md` round 28 named three instances of one family: a gate
+resolving its base or its tree from something other than the change under
+review. This is the structural one. A lane fixing a git hook **could not
+exercise its own fix on push**, and both symptoms point the wrong way:
+
+- a lane that FIXES a broken pre-push still fails, and reads it as its fix not
+  working;
+- a lane that BREAKS pre-push pushes green, and the breakage lands.
+
+PR #708 worked around it by hand with `-c core.hooksPath=<worktree>/_githooks`,
+which is a workaround a lane has to already know to reach for.
+
+Confirmed on this very lane: `rg -c "issue #711"` finds the new assertion in the
+worktree's `_githooks/pre-push` (2 matches) and **not** in the primary's (0 —
+the primary is on the base branch). The lane's `git hook run pre-push` executed
+the assertion. This is the first lane in the family that ran its own hook fix.
+
+## What shipped, and what could not
+
+`core.hooksPath` lives in `.git/config`, which is **per-clone state, not a
+committed file**. The flip itself cannot be shipped. So:
+
+**Operator-machine change (recorded, not committed).** Run via the installer
+rather than by hand, so the installer is proven as the remedy the refusal text
+points at:
+
+    $ ./_githooks/install.sh
+    core.hooksPath changed: /Volumes/ThunderBolt/Development/open-brain/_githooks -> _githooks
+
+**PR payload — the detection mechanism, so it cannot silently recur:**
+
+1. `_githooks/pre-push` — asserts, before any validation work and before the
+   `--explain` early exit, that the effective `core.hooksPath` matches what the
+   installer writes. It **fails the push** rather than warning: when this is
+   wrong the verdict the gate is about to produce is about the wrong tree, and a
+   gate that knows its answer is untrustworthy and returns it anyway is worse
+   than one that stops. The refusal prints the configured value, the expected
+   value, and the literal `./_githooks/install.sh` command — a gate that refuses
+   without saying how to clear it is what makes `--no-verify` habitual.
+
+   Unset is deliberately **not** an error: a clone that never ran the installer
+   has no value, git falls back to `.git/hooks`, and this file is not running at
+   all so it cannot be the thing complaining. Set-but-divergent is the defect.
+
+2. `_githooks/install.sh` — when it corrects a value that was ABSOLUTE, it names
+   the specific damage that value did. A corrected value otherwise looks
+   identical in the output whether it was a harmless typo or this.
+
+3. `scripts/lane-bootstrap.ts` — the LANE READY block now states which hooks the
+   new worktree will run (issue's suggested direction 3; AGENTS.md "nothing is
+   adjusted silently"). It reports and never fixes — `pre-push` is what refuses,
+   because that runs on every push rather than only at bootstrap. The probe
+   never throws: a failed hooks probe is not a reason to fail a lane whose
+   worktree, env, and deps are good.
+
+4. `scripts/install-hooks.sh` — **found during this lane, a live loaded gun.** It
+   ran `git config core.hooksPath .githooks`, and `.githooks/` does not exist in
+   this repo. That does not fail loudly; git finds no hooks and every tracked
+   hook silently stops running — the exact #311 half-landed state the `_githooks`
+   installer was written to end, preserved as a one-line command that
+   reintroduces it. It also wrote the value without `--local` and without
+   resolving a repo root, so what it configured depended on the caller's cwd.
+   Made a refusing stub that points at `_githooks/install.sh` rather than
+   deleted, because `docs/standards/REPO_BOOTSTRAP.md:54` references it by name;
+   it refuses rather than silently forwarding, since a script quietly doing
+   something other than its name is how the original divergence went unnoticed.
+
+## Verification
+
+- `scripts/done-means/711-hookspath-relative.sh` — 5/5 GREEN, exit 0.
+- `bunx tsc --noEmit` — clean (exit 0).
+- The lane's own push exercises the shipped assertion (proven above).

--- a/scripts/done-means/711-hookspath-relative.sh
+++ b/scripts/done-means/711-hookspath-relative.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #711 — core.hooksPath must be the RELATIVE value
+# the installer writes, so each worktree runs its OWN hooks, and the divergence
+# must be DETECTED rather than left to be discovered by a confused lane.
+#
+#   bash scripts/done-means/711-hookspath-relative.sh
+#
+# ---------------------------------------------------------------------------
+# THE DEFECT THIS GATES
+# ---------------------------------------------------------------------------
+# This clone's `.git/config` held the ABSOLUTE value
+# `/Volumes/ThunderBolt/Development/open-brain/_githooks`, while
+# `_githooks/install.sh:24-40` writes the RELATIVE `_githooks`. `.git/config` is
+# SHARED by every linked worktree, so an absolute value points every lane
+# worktree at the PRIMARY CHECKOUT's hooks — the copy sitting on the base
+# branch, not the copy the lane is changing.
+#
+# Measured live on this repo before the fix (throwaway worktree, distinct marker
+# line planted in each tree's `_githooks/pre-push`, `git hook run pre-push`):
+#
+#   absolute config, run from the worktree  -> MARKER: PRIMARY-COPY   <-- defect
+#   relative config, run from the worktree  -> MARKER: WORKTREE-COPY  <-- fixed
+#   relative config, run from the primary   -> MARKER: PRIMARY-COPY   <-- control
+#
+# That is the red/green, and clause (a) below reproduces it hermetically rather
+# than citing the measurement.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS IS THE ROOT OF THE #705-#714 FAMILY
+# ---------------------------------------------------------------------------
+# docs/lane-contract.md round 28 named three instances of ONE family: a gate
+# resolving its base or its tree from something other than the change under
+# review. This is the structural one — a lane fixing a git hook CANNOT EXERCISE
+# ITS OWN FIX on push, because git runs the base branch's copy. The observable
+# symptoms both point the wrong way:
+#
+#   - a lane that FIXES a broken pre-push still fails, and reads it as its fix
+#     not working;
+#   - a lane that BREAKS pre-push pushes green, and the breakage lands.
+#
+# PR #708 worked around it by hand with `-c core.hooksPath=<worktree>/_githooks`,
+# which is a workaround a lane has to already know to reach for.
+#
+# ---------------------------------------------------------------------------
+# WHAT IS AND IS NOT THE PR PAYLOAD
+# ---------------------------------------------------------------------------
+# `core.hooksPath` lives in `.git/config`, which is PER-CLONE STATE and is not a
+# committed file. So the config flip itself cannot be shipped and cannot be
+# asserted on in CI against a fresh clone. The shipped payload is the DETECTION
+# MECHANISM: `_githooks/pre-push` asserts, in its first lines, that the
+# effective `core.hooksPath` equals what the installer writes, and refuses with
+# the exact `./_githooks/install.sh` command when it does not.
+#
+# Clause (e) is therefore the only clause that inspects THIS machine's live
+# config; it is reported separately and is an ENVIRONMENT verdict. Every other
+# clause runs against a hermetic throwaway repo and holds on any machine,
+# including CI.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) THE DEFECT, REPRODUCED. In a throwaway repo with a linked worktree and
+#       a DIFFERENT marker hook in each tree, an ABSOLUTE `core.hooksPath` makes
+#       the worktree run the PRIMARY's hook, and the installer's RELATIVE value
+#       makes it run its OWN. This is the behavioural claim the whole fix rests
+#       on; if git ever stopped resolving a relative hooksPath per-worktree, the
+#       fix would be wrong and this clause would say so.
+#
+#   (b) THE DETECTOR FIRES. `_githooks/pre-push` run under an ABSOLUTE
+#       `core.hooksPath` REFUSES, non-zero, before doing any validation work.
+#       RED pre-fix: the hook had no such assertion and proceeded to typecheck.
+#
+#   (c) THE REFUSAL IS ACTIONABLE. That refusal names `core.hooksPath`, prints
+#       the offending value AND the expected one, and gives the literal
+#       `_githooks/install.sh` command. A gate that refuses without saying how
+#       to clear it is the condition that makes `--no-verify` habitual.
+#
+#   (d) CONTROL — THE DETECTOR DOES NOT FIRE ON THE GOOD VALUE. Under the
+#       installer's relative value the assertion passes and the hook proceeds
+#       past it. Without this, "fixing" #711 with an assertion that always
+#       refuses would pass (b) and (c) and destroy the gate. This is the
+#       mutation-relevant half.
+#
+#   (e) ENVIRONMENT — this machine's live `core.hooksPath` is the installer's
+#       value. Reported as a separate ENV verdict, because it is per-clone state
+#       and a fresh clone legitimately has none set at all.
+#
+# Exit 0 only when clauses (a)-(d) pass. Clause (e) is reported and, when this
+# is a clone that HAS a hooksPath set at all, is also enforced. Exit 3 is a
+# harness error (missing tool, unusable scratch), which is NOT a failure of the
+# thing under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/_githooks/pre-push"
+INSTALLER="$REPO_ROOT/_githooks/install.sh"
+RUN_ID="711-$$-$(date +%s)"
+SCRATCH="${OPENBRAIN_TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch/$RUN_ID"
+
+# The value the installer writes. Read FROM the installer rather than repeated
+# here: a check that hardcodes its own copy of the expected value cannot catch
+# the installer changing, which is half of what "config diverged from its own
+# installer" means.
+EXPECTED="$(sed -n 's/^target="\(.*\)"$/\1/p' "$INSTALLER" 2>/dev/null | head -1)"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v git >/dev/null 2>&1 || fail_hard "git not on PATH"
+[ -r "$HOOK" ] || fail_hard "pre-push not readable at $HOOK"
+[ -r "$INSTALLER" ] || fail_hard "installer not readable at $INSTALLER"
+[ -n "$EXPECTED" ] || fail_hard "could not read the target value out of $INSTALLER (expected a target=\"...\" line)"
+mkdir -p "$SCRATCH" || fail_hard "cannot create scratch dir $SCRATCH"
+
+CLAUSES=()
+record() { CLAUSES+=("$1|$2|$3"); }
+
+# ---------------------------------------------------------------------------
+# Fixture for clause (a): a throwaway repo with a linked worktree, and a hook
+# in each tree that prints WHICH TREE IT IS. Hermetic — it does not touch this
+# repo, so it cannot be perturbed by, and cannot perturb, the live checkout.
+# ---------------------------------------------------------------------------
+FIX="$SCRATCH/fixture"
+mkdir -p "$FIX/primary" || fail_hard "cannot create fixture dir"
+git -C "$FIX/primary" init -q -b main 2>/dev/null || fail_hard "git init failed"
+git -C "$FIX/primary" config user.name "done-means-711" || fail_hard "git config failed"
+git -C "$FIX/primary" config user.email "done-means-711@invalid" || fail_hard "git config failed"
+mkdir -p "$FIX/primary/_githooks"
+printf '#!/bin/sh\necho "MARKER: PRIMARY-COPY"\nexit 0\n' > "$FIX/primary/_githooks/pre-push"
+chmod +x "$FIX/primary/_githooks/pre-push"
+git -C "$FIX/primary" add -A >/dev/null 2>&1
+git -C "$FIX/primary" commit -q -m "fixture base" >/dev/null 2>&1 || fail_hard "fixture commit failed"
+
+FIX_WT="$FIX/worktree"
+git -C "$FIX/primary" worktree add --detach --quiet "$FIX_WT" HEAD 2>"$SCRATCH/wt.err" \
+  || fail_hard "fixture worktree failed: $(cat "$SCRATCH/wt.err")"
+printf '#!/bin/sh\necho "MARKER: WORKTREE-COPY"\nexit 0\n' > "$FIX_WT/_githooks/pre-push"
+chmod +x "$FIX_WT/_githooks/pre-push"
+
+# `git hook run` executes the hook git itself would execute, resolving
+# core.hooksPath exactly as a real push does. It is the shipped resolution, not
+# a reimplementation of it.
+ABS_OUT="$(git -C "$FIX_WT" -c core.hooksPath="$FIX/primary/_githooks" hook run pre-push 2>&1)"
+REL_OUT="$(git -C "$FIX_WT" -c core.hooksPath="$EXPECTED" hook run pre-push 2>&1)"
+CTL_OUT="$(git -C "$FIX/primary" -c core.hooksPath="$EXPECTED" hook run pre-push 2>&1)"
+
+if printf '%s' "$ABS_OUT" | grep -q "PRIMARY-COPY" \
+  && printf '%s' "$REL_OUT" | grep -q "WORKTREE-COPY" \
+  && printf '%s' "$CTL_OUT" | grep -q "PRIMARY-COPY"; then
+  record a PASS "absolute -> worktree ran the PRIMARY's hook; relative ($EXPECTED) -> worktree ran its OWN; primary unchanged"
+else
+  record a FAIL "hooksPath resolution did not behave as the fix assumes — absolute=[$(printf '%s' "$ABS_OUT" | tr '\n' ' ')] relative=[$(printf '%s' "$REL_OUT" | tr '\n' ' ')] control=[$(printf '%s' "$CTL_OUT" | tr '\n' ' ')]"
+fi
+
+git -C "$FIX/primary" worktree remove --force "$FIX_WT" >/dev/null 2>&1
+
+# ---------------------------------------------------------------------------
+# Clauses (b), (c), (d): drive the SHIPPED `_githooks/pre-push` with a
+# core.hooksPath that is wrong, and with one that is right.
+#
+# The hook is invoked with `--explain`, which is its own existing seam for
+# exercising decision logic without the multi-minute typecheck/test phases. The
+# drift assertion runs BEFORE that early exit, so `--explain` reaches it — which
+# is asserted by clause (d) observing the hook proceed past it.
+#
+# The value is delivered through the environment rather than `git -c` because a
+# `-c` override is not written into `.git/config` and the hook reads its
+# effective value with `git config`; either delivery reaches the same
+# `git config --get core.hooksPath` the assertion calls. `git -c` is used here
+# so nothing writes to any real config.
+# ---------------------------------------------------------------------------
+
+# run_hook <hooksPath-value> — run the shipped hook in THIS repo with the given
+# effective core.hooksPath, capturing output and exit code.
+run_hook() {
+  HOOK_OUTPUT="$(cd "$REPO_ROOT" && git -c core.hooksPath="$1" \
+    hook run pre-push -- --explain 2>&1)"
+  HOOK_EXIT=$?
+}
+
+# --- (b) the detector fires on an absolute value ---------------------------
+ABSOLUTE_VALUE="$REPO_ROOT/_githooks"
+run_hook "$ABSOLUTE_VALUE"
+B_OUTPUT="$HOOK_OUTPUT"
+B_EXIT=$HOOK_EXIT
+if [ "$B_EXIT" -ne 0 ]; then
+  record b PASS "absolute core.hooksPath refused by the hook (exit=$B_EXIT)"
+else
+  record b FAIL "absolute core.hooksPath was ACCEPTED (exit=0) — nothing detects the drift: $(printf '%s' "$B_OUTPUT" | tr '\n' ' ' | cut -c1-400)"
+fi
+
+# --- (c) the refusal is actionable -----------------------------------------
+# Anchored on three separate things the refusal must carry: the setting's name,
+# the expected value, and the literal command that clears it. A refusal that
+# names only the problem leaves the reader to guess the remedy.
+C_MISSING=""
+printf '%s' "$B_OUTPUT" | grep -q "core.hooksPath" || C_MISSING="$C_MISSING setting-name"
+printf '%s' "$B_OUTPUT" | grep -qF "$ABSOLUTE_VALUE" || C_MISSING="$C_MISSING offending-value"
+printf '%s' "$B_OUTPUT" | grep -qF "$EXPECTED" || C_MISSING="$C_MISSING expected-value"
+printf '%s' "$B_OUTPUT" | grep -qF "_githooks/install.sh" || C_MISSING="$C_MISSING install-command"
+if [ -z "$C_MISSING" ]; then
+  record c PASS "refusal names core.hooksPath, the offending value, the expected value, and the install.sh command"
+else
+  record c FAIL "refusal is missing:$C_MISSING — output: $(printf '%s' "$B_OUTPUT" | tr '\n' ' ' | cut -c1-400)"
+fi
+
+# --- (d) control: the good value is not refused ----------------------------
+run_hook "$EXPECTED"
+D_OUTPUT="$HOOK_OUTPUT"
+D_EXIT=$HOOK_EXIT
+# The hook must both exit 0 AND be observed to have gone PAST the assertion —
+# an early exit 0 before reaching it would pass a bare exit-code check while
+# proving nothing about the assertion's placement. `base_ref=` is emitted by
+# the `--explain` path, which is downstream of where the assertion sits.
+if [ "$D_EXIT" -eq 0 ] && printf '%s' "$D_OUTPUT" | grep -q "base_ref="; then
+  record d PASS "installer's value ($EXPECTED) passed the assertion and the hook proceeded to its --explain output (exit=0)"
+elif [ "$D_EXIT" -ne 0 ]; then
+  record d FAIL "the installer's own value was REFUSED (exit=$D_EXIT) — the assertion refuses everything: $(printf '%s' "$D_OUTPUT" | tr '\n' ' ' | cut -c1-400)"
+else
+  record d FAIL "hook exited 0 but never reached its --explain output; the assertion's position cannot be confirmed: $(printf '%s' "$D_OUTPUT" | tr '\n' ' ' | cut -c1-400)"
+fi
+
+# ---------------------------------------------------------------------------
+# (e) ENVIRONMENT — this machine's live config.
+#
+# Separate from the pass/fail clauses above because `.git/config` is per-clone
+# state: a fresh clone that has never run the installer has NO value set, which
+# is not the #711 defect (git falls back to .git/hooks and the tracked hooks
+# simply do not run — the #311 problem, not this one). What #711 forbids is a
+# value that is set AND diverges from the installer's.
+# ---------------------------------------------------------------------------
+LIVE="$(git -C "$REPO_ROOT" config --local --get core.hooksPath 2>/dev/null || true)"
+ENV_FAIL=0
+if [ -z "$LIVE" ]; then
+  printf 'CLAUSE e (live core.hooksPath matches the installer): ENV-SKIP — no local core.hooksPath is set in this clone; run ./_githooks/install.sh to install the tracked hooks.\n'
+elif [ "$LIVE" = "$EXPECTED" ]; then
+  printf 'CLAUSE e (live core.hooksPath matches the installer): PASS — local core.hooksPath is %s, matching the installer.\n' "$LIVE"
+else
+  printf 'CLAUSE e (live core.hooksPath matches the installer): FAIL — local core.hooksPath is %s, but the installer writes %s. Every linked worktree is running the primary checkout'"'"'s hooks. Fix: ./_githooks/install.sh\n' "$LIVE" "$EXPECTED"
+  ENV_FAIL=1
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+label_for() {
+  case "$1" in
+    a) printf 'relative hooksPath resolves per-worktree; absolute does not' ;;
+    b) printf 'the hook REFUSES an absolute/divergent core.hooksPath' ;;
+    c) printf 'the refusal names the value, the expectation, and the fix command' ;;
+    d) printf 'the installer'"'"'s own value is NOT refused (mutation control)' ;;
+  esac
+}
+
+ALL_PASS=1
+for entry in "${CLAUSES[@]}"; do
+  id="${entry%%|*}"
+  rest="${entry#*|}"
+  status="${rest%%|*}"
+  evidence="${rest#*|}"
+  printf 'CLAUSE %s (%s): %s — %s\n' "$id" "$(label_for "$id")" "$status" "$evidence"
+  [ "$status" = PASS ] || ALL_PASS=0
+done
+
+if [ "$ALL_PASS" -eq 1 ] && [ "$ENV_FAIL" -eq 0 ]; then
+  exit 0
+fi
+exit 1

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,5 +1,34 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# SUPERSEDED — the hook installer is `_githooks/install.sh` (issue #711).
+#
+# This file used to run:
+#
+#     git config core.hooksPath .githooks
+#
+# `.githooks/` DOES NOT EXIST in this repo; the tracked hooks live in
+# `_githooks/`. Pointing core.hooksPath at a directory that is not there does
+# not fail loudly — git simply finds no hooks and every tracked hook silently
+# stops running. That is the exact #311 half-landed state the `_githooks/`
+# installer was written to end, left behind here as a one-line command that
+# reintroduces it.
+#
+# It also wrote the value WITHOUT `--local` and without resolving a repo root,
+# so what it configured depended on the caller's cwd.
+#
+# This is a redirecting stub rather than a deletion because the path is
+# referenced by name in docs/standards/REPO_BOOTSTRAP.md and may be in a runbook
+# or in muscle memory; a stub that says where to go is more useful than a "no
+# such file" error. It REFUSES rather than silently forwarding to the real
+# installer, because a script that quietly does something other than what its
+# name says is how the original divergence went unnoticed.
+set -uo pipefail
 
-git config core.hooksPath .githooks
-echo "Git hooks installed from .githooks/"
+printf 'scripts/install-hooks.sh is SUPERSEDED and does nothing.\n\n'
+printf 'It pointed core.hooksPath at .githooks/, which does not exist in this\n'
+printf 'repo -- that silently disables every tracked hook. The tracked hooks are\n'
+printf 'in _githooks/, and its installer sets the correct RELATIVE value so each\n'
+printf 'worktree resolves its own copy.\n\n'
+printf 'Run this instead, from the repo root:\n'
+printf '    ./_githooks/install.sh\n\n'
+printf '(issue #711)\n'
+exit 1

--- a/scripts/lane-bootstrap.ts
+++ b/scripts/lane-bootstrap.ts
@@ -248,6 +248,47 @@ function step(name: string, detail: string): void {
   process.stdout.write(`  [ok]   ${name}: ${detail}\n`);
 }
 
+/**
+ * Which hooks the new worktree will actually run (issue #711).
+ *
+ * `.git/config` is SHARED by every linked worktree, so `core.hooksPath` is not
+ * a property of the worktree this script just created — it is inherited. An
+ * ABSOLUTE value points this brand-new lane at the PRIMARY CHECKOUT's hooks,
+ * which is how a lane fixing a git hook ends up unable to exercise its own fix
+ * on push, and how a lane breaking one pushes green. The value diverged from
+ * what `_githooks/install.sh` writes and nothing said so for long enough that a
+ * family of lane failures (#705-#714) traced back to it.
+ *
+ * So the LANE READY block STATES it rather than leaving the lane to discover
+ * which hooks it is about to run (AGENTS.md, "nothing is adjusted silently").
+ * This reports; it does not fix. `_githooks/pre-push` is what refuses, because
+ * that is the thing that runs on every push rather than only on bootstrap.
+ *
+ * Never throws: a hooks-path probe failing is not a reason to fail a lane whose
+ * worktree, env, and deps are all good.
+ */
+function describeHooksPath(worktreePath: string): string {
+  const probe = spawnSync("git", ["config", "--get", "core.hooksPath"], {
+    cwd: worktreePath,
+    encoding: "utf-8",
+  });
+  if (probe.error) {
+    return `could not read core.hooksPath (${probe.error.message}) — check it yourself before trusting a pre-push verdict`;
+  }
+  const value = (probe.stdout || "").trim();
+  if (value === "") {
+    return "core.hooksPath is UNSET — git will use .git/hooks and the tracked _githooks/ will NOT run. Fix: ./_githooks/install.sh (#711)";
+  }
+  if (value === "_githooks") {
+    return `core.hooksPath=${value} (relative) — this worktree runs its OWN _githooks/`;
+  }
+  return (
+    `core.hooksPath=${value} — NOT the relative "_githooks" the installer writes. ` +
+    `This worktree will run the hooks at that path, NOT its own, so a pre-push ` +
+    `verdict here is about a different tree. Fix: ./_githooks/install.sh (#711)`
+  );
+}
+
 /** Parse the repo `.env` for the libpq vars used to create the test database. */
 function readEnvFile(path: string): Record<string, string> {
   const out: Record<string, string> = {};
@@ -515,6 +556,7 @@ function main(): void {
     `  branch:    ${args.branch} (${branchOrigin})`,
     `  env:       .env copied — OK`,
     `  deps:      bun install --frozen-lockfile — OK`,
+    `  hooks:     ${describeHooksPath(worktreePath)}`,
   ];
   if (args.freshDb) {
     lines.push(`  database:  ${dbName} — created and migrated`);


### PR DESCRIPTION
## Summary

- `core.hooksPath` in this clone was the ABSOLUTE path
  `/Volumes/ThunderBolt/Development/open-brain/_githooks`, while
  `_githooks/install.sh:24` writes the RELATIVE `_githooks` under a comment
  written against this exact trap. The config had diverged from its own
  installer and **nothing detected it** — the installer reports "already set"
  only on an exact match, and no check asserted the value.
- `.git/config` is shared by every linked worktree, so an absolute value points
  every lane worktree at the PRIMARY checkout's hooks. This is the root of the
  #705–#714 family: a lane fixing a git hook **could not exercise its own fix**
  on push, and a lane BREAKING one pushed green. PR #708 worked around it by
  hand with `-c core.hooksPath=<worktree>/_githooks`.
- **Does a relative hooksPath actually resolve per-worktree? PROVEN, yes** —
  throwaway worktree, distinct marker line in each tree's `_githooks/pre-push`,
  driven with `git hook run pre-push` (the shipped resolution, not a
  reimplementation):

  | config | run from | hook that executed |
  |---|---|---|
  | absolute | worktree | `MARKER: PRIMARY-COPY` ← the defect |
  | relative `_githooks` | worktree | `MARKER: WORKTREE-COPY` ← the fix |
  | relative `_githooks` | primary | `MARKER: PRIMARY-COPY` ← control |

### Relation to the existing documented design

`_DOCS/STANDARDS-python.md:35` already documents the neighbouring failure: a
**global** `core.hooksPath` silently shadows a repo's own hooks, because git
consults `hooksPath` *instead of* `.git/hooks/`. This PR's delta is the case
that document does not cover — a **repo-local** `hooksPath` that is set
correctly in every respect except being ABSOLUTE, which is invisible in a single
checkout and only misbehaves once linked worktrees exist. Same mechanism, one
layer down.

### Operator-machine change (recorded, NOT committed)

`core.hooksPath` is per-clone state in `.git/config` and is not a committed
file, so the flip cannot ship. Applied on this machine **via the installer**
rather than by hand, so the installer is proven to be the remedy the new
refusal text points at:

```
$ ./_githooks/install.sh
core.hooksPath changed: /Volumes/ThunderBolt/Development/open-brain/_githooks -> _githooks
```

### What ships — the detection mechanism

1. **`_githooks/pre-push`** asserts the effective `core.hooksPath` matches the
   installer's value, before any validation work and before the `--explain`
   early exit. It **fails the push**: when this is wrong, the verdict the gate
   is about to give is about the wrong tree, and a gate that knows its answer is
   untrustworthy and returns it anyway is worse than one that stops. The refusal
   prints the configured value, the expected value, and the literal
   `./_githooks/install.sh` command — a gate that refuses without saying how to
   clear it is what makes `--no-verify` habitual. **Unset stays legal**: git then
   falls back to `.git/hooks` and this file is not running at all, so it cannot
   be the thing complaining (that is #311, not #711).
2. **`_githooks/install.sh`** names the specific damage when the value it
   corrects was absolute — otherwise a corrected value looks identical in the
   output whether it was a harmless typo or this.
3. **`scripts/lane-bootstrap.ts`** — the LANE READY block states which hooks the
   new worktree will run (issue's suggested direction 3). It reports and never
   fixes; the probe never throws.
4. **`scripts/install-hooks.sh`** — **found during this lane, a live loaded
   gun.** It ran `git config core.hooksPath .githooks`, and `.githooks/` does not
   exist in this repo. That fails silently: git finds no hooks and every tracked
   hook stops running — the exact #311 half-landed state, preserved as a
   one-liner that reintroduces it. Also wrote without `--local` or a repo root,
   so it depended on the caller's cwd. Made a refusing stub (not deleted:
   `docs/standards/REPO_BOOTSTRAP.md:54` names it) that points at the real
   installer.

## Verification

- Done-means: scripts/done-means/711-hookspath-relative.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bash scripts/done-means/711-hookspath-relative.sh` — **5/5 GREEN, exit 0**:

```
CLAUSE e (live core.hooksPath matches the installer): PASS — local core.hooksPath is _githooks, matching the installer.
CLAUSE a (relative hooksPath resolves per-worktree; absolute does not): PASS
CLAUSE b (the hook REFUSES an absolute/divergent core.hooksPath): PASS (exit=1)
CLAUSE c (the refusal names the value, the expectation, and the fix command): PASS
CLAUSE d (the installer's own value is NOT refused (mutation control)): PASS
```

RED before the fix: **(b) and (c) FAIL while (a) and (d) PASS** — (d) is the
mutation control, so an "assertion" that refused everything could not have
passed by accident. (e) failed on the live config until the installer ran.

`bunx tsc --noEmit` clean. Full `pre-push` green on the push of this branch.

**This lane ran its own hook fix.** `rg -c "issue #711"` finds the new assertion
in the worktree's `_githooks/pre-push` (2) and NOT in the primary's (0 — still
on the base branch), and the lane's `git hook run pre-push` executed it. First
lane in the #705–#714 family able to do that.

## Critical Self-Review

- Highest-risk behavior: `_githooks/pre-push` now refuses a push it previously
  allowed. A wrong assertion blocks every push in the repo. Bounded by clause
  (d), which proves the installer's own value is NOT refused, and by keeping
  unset legal so a fresh clone is unaffected.
- Assumptions that could be wrong: that git resolves a relative `core.hooksPath`
  against each worktree's root. Not assumed — measured (table above), and clause
  (a) re-measures it hermetically on every run, so a future git that changed this
  goes red here rather than silently reverting the fix.
- Missing/weak tests: clause (e) is the only clause that reads this machine's
  live config, and it is an ENV verdict — it is skipped, correctly, on a clone
  with no hooksPath set, so CI cannot enforce the operator-machine half. That is
  inherent to per-clone state, and the pre-push assertion is what covers it at
  the moment it matters.
- Security/permission risk: none. No auth, namespace, SQL, or network path is
  touched.
- Migration/deploy risk: none. No schema, no runtime service change.
- Downstream client/runtime risk: none — no MCP tool, schema, transport, or
  Python client surface changes, so `docs/downstream-rollout.md` does not apply.
- Rollback/cleanup concern: revert the commit; `core.hooksPath` on this machine
  would stay relative (correct either way) and the assertion would simply stop
  existing. The lane worktree is removed as part of closing this lane.
- Fixes made before PR: the `install-hooks.sh` loaded gun was not in the issue —
  found while tracing every writer of `core.hooksPath`, and fixed here because
  leaving it means one run of a plausibly-named script silently disables the
  whole gate this PR is hardening.
- Known residual risk: the assertion compares against a hardcoded `_githooks` in
  the hook, while the done-means check reads the value out of `install.sh`. If
  the installer's target ever changes, the done-means check catches the hook
  lagging (clause b/d would go red) — but the hook itself would refuse pushes
  until updated. Accepted: one literal in the thing that runs is cheaper than a
  hook shelling out to parse its own installer on every push.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane runs under the harvest model (docs/sop-rlvr-lanes.md step 5) — lessons are returned in the lane report and the tracking-scribe agent owns writing them to root; writing docs/sme/ from a lane is forbidden.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this
  change touches git hook configuration and lane tooling only; no Open Brain
  runtime, schema, or client surface is involved.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, client, or
  fixture path is touched; `pre-push` reported `parity=no` on this branch.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable: no MCP tool, schema, protocol, or client-facing surface
  changes. The payload is git hook config detection plus lane-bootstrap
  reporting, all repo-local developer tooling.

Closes #711
