### PR TITLE
fix(gates): stop feature pushes from matching unrelated main text

### DIFF
--- a/python/openbrain-provider/src/openbrain_provider/policy_safety.py
+++ b/python/openbrain-provider/src/openbrain_provider/policy_safety.py
@@ -8,7 +8,8 @@ Purpose:
 
 Architecture:
     Pure functions over a tool name and its arguments. No state, no I/O except
-    one `git` call to read the current branch. Split out of the entrypoint
+    bounded `git` calls to read each mutating command's current branch. Split out
+    of the entrypoint
     because a safety refusal and a staleness refusal are different mechanisms
     with different triggers, and mixing them in one function is how one hides
     the other (`_plans/python-port-sequence.md`, the two-mechanisms-in-one-file
@@ -28,7 +29,9 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
 import subprocess
+from pathlib import Path
 from typing import Any, Final
 
 __all__ = [
@@ -128,13 +131,52 @@ _GH_MERGE_AUTOMATIC: Final[re.Pattern[str]] = re.compile(
     r"(?:^|\s)--(?:admin|auto)(?:\s|$)"
 )
 _GIT_MUTATES_HISTORY: Final[re.Pattern[str]] = re.compile(
-    r"(^|[\s;&|()])git\s+(?:commit|push)(?:\s|$)", re.IGNORECASE
+    r"(^|[\s;&|()])git(?:\s+-\S+(?:\s+\S+)?)*\s+(?:commit|push)(?:\s|$)",
+    re.IGNORECASE,
 )
-_PROTECTED_REF: Final[re.Pattern[str]] = re.compile(
-    r"\b(?:origin\s+)?(?:main|master)(?::|(?:\s|$))", re.IGNORECASE
+_GIT_LEADING_VALUE_OPTIONS: Final[frozenset[str]] = frozenset(
+    {"-C", "--git-dir", "--work-tree", "--namespace", "-c"}
 )
-_DOUBLE_QUOTED: Final[re.Pattern[str]] = re.compile(r'"(?:[^"\\]|\\.)*"')
-_SINGLE_QUOTED: Final[re.Pattern[str]] = re.compile(r"'[^']*'")
+_PUSH_VALUE_OPTIONS: Final[frozenset[str]] = frozenset(
+    {
+        "--repo",
+        "--receive-pack",
+        "--exec",
+        "-o",
+        "--push-option",
+    }
+)
+_SHELL_SEPARATORS: Final[frozenset[str]] = frozenset(
+    {";", "|", "|&", "&", "&&", "||", "\n"}
+)
+_CWD_PRESERVING_SEPARATORS: Final[frozenset[str | None]] = frozenset(
+    {None, ";", "&&", "\n"}
+)
+_PASS_THROUGH_PREFIXES: Final[frozenset[str]] = frozenset({"command", "exec", "nohup"})
+_ENV_VALUE_OPTIONS: Final[frozenset[str]] = frozenset(
+    {"-u", "--unset", "-C", "--chdir"}
+)
+_SUDO_VALUE_OPTIONS: Final[frozenset[str]] = frozenset(
+    {
+        "-C",
+        "-D",
+        "-g",
+        "-h",
+        "-p",
+        "-R",
+        "-T",
+        "-u",
+        "--chdir",
+        "--close-from",
+        "--group",
+        "--host",
+        "--other-user",
+        "--prompt",
+        "--role",
+        "--type",
+        "--user",
+    }
+)
 
 #: policy-refresh-gate.ts:466-473 — the transient image-output directory.
 _GENERATED_DIR: Final[str] = (
@@ -255,31 +297,197 @@ def _agent_tool_block_reason(env: dict[str, str]) -> str | None:
     )
 
 
-def _git_history_block_reason(command: str, command_cwd: str) -> str | None:
-    """Refuse a commit or push that would land on a protected branch.
+def _shell_words(text: str, *, posix: bool = True) -> list[str]:
+    """Split shell text while retaining command separators and quoted words."""
+    lexer = shlex.shlex(text, posix=posix, punctuation_chars=";&|<>\n")
+    lexer.whitespace = " \t\r"
+    lexer.whitespace_split = True
+    lexer.commenters = "#"
+    return list(lexer)
 
-    Args:
-        command: The shell command.
-        command_cwd: Directory the command would run in.
 
-    Returns:
-        The refusal text, or None.
-    """
-    if not _GIT_MUTATES_HISTORY.search(command):
+def _heredoc_specs(line: str) -> list[tuple[str, bool]]:
+    """Return heredoc delimiters declared by one shell command line."""
+    words = _shell_words(line, posix=False)
+    specs: list[tuple[str, bool]] = []
+    for index, word in enumerate(words[:-1]):
+        if word != "<<":
+            continue
+        raw_delimiter = words[index + 1]
+        strips_tabs = raw_delimiter.startswith("-")
+        if strips_tabs:
+            raw_delimiter = raw_delimiter[1:]
+        delimiter = shlex.split(raw_delimiter, posix=True)[0]
+        specs.append((delimiter, strips_tabs))
+    return specs
+
+
+def _without_heredoc_bodies(command: str) -> str:
+    """Remove heredoc data while retaining the command lines that consume it."""
+    kept: list[str] = []
+    pending: list[tuple[str, bool]] = []
+    for line in command.splitlines():
+        if pending:
+            delimiter, strips_tabs = pending[0]
+            candidate = line.lstrip("\t") if strips_tabs else line
+            if candidate == delimiter:
+                pending.pop(0)
+            continue
+        kept.append(line)
+        pending.extend(_heredoc_specs(line))
+    return "\n".join(kept)
+
+
+def _shell_commands(command: str) -> list[tuple[list[str], str | None]]:
+    """Return argv and following separator for each non-heredoc command."""
+    words = _shell_words(_without_heredoc_bodies(command))
+    commands: list[tuple[list[str], str | None]] = []
+    current: list[str] = []
+    for word in words:
+        if word not in _SHELL_SEPARATORS:
+            current.append(word)
+            continue
+        if current:
+            commands.append((current, word))
+            current = []
+    if current:
+        commands.append((current, None))
+    return commands
+
+
+def _unwrapped_argv(argv: list[str]) -> list[str]:
+    """Expose a command behind assignments and pass-through wrappers."""
+    index = 0
+    while index < len(argv):
+        word = argv[index]
+        if "=" in word and not word.startswith("="):
+            index += 1
+            continue
+        if word == "env":
+            index += 1
+            while index < len(argv):
+                option = argv[index]
+                if "=" in option and not option.startswith("="):
+                    index += 1
+                    continue
+                if option in _ENV_VALUE_OPTIONS:
+                    index += 2
+                    continue
+                if option.startswith("-"):
+                    index += 1
+                    continue
+                break
+            continue
+        if word in _PASS_THROUGH_PREFIXES:
+            index += 1
+            if index < len(argv) and argv[index] == "--":
+                index += 1
+            continue
+        if word == "sudo":
+            index += 1
+            while index < len(argv) and argv[index].startswith("-"):
+                option = argv[index]
+                if option == "--":
+                    index += 1
+                    break
+                index += 2 if option in _SUDO_VALUE_OPTIONS else 1
+            continue
+        break
+    return argv[index:]
+
+
+def _resolve_directory(base: Path, value: str) -> Path:
+    """Resolve a shell directory operand against the active compound cwd."""
+    expanded = Path(value).expanduser()
+    return expanded if expanded.is_absolute() else base / expanded
+
+
+def _cd_target(argv: list[str], cwd: Path) -> Path | None:
+    """Resolve a simple ``cd`` command, or None for another command shape."""
+    words = _unwrapped_argv(argv)
+    if not words or words[0] != "cd":
         return None
-    # Test the ref pattern only OUTSIDE quoted strings: a commit message
-    # containing the English word "main" is not a push to main. Refspecs
-    # (`git push origin main`) are unquoted and still match.
-    outside_quotes = _SINGLE_QUOTED.sub("''", _DOUBLE_QUOTED.sub('""', command))
-    if _PROTECTED_REF.search(outside_quotes):
-        return (
-            "Codex git guard: do not commit or push directly to main/master "
-            "without explicit approval."
-        )
+    operands = [word for word in words[1:] if word != "--"]
+    if len(operands) != 1 or operands[0] == "-":
+        return None
+    return _resolve_directory(cwd, operands[0])
+
+
+def _git_operands(argv: list[str], cwd: Path) -> tuple[list[str], Path] | None:
+    """Return git's subcommand operands and its effective ``-C`` directory."""
+    words = _unwrapped_argv(argv)
+    if not words or words[0] != "git":
+        return None
+    effective_cwd = cwd
+    index = 1
+    while index < len(words):
+        word = words[index]
+        if not word.startswith("-"):
+            return words[index:], effective_cwd
+        if word == "-C" and index + 1 < len(words):
+            effective_cwd = _resolve_directory(effective_cwd, words[index + 1])
+        if word in _GIT_LEADING_VALUE_OPTIONS and "=" not in word:
+            index += 2
+            continue
+        index += 1
+    return [], effective_cwd
+
+
+def _pushes_to_protected_ref(arguments: list[str]) -> bool:
+    """Return whether push arguments contain a main/master destination refspec."""
+    refs: list[str] = []
+    seen_remote = False
+    index = 0
+    while index < len(arguments):
+        word = arguments[index]
+        if word == "--":
+            index += 1
+            continue
+        if word.startswith("-"):
+            if word == "--repo" or word.startswith("--repo="):
+                seen_remote = True
+            index += 2 if word in _PUSH_VALUE_OPTIONS and "=" not in word else 1
+            continue
+        if not seen_remote:
+            seen_remote = True
+            index += 1
+            continue
+        refs.append(word)
+        index += 1
+    for refspec in refs:
+        destination = refspec.rsplit(":", maxsplit=1)[-1].lstrip("+")
+        destination = destination.removeprefix("refs/heads/")
+        if destination in ("main", "master"):
+            return True
+    return False
+
+
+def _history_mutators(
+    command: str, command_cwd: str
+) -> list[tuple[str, list[str], Path]]:
+    """Parse history-mutating git commands with each command's effective cwd."""
+    cwd = Path(command_cwd or os.getcwd())
+    mutators: list[tuple[str, list[str], Path]] = []
+    for argv, separator in _shell_commands(command):
+        target = _cd_target(argv, cwd)
+        if target is not None and separator in _CWD_PRESERVING_SEPARATORS:
+            cwd = target
+            continue
+        parsed = _git_operands(argv, cwd)
+        if parsed is None or not parsed[0]:
+            continue
+        operands, git_cwd = parsed
+        if operands[0] in ("commit", "push"):
+            mutators.append((operands[0], operands[1:], git_cwd))
+    return mutators
+
+
+def _branch_block_reason(cwd: Path) -> str | None:
+    """Return the protected-branch or unreadable-branch refusal for ``cwd``."""
     try:
         completed = subprocess.run(
             ["git", "branch", "--show-current"],
-            cwd=command_cwd or None,
+            cwd=cwd,
             capture_output=True,
             text=True,
             timeout=_GIT_TIMEOUT_SECONDS,
@@ -296,6 +504,32 @@ def _git_history_block_reason(command: str, command_cwd: str) -> str | None:
             f"Codex git guard: current branch is {branch}; do not commit or push "
             "from a protected branch."
         )
+    return None
+
+
+def _git_history_block_reason(command: str, command_cwd: str) -> str | None:
+    """Refuse a commit or push that would land on a protected branch."""
+    try:
+        mutators = _history_mutators(command, command_cwd)
+    except ValueError:
+        if not _GIT_MUTATES_HISTORY.search(command):
+            return None
+        return (
+            "Codex git guard: unable to verify the current branch; commit/push is "
+            "blocked until branch state is readable."
+        )
+    if any(
+        mutator[0] == "push" and _pushes_to_protected_ref(mutator[1])
+        for mutator in mutators
+    ):
+        return (
+            "Codex git guard: do not commit or push directly to main/master "
+            "without explicit approval."
+        )
+    for mutator in mutators:
+        reason = _branch_block_reason(mutator[2])
+        if reason is not None:
+            return reason
     return None
 
 

--- a/python/openbrain-provider/tests/test_policy_gate.py
+++ b/python/openbrain-provider/tests/test_policy_gate.py
@@ -375,9 +375,8 @@ def test_reading_from_system_temp_is_allowed(tmp_path: Path, command: str) -> No
 def test_a_commit_message_mentioning_main_is_not_a_push_to_main(
     tmp_path: Path,
 ) -> None:
-    # The protected-ref test runs OUTSIDE quoted strings, so the English word
-    # "main" in a message is not a refspec. Getting this wrong would refuse a
-    # correct commit for its prose.
+    # A commit has no refspec operands, so the parser never reads its message as
+    # a push target. Getting this wrong would refuse a correct commit for prose.
     result = run_policy_gate(
         tmp_path / "state.json",
         "pre-tool-use",

--- a/python/openbrain-provider/tests/test_policy_safety_git.py
+++ b/python/openbrain-provider/tests/test_policy_safety_git.py
@@ -1,0 +1,216 @@
+"""Protected-branch behavior for the policy safety gate."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from gate_harness import GateResult, run_policy_gate
+
+PROTECTED_REF_REASON = "do not commit or push directly to main/master"
+PROTECTED_BRANCH_REASON = "do not commit or push from a protected branch"
+
+
+def _git(cwd: Path, *args: str) -> None:
+    """Run one fixture-only git command."""
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(path: Path, branch: str) -> None:
+    """Create a committed repository on ``branch`` for branch-state tests."""
+    path.mkdir()
+    _git(path, "init", "-b", branch)
+    _git(path, "config", "user.name", "Policy Safety Test")
+    _git(path, "config", "user.email", "policy-safety@example.invalid")
+    (path / "tracked.txt").write_text("fixture\n", encoding="utf8")
+    _git(path, "add", "tracked.txt")
+    _git(path, "commit", "-m", "fixture")
+
+
+@pytest.fixture
+def main_with_feature_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """Return a main checkout and a linked feature worktree."""
+    primary = tmp_path / "primary-main"
+    feature = tmp_path / "feature-worktree"
+    _init_repo(primary, "main")
+    _git(primary, "worktree", "add", "-b", "feature/guard-fix", str(feature))
+    return primary, feature
+
+
+@pytest.fixture
+def feature_with_main_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """Return a feature checkout and a linked main worktree."""
+    primary = tmp_path / "primary-feature"
+    main_worktree = tmp_path / "main-worktree"
+    _init_repo(primary, "feature/guard-fix")
+    _git(primary, "branch", "main")
+    _git(primary, "worktree", "add", str(main_worktree), "main")
+    return primary, main_worktree
+
+
+def _run(command: str, cwd: Path, state_path: Path) -> GateResult:
+    """Run one Bash PreToolUse event through the real policy gate."""
+    return run_policy_gate(
+        state_path,
+        "pre-tool-use",
+        {
+            "cwd": str(cwd),
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+        },
+    )
+
+
+def test_feature_push_followed_by_pr_base_main_is_allowed(
+    main_with_feature_worktree: tuple[Path, Path], tmp_path: Path
+) -> None:
+    primary, feature = main_with_feature_worktree
+    command = (
+        f"cd '{feature}' && git push -u origin feature/guard-fix "
+        "&& gh pr create --base main --head feature/guard-fix"
+    )
+
+    result = _run(command, primary, tmp_path / "state.json")
+
+    assert not result.blocked
+
+
+def test_git_dash_c_feature_push_is_allowed(
+    main_with_feature_worktree: tuple[Path, Path], tmp_path: Path
+) -> None:
+    primary, feature = main_with_feature_worktree
+
+    result = _run(
+        f"git -C {feature} push -u origin feature/guard-fix",
+        primary,
+        tmp_path / "state.json",
+    )
+
+    assert not result.blocked
+
+
+@pytest.mark.parametrize(
+    "refspec",
+    ["main", "HEAD:main", ":main", "+HEAD:refs/heads/master"],
+)
+def test_push_to_main_is_refused(tmp_path: Path, refspec: str) -> None:
+    repo = tmp_path / "feature-repo"
+    _init_repo(repo, "feature/guard-fix")
+
+    result = _run(
+        f"git push origin {refspec}", repo, tmp_path / f"state-{refspec}.json"
+    )
+
+    assert result.blocked
+    assert PROTECTED_REF_REASON in result.stdout
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git push main feature/guard-fix",
+        "git push -o main origin feature/guard-fix",
+        "git push --receive-pack main origin feature/guard-fix",
+        "git push --repo main feature/guard-fix",
+        "git push origin feature/guard-fix && echo main",
+        "git push origin feature/guard-fix && gh pr create --base main",
+    ],
+)
+def test_non_ref_main_operands_are_allowed(tmp_path: Path, command: str) -> None:
+    repo = tmp_path / "feature-repo"
+    _init_repo(repo, "feature/guard-fix")
+
+    result = _run(command, repo, tmp_path / "state.json")
+
+    assert not result.blocked
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git push --force-with-lease origin main",
+        "git push --signed origin main",
+        "git push --repo origin main",
+        "env -u UNUSED git push origin main",
+        "command -- git push origin main",
+        "exec git push origin main",
+        "nohup git push origin main",
+        "sudo -u root git push origin main",
+    ],
+)
+def test_flagged_push_to_main_is_still_refused(tmp_path: Path, command: str) -> None:
+    repo = tmp_path / "feature-repo"
+    _init_repo(repo, "feature/guard-fix")
+
+    result = _run(command, repo, tmp_path / "state.json")
+
+    assert result.blocked
+    assert PROTECTED_REF_REASON in result.stdout
+
+
+def test_unquoted_commit_message_main_is_allowed(tmp_path: Path) -> None:
+    repo = tmp_path / "feature-repo"
+    _init_repo(repo, "feature/guard-fix")
+
+    result = _run("git commit -m main", repo, tmp_path / "state.json")
+
+    assert not result.blocked
+
+
+def test_cd_feature_worktree_push_uses_feature_branch(
+    main_with_feature_worktree: tuple[Path, Path], tmp_path: Path
+) -> None:
+    primary, feature = main_with_feature_worktree
+
+    result = _run(f"cd {feature} && git push", primary, tmp_path / "state.json")
+
+    assert not result.blocked
+
+
+def test_cd_main_worktree_commit_is_refused(
+    feature_with_main_worktree: tuple[Path, Path], tmp_path: Path
+) -> None:
+    primary, main_worktree = feature_with_main_worktree
+
+    result = _run(f"cd {main_worktree} && git commit", primary, tmp_path / "state.json")
+
+    assert result.blocked
+    assert PROTECTED_BRANCH_REASON in result.stdout
+
+
+def test_heredoc_body_is_not_parsed_as_a_command(tmp_path: Path) -> None:
+    repo = tmp_path / "feature-repo"
+    _init_repo(repo, "feature/guard-fix")
+    command = "git commit -F - <<'MSG'\nnotes: git push origin main\nMSG"
+
+    result = _run(command, repo, tmp_path / "state.json")
+
+    assert not result.blocked
+
+
+def test_quoted_heredoc_marker_does_not_hide_a_later_push(tmp_path: Path) -> None:
+    repo = tmp_path / "feature-repo"
+    _init_repo(repo, "feature/guard-fix")
+    command = "echo '<<' MSG\ngit push origin main\nMSG"
+
+    result = _run(command, repo, tmp_path / "state.json")
+
+    assert result.blocked
+    assert PROTECTED_REF_REASON in result.stdout
+
+
+def test_unreadable_branch_still_fails_closed(tmp_path: Path) -> None:
+    non_repo = tmp_path / "not-a-repo"
+    non_repo.mkdir()
+
+    result = _run("git push", non_repo, tmp_path / "state.json")
+
+    assert result.blocked
+    assert "unable to verify the current branch" in result.stdout


### PR DESCRIPTION
## Summary

- Closes #725. The live Python policy gate judged protected refs with one regex over the entire submitted shell line. A legitimate feature-branch push was refused when a later `gh pr create --base main` or prose segment supplied the word `main`; unquoted `git commit -m main` and heredoc message text had the same defect.
- `_git_history_block_reason` now parses shell commands with `shlex`, removes heredoc bodies before command judgment, and reads protected destinations only from each `git push` command's own refspec operands. The first bare operand remains the remote, push options consume their values, and protected controls including `main`, `HEAD:main`, `:main`, `refs/heads/master`, `--force-with-lease`, `--signed`, and `--repo` remain refused.
- Branch fallback now tracks prior `cd` commands and each git command's `-C` directory. A feature worktree is judged by its feature branch even when the hook session checkout is on `main`; a linked worktree on `main` is still refused. Existing refusal strings and unreadable-branch fail-closed behavior are unchanged.

## Verification

- Done-means: python/openbrain-provider/tests/test_policy_safety_git.py
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Mutation proof against the original `policy_safety.py`:

```text
11 failed, 15 passed in 3.12s
```

Restored implementation:

```text
26 passed in 3.17s
```

Documented package gates:

```text
ruff format --check: 41 files already formatted
ruff check: All checks passed
mypy: Success: no issues found in 19 source files
pytest: 638 passed, 1 skipped in 8.74s
```

The first full pytest invocation inherited this Claudex process's `ANTHROPIC_BASE_URL` and failed the native-session parity case because it correctly took the proxied branch. Removing that external session variable made the parity file pass 33/33 and the full suite pass 638/638 with one intentional skip. Source and package state were unchanged.

The normal pre-push hook then ran the repository-wide validation and reported `pre-push: all checks passed`; no hook was bypassed.

## Critical Self-Review

- Highest-risk behavior: a parser mistake could allow a real push to `main` or `master`. Positive controls cover bare and colon refspecs, deletion refspecs, fully-qualified destinations, value-taking options, remote supplied by `--repo`, and pass-through wrappers; each still returns the unchanged protected-ref refusal.
- Assumptions that could be wrong: this is a bounded shell parser, not a complete POSIX shell interpreter. It handles the required `&&`, `;`, pipelines, newlines, quotes, heredocs, assignments, `env`, `command`, `exec`, `nohup`, `sudo`, `cd`, and git leading options. Subshell grouping and dynamically constructed command words remain outside this issue's contract.
- Missing/weak tests: the tests do not execute real pushes because the safety boundary is the PreToolUse verdict, not git transport. They use real git repositories and linked worktrees for branch-state resolution, and invoke the real policy gate rather than reimplementing its logic.
- Security/permission risk: this changes live enforcement source, so false negatives matter more than false positives. The self-review found and fixed two candidate false negatives before PR: standalone `--force-with-lease`/`--signed` must not consume the remote, and `--repo` must mark the remote as already supplied. It also preserved wrapper detection that the old line regex incidentally covered.
- Migration/deploy risk: no schema, migration, service, or deployment path changes. The installed uv tool was deliberately not reinstalled or modified; live cutover is outside this lane.
- Downstream client/runtime risk: not applicable under `docs/downstream-rollout.md`. No MCP tool, schema, transport, `python/openbrain-memory` client export, generated skill, or Hermes-callable surface changes; this is provider-local PreToolUse policy logic.
- Rollback/cleanup concern: reverting commit `538846e` restores the prior gate behavior with no state migration. The temporary worktree is removed after this PR is created and its clean pushed state is verified.
- Fixes made before PR: corrected push option parsing for `--force-with-lease`, `--signed`, and `--repo`; added wrapper controls for `env`, `command`, `exec`, `nohup`, and `sudo`; prevented a quoted literal `<<` from hiding a later real push; updated the stale quoted-message test comment.
- Known residual risk: shell features outside the explicit parser surface can still be represented in ways this issue does not classify. Parse failures containing a literal git history mutation retain the existing fail-closed unreadable-branch refusal rather than failing open.
- SME review-memory update: [x] not applicable because: no fresh review-swarm finding was produced; the issue-specific parser and mutation lessons are captured in executable regression tests and returned in the lane report for controller harvest.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] not applicable because: this PR changes provider source only and the dispatch explicitly excludes reinstalling the live uv tool; no server or hosted Open Brain behavior changes.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: this is Python provider-local policy enforcement, not an MCP/public contract. Existing TypeScript parity fixtures remain unchanged because the required `cd`-aware branch resolution extends beyond the retired TypeScript implementation.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All downstream steps are not applicable: no public Open Brain contract or consumer-callable surface changed. Live provider reinstall/cutover remains intentionally outside #725's lane.

[gpt-5.6-sol via Claudex] authored on behalf of Rico
