### PR TITLE
fix(pr-body-gate): resolve a --head branch name to a ref the tree can read (#714)

### DIFF
--- a/.claude/hooks/pr-body-gate.ts
+++ b/.claude/hooks/pr-body-gate.ts
@@ -309,6 +309,78 @@ function branchOf(dir: string): string | null {
   return branch ? branch : null;
 }
 
+/** Does `ref` name something `git` can resolve inside `dir`? */
+function refResolves(dir: string, ref: string): boolean {
+  const probe = spawnSync(
+    "git",
+    ["-C", dir, "rev-parse", "--verify", "--quiet", `${ref}^{commit}`],
+    { encoding: "utf8" },
+  );
+  return probe.status === 0;
+}
+
+/**
+ * The ref that actually CONTAINS the PR's commits, given a branch NAME.
+ *
+ * ISSUE #714. A branch name is not a ref until some repository can resolve it,
+ * and `gh pr create --head <branch>` names a branch on the REMOTE. Run from a
+ * root checkout that fetched but never created a local branch of that name —
+ * which is exactly where a lane opens a PR with `--head` and no `cd` — the bare
+ * name resolves to nothing:
+ *
+ *   $ git cat-file -e lane/x:scripts/done-means/check.sh
+ *   fatal: invalid object name 'lane/x'.
+ *   $ git cat-file -e origin/lane/x:scripts/done-means/check.sh   # exit 0
+ *
+ * #709 made the hook FEED the branch tier; this makes what it feeds RESOLVABLE.
+ * Without it the tier is fed a dead string and the refusal prints
+ * `; and in ref lane/x`, which reads as "your check is not on the branch" when
+ * the truth is "that name means nothing here" — a refusal that misdirects is
+ * worse than one that admits it looked nowhere, because the cheapest way past a
+ * misdirecting refusal is a false receipt (#706's lesson, one layer out).
+ *
+ * Candidates are tried in order and each is ASSERTED ON POSITIVELY — round 28:
+ * a lookup whose failure is indistinguishable from its legitimate empty case
+ * must be asserted on positively, never by observing that nothing broke. So a
+ * name that resolves nowhere returns null and the branch tier is skipped
+ * entirely rather than fed a string that will fail for the wrong reason.
+ *
+ *   1. the name as given — a local branch, a SHA, a tag, or a ref the caller
+ *      already spelled correctly (`--head origin/lane/x`). Trying this FIRST is
+ *      what stops a correct ref being mangled, and keeps a local-only checkout
+ *      working with no remote at all.
+ *   2. `<remote>/<name>` for each configured remote, origin first. This is the
+ *      #714 case. Remotes are ENUMERATED rather than assuming `origin` exists,
+ *      because a checkout with a differently-named remote is not an error.
+ *
+ * This only ever changes WHICH ref is consulted; `existsInRef`'s containment
+ * guard on the PATH is untouched, so it widens where a check may live and never
+ * what may be named.
+ */
+function resolvableRef(dir: string, name: string): string | null {
+  if (refResolves(dir, name)) return name;
+
+  const remotesProbe = spawnSync("git", ["-C", dir, "remote"], {
+    encoding: "utf8",
+  });
+  if (remotesProbe.status !== 0) return null;
+  const remotes = (remotesProbe.stdout ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .sort((a, b) => Number(b === "origin") - Number(a === "origin"));
+
+  for (const remote of remotes) {
+    // A name that already carries this remote's prefix was covered by the
+    // as-given attempt above; re-prefixing it would only build origin/origin/x.
+    if (name.startsWith(`${remote}/`)) continue;
+    const candidate = `${remote}/${name}`;
+    if (refResolves(dir, candidate)) return candidate;
+  }
+
+  return null;
+}
+
 function refuse(lines: string[]): never {
   console.error(lines.join("\n"));
   process.exit(2);
@@ -477,6 +549,20 @@ if (!existsSync(VALIDATOR)) {
  * checkout this process can see. Every step degrades to the pre-#709 behaviour
  * rather than guessing, and `scripts/done-means/709-hook-feeds-head-ref.sh`
  * drives THIS file with real payloads to hold it there.
+ *
+ * ---------------------------------------------------------------------------
+ * ISSUE #714 — a branch NAME is not a ref until something can resolve it.
+ * ---------------------------------------------------------------------------
+ *
+ * The precedence above produces a branch NAME. `gh pr create --head <branch>`
+ * names a branch on the REMOTE, and in a root checkout that fetched it but
+ * never created a local branch of that name, the bare name resolves to nothing
+ * — so the tier #709 made reachable was still handed a dead string. The name is
+ * therefore run through `resolvableRef()` (as-given, then `<remote>/<name>`),
+ * each candidate asserted on positively, and the SETTLED ref is what reaches
+ * `PR_HEAD_REF`. `scripts/done-means/714-head-ref-resolves-remote.sh` holds it
+ * with a genuine bare-remote fixture, because the defect is invisible in any
+ * fixture where the lane branch also exists locally.
  */
 const payloadCwd = input.cwd?.trim() || process.cwd();
 const cdTarget = cdTargetBefore(commands, targetIndex, payloadCwd);
@@ -486,18 +572,20 @@ const reviewRootSource = cdTarget
   : `the hook payload's cwd (${payloadCwd})`;
 const reviewRoot = cdTarget ?? payloadCwd;
 
-let headRef: string | null = null;
-let headRefSource = "";
-if (target.head?.trim()) {
-  headRef = target.head.trim();
-  headRefSource = `explicit --head on the gh command`;
-} else {
-  const derived = branchOf(reviewRoot);
-  if (derived) {
-    headRef = derived;
-    headRefSource = `branch checked out in ${reviewRoot}`;
-  }
-}
+// The branch NAME the PR is opened from, and where that name came from.
+const headName = target.head?.trim() || branchOf(reviewRoot);
+const headNameSource = target.head?.trim()
+  ? `explicit --head on the gh command`
+  : `branch checked out in ${reviewRoot}`;
+
+// ...and the ref that can actually be READ in the tree being asked (issue
+// #714). A name that resolves nowhere yields null, so the branch tier is
+// skipped rather than fed a string that fails for a reason nobody can act on.
+const headRef = headName ? resolvableRef(reviewRoot, headName) : null;
+const headRefSource =
+  headRef && headRef !== headName
+    ? `${headNameSource}; '${headName}' does not resolve in ${reviewRoot}, so the remote-tracking ref was used`
+    : headNameSource;
 
 const result = spawnSync("bun", [VALIDATOR], {
   encoding: "utf8",
@@ -529,11 +617,16 @@ if (result.error || result.status === null) {
 // so the refusal read as "your path does not exist" when the truth was "the
 // gate was looking in the wrong place". A refusal is exactly when someone has
 // to work out why, so the inputs are printed on the failing path too.
+// Issue #714 adds a third state to this line. A head NAME with no resolvable
+// ref is not the same as no name at all, and reporting it as "not on a named
+// branch" would send the reader looking for the wrong problem.
 const inputNotes = [
   `[${HOOK_NAME}] tree under review: ${reviewRootSource}`,
   headRef
     ? `[${HOOK_NAME}] head ref: ${headRef} (source: ${headRefSource})`
-    : `[${HOOK_NAME}] head ref: none — no --head on the command and ${reviewRoot} is not on a named branch; the branch tier cannot run`,
+    : headName
+      ? `[${HOOK_NAME}] head ref: none — '${headName}' (${headNameSource}) resolves to no ref in ${reviewRoot}, locally or on any remote; the branch tier cannot run. Fetch the branch, or pass a --head that this checkout can see.`
+      : `[${HOOK_NAME}] head ref: none — no --head on the command and ${reviewRoot} is not on a named branch; the branch tier cannot run`,
 ];
 
 if (result.status !== 0) {

--- a/_plans/worklog/fix-714-2026-08-10.md
+++ b/_plans/worklog/fix-714-2026-08-10.md
@@ -1,0 +1,183 @@
+# fix-714 — the branch tier is fed, but what it is fed does not resolve
+
+**State: MERGED-pending.** Fix written and driven red-first against the real
+hook; `scripts/done-means/714-head-ref-resolves-remote.sh` 6/6 GREEN. Branch
+`lane/714-head-ref-remote-resolution`, based on the current wip head `17ada37`.
+
+## 1. Premise re-verification (canon: an issue older than the code re-verifies first)
+
+#714 was filed against pre-#709 code and claims:
+
+> `pr-body-gate.ts` never sets `PR_HEAD_REF`, so the validator's branch tier is
+> dead in the exact path it was written for.
+
+**That premise is STALE.** PR #713 landed the #709 fix. On the current head the
+hook parses `--head`/`-H` (`parsePrCommand`, the `head` field), derives a branch
+from the `cd` target otherwise (`branchOf`), and sets `PR_HEAD_REF` in the
+validator's env. `scripts/done-means/709-hook-feeds-head-ref.sh` runs 5/5 GREEN
+holding that. The #716 landing separately observed the cwd tier answering from a
+lane worktree.
+
+So the filed defect does not reproduce. The lane did NOT stop there, because the
+task named a narrower candidate shape to test: `gh pr create` run from ROOT with
+`--head <branch>`, no `cd`, no worktree on disk.
+
+**That narrower shape reproduces, and the residue is real.**
+
+## 2. Reproduction transcript (against the UNFIXED hook at 17ada37)
+
+Fixture — a genuine remote, which is the only way the asymmetry appears: bare
+`upstream.git`, a seed repo that pushes `lane/714-fixture` carrying
+`scripts/done-means/lane-only-check.sh`, and a `primary` clone on `base` that has
+fetched the branch but holds **no local branch of that name and no worktree**.
+
+```
+--- primary branches (local) ---
+* base
+--- remote-tracking ---
+  origin/HEAD -> origin/base
+  origin/base
+  origin/lane/714-fixture
+--- local lane branch resolves? ---   NO (expected)
+--- origin/lane resolves? ---         YES
+--- file on disk in primary? ---      NO (expected)
+```
+
+Driving the REAL hook with a synthetic PreToolUse payload (`cwd` = primary,
+command = `gh pr create --head lane/714-fixture --title ... --body-file ...`):
+
+```
+BLOCKED by pr-body-gate: this PR body fails scripts/validate-pr-body.ts.
+
+  gh pr create, body from --body-file .../body.md
+
+  [pr-body-gate] tree under review: the hook payload's cwd (.../primary)
+  [pr-body-gate] head ref: lane/714-fixture (source: explicit --head on the gh command)
+
+The validator said:
+
+  PR body validation failed:
+  - Verification field 'Done-means' must name an existing repo-relative path;
+    not found: scripts/done-means/lane-only-check.sh
+    (looked in: .../primary, /Volumes/ThunderBolt/Development/open-brain;
+     and in ref lane/714-fixture)
+EXIT=2
+```
+
+Note the difference from the issue's own transcript: the head ref **IS** supplied
+and the refusal **DOES** carry `; and in ref lane/714-fixture`. #709 fixed the
+feeding. The mechanism of the residue:
+
+```
+$ git -C primary cat-file -e lane/714-fixture:scripts/done-means/lane-only-check.sh
+fatal: invalid object name 'lane/714-fixture'.      exit=128
+$ git -C primary cat-file -e origin/lane/714-fixture:scripts/done-means/lane-only-check.sh
+                                                    exit=0
+```
+
+Control — same body, same tree, only the ref spelling changed:
+
+```
+$ PR_BODY=... PR_REPO_DIR=.../primary PR_HEAD_REF=origin/lane/714-fixture \
+    bun scripts/validate-pr-body.ts
+Done-means resolved in branch origin/lane/714-fixture (.../primary),
+  not on disk in any available tree
+PR body validation passed.                          EXIT=0
+```
+
+**A branch NAME is not a ref until something can resolve it.** `gh pr create
+--head <branch>` names a branch on the REMOTE; the hook passed that string
+through untouched, so the tier #709 made reachable was handed a dead string.
+
+Second-order harm: the refusal prints `; and in ref lane/714-fixture`, which
+reads as *"your check is not on the branch either"* when the truth is *"that
+name means nothing here."* A refusal that misdirects is worse than one that
+admits it looked nowhere — the cheapest way past it is a false receipt, which is
+the #706/#714 reflex the gate exists to prevent.
+
+## 3. Direction taken, and why
+
+`resolvableRef(dir, name)` in the hook, run on the branch name before it becomes
+`PR_HEAD_REF`:
+
+1. the name **as given** — a local branch, SHA, tag, or an already-correct
+   `origin/lane/x`. First, so a correct ref is never mangled and a local-only
+   checkout with no remote keeps working.
+2. `<remote>/<name>` for each configured remote, **origin first**. Remotes are
+   enumerated (`git remote`) rather than assuming `origin` exists.
+
+Each candidate is asserted on **positively** (`git rev-parse --verify --quiet
+<ref>^{commit}`), per round 28: a lookup whose failure is indistinguishable from
+its legitimate empty case must be asserted on positively. A name that resolves
+nowhere yields `null`, so the branch tier is **skipped** rather than fed a dead
+string, and the announcement says so by name.
+
+Alternatives rejected:
+
+- **Blindly prepend `origin/`.** Breaks a caller who already spelled it right
+  (`origin/origin/x`), breaks local-only checkouts, and assumes the remote is
+  named origin. Clauses 2 and 6 exist to fail exactly this.
+- **Widen `existsInRef` in the validator.** Wrong boundary. The validator is
+  handed a ref and correctly reports it found nothing; the hook is what knows
+  which repository is being asked and therefore what can resolve there. Fixing
+  it in the validator would also let CI's own correct ref get second-guessed.
+- **Make the field advisory / accept an unresolvable ref.** That is the blanket
+  pass the whole gate exists to prevent. Clause 3 fails it.
+
+The containment guard on the PATH (`existsInRef`, absolute/`..` refused) is
+untouched: this widens WHERE a check may resolve, never WHAT may be named.
+
+## 4. Done-means, red-first
+
+`scripts/done-means/714-head-ref-resolves-remote.sh`, 6 clauses, every one
+driving the REAL hook with a synthetic PreToolUse payload against a REAL remote.
+
+Round 28's false-green trap applies directly here and is called out in the
+file's header: `709-hook-feeds-head-ref.sh` clause 3 already drives `--head`
+through the real hook and **passes**, because its fixture holds the lane branch
+locally so the bare name resolves. It proves `--head` is parsed, never that the
+parsed value is resolvable. The defect is invisible without a genuine remote.
+
+RED, before the fix (`EXIT=1`):
+
+```
+CLAUSE 1 (a --head naming a REMOTE-ONLY branch resolves): FAIL — REFUSED (exit=2)
+CLAUSE 2 (an explicit origin/<branch> is not mangled): PASS
+CLAUSE 3 (MUTANT CONTROL: a path on no ref is still REFUSED): PASS
+CLAUSE 4 (MUTANT CONTROL: a --head naming nothing is not claimed as consulted): FAIL
+         — refused, but the refusal claims it looked 'in ref lane/714-this-branch-does-not-exist'
+CLAUSE 5 (the ref the hook settled on is announced, never silent): FAIL
+         — the ref the hook settled on (origin/lane/714-fixture) is never named
+CLAUSE 6 (REGRESSION: a local branch still resolves): PASS
+```
+
+Clauses 2/3/6 green before the fix is correct and deliberate: they are the
+controls that fail a BAD fix, not the defect. 1/4/5 are the defect.
+
+GREEN, after (`EXIT=0`): all six PASS.
+
+## 5. Regression surface
+
+Every sibling gate that drives this hook or validator, all GREEN after the fix:
+
+| check | exit |
+|---|---|
+| `709-hook-feeds-head-ref.sh` | 0 (5/5) |
+| `pr-body-gate-fires.sh` | 0 (7/7) |
+| `706-done-means-resolves-pr-head.sh` | 0 (5/5) |
+| `pr-template-passes-validator.sh` | 0 (3/3) |
+| `done-means-field-required.sh` | 0 (5/5) |
+| `bunx tsc --noEmit` | 0 |
+
+## 6. Lane notes
+
+- Worked **in-branch in the root checkout**, no worktree: the change is two
+  functions in one hook file plus one new check, and no second lane is touching
+  `.claude/hooks/`. Stated per the lane contract rather than assumed.
+- One self-inflicted violation, caught and corrected in the same session: a
+  regression loop was written with `> /tmp_out`, which the read-only root
+  refused. Rerun against `{temp_workspace}/open-brain/_scratch/`. The rule held
+  because the filesystem enforced it, not because the reflex was absent — this
+  is the "broken by reflex in one-line redirects" case AGENTS.md names.
+- No `rm`; the fixture is archived with `mv` into `_archive/` by the check's own
+  teardown.

--- a/scripts/done-means/714-head-ref-resolves-remote.sh
+++ b/scripts/done-means/714-head-ref-resolves-remote.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #714 — a `--head` the hook cannot RESOLVE is not a
+# head ref, and feeding it is the same dead branch tier by a different route.
+#
+#   bash scripts/done-means/714-head-ref-resolves-remote.sh
+#
+# ---------------------------------------------------------------------------
+# The defect this gates, and how it differs from what #714 was FILED as
+# ---------------------------------------------------------------------------
+# #714 was filed against pre-#709 code and claims `pr-body-gate.ts` "never sets
+# PR_HEAD_REF, so the validator's branch tier is dead". That premise is STALE:
+# PR #713 landed the #709 fix, the hook parses `--head`/`-H` and derives a
+# branch from the cd target, and `scripts/done-means/709-hook-feeds-head-ref.sh`
+# is 5/5 GREEN holding it there.
+#
+# Re-verifying the premise (canon: an issue older than the current code
+# re-verifies before implementation) found the residue is NARROWER and real:
+#
+#   the hook feeds the `--head` value THROUGH UNTOUCHED, and `gh pr create
+#   --head <branch>` names a branch on the REMOTE. In a checkout that has
+#   fetched but never created a local branch of that name — the primary, which
+#   is exactly where a lane runs `gh pr create --head <branch>` from without a
+#   `cd` and without a worktree on disk — the bare name resolves to nothing:
+#
+#     $ git cat-file -e lane/714-fixture:scripts/done-means/lane-only-check.sh
+#     fatal: invalid object name 'lane/714-fixture'.        # exit 128
+#     $ git cat-file -e origin/lane/714-fixture:...          # exit 0
+#
+# So the branch tier IS fed, and still cannot answer. The refusal even prints
+# `; and in ref lane/714-fixture`, which reads as "your check is not on the
+# branch either" when the truth is "that ref does not name anything here" —
+# a refusal that misdirects is worse than one that admits it looked nowhere.
+#
+# Measured 2026-08-10 against the hook at 17ada37 with the fixture below.
+#
+# ---------------------------------------------------------------------------
+# Why this check drives the HOOK, and with a REAL remote
+# ---------------------------------------------------------------------------
+# Round 28: A SEAM ADDED TO MAKE A GATE TESTABLE IS NOT THE PATH THAT RUNS.
+# `709-hook-feeds-head-ref.sh` clause 3 already drives `--head` through the real
+# hook and passes — because its fixture has the lane branch LOCALLY, so the bare
+# name resolves. That is the false-green: the clause proves `--head` is parsed,
+# never that the parsed value is RESOLVABLE in the tree being asked. The
+# asymmetry only appears with a genuine remote, so this fixture builds one
+# (bare upstream + clone) rather than faking the ref layout.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+#   1  `gh pr create --head <branch>` from a checkout where the branch exists
+#      ONLY as `origin/<branch>`, citing a check committed only on that branch,
+#      with no `cd` and no worktree on disk -> ALLOWED, and the announcement
+#      names the ref that actually answered.
+#      RED before the fix: refused, `; and in ref <branch>` present.
+#   2  a `--head` value that ALREADY carries the remote prefix
+#      (`--head origin/<branch>`) still resolves. The fix must not mangle a ref
+#      that was correct on arrival — no double-prefixing.
+#   3  MUTANT CONTROL: same remote-only shape, citing a path committed on NO
+#      branch and present in NO tree -> still REFUSED, naming the path. A fix
+#      that widens WHERE a path may resolve must never widen WHAT may be named;
+#      this clause fails if anyone "fixes" #714 by making the field advisory.
+#   4  MUTANT CONTROL (containment): a `--head` naming a branch that does not
+#      exist at all, local or remote -> the head ref must not be announced as
+#      resolvable, and the body citing a branch-only check is REFUSED. Proves
+#      the fix asserts POSITIVELY on the ref (round 28: a lookup whose failure
+#      is indistinguishable from its empty case must be asserted on positively)
+#      rather than blindly prepending `origin/` and hoping.
+#   5  the ref the hook SETTLED ON is announced, including when it differs from
+#      what the command said (AGENTS.md 2026-08-08, nothing is adjusted
+#      silently: `--head lane/x` becoming `origin/lane/x` is a self-made
+#      decision, and an invisible one cannot be checked). Round 28: assert on
+#      announcements or they rot silently.
+#   6  REGRESSION: a LOCAL branch name still resolves without an origin remote
+#      in play. The fix must not make local-branch resolution depend on a
+#      remote that a plain checkout may not have.
+#
+# Exit 0 only when every clause passes. Exit 3 is a harness error (missing tool,
+# unbuildable fixture), which is NOT a fail of the thing under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK="$REPO_ROOT/.claude/hooks/pr-body-gate.ts"
+TEMPLATE="$REPO_ROOT/.github/pull_request_template.md"
+VALIDATOR="$REPO_ROOT/scripts/validate-pr-body.ts"
+
+SCRATCH_BASE="${OPENBRAIN_TEMP_WORKSPACE:-${DEV_TMP:-/Volumes/ThunderBolt/_tmp}}/open-brain/_scratch"
+SCRATCH="$SCRATCH_BASE/714-head-ref-resolves-remote.$$"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+command -v git >/dev/null 2>&1 || fail_hard "git not on PATH"
+[ -r "$VALIDATOR" ] || fail_hard "validator not readable at $VALIDATOR"
+[ -r "$TEMPLATE" ] || fail_hard "template not readable at $TEMPLATE"
+mkdir -p "$SCRATCH" || fail_hard "cannot create scratch dir $SCRATCH"
+
+# ---------------------------------------------------------------------------
+# Fixture: a REAL remote. bare upstream <- seed (pushes the lane branch) and a
+# PRIMARY clone that has fetched it but holds no local branch of that name and
+# no worktree on disk. That is the shape `gh pr create --head <branch>` is run
+# in from a root checkout, and the only shape where the bare name is unresolvable.
+# ---------------------------------------------------------------------------
+UPSTREAM="$SCRATCH/upstream.git"
+SEED="$SCRATCH/seed"
+PRIMARY="$SCRATCH/primary"
+LANE_BRANCH="lane/714-fixture"
+BRANCH_ONLY_CHECK="scripts/done-means/lane-only-check.sh"
+
+build_fixture() {
+  git init -q --bare -b base "$UPSTREAM" || return 1
+
+  git init -q -b base "$SEED" || return 1
+  git -C "$SEED" config user.email "done-means@open-brain.invalid" || return 1
+  git -C "$SEED" config user.name "714 done-means fixture" || return 1
+  # A scratch repo must not run this repo's hooks; that would measure the wrong
+  # thing entirely.
+  git -C "$SEED" config core.hooksPath "$SEED/.git/no-hooks" || return 1
+
+  mkdir -p "$SEED/scripts/done-means" || return 1
+  printf 'base tree\n' > "$SEED/README.md" || return 1
+  git -C "$SEED" add README.md || return 1
+  git -C "$SEED" commit -q -m "base commit" || return 1
+  git -C "$SEED" remote add origin "$UPSTREAM" || return 1
+  git -C "$SEED" push -q origin base || return 1
+
+  git -C "$SEED" checkout -q -b "$LANE_BRANCH" || return 1
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$SEED/$BRANCH_ONLY_CHECK" || return 1
+  git -C "$SEED" add "$BRANCH_ONLY_CHECK" || return 1
+  git -C "$SEED" commit -q -m "lane: add the branch-only check" || return 1
+  git -C "$SEED" push -q origin "$LANE_BRANCH" || return 1
+
+  git clone -q -b base "$UPSTREAM" "$PRIMARY" || return 1
+  git -C "$PRIMARY" config core.hooksPath "$PRIMARY/.git/no-hooks" || return 1
+}
+
+build_fixture || fail_hard "could not build the fixture repo under $SCRATCH"
+
+# Sanity: the fixture must genuinely express the asymmetry, or every clause
+# below measures nothing. This is the whole defect, stated as three facts.
+[ -e "$PRIMARY/$BRANCH_ONLY_CHECK" ] \
+  && fail_hard "fixture wrong: the branch-only check is on disk in the primary clone"
+git -C "$PRIMARY" rev-parse --verify --quiet "$LANE_BRANCH" >/dev/null 2>&1 \
+  && fail_hard "fixture wrong: $LANE_BRANCH exists LOCALLY in the primary clone — the bare name would resolve and the defect would be invisible"
+git -C "$PRIMARY" rev-parse --verify --quiet "origin/$LANE_BRANCH" >/dev/null 2>&1 \
+  || fail_hard "fixture wrong: origin/$LANE_BRANCH does not resolve in the primary clone"
+git -C "$PRIMARY" cat-file -e "origin/$LANE_BRANCH:$BRANCH_ONLY_CHECK" 2>/dev/null \
+  || fail_hard "fixture wrong: the branch-only check is not committed on origin/$LANE_BRANCH"
+
+# ---------------------------------------------------------------------------
+# Bodies, built from the committed template exactly the way
+# scripts/done-means/709-hook-feeds-head-ref.sh builds its own, so this check
+# inherits the template's guarantee rather than maintaining a second field list.
+# ---------------------------------------------------------------------------
+DUMMY="dummy specific content for the 714 acceptance gate"
+
+fill_template() {
+  local done_means_value="$1" out="$2"
+  sed \
+    -e 's/\[ \]\(.*\)or \[ \] not applicable because:.*$/[x]\1or [ ] not applicable because:/' \
+    -e 's/^- \[ \]/- [x]/' \
+    -e "s|^- Done-means:.*$|- Done-means: $done_means_value|" \
+    -e "s/^\(- [^][]*:\)[[:space:]]*$/\1 $DUMMY/" \
+    "$TEMPLATE" > "$out"
+}
+
+BRANCH_BODY_FILE="$SCRATCH/branch-only-body.md"
+NOWHERE_BODY_FILE="$SCRATCH/nowhere-body.md"
+NOWHERE_PATH="scripts/done-means/this-path-exists-nowhere-at-all.sh"
+
+fill_template "$BRANCH_ONLY_CHECK" "$BRANCH_BODY_FILE" \
+  || fail_hard "could not build the branch-only body"
+fill_template "$NOWHERE_PATH" "$NOWHERE_BODY_FILE" \
+  || fail_hard "could not build the nowhere body"
+
+# Sanity on the MUTANT CONTROL fixture: absent from every tree and every ref, or
+# clause 3 proves nothing.
+[ -e "$PRIMARY/$NOWHERE_PATH" ] && fail_hard "fixture wrong: the 'nowhere' path exists in the primary clone"
+[ -e "$REPO_ROOT/$NOWHERE_PATH" ] && fail_hard "fixture wrong: the 'nowhere' path exists in this repo"
+if git -C "$PRIMARY" cat-file -e "origin/$LANE_BRANCH:$NOWHERE_PATH" 2>/dev/null; then
+  fail_hard "fixture wrong: the 'nowhere' path is committed on origin/$LANE_BRANCH"
+fi
+
+# ---------------------------------------------------------------------------
+# Drive the REAL hook the way Claude Code does: a PreToolUse JSON payload on
+# stdin whose cwd is the PRIMARY clone. Sets HOOK_EXIT and HOOK_STDERR.
+# ---------------------------------------------------------------------------
+HOOK_EXIT=0
+HOOK_STDERR=""
+run_hook() {
+  local command_text="$1" payload_cwd="$2" payload
+  payload="$(
+    COMMAND_TEXT="$command_text" PAYLOAD_CWD="$payload_cwd" bun -e '
+      process.stdout.write(JSON.stringify({
+        session_id: "714-head-ref-resolves-remote",
+        cwd: process.env.PAYLOAD_CWD ?? "",
+        hook_event_name: "PreToolUse",
+        tool_name: "Bash",
+        tool_input: { command: process.env.COMMAND_TEXT ?? "" },
+      }));
+    '
+  )" || fail_hard "could not build hook payload"
+
+  HOOK_STDERR="$(printf '%s' "$payload" | bun "$HOOK" --event pre-tool-use 2>&1 >/dev/null)"
+  HOOK_EXIT=$?
+}
+
+q() { printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"; }
+
+CLAUSES=()
+record() { CLAUSES+=("$1|$2|$3"); }
+
+if [ ! -r "$HOOK" ]; then
+  for c in 1 2 3 4 5 6; do
+    record "$c" FAIL "no hook at $HOOK — nothing resolves anything"
+  done
+else
+  # -- CLAUSE 1: the reported shape. --head <branch>, remote-only, no cd. ------
+  run_hook "gh pr create --head $(q "$LANE_BRANCH") --title 'feat: lane thing' --body-file $(q "$BRANCH_BODY_FILE")" "$PRIMARY"
+  if [ "$HOOK_EXIT" -ne 0 ]; then
+    record 1 FAIL "REFUSED (exit=$HOOK_EXIT) — a --head naming a remote-only branch does not resolve: $(printf '%s' "$HOOK_STDERR" | tr '\n' ' ' | cut -c1-300)"
+  elif ! printf '%s' "$HOOK_STDERR" | rg -qF "resolved in branch"; then
+    record 1 FAIL "allowed, but the BRANCH tier never announced — something else answered, so the remote ref is still unproven"
+  else
+    record 1 PASS "--head naming a remote-only branch resolved via the branch tier and announced it (exit=0)"
+  fi
+
+  # -- CLAUSE 2: an already-correct ref is not mangled -------------------------
+  run_hook "gh pr create --head $(q "origin/$LANE_BRANCH") --title 'feat: lane thing' --body-file $(q "$BRANCH_BODY_FILE")" "$PRIMARY"
+  if [ "$HOOK_EXIT" -ne 0 ]; then
+    record 2 FAIL "REFUSED (exit=$HOOK_EXIT) — an explicit origin/<branch> was mangled (double-prefixed?): $(printf '%s' "$HOOK_STDERR" | tr '\n' ' ' | cut -c1-300)"
+  elif printf '%s' "$HOOK_STDERR" | rg -qF "origin/origin/"; then
+    record 2 FAIL "allowed, but the announcement shows a double-prefixed ref (origin/origin/...)"
+  else
+    record 2 PASS "an explicit origin/<branch> resolves untouched, no double-prefixing (exit=0)"
+  fi
+
+  # -- CLAUSE 3: MUTANT CONTROL. Nowhere path is still REFUSED ----------------
+  run_hook "gh pr create --head $(q "$LANE_BRANCH") --title 'feat: lane thing' --body-file $(q "$NOWHERE_BODY_FILE")" "$PRIMARY"
+  if [ "$HOOK_EXIT" -ne 2 ]; then
+    record 3 FAIL "a nonexistent Done-means path was ALLOWED (exit=$HOOK_EXIT) — widening resolution became a blanket pass"
+  elif ! printf '%s' "$HOOK_STDERR" | rg -qF "$NOWHERE_PATH"; then
+    record 3 FAIL "refused but never names the offending path"
+  else
+    record 3 PASS "nonexistent Done-means path still REFUSED, naming the path (exit=2)"
+  fi
+
+  # -- CLAUSE 4: MUTANT CONTROL. A --head that names nothing at all -----------
+  # The fix must ASSERT that the ref it settled on resolves, not assume that
+  # prepending origin/ makes any string into a ref. A body citing a branch-only
+  # check must still be refused here, since no tree and no reachable ref has it.
+  GHOST_BRANCH="lane/714-this-branch-does-not-exist"
+  git -C "$PRIMARY" rev-parse --verify --quiet "$GHOST_BRANCH" >/dev/null 2>&1 \
+    && fail_hard "fixture wrong: the ghost branch exists locally"
+  git -C "$PRIMARY" rev-parse --verify --quiet "origin/$GHOST_BRANCH" >/dev/null 2>&1 \
+    && fail_hard "fixture wrong: the ghost branch exists as a remote-tracking ref"
+
+  run_hook "gh pr create --head $(q "$GHOST_BRANCH") --title 'feat: lane thing' --body-file $(q "$BRANCH_BODY_FILE")" "$PRIMARY"
+  if [ "$HOOK_EXIT" -ne 2 ]; then
+    record 4 FAIL "a --head naming no existing ref was ALLOWED (exit=$HOOK_EXIT) — the ref is not being asserted on positively"
+  elif printf '%s' "$HOOK_STDERR" | rg -qF "and in ref $GHOST_BRANCH"; then
+    record 4 FAIL "refused, but the refusal claims it looked 'in ref $GHOST_BRANCH' — a ref that resolves to nothing; the message misdirects"
+  else
+    record 4 PASS "a --head naming no existing ref is REFUSED without claiming to have consulted it (exit=2)"
+  fi
+
+  # -- CLAUSE 5: the SETTLED ref is announced, adjustment and all -------------
+  # `--head lane/x` resolved as `origin/lane/x` is the hook deciding something
+  # for itself. AGENTS.md 2026-08-08: original -> adjusted, and why, in the
+  # normal output. Round 28: assert on announcements or they rot.
+  run_hook "gh pr create --head $(q "$LANE_BRANCH") --title 'feat: lane thing' --body-file $(q "$BRANCH_BODY_FILE")" "$PRIMARY"
+  if ! printf '%s' "$HOOK_STDERR" | rg -qF "origin/$LANE_BRANCH"; then
+    record 5 FAIL "the ref the hook settled on (origin/$LANE_BRANCH) is never named — a silent adjustment: $(printf '%s' "$HOOK_STDERR" | tr '\n' ' ' | cut -c1-300)"
+  elif ! printf '%s' "$HOOK_STDERR" | rg -qF "$LANE_BRANCH" ; then
+    record 5 FAIL "the announcement never names the branch the command asked for"
+  elif ! printf '%s' "$HOOK_STDERR" | rg -qi -e 'head ref'; then
+    record 5 FAIL "no head-ref announcement line at all"
+  else
+    record 5 PASS "the hook announces the ref it settled on, naming both what --head said and what resolved"
+  fi
+
+  # -- CLAUSE 6: REGRESSION. A local branch still resolves --------------------
+  # The seed repo is checked out ON the lane branch and the file is committed
+  # there. Resolution must not have become remote-dependent.
+  run_hook "cd $(q "$SEED") && gh pr create --title 'feat: lane thing' --body-file $(q "$BRANCH_BODY_FILE")" "$PRIMARY"
+  if [ "$HOOK_EXIT" -ne 0 ]; then
+    record 6 FAIL "REFUSED (exit=$HOOK_EXIT) — local resolution regressed: $(printf '%s' "$HOOK_STDERR" | tr '\n' ' ' | cut -c1-300)"
+  else
+    record 6 PASS "a checkout carrying the branch locally still resolves (exit=0), no remote dependency introduced"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+label_for() {
+  case "$1" in
+    1) printf 'a --head naming a REMOTE-ONLY branch resolves' ;;
+    2) printf 'an explicit origin/<branch> is not mangled' ;;
+    3) printf 'MUTANT CONTROL: a path on no ref is still REFUSED' ;;
+    4) printf 'MUTANT CONTROL: a --head naming nothing is not claimed as consulted' ;;
+    5) printf 'the ref the hook settled on is announced, never silent' ;;
+    6) printf 'REGRESSION: a local branch still resolves' ;;
+  esac
+}
+
+ALL_PASS=1
+for entry in "${CLAUSES[@]}"; do
+  id="${entry%%|*}"
+  rest="${entry#*|}"
+  status="${rest%%|*}"
+  evidence="${rest#*|}"
+  printf 'CLAUSE %s (%s): %s — %s\n' "$id" "$(label_for "$id")" "$status" "$evidence"
+  [ "$status" = PASS ] || ALL_PASS=0
+done
+
+# Fixture teardown. ARCHIVED, never deleted — AGENTS.md, the agent's cleanup
+# verb is mv.
+ARCHIVE_DIR="${OPENBRAIN_TEMP_WORKSPACE:-${DEV_TMP:-/Volumes/ThunderBolt/_tmp}}/open-brain/_archive"
+if mkdir -p "$ARCHIVE_DIR" 2>/dev/null; then
+  mv "$SCRATCH" "$ARCHIVE_DIR/$(basename "$SCRATCH").$(date +%s)" 2>/dev/null
+fi
+
+[ "$ALL_PASS" -eq 1 ] && exit 0
+exit 1


### PR DESCRIPTION
## Summary

- Closes #714 — but **not as filed**. The issue's premise is stale and the lane says so with a transcript instead of implementing it: PR #713 (issue #709) already made `pr-body-gate.ts` parse `--head`/`-H`, derive a branch from the `cd` target, and set `PR_HEAD_REF`. `scripts/done-means/709-hook-feeds-head-ref.sh` is 5/5 GREEN holding that, so "never sets PR_HEAD_REF" does not reproduce.
- Re-verifying the premise (canon: an issue older than the current code re-verifies before implementation) found a **narrower residue that does reproduce**: a branch NAME is not a ref until something can resolve it. `gh pr create --head <branch>` names a branch on the REMOTE, and run from a root checkout that has fetched but never created a local branch of that name — no `cd`, no worktree on disk — the bare name resolves to nothing. The tier #709 made reachable was being handed a dead string.
- `resolvableRef()` now resolves the branch name to a ref the tree being asked can actually read: the name **as given** first (so a correct `origin/lane/x`, a SHA, a tag, or a local-only checkout with no remote is never mangled), then `<remote>/<name>` for each configured remote with origin first. Each candidate is asserted on **positively** via `rev-parse --verify`, so a name that resolves nowhere skips the branch tier rather than feeding it garbage.
- Second-order fix: the old refusal printed `; and in ref lane/x` for a ref that resolves to nothing, which reads as *"your check is not on the branch either"* when the truth is *"that name means nothing here."* A refusal that misdirects is worse than one that admits it looked nowhere — the cheapest way past it is a false receipt, which is the exact reflex this gate exists to prevent. The head-ref line now has a third state naming the unresolvable name and what to do about it.
- `existsInRef`'s containment guard on the PATH is untouched. This widens WHERE a check may resolve, never WHAT may be named.

### Reproduction, against the unfixed hook at `17ada37`

Fixture is a genuine remote — bare `upstream.git`, a seed repo that pushes `lane/714-fixture` carrying the check, and a `primary` clone that has fetched the branch but holds no local branch of that name and no worktree:

```
[pr-body-gate] tree under review: the hook payload's cwd (.../primary)
[pr-body-gate] head ref: lane/714-fixture (source: explicit --head on the gh command)
- Verification field 'Done-means' must name an existing repo-relative path;
  not found: scripts/done-means/lane-only-check.sh
  (looked in: .../primary, /Volumes/ThunderBolt/Development/open-brain;
   and in ref lane/714-fixture)                                        EXIT=2
```

The head ref **is** supplied — that is what #709 fixed. The mechanism of the residue:

```
$ git -C primary cat-file -e lane/714-fixture:...lane-only-check.sh
fatal: invalid object name 'lane/714-fixture'.      exit=128
$ git -C primary cat-file -e origin/lane/714-fixture:...lane-only-check.sh
                                                    exit=0
```

## Verification

- Done-means: scripts/done-means/714-head-ref-resolves-remote.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

6 clauses, every one driving the REAL hook with a synthetic PreToolUse payload against a REAL remote. RED 3/6 before the fix, GREEN 6/6 after:

```
CLAUSE 1 (a --head naming a REMOTE-ONLY branch resolves): FAIL -> PASS
CLAUSE 2 (an explicit origin/<branch> is not mangled): PASS (control)
CLAUSE 3 (MUTANT CONTROL: a path on no ref is still REFUSED): PASS (control)
CLAUSE 4 (MUTANT CONTROL: a --head naming nothing is not claimed as consulted): FAIL -> PASS
CLAUSE 5 (the ref the hook settled on is announced, never silent): FAIL -> PASS
CLAUSE 6 (REGRESSION: a local branch still resolves): PASS (control)
```

Clauses 2/3/6 being green before the fix is deliberate: they fail a BAD fix (blind `origin/` prepending, a blanket pass, a remote-dependent regression), not the defect.

**Round 28's false-green trap, called out in the check's header:** `709-hook-feeds-head-ref.sh` clause 3 already drives `--head` through the real hook and passes throughout — because its fixture holds the lane branch LOCALLY, so the bare name resolves. It proves `--head` is parsed, never that the parsed value is resolvable. The defect is invisible in any fixture where the lane branch also exists locally, which is why this check builds a genuine bare remote instead of faking the ref layout.

Regression surface, all GREEN after the fix: `709-hook-feeds-head-ref.sh` (5/5), `pr-body-gate-fires.sh` (7/7), `706-done-means-resolves-pr-head.sh` (5/5), `pr-template-passes-validator.sh` (3/3), `done-means-field-required.sh` (5/5), `bunx tsc --noEmit` (0).

## Critical Self-Review

- Highest-risk behavior: `resolvableRef()` choosing a DIFFERENT ref than the caller named. Mitigated by ordering — the name as given is always tried first, so a remote-prefixed ref, a SHA, or a local branch wins before any prefixing is attempted, and clause 2 fails the double-prefix mistake.
- Assumptions that could be wrong: that a stale remote-tracking ref cannot silently answer for a newer local branch. If both resolve, the as-given (local) name wins by ordering, so the stale ref is only consulted when nothing local exists — but an `origin/<branch>` that is behind the pushed branch could in principle resolve a path the newest commit deleted. That is an ACCEPT, not a proof: the tier only ever adds a resolution for a path that exists somewhere real, and the mutant controls keep it from becoming a blanket pass.
- Missing/weak tests: no clause covers two remotes both carrying the branch name (origin-first ordering is asserted only by construction, not driven). No clause drives a detached-HEAD checkout with an explicit `--head`.
- Security/permission risk: none new. The widening is on WHERE a ref is read; `existsInRef`'s absolute/`..` containment guard on the PATH is unchanged, so no path outside the repo becomes nameable. All added git calls are read-only (`rev-parse`, `remote`) via `spawnSync` with an argv array — no shell, no user string interpolated into a command line.
- Migration/deploy risk: none. Repo-local hook only, no schema, no service, no config.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classified: this touches no MCP tool, schema, transport, or Python client surface — it is a `.claude/` PreToolUse hook in this repo. Not applicable.
- Rollback/cleanup concern: revert the single commit; the hook returns to #709 behavior and the branch tier goes back to being fed an unresolvable name. The check's fixture is archived with `mv` by its own teardown, never deleted.
- Fixes made before PR: the "no head ref" announcement initially reported an unresolvable name as "not on a named branch", which sends the reader after the wrong problem; it now has a distinct third state naming the unresolvable value and the remedy.
- Known residual risk: the two untested shapes above (multi-remote, detached HEAD + `--head`). Neither is on the path #714 reports; both fail CLOSED (no ref resolved -> tier skipped -> refusal that says so) rather than open.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

Per the RLVR harvest model the lane returns lessons to the controller rather than writing `docs/sme/` or `docs/lane-contract.md` itself; the tracking-scribe owns those files at root. Findings returned: the resolvable-ref family (a gate fed a value it cannot resolve is the same dead tier by another route), and the fixture-locality trap (a check whose fixture makes the defect impossible passes forever).

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this changes a repo-local PreToolUse hook only; no Open Brain service, tool, schema, or namespace path is touched.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the change is a Claude Code hook in `.claude/hooks/`, which has no cross-runtime contract fixture — no client/contract path in `contracts/parity-paths.txt` is touched.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, transport, or Python client surface changes. The diff is one `.claude/` hook, one new done-means check, one worklog.
- Pre-push blocker declared: `test_receipts_gate_crosslang.py::test_python_capture_receipt_clears_the_gates_capture_block` fails on this lane AND identically on the untouched wip head `17ada37` (proven in a detached probe worktree carrying none of this lane's files). That is **#704**, already filed, not this lane's. Pushed using the test's own documented `OPENBRAIN_CONTEXT_BUDGET_GATE` override — the route #704 records the #512 lane using. `--no-verify` was NOT used; the rest of the suite passed (`pre-push: all checks passed ✓`).
