### PR TITLE
feat(nats-worker): surface embed watermark liveness on worker /health (#724)

### DIFF
--- a/docs/core01-nats-worker-runbook.md
+++ b/docs/core01-nats-worker-runbook.md
@@ -334,6 +334,64 @@ Do not "fix" 3100 by setting `OPENBRAIN_TRANSPORT=nats` in the clone env — tha
 would put the HTTP service back into the bridge business, which is exactly the
 boundary this runbook exists to keep.
 
+### `embed_watermark` on 3110 (#724 item 3)
+
+`/health` on 3110 carries an OPTIONAL `embed_watermark` block beside `nats`:
+
+```json
+{
+  "status": "healthy",
+  "nats": { "availability": "available", "...": "..." },
+  "embed_watermark": {
+    "stale": false,
+    "newest_raw_age_seconds": 45,
+    "newest_embedded_age_seconds": 60,
+    "lag_seconds": 15,
+    "lag_threshold_seconds": 3600,
+    "raw_rows_recent": 128,
+    "reason": "embed watermark within threshold"
+  },
+  "timestamp": "..."
+}
+```
+
+**Why it exists.** The maintenance producer ticked for three days with no
+consumer draining the embed queue. Raw rows kept arriving, embedded rows
+stopped, and nothing anywhere COMPARED the two — so every liveness surface
+stayed green while the corpus quietly stopped being searchable. This is the
+same argument `maintenance_producer` (#625) and `capture` (#647) make on the
+HTTP payload, applied to the third background lane, and the block deliberately
+matches their shape (`server/transport/health.ts:14-33`, `:35-79`).
+
+**Reading it.**
+
+- `stale: true` is THE verdict and flips `status` to `degraded` with HTTP 503,
+  even when `nats.availability` is `available`. A healthy bridge must not be
+  able to hold this endpoint green while the embed lane is days behind — that
+  combination is exactly the shape of the outage.
+- `stale` requires `raw_rows_recent > 0`. A quiet week produces an old embedded
+  row too; alarming on an idle corpus is how a check stops being read. An idle
+  corpus reports the lag numbers and stays `healthy`.
+- **Absence is not staleness.** A worker that composes no embed observer emits
+  NO `embed_watermark` key and cannot be degraded by one. Missing block means
+  "not my job"; `stale: true` means "my job and I am not doing it". Do not read
+  an absent block as a failure.
+- `lag_threshold_seconds` reports the bound the verdict was actually taken
+  against, so a reading is interpretable without knowing the deployed config.
+
+**Threshold.** `OPENBRAIN_EMBED_WATERMARK_LAG_THRESHOLD_SECONDS`, default
+`3600` (one hour — the outage ran three days; the goal is catching it in about
+an hour). Nothing is adjusted silently: the worker's startup log line carries
+`embed_watermark_lag_threshold_seconds` and
+`embed_watermark_lag_threshold_source` (`default`, `env`, or
+`invalid_env_default`), plus `embed_watermark_observed`, so an unset key is
+visible as a default rather than looking configured, and an unusable value
+announces the original it replaced.
+
+```zsh
+curl -fsS http://127.0.0.1:3110/health | jq .embed_watermark
+```
+
 ### Verify
 
 ```zsh

--- a/scripts/done-means/724-embed-watermark-health.sh
+++ b/scripts/done-means/724-embed-watermark-health.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #724, item 3 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/724-embed-watermark-health.sh
+#
+# #724 item 3: the maintenance producer ticked for three days with no consumer
+# draining the embed queue, and every liveness surface stayed green because
+# nothing COMPARED raw arrivals against embedded rows. The acceptance surface is
+# an `embed_watermark` block on the NATS worker's /health (3110) whose `stale`
+# verdict flips the endpoint to degraded/503.
+#
+# The executable acceptance for that surface is a bun test file:
+#
+#   scripts/run-nats-worker-embed-watermark.test.ts
+#
+# This wrapper exists because `scripts/verify-lane.ts` runs every Done-means
+# check with `bash` (verify-lane.ts:473, filed as #733), so a Done-means that is
+# a bun test file cannot be named directly in a PR body. This script is the
+# bash-shaped front door to that test file and adds nothing to its semantics.
+#
+# ACCEPTANCE, as this script enforces it:
+#
+#   1. The test FILE exists. A run that examines zero files is a HARNESS ERROR,
+#      never a pass — the same silent-skip trap AGENTS.md names for
+#      OPENBRAIN_TEST_DATABASE_URL, one level up.
+#   2. `bun run test:isolated <that file>` exits 0, having actually executed
+#      tests (>0 reported passing). The isolated runner is the trustworthy
+#      path per AGENTS.md; a shared-dogfood `bun test` count is not evidence.
+#
+# EXIT GRAMMAR (repo convention):
+#
+#   0  the thing under test is present and green
+#   1  the thing under test FAILED (tests red, or ran nothing)
+#   3  HARNESS ERROR — bun missing, the test file missing, or the isolated
+#      database bootstrap could not run. A broken harness is not a red result
+#      and must not be reported as one.
+#
+# ---------------------------------------------------------------------------
+# Isolation and teardown
+# ---------------------------------------------------------------------------
+# This script creates NOTHING in the database. `bun run test:isolated` owns the
+# database it creates and drops it on the way out, including on interrupt. What
+# this script owns is one transcript file under {temp_workspace}/open-brain/
+# _scratch, retired (moved, never deleted) on exit.
+#
+# Output is content-free: counts, exit codes, and verdicts only.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+TEST_FILE="scripts/run-nats-worker-embed-watermark.test.ts"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  printf '\nVERDICT: HARNESS-ERROR\n\n'
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+
+# 0-files-examined is not a pass. If the acceptance file is absent from THIS
+# tree, the check has nothing to measure and says so loudly.
+[ -f "$REPO_ROOT/$TEST_FILE" ] ||
+  fail_hard "acceptance file $TEST_FILE does not exist in $REPO_ROOT — zero files examined is not a pass"
+
+rg -q '"test:isolated"' "$REPO_ROOT/package.json" 2>/dev/null ||
+  fail_hard "no \`test:isolated\` entry point in package.json; the isolated-database runner is the only trustworthy path (AGENTS.md)"
+
+# .env carries the libpq/DB_* vars the isolated runner needs to create its
+# database. A worktree or lane clone may lack it; fall back to the canonical
+# checkout's copy so this runs from either (same fallback as 614).
+ENV_FILE="$REPO_ROOT/.env"
+[ -r "$ENV_FILE" ] || ENV_FILE="/Volumes/ThunderBolt/Development/open-brain/.env"
+[ -r "$ENV_FILE" ] || fail_hard "no readable .env for Postgres credentials; the isolated runner cannot create a database"
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+SCRATCH="${TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch"
+mkdir -p "$SCRATCH" 2>/dev/null || fail_hard "cannot create scratch dir $SCRATCH"
+OUT="$SCRATCH/done-means-724-${RUN_ID}.log"
+
+teardown() {
+  mv -f "$OUT" "$OUT.done" 2>/dev/null
+}
+trap teardown EXIT
+
+(cd "$REPO_ROOT" && bun run test:isolated "$TEST_FILE") >"$OUT" 2>&1
+RUN_EXIT=$?
+
+PASS_COUNT="$(rg -o -N '^\s*(\d+) pass' -r '$1' "$OUT" 2>/dev/null | tail -1 | tr -d '[:space:]')"
+[ -n "$PASS_COUNT" ] || PASS_COUNT=0
+FAIL_COUNT="$(rg -o -N '^\s*(\d+) fail' -r '$1' "$OUT" 2>/dev/null | tail -1 | tr -d '[:space:]')"
+[ -n "$FAIL_COUNT" ] || FAIL_COUNT=0
+ISO_DB="$(rg -o -N '\bob_isolated_[a-z0-9_]+' "$OUT" 2>/dev/null | head -1)"
+
+printf '\n=== DONE-MEANS #724 item 3: embed watermark liveness on worker /health ===\n\n'
+printf 'acceptance file: %s\n' "$TEST_FILE"
+printf 'runner:          bun run test:isolated %s\n' "$TEST_FILE"
+printf 'isolated db:     %s\n' "${ISO_DB:-<none printed>}"
+printf 'tally:           %s pass, %s fail (runner exit %s)\n\n' "$PASS_COUNT" "$FAIL_COUNT" "$RUN_EXIT"
+
+# A runner that never named a database, and never reported a tally, did not get
+# far enough to have tested anything: that is a harness problem, not a red test.
+if [ -z "$ISO_DB" ] && [ "$PASS_COUNT" -eq 0 ] && [ "$FAIL_COUNT" -eq 0 ]; then
+  printf 'transcript: %s.done\n' "$OUT.done"
+  tail -20 "$OUT" >&2
+  fail_hard "the isolated runner printed no database name and no test tally (exit ${RUN_EXIT}); the database bootstrap or bun itself did not run — a broken harness is not a failing test"
+fi
+
+VERDICT=PASS
+if [ "$RUN_EXIT" -ne 0 ]; then
+  VERDICT=FAIL
+  printf 'FAIL — the runner exited %s with %s failing test(s)\n' "$RUN_EXIT" "$FAIL_COUNT"
+elif [ "$PASS_COUNT" -lt 1 ]; then
+  VERDICT=FAIL
+  printf 'FAIL — exit 0 but 0 tests passed: the file was silently skipped, so nothing was proven\n'
+else
+  printf 'PASS — %s tests executed against %s, 0 failures, exit 0\n' "$PASS_COUNT" "${ISO_DB:-an isolated database}"
+fi
+
+printf '\ntranscript: %s.done\n' "$OUT.done"
+printf '\nVERDICT: %s\n\n' "$VERDICT"
+
+[ "$VERDICT" = PASS ] || exit 1
+exit 0

--- a/scripts/run-nats-worker-embed-watermark.test.ts
+++ b/scripts/run-nats-worker-embed-watermark.test.ts
@@ -1,0 +1,241 @@
+/**
+ * RED-FIRST done-means check for issue #724 item 3 — the embed watermark is
+ * invisible to health.
+ *
+ * WHAT WENT WRONG. The maintenance producer ticked for three days with no
+ * consumer draining the embed queue. Raw rows kept arriving; embedded rows
+ * stopped. Nothing anywhere compared the two, so every liveness surface stayed
+ * green while the corpus silently stopped being searchable. A watermark check —
+ * newest embedded-row age against newest raw-row age — would have caught it in
+ * about an hour instead of three days.
+ *
+ * WHY THIS SURFACE, ON THIS PORT. `docs/core01-nats-worker-runbook.md`
+ * ("What `/health` on 3100 does and does NOT show") is explicit that the HTTP
+ * service derives its blocks from its OWN process environment and deliberately
+ * never observes the separate worker process. The runbook forbids "fixing"
+ * 3100 by putting the worker back in the HTTP service's business. The worker's
+ * own health is on `OPEN_BRAIN_NATS_WORKER_HEALTH_PORT` (3110), composed by
+ * `startHealthServer` in `scripts/run-nats-worker.ts:83-113` and reachable only
+ * through `startNatsWorkerProcess` (`scripts/run-nats-worker.ts:174`), which is
+ * why this test drives it through an injected `serve` rather than binding a
+ * port.
+ *
+ * NAMING MATCHED, NOT INVENTED. `server/transport/health.ts:14-33` and
+ * `:35-79` already establish the convention for a background-lane liveness
+ * block on this repo's health payloads: a snake_case named block, a boolean
+ * `stale` that is the verdict, the raw counters beside it, an explicit
+ * `*_threshold_*` naming the bound the verdict used, and a content-free
+ * `reason`. `src/operator-doctor.ts:111` establishes `*_age_seconds` as the
+ * spelling for an age. This block therefore reads:
+ *
+ *   embed_watermark: {
+ *     stale, newest_raw_age_seconds, newest_embedded_age_seconds,
+ *     lag_seconds, lag_threshold_seconds, raw_rows_recent, reason
+ *   }
+ *
+ * ABSENCE IS NOT STALENESS (`docs/lane-contract.md`, Tightenings rounds 8/13,
+ * restated at `server/transport/health.ts:93-105`): a worker that composes no
+ * watermark observer publishes no block and cannot be degraded by one. That is
+ * asserted here too, so the fix cannot degrade every worker that opts out.
+ *
+ * INJECTED CLOCK, NO WALL-CLOCK SLEEPS (`docs/lane-contract.md`, Tightenings
+ * round 5 — wall-clock assertions are flake generators). Every age in this file
+ * comes from fixture data, and the lag verdict is a comparison of two supplied
+ * ages, never of `Date.now()` against anything.
+ *
+ * STATUS: RED as written. `startHealthServer` composes only `status`, `nats`,
+ * and `timestamp` (`scripts/run-nats-worker.ts:100-111`); there is no
+ * `embedWatermarkHealth` option on `StartNatsWorkerProcessOptions`
+ * (`scripts/run-nats-worker.ts:28-36`) and no `embed_watermark` key on the
+ * payload. This file asserts the DESIRED behavior and is expected to fail until
+ * that surface exists. It does not implement it.
+ */
+import { describe, expect, it } from "bun:test";
+import { createNatsBridgeHealth } from "../src/nats-bridge.ts";
+import {
+  readNatsWorkerBoundary,
+  type NatsWorkerRuntime,
+} from "../src/nats-worker.ts";
+import { startNatsWorkerProcess } from "./run-nats-worker.ts";
+
+/**
+ * The block this lane's fix must add to the worker health payload.
+ *
+ * Deliberately declared in the TEST, not imported: the type does not exist on
+ * the branch yet, and importing it would make this file fail to typecheck
+ * rather than fail as a red assertion. The fix replaces this with an import.
+ */
+interface EmbedWatermarkHealthShape {
+  readonly stale: boolean;
+  readonly newest_raw_age_seconds: number;
+  readonly newest_embedded_age_seconds: number;
+  readonly lag_seconds: number;
+  readonly lag_threshold_seconds: number;
+  readonly raw_rows_recent: number;
+  readonly reason: string;
+}
+
+const NATS_URL = "nats://127.0.0.1:4222";
+
+function workerRuntime(env: NodeJS.ProcessEnv): NatsWorkerRuntime {
+  return {
+    boundary: readNatsWorkerBoundary(env),
+    // The bridge itself is AVAILABLE in every case below. That is the whole
+    // point: a healthy bridge must not be able to mask a stalled embed lane,
+    // which is exactly the shape of the three-day outage.
+    health: createNatsBridgeHealth("available"),
+    subject: "dev.ob.memory.context_pack",
+    close: async () => undefined,
+  };
+}
+
+/**
+ * Start the worker with `serve` captured rather than bound, hit `/health`, and
+ * return the parsed body with its HTTP status.
+ *
+ * No port is opened and no clock is read; `serve` is a fake that hands back the
+ * `fetch` handler `startHealthServer` registered.
+ */
+async function readWorkerHealth(
+  embedWatermark: EmbedWatermarkHealthShape | undefined,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const env: NodeJS.ProcessEnv = {
+    OPENBRAIN_NATS_URL: NATS_URL,
+    OPEN_BRAIN_NATS_WORKER_HEALTH_PORT: "3110",
+  };
+  let handler: ((request: Request) => Response | Promise<Response>) | null =
+    null;
+
+  const processRuntime = await startNatsWorkerProcess({
+    env,
+    log: { info: () => undefined, error: () => undefined },
+    buildTokens: () =>
+      new Map([["secret-token", { role: "admin", clientId: "rico" }]]),
+    createDbPool: () => ({ end: async () => undefined }) as any,
+    startWorker: async () => workerRuntime(env),
+    serve: ((options: {
+      fetch: (request: Request) => Response | Promise<Response>;
+    }) => {
+      handler = options.fetch;
+      return { stop: () => undefined };
+    }) as any,
+    // Injected the same way `natsHealth`, `producerHealth`, and `captureHealth`
+    // are on the HTTP side (`server/transport/health.ts:118-138`): the live
+    // component knows its own counters and the health composer must not guess
+    // them. `undefined` composes no block.
+    embedWatermarkHealth: () => embedWatermark,
+  } as any);
+
+  try {
+    if (!handler) throw new Error("worker health server was never composed");
+    const response = await (
+      handler as (request: Request) => Response | Promise<Response>
+    )(new Request("http://127.0.0.1:3110/health"));
+    return {
+      status: response.status,
+      body: (await response.json()) as Record<string, unknown>,
+    };
+  } finally {
+    await processRuntime.shutdown();
+  }
+}
+
+/** Ages are fixture data. Nothing here reads a wall clock. */
+const CURRENT_WATERMARK: EmbedWatermarkHealthShape = {
+  stale: false,
+  newest_raw_age_seconds: 45,
+  newest_embedded_age_seconds: 60,
+  lag_seconds: 15,
+  lag_threshold_seconds: 3_600,
+  raw_rows_recent: 128,
+  reason: "embed watermark within threshold",
+};
+
+/**
+ * The three-day outage, compressed into a fixture: raw rows are arriving
+ * steadily and the newest embedded row is over three days behind them.
+ */
+const LAGGING_WATERMARK: EmbedWatermarkHealthShape = {
+  stale: true,
+  newest_raw_age_seconds: 30,
+  newest_embedded_age_seconds: 259_230,
+  lag_seconds: 259_200,
+  lag_threshold_seconds: 3_600,
+  raw_rows_recent: 1_412,
+  reason: "embed watermark lags newest raw row past threshold",
+};
+
+describe("nats worker /health embed watermark (#724 item 3)", () => {
+  it("carries the embed watermark ages when an observer is composed", async () => {
+    const { body } = await readWorkerHealth(CURRENT_WATERMARK);
+
+    const block = body.embed_watermark as EmbedWatermarkHealthShape | undefined;
+    expect(block).toBeDefined();
+    expect(block?.newest_raw_age_seconds).toBe(45);
+    expect(block?.newest_embedded_age_seconds).toBe(60);
+    expect(block?.lag_seconds).toBe(15);
+    expect(block?.lag_threshold_seconds).toBe(3_600);
+    expect(block?.raw_rows_recent).toBe(128);
+  });
+
+  it("CONTROL — a current watermark leaves the worker healthy", async () => {
+    // Without this control the lagging assertion below proves nothing: a
+    // surface that reported `degraded` unconditionally would pass it.
+    const { status, body } = await readWorkerHealth(CURRENT_WATERMARK);
+
+    expect(body.status).toBe("healthy");
+    expect(status).toBe(200);
+    expect((body.embed_watermark as EmbedWatermarkHealthShape).stale).toBe(
+      false,
+    );
+  });
+
+  it("flips off healthy when the embed watermark lags raw past the threshold", async () => {
+    // The bridge is `available` in this fixture — a healthy NATS block must not
+    // be able to hold the endpoint green while the embed lane is three days
+    // behind. This is the assertion the three-day outage would have tripped.
+    const { status, body } = await readWorkerHealth(LAGGING_WATERMARK);
+
+    expect(body.status).toBe("degraded");
+    expect(status).toBe(503);
+    const block = body.embed_watermark as EmbedWatermarkHealthShape;
+    expect(block.stale).toBe(true);
+    expect(block.lag_seconds).toBeGreaterThan(block.lag_threshold_seconds);
+    expect(block.raw_rows_recent).toBeGreaterThan(0);
+    expect(block.reason).toBeTruthy();
+  });
+
+  it("stale requires FRESH RAW ROWS — an idle corpus is not a stalled embedder", async () => {
+    // A quiet week produces an old embedded row too, and alarming on that is
+    // how a check stops being read (`server/capture/liveness-observer.ts`
+    // MIN_SESSIONS_FOR_SILENCE carries the same argument for capture). The
+    // verdict must need evidence that raw rows were still arriving.
+    const idleCorpus: EmbedWatermarkHealthShape = {
+      stale: false,
+      newest_raw_age_seconds: 259_200,
+      newest_embedded_age_seconds: 259_260,
+      lag_seconds: 60,
+      lag_threshold_seconds: 3_600,
+      raw_rows_recent: 0,
+      reason: "no recent raw rows; watermark lag is not evidence of a stall",
+    };
+    const { status, body } = await readWorkerHealth(idleCorpus);
+
+    expect(body.status).toBe("healthy");
+    expect(status).toBe(200);
+    expect((body.embed_watermark as EmbedWatermarkHealthShape).stale).toBe(
+      false,
+    );
+  });
+
+  it("ABSENCE IS NOT STALENESS — no observer composes no block and stays healthy", async () => {
+    // A worker that does not own the embed lane must be unaffected, exactly as
+    // `maintenance_producer` and `capture` are optional on the HTTP payload
+    // (`server/transport/health.ts:93-105`).
+    const { status, body } = await readWorkerHealth(undefined);
+
+    expect(body.status).toBe("healthy");
+    expect(status).toBe(200);
+    expect(body.embed_watermark).toBeUndefined();
+  });
+});

--- a/scripts/run-nats-worker.ts
+++ b/scripts/run-nats-worker.ts
@@ -18,6 +18,98 @@ type HealthServer = { stop(force?: boolean): void };
 type ServeFn = typeof Bun.serve;
 type TracingRuntime = ReturnType<typeof createTracingRuntime>;
 
+/**
+ * The embed lane's liveness, as the worker's `/health` on 3110 reports it.
+ *
+ * WHY THIS IS A HEALTH INPUT AT ALL (#724 item 3). The maintenance producer
+ * ticked for three days with no consumer draining the embed queue: raw rows
+ * kept arriving, embedded rows stopped, and nothing anywhere COMPARED the two.
+ * Every liveness surface stayed green while the corpus quietly stopped being
+ * searchable. This is the #625 producer argument and the #647 capture argument
+ * applied to the third background lane — the pattern those two established is
+ * matched here deliberately (`server/transport/health.ts:14-33` and `:35-79`):
+ * a snake_case named block, a boolean `stale` that is THE verdict, the raw
+ * counters beside it, an explicit `*_threshold_*` naming the bound the verdict
+ * used, and a content-free `reason`.
+ *
+ * WHY ON 3110 AND NOT 3100. `docs/core01-nats-worker-runbook.md` ("What
+ * `/health` on 3100 does and does NOT show") is explicit that the HTTP service
+ * derives its blocks from its OWN process environment
+ * (`parseNatsConfig(process.env)` in `server/config/nats.ts`) and deliberately
+ * never observes the separate worker process — and forbids "fixing" 3100 by
+ * putting it back in the worker's business.
+ *
+ * `*_age_seconds` is the repo's spelling for an age
+ * (`src/operator-doctor.ts:111` `oldest_undistilled_age_seconds`); `quiet_ms`
+ * on the producer block is a duration, not an age, and is not the precedent.
+ */
+export interface EmbedWatermarkHealth {
+  /**
+   * True once the embed lane is behind past its threshold WITH fresh raw rows
+   * present. Both halves are required — see `raw_rows_recent`.
+   */
+  readonly stale: boolean;
+  /** Age of the newest raw row. */
+  readonly newest_raw_age_seconds: number;
+  /** Age of the newest embedded row. */
+  readonly newest_embedded_age_seconds: number;
+  /** How far the embedded watermark trails the raw one. */
+  readonly lag_seconds: number;
+  /** The bound the `stale` verdict was taken against. */
+  readonly lag_threshold_seconds: number;
+  /**
+   * Raw rows seen recently. `stale` REQUIRES this to be positive: a quiet week
+   * produces an old embedded row too, and alarming on an idle corpus is how a
+   * check stops being read (`server/capture/liveness-observer.ts`
+   * MIN_SESSIONS_FOR_SILENCE carries the same argument for capture).
+   */
+  readonly raw_rows_recent: number;
+  /** Content-free sentence naming which condition produced the verdict. */
+  readonly reason: string;
+}
+
+/**
+ * Default bound for the embed watermark lag verdict, in seconds.
+ *
+ * One hour: the outage this block exists to catch ran three days, and the
+ * stated goal was catching it "in about an hour instead of three days".
+ * Overridable via `OPENBRAIN_EMBED_WATERMARK_LAG_THRESHOLD_SECONDS`.
+ */
+export const DEFAULT_EMBED_WATERMARK_LAG_THRESHOLD_SECONDS = 3600;
+
+/**
+ * Resolve the embed watermark lag threshold from the environment.
+ *
+ * NOTHING IS ADJUSTED SILENTLY (AGENTS.md Coding Standards, 2026-08-08): an
+ * unset key announces the default it fell back to, and an unusable value
+ * announces the original alongside the substitute. The caller logs what this
+ * returns; the reader can map what was configured to what is in force.
+ */
+export function readEmbedWatermarkThresholdSeconds(env: NodeJS.ProcessEnv): {
+  thresholdSeconds: number;
+  source: "env" | "default" | "invalid_env_default";
+  configured: string | null;
+} {
+  const configured =
+    env.OPENBRAIN_EMBED_WATERMARK_LAG_THRESHOLD_SECONDS ?? null;
+  if (configured === null || configured.trim() === "") {
+    return {
+      thresholdSeconds: DEFAULT_EMBED_WATERMARK_LAG_THRESHOLD_SECONDS,
+      source: "default",
+      configured: null,
+    };
+  }
+  const parsed = Number.parseInt(configured, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return {
+      thresholdSeconds: DEFAULT_EMBED_WATERMARK_LAG_THRESHOLD_SECONDS,
+      source: "invalid_env_default",
+      configured,
+    };
+  }
+  return { thresholdSeconds: parsed, source: "env", configured };
+}
+
 export interface NatsWorkerProcess {
   runtime: NatsWorkerRuntime;
   pool: pg.Pool;
@@ -33,6 +125,20 @@ export interface StartNatsWorkerProcessOptions {
   startWorker?: typeof startNatsWorker;
   createTracing?: typeof createTracingRuntime;
   serve?: ServeFn;
+  /**
+   * The embed lane's liveness reading, injected the same way `natsHealth`,
+   * `producerHealth`, and `captureHealth` are on the HTTP side
+   * (`server/transport/health.ts:118-138`): the live component knows its own
+   * counters and the health composer must not guess them.
+   *
+   * ABSENCE IS NOT STALENESS. Omitted composes no `embed_watermark` block and
+   * cannot degrade the status — the ordinary case for a worker that does not
+   * own the embed lane, exactly as `maintenance_producer` and `capture` are
+   * optional on the HTTP payload (`server/transport/health.ts:93-105`).
+   * Absent means "not my job"; `stale: true` means "my job and I am not doing
+   * it".
+   */
+  embedWatermarkHealth?: () => EmbedWatermarkHealth | undefined;
 }
 
 // Redaction: classify by an instanceof-allowlist returning STATIC strings,
@@ -86,6 +192,7 @@ function startHealthServer(input: {
   env: NodeJS.ProcessEnv;
   runtime: NatsWorkerRuntime;
   serve: ServeFn;
+  embedWatermarkHealth?: () => EmbedWatermarkHealth | undefined;
 }): HealthServer | null {
   const healthPort = healthPortFromEnv(input.env);
   if (!healthPort) return null;
@@ -97,16 +204,27 @@ function startHealthServer(input: {
       if (url.pathname !== "/health") {
         return Response.json({ error: "Not found" }, { status: 404 });
       }
-      const healthy = input.runtime.health.availability === "available";
+      const bridgeAvailable = input.runtime.health.availability === "available";
+      // #724 item 3: a stalled embed lane degrades this worker, on the same
+      // argument as the producer (#625) and capture (#647) blocks on the HTTP
+      // payload. A healthy BRIDGE must not be able to hold this endpoint green
+      // while the corpus stops being searchable — that combination is exactly
+      // the shape of the three-day outage. A worker that composes no observer
+      // supplies nothing here and is unaffected: absence is not staleness.
+      const embedWatermark = input.embedWatermarkHealth?.();
+      const embedDegraded = embedWatermark?.stale === true;
+      const healthy = bridgeAvailable && !embedDegraded;
       return Response.json(
         {
           status: healthy ? "healthy" : "degraded",
           nats: {
             availability: input.runtime.health.availability,
-            context_pack_subject: input.runtime.boundary.nats.context_pack_subject,
+            context_pack_subject:
+              input.runtime.boundary.nats.context_pack_subject,
             consecutive_failures: input.runtime.health.consecutiveFailures,
             last_error: input.runtime.health.lastError ? "redacted" : null,
           },
+          ...(embedWatermark ? { embed_watermark: embedWatermark } : {}),
           timestamp: new Date().toISOString(),
         },
         { status: healthy ? 200 : 503 },
@@ -128,7 +246,10 @@ async function closeRuntime(
       "Open Brain NATS worker bridge close timed out",
     );
   } catch (err) {
-    log.error("Open Brain NATS worker bridge close failed", safeWorkerError(err));
+    log.error(
+      "Open Brain NATS worker bridge close failed",
+      safeWorkerError(err),
+    );
   }
 }
 
@@ -155,7 +276,10 @@ async function closeTracing(
   try {
     await tracing.shutdown();
   } catch (err) {
-    log.error("Open Brain NATS worker tracing shutdown failed", safeWorkerError(err));
+    log.error(
+      "Open Brain NATS worker tracing shutdown failed",
+      safeWorkerError(err),
+    );
   }
 }
 
@@ -202,11 +326,30 @@ export async function startNatsWorkerProcess(
       tokenMap: tokenMap as Map<string, AuthInfo>,
       ...(tracing.background ? { tracing: tracing.background } : {}),
     });
-    healthServer = startHealthServer({ env, runtime, serve });
+    healthServer = startHealthServer({
+      env,
+      runtime,
+      serve,
+      ...(options.embedWatermarkHealth
+        ? { embedWatermarkHealth: options.embedWatermarkHealth }
+        : {}),
+    });
+    // NOTHING IS ADJUSTED SILENTLY: the threshold in force is announced at
+    // startup along with WHERE it came from, so an unset env key is visible as
+    // a default rather than looking like a configured value.
+    const embedThreshold = readEmbedWatermarkThresholdSeconds(env);
     log.info("Open Brain NATS worker started", {
       ...natsWorkerLogSummary(runtime.boundary),
       availability: runtime.health.availability,
       health_port: healthPortFromEnv(env),
+      embed_watermark_observed: Boolean(options.embedWatermarkHealth),
+      embed_watermark_lag_threshold_seconds: embedThreshold.thresholdSeconds,
+      embed_watermark_lag_threshold_source: embedThreshold.source,
+      ...(embedThreshold.source === "invalid_env_default"
+        ? {
+            embed_watermark_lag_threshold_configured: embedThreshold.configured,
+          }
+        : {}),
     });
     return {
       runtime,


### PR DESCRIPTION
## Summary

- The maintenance producer ticked for three days with no consumer draining the embed queue. Raw rows kept arriving, embedded rows stopped, and nothing anywhere COMPARED the two — so every liveness surface stayed green while the corpus quietly stopped being searchable. This adds the comparison to a health surface.
- Adds an optional `embed_watermark` block to the NATS worker's `/health` on 3110, composed by `startHealthServer` (`scripts/run-nats-worker.ts:206-250`). `stale: true` flips `status` to `degraded` with HTTP 503 **even when `nats.availability` is `available`** — a healthy bridge must not be able to hold the endpoint green while the embed lane is days behind, which is exactly the shape of the outage.
- **Shape matched, not invented.** The block follows the convention `maintenance_producer` (#625, `server/transport/health.ts:14-33`) and `capture` (#647, `server/transport/health.ts:35-79`) already established for a background-lane liveness block: a snake_case named block, a boolean `stale` that is THE verdict, raw counters beside it, an explicit `*_threshold_*` naming the bound the verdict used, and a content-free `reason`. `*_age_seconds` is this repo's spelling for an age (`src/operator-doctor.ts:111` `oldest_undistilled_age_seconds`); `quiet_ms` on the producer block is a duration, not an age, so it is not the precedent. Injection matches the optional-input pattern at `server/transport/health.ts:118-138`, and degradation matches `server/transport/health.ts:185-196` where `producer?.stale === true` and `capture?.stale === true` each flip status.
- **Absence is not staleness.** A worker composing no observer emits no `embed_watermark` key and cannot be degraded by one — the ordinary case for a worker that does not own the embed lane, exactly as those two blocks are optional at `server/transport/health.ts:93-105`. Absent means "not my job"; `stale: true` means "my job and I am not doing it".
- **`stale` additionally requires `raw_rows_recent > 0`.** A quiet week produces an old embedded row too, and alarming on an idle corpus is how a check stops being read — the same argument `server/capture/liveness-observer.ts` MIN_SESSIONS_FOR_SILENCE makes for capture.
- **Threshold:** `OPENBRAIN_EMBED_WATERMARK_LAG_THRESHOLD_SECONDS`, default `3600` (one hour; the outage ran three days). Nothing is adjusted silently — `readEmbedWatermarkThresholdSeconds` returns the value AND its source, and the startup log carries `embed_watermark_lag_threshold_seconds`, `embed_watermark_lag_threshold_source` (`default` / `env` / `invalid_env_default`), and `embed_watermark_observed`. An unset key is visible as a default rather than looking configured; an unusable value announces the original it replaced.
- **Sited on 3110, not 3100**, per `docs/core01-nats-worker-runbook.md` ("What `/health` on 3100 does and does NOT show"): the HTTP service derives its blocks from its OWN process env (`parseNatsConfig(process.env)` in `server/config/nats.ts`) and deliberately never observes the worker process; the runbook forbids "fixing" 3100 by putting it back in the worker's business.
- Runbook `/health` section documents the new fields, how to read them, the absence rule, and the threshold key.
- **NO DEPLOY IN THIS LANE.** Code and tests only. Deploying the local clone is a controller-gated step after merge (T2). Nothing was deployed and nothing is claimed RUNNING in production.

Refs #724

## Verification

- Done-means: scripts/done-means/724-embed-watermark-health.sh

The acceptance is unchanged — `scripts/run-nats-worker-embed-watermark.test.ts`, the same five tests. `scripts/verify-lane.ts:473` runs every Done-means check with `bash`, so a bun test file cannot be named here directly (that runner limitation is filed as #733). The `.sh` above is the bash-shaped front door: it runs `bun run test:isolated` on that one file, exits 0 green / 1 red / 3 harness error, and fails loudly at exit 3 when the test file is absent, because zero files examined is not a pass. Observed this session on commit `bd839d8`: exit 0, 5 pass / 0 fail against isolated database `ob_isolated_80153_msy175db07`.
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED (RUNNING, observed by the author lane on commit f47c25c, before this commit existed): `bun run test:isolated scripts/run-nats-worker-embed-watermark.test.ts` -> 1 pass, 4 fail, 5 tests. Failures were the missing surface: `Received: undefined` for the ages block, `TypeError: undefined is not an object (evaluating 'body.embed_watermark.stale')` twice, and `Expected: "degraded", Received: "healthy"` for the lag case. The one pass was ABSENCE IS NOT STALENESS, correct on current code and not a false green.

GREEN (RUNNING, observed this session on commit 2d8355f, isolated DB `ob_isolated_22058_msy05my7bn`, created and dropped by the harness):

```
bun run test:isolated scripts/run-nats-worker-embed-watermark.test.ts
 5 pass
 0 fail
 21 expect() calls
Ran 5 tests across 1 file. [223.00ms]
  tests exited 0
```

NO REGRESSION in the touched area (RUNNING, this session, isolated DB `ob_isolated_27744_msy05xp666`):

```
bun run test:isolated scripts/run-nats-worker.test.ts src/nats-worker.test.ts scripts/local-clone-deploy.nats-worker.test.ts
 15 pass
 0 fail
Ran 15 tests across 3 files.
  tests exited 0
```

Re-run after the pre-commit prettier reformat, to prove the formatted tree is what is green (RUNNING, this session): `bun run test:isolated scripts/run-nats-worker-embed-watermark.test.ts scripts/run-nats-worker.test.ts` -> 11 pass, 0 fail. `bunx tsc --noEmit` exit 0 on the committed tree.

Per `AGENTS.md`, no bare full-suite `bun test` count is cited; the isolated harness is the trustworthy runner and only the touched areas were run.

## Critical Self-Review

- Highest-risk behavior: `embed_watermark.stale === true` now flips the worker's 3110 endpoint to 503. Anything polling 3110 as a restart or alerting trigger will act on an embed-lane stall, not just a bridge failure. That is the intended semantic (a green surface over a dead lane is the defect being fixed), but it widens what 503 means on that port, and a supervisor configured to restart the worker on 503 would now restart it for a condition restarting does not fix. The runbook section names the new meaning; wiring a restart policy to it is out of scope here.
- Assumptions that could be wrong: (1) **SITING — the load-bearing one.** The runbook rules OUT 3100 but never positively assigns the EMBED lane to the NATS worker. The maintenance producer is not the NATS bridge, and `server/transport/health.ts:14-33` already owns producer liveness on the HTTP side; a reviewer could reasonably hold `embed_watermark` belongs beside `maintenance_producer` on the HTTP worker instead. It is sited on 3110 per the task brief and the author lane's red check; that decision is PROPOSED, not settled, and a reviewer should rule on it. (2) `raw_rows_recent` as the guard field name is PROPOSED. (3) `degraded`/503 rather than a distinct `unhealthy` state is PROPOSED. (4) One hour as the default threshold is a judgment from the outage's stated goal, not a measured figure.
- Missing/weak tests: **no producer of this block exists yet.** This PR adds the health SURFACE and the injection point; nothing in the repo computes real `newest_raw_age_seconds` / `newest_embedded_age_seconds` from the database and passes them in, so the observer that would actually catch the next outage is not here and is not tested. Every age in the check is fixture data. The threshold resolver `readEmbedWatermarkThresholdSeconds` is exported and exercised only indirectly through the startup log path — the `invalid_env_default` and empty-string branches have no direct assertion. Both are honest gaps, not oversights: the surface has to exist before an observer can be wired to it.
- Security/permission risk: low, and deliberately so. The block carries counters and ages only — no row contents, no identifiers, no namespace data, nothing operator-supplied. `reason` is a content-free sentence, matching `TransportCaptureHealth.reason`. No namespace predicate is involved because no user data is read. The endpoint's existing exposure is unchanged; it binds the same port under the same conditions.
- Migration/deploy risk: no migration, no schema change. `embedWatermarkHealth` is optional, so every existing caller — including `import.meta.main`, which passes only `env` — composes no block and keeps its current payload and status byte-for-byte. The only deploy-visible change for a worker that opts out is three additional startup log fields.
- Downstream client/runtime risk: `docs/downstream-rollout.md` classification — NOT APPLICABLE. This touches no MCP tool, schema, protocol, or client-facing contract. It is an internal operational health payload on a worker's own port, additive and optional; no rtech-mcps, mcp2cli, or rtech-hermes surface reads it.
- Rollback/cleanup concern: revert of a single commit touching two files; no state to unwind. The lane clone is archived (not deleted) per the no-delete rule; both isolated test databases were dropped by the harness, confirmed by its own teardown lines.
- Fixes made before PR: re-ran typecheck and both test groups AFTER the pre-commit prettier hook reformatted `scripts/run-nats-worker.ts`, rather than citing the pre-format run — the formatted tree is the one that is green. Threshold resolution was widened from a plain parse to also announce its source, so an unset key cannot read as a configured one.
- Known residual risk: the surface is inert until an observer is wired to it. Merging this alone does NOT catch the next embed stall — it makes catching it possible. Treating this PR as closing #724 item 3 end-to-end would be the same class of mistake as the outage itself: a green artifact standing in for a working check. The siting question above should be settled before the observer is built against it.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no MEDIUM+ review finding surfaced in this lane; the operating lessons (validator/hook path resolution, environment-failure-is-not-a-red-result) belong in `docs/lane-contract.md` Tightenings, which is the controller's merge-pass harvest step.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this lane is code and tests only with no deploy — the brief gates deploying the local clone as a controller step after merge (T2), so there is no running instance carrying this change to smoke, and claiming one would be a false receipt.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the change is confined to the TypeScript NATS worker's own `/health` payload on 3110. There is no cross-runtime contract fixture for that surface — the Python client does not read it, and no MCP tool schema describes it.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All four are NOT APPLICABLE on the same basis: no MCP tool, schema, protocol, or client-facing contract changed. The diff is two files — an internal worker health payload and its runbook section. No downstream runtime reads `/health` on 3110.
- Python package checks marked not applicable: `python/openbrain-memory/` is untouched by this diff (`git diff --name-only` is `scripts/run-nats-worker.ts` and `docs/core01-nats-worker-runbook.md`).
- Truth grammar: everything in this PR is WRITTEN and pushed to `lane/724-embed-watermark-health`. The test results above are RUNNING — observed this session against isolated databases. Nothing here is MERGED or deployed. The lane does not self-certify; the controller re-runs the done-means check before merge, and closing #724 is the controller's call, not this PR's.

