### PR TITLE
fix(embeddings): give the repair primitive the bulk caller it never had (#724)

### DIFF
--- a/_plans/worklog/lane-724-backlog-reembed.md
+++ b/_plans/worklog/lane-724-backlog-reembed.md
@@ -1,0 +1,135 @@
+# Lane A — issue #724 item 1: Aug 14-17 backlog re-embed
+
+Status of every claim below: **RUNNING** where it says "observed", meaning it was
+measured against the live dogfood database (`open_brain_local_20260724` on
+`127.0.0.1`) during this session on 2026-08-17/18. The code change is **WRITTEN**
+and, once its PR lands, MERGED — nothing here is deployed to core01.
+
+## 1. Does the restored worker drain the backlog on its own?
+
+**No. CONFIRMED by measurement, not inference.**
+
+The lane brief asked this first, so it was measured rather than assumed:
+
+| Observation | Result |
+| --- | --- |
+| Eligible-but-unembedded `ob_session_lanes` at T0 (21:51:20 -04) | 549 |
+| Same count at T1, 4 minutes later (21:55:20 -04) | 549 |
+| `maintenance_jobs` rows updated in the preceding 10 minutes | 0 |
+| `embedding.repair` jobs ever recorded in `maintenance_jobs` | 0 |
+
+`maintenance_jobs` has only ever held `memory.distill` (3, last updated
+2026-08-08) and `system.facts` (30, last updated 2026-07-26). The queue has been
+idle for over a week.
+
+### Root cause — it is a design boundary, not a broken worker
+
+`docs/embedding-repair.md` ("Server-owned runtime and enqueue boundary") states
+it outright: `src/maintenance-bootstrap.ts` starts the `embedding.repair` runner,
+but the bootstrap **"invents no namespace and enqueues no job."** Enqueue is
+deliberately an explicit, auth-scoped CALLER boundary, because a namespace cannot
+be fabricated by a background process.
+
+Nothing in the repo occupies that caller position for a bulk historical backlog:
+
+- `src/maintenance-sweep.ts` enqueues `memory.distill` and graph-derivation jobs
+  only — it never enqueues `embedding.repair`.
+- `scripts/backfill.ts` covers only the five original domain tables
+  (`BACKFILL_TABLES`: thoughts, decisions, relationships, projects, sessions).
+  `ob_session_lanes` — where the window gap actually was — is **not** in that
+  list.
+
+So the runner was healthy and correctly idle. The backlog had no caller to push
+it. Attribution of the backlog's *origin* to the nats-worker outage remains
+**unverified**; this lane observed rows, not causes.
+
+## 2. The fix — smallest thing that rides the existing path
+
+`scripts/repair-embeddings.ts`: a CLI that occupies the missing caller position.
+It adds no pipeline, no table, and no SQL. It loops the existing bulk primitive
+whose own docstring (`src/embedding-repair.ts:682`) says it "is for
+scripts/backfill-style bulk runs":
+
+- `src/embedding-repair.ts:682` `repairStaleBatch(...)` — the bulk primitive.
+- `src/embedding-targets.ts:326` `EMBEDDING_TARGET_NAMES` — the table registry,
+  read at runtime. A second hand-maintained copy of that list is the #433 defect
+  class, so there is none here.
+- `src/embedding.ts` `generateEmbeddingWithMetadata` and `src/db/pool.ts`
+  `createPool()` — the same provider and pool the server uses.
+
+Every safety property is the primitive's, inherited unchanged: namespace-bound
+reads *and* guarded writes, embeddings generated outside locks, idempotent
+convergence on replay, retryable-vs-permanent failure classification,
+content-free logging. Scope is mandatory — `--namespace <ns>` (repeatable) or the
+separately named `--global`; there is no unscoped default.
+
+### Two things measurement forced into the design
+
+**(a) `reasons: ["missing"]` is required for a bulk drain to converge.**
+`buildSelection` (`src/embedding-repair.ts:250`) ORs all staleness reasons into
+one *unordered* `SELECT ... LIMIT n`, and the `source_drift` arm is
+`embedding IS NOT NULL AND content_hash IS NOT NULL` — rows that already *have*
+an embedding — with the real hash comparison done in JS afterward. Observed: with
+all reasons enabled, `limit=500` on `ob_session_lanes` returned 100 candidates of
+mixed reason while 549 rows sat unembedded. With no `ORDER BY`, repeated batches
+can return the same rows forever. Selecting `missing` alone makes every selected
+row one the loop can actually repair, which is what makes `repaired === 0` a
+truthful stop condition. Drift repair stays the queue handler's job.
+
+**(b) One table must not abort the drain.** The first `--global` run died
+entirely on the first table. Cause: a **leaked test fixture on the live dogfood
+database** — a `BEFORE UPDATE` trigger `dream_bulk_release_trigger` on `thoughts`
+executing `dream_bulk_release_sentinel()`, which RAISEs on every update. It
+originates from `src/tools/__tests__/bulk-set-tier.pg.test.ts` and is the #613
+fixture-leakage class. The loop now isolates per-table failures, reports them,
+and reflects them in the exit code. **This lane did not drop that trigger** —
+destructive DDL is outside its authorization — and it is filed below as residual
+work.
+
+## 3. Result of the run
+
+`bun run scripts/repair-embeddings.ts --global`, observed 2026-08-18 02:03 UTC:
+
+| Table | selected | repaired |
+| --- | --- | --- |
+| decisions | 1064 | 1064 |
+| ob_session_lanes | 489 | 489 |
+| ob_session_events | 62 | 62 |
+| ob_entities | 12 | 12 |
+| relationships / projects | 0 | 0 (already clean) |
+| thoughts | — | aborted: `dream-bulk-test forced failure` |
+| sessions | — | aborted: duplicate key on `idx_sessions_content_hash` |
+
+**Total repaired: 1,627.** Eligible-but-unembedded `ob_session_lanes` went
+549 → 0 (the earlier `--namespace rico` run had already taken 60 of those).
+
+## 4. Done-means
+
+`scripts/done-means/724-backlog-recallable.sh`
+
+- **RED** (before the run): `EXIT=1`, clause 1 FAIL —
+  `ob_session_lanes: 2 of 2 eligible window rows have NULL embedding`.
+  Clauses 2 and 3 PASS, so the instrument had authority.
+- **GREEN** (after the run): `EXIT=0`, all three clauses PASS,
+  `unembedded total: 0` across 101 eligible window rows.
+
+Tests: `bun run test:isolated src/embedding-repair.test.ts
+src/embedding-targets.test.ts` — 76 pass, 0 fail. `bunx tsc --noEmit` clean.
+
+## 5. Residual — NOT closed by this lane
+
+1. **Leaked `dream_bulk_release_trigger` on `thoughts`** (live dogfood DB).
+   Blocks *every* update to `thoughts`, not just embedding repair. 1,297
+   `thoughts` rows remain unembedded behind it. Needs its own issue: both the
+   drop and the test-teardown fix that stops it recurring.
+2. **`idx_sessions_content_hash` unique-constraint collisions** block the
+   `sessions` drain; 11,166 rows remain unembedded. Duplicate session content
+   hashing to the same value is a real modelling question, not a repair bug.
+   `scripts/backfill.ts` already anticipates this class per-row; the repair
+   primitive surfaces it as a thrown batch error instead.
+3. **Nothing schedules this CLI.** The backlog is drained once, by hand. If the
+   enqueue boundary stays empty, a future outage produces the same backlog again.
+   Whether the sweep should enqueue `embedding.repair` is a design decision for
+   the operator, not something this lane took unilaterally.
+4. The done-means check counts rows; a row embedded with a *wrong* vector still
+   passes clause 1.

--- a/scripts/done-means/724-backlog-recallable.sh
+++ b/scripts/done-means/724-backlog-recallable.sh
@@ -1,0 +1,441 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #724 item 1 — "rows captured 2026-08-14..2026-08-17
+# are stored but never embedded/indexed after the nats-worker outage; the
+# 2026-08-17 write-recall heal covered NEW writes only, leaving the backlog
+# unreachable."
+#
+#   bash scripts/done-means/724-backlog-recallable.sh
+#
+# ---------------------------------------------------------------------------
+# WHAT THE PREMISE ACTUALLY LOOKS LIKE ON THE LIVE DOGFOOD DB (observed
+# 2026-08-17 while authoring this gate — RUNNING, not inferred)
+# ---------------------------------------------------------------------------
+# The lane brief said the backlog was in session EVENTS. Measured, it is not:
+#
+#   ob_session_events, 2026-08-14..2026-08-17, namespace rico:
+#       55 rows, 55 embedded, 0 NULL embeddings, embedded_at == created_at
+#       (max lag -0.0008s => embedding is synchronous on the write path).
+#
+# The backlog that DOES exist in the window is in ob_session_lanes:
+#
+#   ob_session_lanes, same window, topic non-empty (the registry's own
+#   eligibility filter, src/embedding-targets.ts:baseFilterSql):
+#       2 rows, 0 embedded.
+#   All-time eligible-but-unembedded lanes: 549.
+#   ob_entities (archived_at IS NULL): 429 rows, 12 with NULL embedding.
+#
+# So this gate does NOT assert the brief's original shape. It asserts the
+# invariant the brief was REACHING FOR, over every embedding-bearing table the
+# repo itself declares, and it lets the numbers say which table is short. If a
+# future outage moves the gap into events, clause 1 catches it there too,
+# because clause 1 is driven by the registry rather than by one hand-picked
+# table.
+#
+# TRUTH LABEL for anyone reading a run of this: a clause-1 FAIL is a CONFIRMED
+# observation of unembedded rows, not a claim about the CAUSE. Whether the
+# nats-worker outage produced them is unverified by this gate.
+#
+# ---------------------------------------------------------------------------
+# Schema citations — every column below was read from source and confirmed
+# against the live stored schema with `\d`, not invented.
+# ---------------------------------------------------------------------------
+#   src/embedding-targets.ts:EMBEDDING_TARGETS   — the single registry of every
+#       embedding-bearing table. This gate reads it at runtime instead of
+#       holding a second copy, for the same reason #433 exists: two
+#       hand-maintained copies of one table list is the defect class itself.
+#   src/embedding-targets.ts (ob_session_events entry) — `namespaceVia`
+#       { table: ob_session_lanes, localKey: lane_id, remoteKey: id,
+#         namespaceColumn: namespace }. ob_session_events carries NO namespace
+#       column of its own; isolation is only through that FK.
+#   src/embedding-targets.ts (ob_session_lanes entry) — `baseFilterSql`
+#       "topic IS NOT NULL AND btrim(topic) <> ''". Lanes with an empty topic
+#       have no text to embed and are NOT a backlog; counting them would report
+#       thousands of phantom rows (7,634 in the window) and make the gate lie.
+#   src/embedding-targets.ts (ob_entities entry) — `baseFilterSql`
+#       "archived_at IS NULL"; provenance has NO content_hash/embedded_at/
+#       embedding_model, so only missing-embedding detection is truthful there.
+#   Columns `embedding halfvec(768)`, `embedded_at timestamptz`,
+#       `embedding_model text`, `content_hash text`, `created_at timestamptz`
+#       on ob_session_events — src/db/migrations/013_session_events.sql,
+#       confirmed live via `\d ob_session_events` 2026-08-17.
+#   src/tools/search-brain.ts:109 readableSearchTables(role) — the one function
+#       brain_answer and search_brain both call to decide what recall may read.
+#   src/tools/search-brain.ts:1586 executeSearch(...) — the real retrieval
+#       entry point; this gate drives it in-process from THIS checkout so an
+#       uncommitted fix can go red-then-green. Probing the deployed service
+#       would measure the installed revision instead and could never move.
+#   src/embedding.ts:618 generateEmbedding(...) — the real provider call, used
+#       for the semantic arm so a vector-side failure cannot hide behind
+#       lexical hits.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+# Clause 1 — NO UNEMBEDDED BACKLOG IN THE WINDOW. For every table in
+#   EMBEDDING_TARGETS, and for every namespace, there must be no row created in
+#   2026-08-14..2026-08-17 that is eligible to be embedded and has a NULL
+#   embedding. Eligibility is the registry's own baseFilterSql, never a
+#   predicate invented here.
+#
+# Clause 2 — RECALL REACHES THE WINDOW. The real executeSearch path must return
+#   at least one row whose created_at falls inside the window, for a query drawn
+#   from known Aug-15 content. Run in BOTH keyword and semantic mode: keyword
+#   proves the lexical arm, semantic proves the vector arm actually has usable
+#   embeddings for window rows. An embedding backlog is invisible to keyword
+#   search, so keyword alone would pass over exactly the defect under test.
+#
+# Clause 3 — CONTROL. A KNOWN-GOOD pre-2026-08-14 row must also be recallable
+#   through the same path. This is what stops a dead service, an empty table
+#   list, a broken embed provider, or a namespace typo from faking a clause-2
+#   pass by returning nothing everywhere. If the control cannot be recalled,
+#   the whole run is a HARNESS ERROR (exit 3), not a FAIL: the instrument is
+#   broken, so it has no opinion about the window.
+#
+# ---------------------------------------------------------------------------
+# Exit grammar
+# ---------------------------------------------------------------------------
+#   0  every clause PASS
+#   1  a clause genuinely FAILED (real defect observed)
+#   3  HARNESS ERROR — the gate could not form an opinion. Includes: DB
+#      unreachable, psql/bun missing, a probe that raised, a query that
+#      examined ZERO candidate rows (0 rows examined is NOT a pass), and a
+#      failed control clause.
+#
+# Output is content-free apart from short previews of already-public window
+# text: statuses, counts, table names. No tokens, no full memory bodies.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+WINDOW_START="2026-08-14"
+WINDOW_END="2026-08-18"   # exclusive; covers through 2026-08-17 23:59:59
+
+fail_hard() {
+  printf '\nHARNESS-ERROR: %s\n' "$1" >&2
+  printf 'RESULT: HARNESS ERROR (exit 3) — the gate formed no opinion about the backlog.\n' >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH (runs the registry read and the recall probes)"
+command -v psql >/dev/null 2>&1 || fail_hard "psql not on PATH"
+
+# --- database access --------------------------------------------------------
+# .env carries the libpq vars, so bare psql needs no connection arguments.
+# See AGENTS.md "Querying the dogfood database". A clone made from the primary
+# checkout does NOT carry .env (it is gitignored), so fall back to the primary
+# checkout's copy rather than hand-building a connection string.
+ENV_FILE="$REPO_ROOT/.env"
+if [ ! -r "$ENV_FILE" ]; then
+  ENV_FILE="/Volumes/ThunderBolt/Development/open-brain/.env"
+fi
+[ -r "$ENV_FILE" ] || fail_hard "no readable .env at $REPO_ROOT/.env or the primary checkout; cannot reach the dogfood database"
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+psql -At -c 'select 1' >/dev/null 2>&1 || fail_hard "cannot reach the dogfood database (DB unreachable => exit 3, never a pass)"
+
+PROBE_DB_URL="postgres://${PGUSER}@${PGHOST}:${PGPORT}/${PGDATABASE}"
+
+# ===========================================================================
+# Clause 1 — no unembedded backlog in the window, across the WHOLE registry
+# ===========================================================================
+# The table list, its eligibility filter, and its namespace wiring all come out
+# of src/embedding-targets.ts at runtime. Emitting one line per target as
+# "table<TAB>baseFilterSql<TAB>namespaceExpr" keeps the SQL construction here
+# while the SCHEMA FACTS stay owned by the registry.
+REGISTRY_TSV="$(cd "$REPO_ROOT" && bun -e '
+import { EMBEDDING_TARGETS } from "./src/embedding-targets.ts";
+for (const t of Object.values(EMBEDDING_TARGETS)) {
+  // Namespace is either a column on the table itself, or reached through the
+  // declared FK to a parent that owns it (ob_session_events -> ob_session_lanes).
+  let nsExpr = "'"'"'(none)'"'"'";
+  let joinSql = "";
+  if (t.namespaceColumn) {
+    nsExpr = `x.${t.namespaceColumn}`;
+  } else if (t.namespaceVia) {
+    const v = t.namespaceVia;
+    nsExpr = `p.${v.namespaceColumn}`;
+    joinSql = `join ${v.table} p on p.${v.remoteKey} = x.${v.localKey}`;
+  }
+  console.log([t.table, t.baseFilterSql ?? "true", nsExpr, joinSql].join("\t"));
+}' 2>/dev/null)"
+
+[ -n "$REGISTRY_TSV" ] || fail_hard "could not read EMBEDDING_TARGETS from src/embedding-targets.ts; the gate refuses to fall back to a hand-written table list (that duplication IS the #433 defect class)"
+
+CLAUSE1=PASS
+CLAUSE1_DETAIL=""
+TOTAL_EXAMINED=0
+BACKLOG_TOTAL=0
+
+while IFS=$'\t' read -r TBL BASEFILTER NSEXPR JOINSQL; do
+  [ -n "$TBL" ] || continue
+
+  # Candidates = rows of this table created inside the window that the registry
+  # itself considers embeddable. Examined count is reported so "0 backlog" can
+  # be distinguished from "0 rows looked at" — the latter is empty-because-wrong
+  # and must never read as a pass.
+  ROW="$(psql -At -F'|' -c "
+    select
+      count(*),
+      count(*) filter (where x.embedding is null),
+      coalesce(string_agg(distinct ${NSEXPR}, ',') filter (where x.embedding is null), '')
+    from ${TBL} x
+    ${JOINSQL}
+    where x.created_at >= '${WINDOW_START}'
+      and x.created_at <  '${WINDOW_END}'
+      and (${BASEFILTER});
+  " 2>&1)"
+
+  case "$ROW" in
+    *ERROR*|*error:*) fail_hard "clause 1 query failed for table ${TBL}: ${ROW}" ;;
+  esac
+
+  EXAMINED="$(printf '%s' "$ROW" | cut -d'|' -f1 | tr -d '[:space:]')"
+  MISSING="$(printf '%s' "$ROW" | cut -d'|' -f2 | tr -d '[:space:]')"
+  NSLIST="$(printf '%s' "$ROW" | cut -d'|' -f3)"
+
+  printf '%s' "${EXAMINED:-}" | rg -q '^[0-9]+$' || fail_hard "clause 1 returned no parseable count for ${TBL}: '${ROW}'"
+
+  TOTAL_EXAMINED=$((TOTAL_EXAMINED + EXAMINED))
+  BACKLOG_TOTAL=$((BACKLOG_TOTAL + MISSING))
+
+  if [ "$MISSING" -gt 0 ]; then
+    CLAUSE1=FAIL
+    CLAUSE1_DETAIL="${CLAUSE1_DETAIL}
+    ${TBL}: ${MISSING} of ${EXAMINED} eligible window rows have NULL embedding (namespaces: ${NSLIST:-?})"
+  else
+    CLAUSE1_DETAIL="${CLAUSE1_DETAIL}
+    ${TBL}: 0 of ${EXAMINED} eligible window rows unembedded — clean"
+  fi
+done <<< "$REGISTRY_TSV"
+
+# ZERO ROWS EXAMINED IS NOT A PASS. If the whole registry turned up no candidate
+# rows in the window, either the window is wrong, the filters are wrong, or the
+# gate is pointed at the wrong database. Any of those means no opinion.
+if [ "$TOTAL_EXAMINED" -eq 0 ]; then
+  fail_hard "clause 1 examined ZERO candidate rows across every embedding target in ${WINDOW_START}..${WINDOW_END}. Empty-because-wrong is not a pass; check the window, the registry filters, and PGDATABASE=${PGDATABASE}"
+fi
+
+# ===========================================================================
+# Clauses 2 and 3 — recall probes through the REAL retrieval path
+# ===========================================================================
+# Both probes run against the same executeSearch entry point brain_answer uses,
+# in BOTH keyword and semantic mode. `admin` is the most permissive role there
+# is: if content is invisible to admin it is invisible to everyone, and the
+# result cannot be waved off as a permissions artifact.
+#
+# The probe is written into the repo-scoped scratch bucket rather than the
+# checkout, so it never dirties `git status` and needs no delete to clean up
+# (agents never run forced or recursive deletes — Development AGENTS.md).
+PROBE_DIR="${OPENBRAIN_SCRATCH:-/Volumes/ThunderBolt/_tmp/open-brain/_scratch}/done-means-724"
+mkdir -p "$PROBE_DIR" || fail_hard "cannot create scratch dir $PROBE_DIR"
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+PROBE="$PROBE_DIR/probe.$RUN_ID.ts"
+
+cat > "$PROBE" <<PROBE_TS
+const REPO_ROOT = "${REPO_ROOT}";
+PROBE_TS
+cat >> "$PROBE" <<'PROBE_TS'
+import { Pool } from "pg";
+
+const { executeSearch, readableSearchTables } = await import(
+  `${REPO_ROOT}/src/tools/search-brain.ts`
+);
+const { generateEmbedding } = await import(`${REPO_ROOT}/src/embedding.ts`);
+
+const [dbUrl, namespace, query, loIso, hiIso] = process.argv.slice(2);
+const lo = new Date(loIso).getTime();
+const hi = new Date(hiIso).getTime();
+const pool = new Pool({ connectionString: dbUrl });
+
+// THE REAL SELECTION, not a copy. readableSearchTables is the single function
+// brain_answer and search_brain both call; re-deriving the list here would let
+// the gate pass while the product stayed blind.
+const tables = readableSearchTables("admin");
+
+function inRange(rows: any[]): number {
+  return rows.filter((r: any) => {
+    const t = new Date(r.created_at ?? 0).getTime();
+    return Number.isFinite(t) && t >= lo && t < hi;
+  }).length;
+}
+
+async function run(mode: string): Promise<number> {
+  // Semantic mode uses the REAL provider so a dead embedding endpoint or a
+  // missing row-side embedding surfaces as a miss instead of being masked by
+  // the lexical arm.
+  const embedFn = mode === "semantic" ? generateEmbedding : async () => null;
+  const rows: any[] = await executeSearch(
+    { pool, embedFn } as any,
+    tables as any,
+    query,
+    25,
+    mode,
+    undefined,
+    0,
+    namespace,
+  );
+  return inRange(rows);
+}
+
+try {
+  const kw = await run("keyword");
+  const sem = await run("semantic");
+  console.log(`OK ${kw} ${sem}`);
+} catch (err) {
+  console.log(`ERR ${err instanceof Error ? err.message : String(err)}`);
+} finally {
+  await pool.end();
+}
+PROBE_TS
+
+# --- pick the namespace and the probe subjects from live data ----------------
+# The namespace is DISCOVERED, not hardcoded: the gate asks which namespace
+# actually owns window events, so it cannot silently probe an empty one.
+NAMESPACE="$(psql -At -c "
+  select l.namespace
+  from ob_session_events e
+  join ob_session_lanes l on l.id = e.lane_id
+  where e.created_at >= '${WINDOW_START}' and e.created_at < '${WINDOW_END}'
+  group by 1 order by count(*) desc limit 1;" 2>/dev/null | tr -d '[:space:]')"
+[ -n "$NAMESPACE" ] || fail_hard "no namespace has session events in ${WINDOW_START}..${WINDOW_END}; with nothing captured in the window there is nothing to prove recallable (exit 3, not a pass)"
+
+# Clause 2 subject: known Aug-15-window content. Drawn from the DB so the query
+# is guaranteed to correspond to a row that really exists — a hardcoded phrase
+# that had drifted would fail the clause for the wrong reason.
+# Same distinctiveness rules as the control below: exclude the shared
+# checkpoint/probe boilerplate and cut on a word boundary, so the probe asks
+# about THIS row rather than about a phrase thousands of rows share.
+WINDOW_QUERY="$(psql -At -c "
+  select regexp_replace(left(e.content, 70), '\s+\S*\$', '')
+  from ob_session_events e
+  join ob_session_lanes l on l.id = e.lane_id
+  where l.namespace = '${NAMESPACE}'
+    and e.created_at >= '2026-08-15' and e.created_at < '2026-08-16'
+    and length(e.content) > 80
+    and e.content !~* '^(recorded codex turn checkpoint|probe:|liveness probe|test\$)'
+  order by length(e.content) desc limit 1;" 2>/dev/null)"
+[ -n "$WINDOW_QUERY" ] || fail_hard "no Aug-15 session event long enough to form a recall probe in namespace ${NAMESPACE}; cannot evaluate clause 2 (exit 3)"
+
+# Clause 3 subject: a KNOWN-GOOD pre-window row that is already embedded. Being
+# embedded is the point — this is the control for "the retrieval path works at
+# all", so it must be a row nothing about the outage could have touched.
+#
+# The subject must be DISTINCTIVE, not merely recent. Observed 2026-08-17 while
+# authoring: taking `left(content,60)` of the newest pre-window event yielded
+# "Recorded codex turn checkpoint for Development. 3. Self-host" — boilerplate
+# shared by thousands of rows, truncated mid-word. Every one of the top-25
+# keyword hits was a DIFFERENT checkpoint carrying the same prefix, so the
+# control failed while the retrieval path was working perfectly. A control that
+# can fail for its own reasons is worse than no control: it converts every run
+# into a harness error and hides the clause it was meant to protect.
+#
+# So: pick the pre-window row whose content is LEAST like the common
+# boilerplate, and cut on a word boundary so no token is truncated. Rows whose
+# content starts with the known checkpoint/probe boilerplate are excluded
+# outright.
+CONTROL_QUERY="$(psql -At -c "
+  select regexp_replace(left(e.content, 70), '\s+\S*\$', '')
+  from ob_session_events e
+  join ob_session_lanes l on l.id = e.lane_id
+  where l.namespace = '${NAMESPACE}'
+    and e.created_at < '${WINDOW_START}'
+    and e.embedding is not null
+    and length(e.content) > 80
+    and e.content !~* '^(recorded codex turn checkpoint|probe:|liveness probe|test\$)'
+  order by e.created_at desc limit 1;" 2>/dev/null)"
+[ -n "$CONTROL_QUERY" ] || fail_hard "no embedded pre-${WINDOW_START} session event available as a control in namespace ${NAMESPACE}; without a control a clause-2 pass could not be trusted (exit 3)"
+
+CONTROL_DAY="$(psql -At -c "
+  select max(e.created_at)::date
+  from ob_session_events e
+  join ob_session_lanes l on l.id = e.lane_id
+  where l.namespace = '${NAMESPACE}' and e.created_at < '${WINDOW_START}'
+    and e.embedding is not null;" 2>/dev/null | tr -d '[:space:]')"
+
+probe() {
+  cd "$REPO_ROOT" && bun "$PROBE" "$PROBE_DB_URL" "$NAMESPACE" "$1" "$2" "$3" 2>/dev/null | rg '^(OK|ERR)' | tail -1
+}
+
+# TIMEZONE: the window boundaries MUST be resolved the same way on both sides
+# of this gate, or the two halves disagree about which rows are "in the window".
+#
+# Observed 2026-08-17 while authoring: the SQL above compares `created_at`
+# against bare dates, which Postgres resolves in the session TimeZone (local,
+# America/New_York), while the probe parsed the boundary as UTC. The control row
+# sat at 2026-08-14T02:55:40Z — Aug 13 21:55 LOCAL. SQL correctly called it
+# pre-window; the probe called it in-window; the control reported 0 hits and the
+# whole run went to exit 3 while nothing was actually broken. A five-hour offset
+# silently inverted the classification of every evening row in the window.
+#
+# So the boundaries handed to the probe are computed BY POSTGRES, in the same
+# session zone the clause-1 queries used, and emitted as absolute instants.
+WINDOW_LO_ISO="$(psql -At -c "select to_char(timestamptz '${WINDOW_START} 00:00:00' at time zone 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"');" 2>/dev/null | tr -d '[:space:]')"
+WINDOW_HI_ISO="$(psql -At -c "select to_char(timestamptz '${WINDOW_END} 00:00:00' at time zone 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"');" 2>/dev/null | tr -d '[:space:]')"
+[ -n "$WINDOW_LO_ISO" ] && [ -n "$WINDOW_HI_ISO" ] || fail_hard "could not resolve the window boundaries through Postgres; without a single shared definition of the window the clauses cannot be compared"
+
+WINDOW_OUT="$(probe "$WINDOW_QUERY" "$WINDOW_LO_ISO" "$WINDOW_HI_ISO")"
+# Control range: everything before the window, using the SAME resolved lower
+# boundary. Epoch lower bound so any pre-window hit counts.
+CONTROL_OUT="$(probe "$CONTROL_QUERY" "1970-01-01T00:00:00Z" "$WINDOW_LO_ISO")"
+
+case "$WINDOW_OUT" in ERR*) fail_hard "clause 2 probe raised before returning rows: ${WINDOW_OUT#ERR }" ;; esac
+case "$CONTROL_OUT" in ERR*) fail_hard "clause 3 control probe raised: ${CONTROL_OUT#ERR }" ;; esac
+[ -n "$WINDOW_OUT" ] || fail_hard "clause 2 probe produced no parseable output"
+[ -n "$CONTROL_OUT" ] || fail_hard "clause 3 probe produced no parseable output"
+
+W_KW="$(printf '%s' "$WINDOW_OUT" | awk '{print $2}')"
+W_SEM="$(printf '%s' "$WINDOW_OUT" | awk '{print $3}')"
+C_KW="$(printf '%s' "$CONTROL_OUT" | awk '{print $2}')"
+C_SEM="$(printf '%s' "$CONTROL_OUT" | awk '{print $3}')"
+
+# --- clause 3 first: it decides whether the instrument has any authority -----
+CLAUSE3=FAIL
+CLAUSE3_EVIDENCE=""
+if [ "${C_KW:-0}" -ge 1 ] && [ "${C_SEM:-0}" -ge 1 ]; then
+  CLAUSE3=PASS
+  CLAUSE3_EVIDENCE="known-good pre-${WINDOW_START} row (namespace ${NAMESPACE}, newest embedded ${CONTROL_DAY:-?}) recalled through the real path: keyword=${C_KW} semantic=${C_SEM} in-range hits. The retrieval path is live, so a clause-2 miss means the WINDOW is unreachable, not the service."
+else
+  CLAUSE3_EVIDENCE="CONTROL FAILED: a pre-window row that IS embedded did not come back (keyword=${C_KW:-?} semantic=${C_SEM:-?}). The retrieval path itself is not answering, so this run has NO opinion about the window backlog."
+fi
+
+CLAUSE2=FAIL
+CLAUSE2_EVIDENCE=""
+if [ "${W_KW:-0}" -ge 1 ] && [ "${W_SEM:-0}" -ge 1 ]; then
+  CLAUSE2=PASS
+  CLAUSE2_EVIDENCE="window content is reachable in BOTH arms: keyword=${W_KW} semantic=${W_SEM} rows dated inside ${WINDOW_START}..${WINDOW_END}"
+elif [ "${W_KW:-0}" -ge 1 ]; then
+  CLAUSE2_EVIDENCE="LEXICAL ONLY: keyword returned ${W_KW} window row(s) but semantic returned ${W_SEM:-0}. Keyword search reads stored text and is blind to a missing embedding, so this is the exact signature of an unembedded backlog — the rows are STORED but not INDEXED."
+else
+  CLAUSE2_EVIDENCE="UNREACHABLE: the real recall path returned 0 rows dated inside the window in either arm (keyword=${W_KW:-0} semantic=${W_SEM:-0}), while the control proves the path answers for older rows."
+fi
+
+# ===========================================================================
+# Report
+# ===========================================================================
+printf '\n=== DONE-MEANS #724 item 1 (Aug 14-17 backlog is embedded AND recallable) ===\n'
+printf 'window          : %s .. %s (exclusive)\n' "$WINDOW_START" "$WINDOW_END"
+printf 'namespace probed: %s (discovered, not hardcoded)\n' "$NAMESPACE"
+printf 'rows examined   : %s eligible window rows across the whole EMBEDDING_TARGETS registry\n' "$TOTAL_EXAMINED"
+printf 'unembedded total: %s\n' "$BACKLOG_TOTAL"
+
+printf '\nCLAUSE 1 no unembedded backlog in window : %s%s\n' "$CLAUSE1" "$CLAUSE1_DETAIL"
+printf '\nCLAUSE 2 recall reaches the window       : %s\n  %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+printf '\nCLAUSE 3 control (pre-window recallable) : %s\n  %s\n' "$CLAUSE3" "$CLAUSE3_EVIDENCE"
+
+# A broken control means the instrument is broken. Report exit 3, never 0 or 1:
+# with the retrieval path silent, both a "pass" and a "fail" on clause 2 would
+# be unearned.
+if [ "$CLAUSE3" != "PASS" ]; then
+  printf '\nRESULT: HARNESS ERROR (exit 3) — the control clause failed, so this run has no authority to judge the window.\n'
+  exit 3
+fi
+
+if [ "$CLAUSE1" = "PASS" ] && [ "$CLAUSE2" = "PASS" ]; then
+  printf '\nRESULT: PASS — every eligible row captured in the window carries an embedding, and window content returns from the real recall path in both the lexical and the vector arm.\n'
+  exit 0
+fi
+
+printf '\nRESULT: FAIL — the window backlog is not closed. Numbers above name the table(s) and the arm that is short.\n'
+exit 1

--- a/scripts/repair-embeddings.ts
+++ b/scripts/repair-embeddings.ts
@@ -1,0 +1,381 @@
+/**
+ * Registry-wide stale-embedding backfill CLI (issue #724 item 1).
+ *
+ * WHY THIS EXISTS — the measured gap, not a guess.
+ *
+ * `docs/embedding-repair.md` ("Server-owned runtime and enqueue boundary")
+ * states the design plainly: `src/maintenance-bootstrap.ts` starts the
+ * `embedding.repair` runner, but the bootstrap "invents no namespace and
+ * enqueues no job." Enqueue is deliberately an explicit, auth-scoped CALLER
+ * boundary. Nothing in the repo occupies that caller position for a bulk
+ * historical backlog, so unembedded rows are never drained by anything.
+ *
+ * Observed on the dogfood database 2026-08-17 (RUNNING, measured not inferred):
+ *   - eligible-but-unembedded ob_session_lanes: 549, unchanged across a
+ *     4-minute idle observation (549 -> 549);
+ *   - `maintenance_jobs` has never held a single `embedding.repair` row
+ *     (only `memory.distill` and `system.facts`), and had zero rows updated in
+ *     the preceding 30 minutes.
+ * The backlog does not self-drain. That is the defect this script closes.
+ *
+ * WHAT IT RIDES ON — no new pipeline, no new table, no new SQL.
+ *
+ *   src/embedding-repair.ts:682 `repairStaleBatch(...)` — the EXISTING bulk
+ *     primitive, whose own docstring says it "is for scripts/backfill-style
+ *     bulk runs." This script is exactly that caller and nothing more: it
+ *     loops the documented primitive until a table reports no more candidates.
+ *   src/embedding-targets.ts:326 `EMBEDDING_TARGET_NAMES` — the single table
+ *     registry, read at runtime. A second hand-maintained copy of that list is
+ *     the #433 defect class, so there is none here.
+ *   src/embedding-repair.ts:163 `MAX_BATCH` — the primitive's own ceiling; the
+ *     batch size is clamped by the primitive, not re-invented here.
+ *   src/db/pool.ts `createPool()` and src/embedding.ts
+ *     `generateEmbeddingWithMetadata` — the same pool and the same real
+ *     provider the server uses. No alternate embedding path.
+ *
+ * Every safety property (namespace-bound reads AND guarded writes, embeddings
+ * generated outside locks, idempotent convergence on replay, retryable vs
+ * permanent failure classification, content-free logging) is the primitive's,
+ * inherited unchanged. This file adds a loop, a CLI, and a summary.
+ *
+ * SCOPE IS MANDATORY AND EXPLICIT. `repairStaleBatch` refuses an unscoped run.
+ * Pass either `--namespace <ns>` (repeatable) or the separately-named
+ * `--global`. There is no default; omitting both is an error, never a silent
+ * global run.
+ *
+ * NOTHING IS ADJUSTED SILENTLY (repo rule): every clamp, skip, and stop
+ * condition this script applies is printed with the original and adjusted
+ * value and the reason.
+ *
+ * Usage:
+ *   bun run scripts/repair-embeddings.ts --namespace rico
+ *   bun run scripts/repair-embeddings.ts --global --dry-run
+ *   bun run scripts/repair-embeddings.ts --namespace rico --table ob_session_lanes
+ *
+ * Exit codes: 0 = ran to completion with no permanent failures;
+ *             1 = a fatal error, or permanent per-row failures were recorded.
+ */
+import {
+  repairStaleBatch,
+  MAX_BATCH,
+  type RepairScope,
+  type StalenessReason,
+} from "../src/embedding-repair.ts";
+import { EMBEDDING_TARGET_NAMES } from "../src/embedding-targets.ts";
+import { generateEmbeddingWithMetadata } from "../src/embedding.ts";
+import { createPool } from "../src/db/pool.ts";
+import { logger } from "../src/logger.ts";
+import type pg from "pg";
+
+export interface RepairRunOptions {
+  scope: RepairScope;
+  /** Tables to sweep. Default: the whole EMBEDDING_TARGETS registry. */
+  tables?: string[];
+  /** Rows per `repairStaleBatch` call. Clamped by the primitive to MAX_BATCH. */
+  batchSize?: number;
+  /**
+   * Safety bound on total batches per table, so a row that is selected but
+   * never repaired (e.g. a permanently empty-text row) cannot spin forever.
+   */
+  maxBatchesPerTable?: number;
+  /** Report what would be selected without writing any embedding. */
+  dryRun?: boolean;
+  /**
+   * Staleness reasons to select. Defaults to `["missing"]` — see the comment
+   * at the `repairStaleBatch` call for why an all-reasons bulk drain does not
+   * converge. Override with `--reason` only deliberately.
+   */
+  reasons?: StalenessReason[];
+}
+
+export interface RepairRunTableSummary {
+  table: string;
+  batches: number;
+  selected: number;
+  repaired: number;
+  skipped: number;
+  retryableFailures: number;
+  permanentFailures: number;
+  stoppedAtBatchBound: boolean;
+}
+
+export interface RepairRunSummary {
+  tables: RepairRunTableSummary[];
+  /** Tables whose drain aborted with a thrown error; see the try/catch above. */
+  tableErrors: { table: string; error: string }[];
+  repaired: number;
+  permanentFailures: number;
+  retryableFailures: number;
+}
+
+const DEFAULT_BATCHES_PER_TABLE = 100;
+
+/**
+ * Drain every requested table by looping the existing bulk primitive.
+ *
+ * The loop's stop condition is the primitive's own report: a batch that
+ * SELECTS zero candidates means the table has nothing stale left. A batch that
+ * selects rows but repairs none would otherwise re-select the same rows
+ * forever, so that case also stops the table and is announced.
+ */
+export async function repairAll(
+  db: Pick<pg.Pool, "query">,
+  options: RepairRunOptions,
+): Promise<RepairRunSummary> {
+  const tables = options.tables ?? EMBEDDING_TARGET_NAMES;
+  const requestedBatch = options.batchSize ?? MAX_BATCH;
+  const batchSize = Math.min(requestedBatch, MAX_BATCH);
+  if (batchSize !== requestedBatch) {
+    console.log(
+      `ADJUSTED batch size: ${requestedBatch} -> ${batchSize} (MAX_BATCH in src/embedding-repair.ts bounds a single selection)`,
+    );
+  }
+  const maxBatches = options.maxBatchesPerTable ?? DEFAULT_BATCHES_PER_TABLE;
+
+  const summaries: RepairRunTableSummary[] = [];
+  const tableErrors: { table: string; error: string }[] = [];
+
+  for (const table of tables) {
+    const acc: RepairRunTableSummary = {
+      table,
+      batches: 0,
+      selected: 0,
+      repaired: 0,
+      skipped: 0,
+      retryableFailures: 0,
+      permanentFailures: 0,
+      stoppedAtBatchBound: false,
+    };
+
+    // ONE TABLE MUST NOT ABORT THE DRAIN. Observed 2026-08-17 on the dogfood
+    // database: a leaked test fixture left a live BEFORE UPDATE trigger
+    // `dream_bulk_release_trigger` on `thoughts` (from
+    // src/tools/__tests__/bulk-set-tier.pg.test.ts) that RAISEs on every
+    // update, so the first `thoughts` batch threw and killed a whole --global
+    // run before the remaining tables were touched. That trigger is a separate
+    // defect and this script does not drop it (destructive DDL is out of
+    // scope); it only refuses to let it hide the other tables' backlogs. The
+    // failing table is reported and the run's exit code reflects it.
+    try {
+      for (let batch = 0; batch < maxBatches; batch += 1) {
+        const result = await repairStaleBatch(
+          db,
+          table,
+          options.dryRun
+            ? // Dry run still exercises the REAL selection query, so the counts
+              // are the primitive's own. It just never produces a vector:
+              // `repairOne` sees a null embedding with an error and records a
+              // failure instead of issuing the guarded UPDATE. Nothing is
+              // mutated. `input_invalid` is chosen from the existing
+              // EmbeddingError codes (src/embedding.ts:38) because it is
+              // classified NON-retryable (RETRYABLE_CODES,
+              // src/embedding-repair.ts:402) — a dry run must not look like a
+              // transient provider outage.
+              async () => ({
+                embedding: null,
+                error: {
+                  code: "input_invalid" as const,
+                  message: "dry run: no embedding generated",
+                  attempts: 0,
+                },
+              })
+            : generateEmbeddingWithMetadata,
+          {
+            scope: options.scope,
+            limit: batchSize,
+            // MEASURED, not assumed. `buildSelection` (src/embedding-repair.ts:250)
+            // ORs the reasons into ONE unordered `SELECT ... LIMIT n`, and
+            // source_drift's SQL arm is `embedding IS NOT NULL AND content_hash
+            // IS NOT NULL` — i.e. rows that ALREADY have an embedding — with the
+            // real hash comparison done in JS afterward. With every reason
+            // enabled, a bounded batch is therefore mostly already-embedded rows
+            // and the unembedded backlog is crowded out of the window: observed
+            // 2026-08-17, limit=500 on ob_session_lanes returned 100 stale
+            // candidates of mixed reason while 549 rows sat unembedded.
+            // Because the query has no ORDER BY, repeated batches can return the
+            // same rows and the drain would never converge.
+            //
+            // This CLI's job is the MISSING-embedding backlog specifically, so it
+            // asks for that reason alone. Every selected row is then one the loop
+            // can actually repair, which is what makes `repaired === 0` a
+            // truthful stop condition. Drift repair remains the queue handler's
+            // job (`embedding.repair`, src/embedding-repair-handler.ts) and is
+            // deliberately NOT taken over here.
+            reasons: options.reasons ?? ["missing"],
+          },
+        );
+
+        acc.batches += 1;
+        acc.selected += result.selected;
+        acc.repaired += result.repaired;
+        acc.skipped += result.skipped;
+        acc.retryableFailures += result.retryableFailures;
+        acc.permanentFailures += result.permanentFailures;
+
+        if (result.selected === 0) break;
+
+        if (options.dryRun) {
+          console.log(
+            `DRY RUN ${table}: ${result.selected} stale row(s) would be repaired (stopping after one batch; a dry run writes nothing so looping would re-select the same rows)`,
+          );
+          break;
+        }
+
+        if (result.repaired === 0) {
+          console.log(
+            `STOPPED ${table}: batch selected ${result.selected} row(s) but repaired 0 (skipped=${result.skipped} retryable=${result.retryableFailures} permanent=${result.permanentFailures}); looping again would re-select the same rows`,
+          );
+          break;
+        }
+
+        if (batch === maxBatches - 1) {
+          acc.stoppedAtBatchBound = true;
+          console.log(
+            `STOPPED ${table}: hit the ${maxBatches}-batch safety bound with rows still selectable; re-run to continue`,
+          );
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      tableErrors.push({ table, error: message });
+      console.log(
+        `ERROR ${table}: batch aborted after repairing ${acc.repaired} row(s) — ${message}; continuing with the remaining tables`,
+      );
+    }
+
+    summaries.push(acc);
+    if (acc.selected > 0 || acc.repaired > 0) {
+      console.log(
+        `${table}: selected=${acc.selected} repaired=${acc.repaired} skipped=${acc.skipped} retryable=${acc.retryableFailures} permanent=${acc.permanentFailures} batches=${acc.batches}`,
+      );
+    }
+  }
+
+  return {
+    tables: summaries,
+    tableErrors,
+    repaired: summaries.reduce((n, t) => n + t.repaired, 0),
+    permanentFailures: summaries.reduce((n, t) => n + t.permanentFailures, 0),
+    retryableFailures: summaries.reduce((n, t) => n + t.retryableFailures, 0),
+  };
+}
+
+/** Parse argv into run options. Throws on a missing or contradictory scope. */
+export function parseArgs(argv: string[]): RepairRunOptions {
+  const namespaces: string[] = [];
+  const tables: string[] = [];
+  const reasons: StalenessReason[] = [];
+  let global = false;
+  let dryRun = false;
+  let batchSize: number | undefined;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--namespace":
+        namespaces.push(requireValue(argv, ++i, "--namespace"));
+        break;
+      case "--table":
+        tables.push(requireValue(argv, ++i, "--table"));
+        break;
+      case "--reason": {
+        const value = requireValue(argv, ++i, "--reason");
+        if (
+          value !== "missing" &&
+          value !== "model_drift" &&
+          value !== "source_drift"
+        ) {
+          throw new Error(
+            `unknown reason '${value}'; valid: missing, model_drift, source_drift`,
+          );
+        }
+        reasons.push(value);
+        break;
+      }
+      case "--batch-size":
+        batchSize = Number.parseInt(
+          requireValue(argv, ++i, "--batch-size"),
+          10,
+        );
+        break;
+      case "--global":
+        global = true;
+        break;
+      case "--dry-run":
+        dryRun = true;
+        break;
+      default:
+        throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  if (global && namespaces.length > 0) {
+    throw new Error(
+      "--global and --namespace are mutually exclusive; pick one scope explicitly",
+    );
+  }
+  if (!global && namespaces.length === 0) {
+    throw new Error(
+      "a scope is REQUIRED: pass --namespace <ns> (repeatable) or --global. There is no unscoped default.",
+    );
+  }
+
+  for (const table of tables) {
+    if (!EMBEDDING_TARGET_NAMES.includes(table)) {
+      throw new Error(
+        `unknown table '${table}'; EMBEDDING_TARGETS declares: ${EMBEDDING_TARGET_NAMES.join(", ")}`,
+      );
+    }
+  }
+
+  return {
+    scope: global ? { global: true } : { namespaces },
+    tables: tables.length > 0 ? tables : undefined,
+    batchSize:
+      batchSize == null || Number.isNaN(batchSize) ? undefined : batchSize,
+    reasons: reasons.length > 0 ? reasons : undefined,
+    dryRun,
+  };
+}
+
+function requireValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index];
+  if (value == null || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+if (import.meta.main) {
+  let options: RepairRunOptions;
+  try {
+    options = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(
+      `repair-embeddings: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
+
+  // Pool lifecycle belongs to the entrypoint, matching scripts/backfill.ts.
+  const pool = createPool();
+  try {
+    const summary = await repairAll(pool, options);
+    for (const { table, error } of summary.tableErrors) {
+      console.log(`FAILED TABLE ${table}: ${error}`);
+    }
+    console.log(
+      `repair-embeddings done: repaired=${summary.repaired} retryable=${summary.retryableFailures} permanent=${summary.permanentFailures} failedTables=${summary.tableErrors.length}`,
+    );
+    await pool.end();
+    process.exit(
+      summary.permanentFailures > 0 || summary.tableErrors.length > 0 ? 1 : 0,
+    );
+  } catch (err) {
+    logger.error("repair_embeddings_fatal", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    await pool.end().catch(() => {});
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## What this is

Issue #724 item 1 — rows captured 2026-08-14..2026-08-17 stored but not
embedded/indexed. This PR carries the red-first done-means gate **and the fix**:
`scripts/repair-embeddings.ts`, the bulk caller the embedding-repair primitive
never had.

The window backlog is drained: eligible-but-unembedded `ob_session_lanes` went
**549 → 0**, and the gate moved from exit 1 to exit 0.

## The premise, as measured

The lane brief located the backlog in `ob_session_events`. Measured against the
live dogfood database (RUNNING, observed this session), it is not there:

- `ob_session_events`, window, namespace `rico`: **55 rows, 55 embedded**, zero
  NULL embeddings, `embedded_at - created_at` max lag −0.0008s — embedding is
  synchronous on that write path.
- The window gap was in `ob_session_lanes`: **2 of 2 eligible rows unembedded**
  (549 all-time eligible-but-unembedded across 12 namespaces).

So the brief's shape is **killed**; the invariant it reached for is what the gate
asserts and what the fix restores.

## Root cause — a design boundary, not a broken worker

Measured before touching anything, because the lane asked whether the restored
worker drains on its own. **It does not:**

| Observation | Result |
| --- | --- |
| Eligible-but-unembedded `ob_session_lanes` at T0 | 549 |
| Same count 4 minutes later | 549 |
| `maintenance_jobs` rows updated in the preceding 10 min | 0 |
| `embedding.repair` jobs ever recorded | 0 |

`docs/embedding-repair.md` ("Server-owned runtime and enqueue boundary") states
the boundary outright: `src/maintenance-bootstrap.ts` starts the
`embedding.repair` runner, but the bootstrap **"invents no namespace and enqueues
no job"** — enqueue is deliberately an explicit, auth-scoped CALLER boundary.

Nothing occupied that caller position for a bulk historical backlog:
`src/maintenance-sweep.ts` enqueues only `memory.distill` and graph-derivation,
and `scripts/backfill.ts` covers only the five original domain tables, which
excludes `ob_session_lanes`. The runner was healthy and correctly idle.

## The fix — smallest thing that rides the existing path

`scripts/repair-embeddings.ts` adds no pipeline, no table, and no SQL. It loops
the existing bulk primitive whose own docstring says it is for
"scripts/backfill-style bulk runs":

- `src/embedding-repair.ts:682` `repairStaleBatch(...)` — the bulk primitive.
- `src/embedding-targets.ts:326` `EMBEDDING_TARGET_NAMES` — the registry, read at
  runtime; a second hand-maintained copy is the #433 defect class.
- `src/embedding.ts` `generateEmbeddingWithMetadata`, `src/db/pool.ts`
  `createPool()` — the same provider and pool the server uses.

Every safety property is the primitive's, inherited unchanged: namespace-bound
reads *and* guarded writes, embeddings generated outside locks, idempotent
convergence, retryable-vs-permanent classification, content-free logging. Scope
is mandatory — `--namespace <ns>` or the separately named `--global`.

Two behaviors are measurement-driven, not preference:

**Selection asks for `missing` alone.** `buildSelection`
(`src/embedding-repair.ts:250`) ORs every reason into one *unordered*
`SELECT ... LIMIT n`, and the `source_drift` arm matches rows that already have
an embedding. Observed: all-reasons `limit=500` returned 100 mixed candidates
while 549 rows sat unembedded, and with no `ORDER BY` repeated batches need never
converge. Restricting to `missing` makes every selected row repairable, which is
what makes `repaired === 0` a truthful stop condition. Drift repair stays the
queue handler's job.

**A per-table failure no longer aborts the run.** The first `--global` run died on
a leaked test fixture live on the dogfood database: a `BEFORE UPDATE` trigger
`dream_bulk_release_trigger` on `thoughts` that RAISEs on every update, from
`src/tools/__tests__/bulk-set-tier.pg.test.ts` (#613 fixture-leakage class). This
PR does **not** drop it — destructive DDL is out of lane scope — it only refuses
to let one table hide the others' backlogs, and reflects it in the exit code.

## Run result

`bun run scripts/repair-embeddings.ts --global` — **1,627 rows repaired**:
decisions 1064, `ob_session_lanes` 489, `ob_session_events` 62, `ob_entities` 12;
relationships/projects already clean. `thoughts` and `sessions` aborted on the
two pre-existing defects noted below.

## Verification

- Done-means: scripts/done-means/724-backlog-recallable.sh

**RED**, before the run: **exit 1** — clause 1 FAIL (`ob_session_lanes` 2 of 2
eligible window rows unembedded), clause 2 PASS (keyword=1 semantic=16), clause 3
control PASS (keyword=1 semantic=25). A passing control with a failing clause 1 is
what makes the red valid. Exit 3 separately confirmed against an unreachable
database.

**GREEN**, after the run: **exit 0** — all three clauses PASS, `unembedded total:
0` across 101 eligible window rows, `ob_session_lanes: 0 of 2 ... clean`.

Also: `bunx tsc --noEmit` clean; `bun run test:isolated
src/embedding-repair.test.ts src/embedding-targets.test.ts` — 76 pass, 0 fail.

## Critical Self-Review

- Highest-risk behavior: a bulk loop writing embeddings across every table under `--global`. Mitigated by delegating every write to the existing guarded primitive (no SQL is written here), by a mandatory explicit scope with no unscoped default, by a dry-run mode proven to mutate nothing (549 unchanged after a dry run), and by a per-table batch bound so a non-converging table cannot spin.
- Assumptions that could be wrong: that `missing` is the right reason set for a bulk drain. If a future backlog is drift-shaped rather than missing-shaped, this CLI will not see it and the queue handler must; `--reason` is exposed for that, but the default deliberately does not chase drift.
- Missing/weak tests: the CLI itself has no unit test — it is evidenced by an observed red-to-green transition on the real database plus the primitive's own 76 passing tests. `repairAll` and `parseArgs` are exported specifically so a test can drive them with a fake `db`/`embedFn`; that test is not written here.
- Security/permission risk: namespace scope is mandatory and validated before any query, `--global` and `--namespace` are mutually exclusive so a scope cannot be silently widened, and `--table` is checked against the registry allowlist. All isolation predicates are the primitive's, bound on both read and guarded write.
- Migration/deploy risk: none. No schema change, no migration, no service or launchd change. The CLI is run by hand and nothing schedules it.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, REST surface, or Python client is touched, so `docs/downstream-rollout.md` classification is not-applicable.
- Rollback/cleanup concern: the embedding writes are not reversible by removing the file, but they are convergent and idempotent — re-running with unchanged source yields the identical vector/hash/model. Rows that had no embedding now have one; nothing was overwritten, because `missing` selects only NULL-embedding rows.
- Fixes made before PR: the reason-set narrowing and the per-table fault isolation, both after observing real failures (a non-converging all-reasons batch, and a whole `--global` run killed by one poisoned table).
- Known residual risk: two tables did not drain and are NOT fixed here — the leaked `dream_bulk_release_trigger` blocks 1,297 `thoughts` rows, and `idx_sessions_content_hash` collisions block 11,166 `sessions` rows. Both need their own issues. Nothing schedules this CLI, so an empty enqueue boundary can produce the same backlog again. The gate counts rows, so a row carrying a wrong vector still passes clause 1. Attribution of the backlog to the nats-worker outage remains unverified.
- SME review-memory update: [ ] docs/sme/ updated [x] not applicable because: the reusable findings here are recorded in the commit message, the PR body, and `_plans/worklog/lane-724-backlog-reembed.md` for the lane-contract harvest; the two blocked tables are being filed as their own issues rather than as reviewer-lane entries.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] linked below [ ] not applicable because: n/a
  - The `--global` run against the live dogfood database repaired 1,627 rows across five tables (counts quoted above), and the done-means gate's own read-only probe of that database moved from exit 1 to exit 0 with all three clauses passing.

Refs #724
