### PR TITLE
fix(done-means): the verify-lane skip guard must be EARNED, not inherited (#721)

### DIFF
--- a/scripts/done-means/721-verify-lane-guard-earned.sh
+++ b/scripts/done-means/721-verify-lane-guard-earned.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for #721 — "merge-gate-and-verify-lane.sh records its only
+# live clause as PASS when any non-empty MGVL_IN_VERIFY_LANE is inherited."
+#
+#   bash scripts/done-means/721-verify-lane-guard-earned.sh
+#
+# ---------------------------------------------------------------------------
+# The defect
+# ---------------------------------------------------------------------------
+# Family B, from the 2026-08-10 gate-layer audit (docs/gate-layer-audit-2026-08-10.md):
+# a gate letting its ENVIRONMENT decide the verdict instead of the code. Same
+# shape as #705 (inherited env) and CLOSED #483 (inherited GIT_DIR).
+#
+# merge-gate-and-verify-lane.sh clause 9 is the ONLY clause that exercises
+# verify-lane end to end against a real PR, worktree and receipt. Before this
+# fix it skipped on the mere PRESENCE of MGVL_IN_VERIFY_LANE and recorded that
+# skip as PASS:
+#
+#   $ MGVL_IN_VERIFY_LANE=fabricated-value bash scripts/done-means/merge-gate-and-verify-lane.sh
+#   CLAUSE 9 (LIVE: ...): PASS — SKIP-BY-GUARD: ... (MGVL_IN_VERIFY_LANE=fabricated-value)
+#   $ echo $?
+#   0
+#
+# Full green, exit 0, the live proof never executed. A stale export, a CI env
+# leak, or a value set by hand turns the live clause off and the transcript a
+# controller pastes into a PR body is indistinguishable from a genuine run.
+#
+# The GUARD ITSELF IS RIGHT — the recursion it prevents is measured (331
+# worktrees, 2026-08-08). The defect is that the guard is ASSERTED rather than
+# EARNED, and that a skip is recorded as a pass.
+#
+# ---------------------------------------------------------------------------
+# What "earned" means here
+# ---------------------------------------------------------------------------
+# verify-lane.ts:479-480 sets BOTH markers together, and they are structured:
+#
+#   MGVL_IN_VERIFY_LANE  = `pr-${args.pr}`
+#   MGVL_VERIFY_LANE_PRS = [...ancestry, args.pr].join(",")
+#
+# Only the real verify-lane path can produce that PAIR in agreement. So the
+# guard re-derives the claim from the value instead of trusting its presence:
+# the marker must match `pr-<n>` AND `<n>` must appear in the ancestry list.
+# Anything else is a POLLUTED ENVIRONMENT — a HARNESS-ERROR (exit 3), not a
+# free pass, because the operator needs to know their shell is lying to their
+# gates rather than have a gate quietly accommodate it.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+#   1  fabricated MGVL_IN_VERIFY_LANE => NOT a clean exit 0. This single
+#      command is the whole red/green of the issue.
+#   2  ... and the refusal is a HARNESS-ERROR naming the variable and the
+#      shape it expected — never a silent pass and never a bare failure.
+#   3  a SHAPE-VALID marker with NO matching ancestry (pr-999 + empty
+#      MGVL_VERIFY_LANE_PRS) is ALSO refused. Without this, "validation" is
+#      satisfiable by anyone who reads the source and types `pr-1`.
+#   4  a GENUINE nested pair (pr-<n> + <n> in the ancestry) still skips
+#      politely, records SKIP (not PASS), and does not recurse.
+#   5  a skipped live clause does NOT report a clean all-passed exit 0, and
+#      the summary SAYS the live clause is unproven this run —
+#      issue-resolution-artifacts.sh's "skipped is not passed" convention.
+#   6  the PASS verdict is no longer reachable for clause 9 without the live
+#      run: the string SKIP-BY-GUARD and the token PASS are not recorded
+#      together anywhere in the subject.
+#   7  SIBLING SWEEP (the pattern, not the instance): MGVL_LIVE_PR — the other
+#      inherited variable that steers the live clause — is validated as a
+#      number and refused when it names the PR that contains this check.
+#
+# Clauses 1-5 drive THE REAL INVOCATION PATH: they execute the subject script
+# itself with the environment under test, exactly as the issue's reproduction
+# does. Nothing here calls an --explain seam or a helper function (round 28's
+# rule), and the fixture environment is the very thing that expresses the
+# defect (round 30's rule) — an inherited variable is the input under test, so
+# setting it IS the fixture.
+#
+# COST NOTE, announced rather than silent: clauses 1-5 each run the subject to
+# completion. On the SKIP paths (2, 3, 4, 5) the live clause does not fire, so
+# no PR is created. Clause 1 pre-#721 would ALSO skip; post-fix it refuses at
+# exit 3 BEFORE the live clause, so this check never creates a throwaway PR.
+# That is deliberate: a done-means check for a guard must not itself depend on
+# network mutation.
+#
+# Exit 0 only when every clause passes. Exit 3 is a harness error (missing
+# tool), which is NOT a fail of the thing under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SUBJECT="$REPO_ROOT/scripts/done-means/merge-gate-and-verify-lane.sh"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bash >/dev/null 2>&1 || fail_hard "bash not on PATH"
+command -v rg   >/dev/null 2>&1 || fail_hard "rg not on PATH"
+[ -r "$SUBJECT" ] || fail_hard "no subject script at $SUBJECT"
+
+FAILURES=0
+pass() { printf 'PASS  %s\n' "$*"; }
+fail() { printf 'FAIL  %s\n' "$*"; FAILURES=$((FAILURES + 1)); }
+
+# Run the subject with a controlled environment. Sets S_OUT and S_EXIT.
+#
+# MGVL_LIVE_PR is cleared on every invocation. It is an operator override that
+# redirects the live clause's subject, and inheriting one from the controller's
+# shell would make these clauses measure a different PR than they name. Cleared
+# deliberately and announced here, per "nothing is adjusted silently".
+S_OUT=""
+S_EXIT=0
+run_subject() {
+  local marker="$1" ancestry="$2"
+  S_OUT="$(
+    MGVL_IN_VERIFY_LANE="$marker" \
+    MGVL_VERIFY_LANE_PRS="$ancestry" \
+    MGVL_LIVE_PR="" \
+      bash "$SUBJECT" 2>&1
+  )"
+  S_EXIT=$?
+}
+
+# ===========================================================================
+# CLAUSE 1 — the issue's reproduction. A fabricated value must NOT yield a
+# clean exit 0. This is the whole red/green.
+# ===========================================================================
+run_subject "fabricated-value" ""
+if [ "$S_EXIT" -eq 0 ]; then
+  fail "(1) MGVL_IN_VERIFY_LANE=fabricated-value still exits 0 — #721 live: the live clause is disabled by an inherited variable and the run reads as full green"
+else
+  pass "(1) MGVL_IN_VERIFY_LANE=fabricated-value no longer exits 0 (exit=$S_EXIT)"
+fi
+
+# ===========================================================================
+# CLAUSE 2 — and it refuses OUT LOUD, as a harness error, naming the variable
+# and the shape expected. A bare non-zero would leave the operator unable to
+# tell a polluted environment from a genuine regression — the #722 lesson
+# ("I could not parse the output" and "the subject regressed" are different
+# defects with different owners).
+# ===========================================================================
+if [ "$S_EXIT" -ne 3 ]; then
+  fail "(2) fabricated marker exited $S_EXIT, not 3 — a polluted environment must be a HARNESS-ERROR, distinct from a clause failure"
+elif ! printf '%s' "$S_OUT" | rg -qF -- 'MGVL_IN_VERIFY_LANE'; then
+  fail "(2) refused but never names the variable that caused it"
+elif ! printf '%s' "$S_OUT" | rg -qF -- 'fabricated-value'; then
+  fail "(2) refused but never quotes the offending value the operator must go find"
+elif ! printf '%s' "$S_OUT" | rg -qF -- 'pr-'; then
+  fail "(2) refused but never states the pr-<n> shape it required"
+else
+  pass "(2) fabricated marker is a HARNESS-ERROR (exit 3) naming the variable, the value, and the expected shape"
+fi
+
+# ===========================================================================
+# CLAUSE 3 — the ANTI-GUESS clause. A shape-valid marker with no corroborating
+# ancestry must still be refused. Without this, the "validation" is a password
+# printed in the source: anyone (or any stale export) spelling `pr-1` gets the
+# same free pass the old guard gave to `fabricated-value`.
+# ===========================================================================
+run_subject "pr-999" ""
+if [ "$S_EXIT" -eq 0 ]; then
+  fail "(3) a shape-valid marker with EMPTY ancestry exited 0 — the guard checks spelling, not provenance; pr-<n> is now the new magic word"
+elif [ "$S_EXIT" -ne 3 ]; then
+  fail "(3) shape-valid-but-uncorroborated marker exited $S_EXIT, not 3 — it is the same polluted-environment class as clause 2"
+elif ! printf '%s' "$S_OUT" | rg -qF -- 'MGVL_VERIFY_LANE_PRS'; then
+  fail "(3) refused but never names the ancestry variable that failed to corroborate it"
+else
+  pass "(3) shape-valid marker with no matching ancestry is refused (exit 3), naming the ancestry variable"
+fi
+
+# ===========================================================================
+# CLAUSE 4 — POSITIVE CONTROL. A genuine nested run — the exact pair
+# verify-lane.ts:479-480 exports together — must still skip politely rather
+# than recursing. A guard that refuses everything is not a fix; it just moves
+# the 331-worktree recursion into a permanent refusal.
+# ===========================================================================
+run_subject "pr-4242" "4242"
+if [ "$S_EXIT" -eq 3 ]; then
+  fail "(4) a GENUINE nested pair was refused as a harness error (exit 3) — the guard now blocks the legitimate nested run it exists to permit"
+elif ! printf '%s' "$S_OUT" | rg -qF -- 'SKIP-BY-GUARD'; then
+  fail "(4) genuine nested pair did not report SKIP-BY-GUARD (exit=$S_EXIT) — it either recursed or failed for another reason"
+elif ! printf '%s' "$S_OUT" | rg -qF -- 'pr-4242'; then
+  fail "(4) skipped but never echoes the marker it honoured"
+else
+  pass "(4) genuine nested pair (pr-4242 + ancestry 4242) skips politely without recursing"
+fi
+
+# ===========================================================================
+# CLAUSE 5 — A SKIP IS NOT A PASS. Same run as clause 4. The exit status must
+# distinguish "all clauses passed" from "passed with the live clause skipped",
+# and the summary must SAY the live clause is unproven — the convention
+# issue-resolution-artifacts.sh already follows in this same directory.
+# ===========================================================================
+if [ "$S_EXIT" -eq 0 ]; then
+  fail "(5) a run whose live clause was SKIPPED still exits 0 — indistinguishable from a run that genuinely exercised verify-lane, which is the #721 defect surviving in its second form"
+elif ! printf '%s' "$S_OUT" | rg -qi -e 'skipped is not passed|unproven'; then
+  fail "(5) exit=$S_EXIT but the summary never says the skipped live clause leaves verify-lane unproven this run"
+elif ! printf '%s' "$S_OUT" | rg -q -e 'CLAUSE 9 .*: *SKIP'; then
+  fail "(5) clause 9 is not recorded with a SKIP verdict — a distinct verdict is what stops a skip reading as a pass"
+else
+  pass "(5) skipped live clause exits non-zero ($S_EXIT) and the summary states verify-lane is unproven this run"
+fi
+
+# ===========================================================================
+# CLAUSE 6 — the PASS verdict is structurally unreachable for a skip. Asserted
+# on the SOURCE because clauses 1-5 can only sample the paths they run: a
+# lingering `record 9 PASS "SKIP-...` on some other branch would be invisible
+# to them and would reintroduce the exact defect.
+# ===========================================================================
+if rg -q -e 'record +9 +PASS +"SKIP' "$SUBJECT"; then
+  fail "(6) the subject still records clause 9 PASS on a SKIP path — the skip-reported-as-pass defect is live in the source"
+else
+  pass "(6) no 'record 9 PASS \"SKIP...' remains in the subject — a skip cannot be recorded as a pass"
+fi
+
+# ===========================================================================
+# CLAUSE 7 — SIBLING SWEEP. #721 named ONE clause; the audit's lesson is that
+# the family reproduces through new surfaces, so fix the PATTERN.
+#
+# MGVL_LIVE_PR is the file's other inherited variable that steers the live
+# clause — it chooses the clause's SUBJECT. Pre-fix it was announced but never
+# validated, so a stale export sent the live proof at an arbitrary PR, and the
+# file's own comments warn that pointing it at the PR containing this check is
+# the measured 331-worktree recursion. An announcement is not a check.
+# ===========================================================================
+SWEEP_OK=1
+if ! rg -q -e 'MGVL_LIVE_PR' "$SUBJECT"; then
+  fail "(7) MGVL_LIVE_PR no longer appears in the subject — this clause has lost its subject and must be re-aimed, not deleted"
+  SWEEP_OK=0
+else
+  # NOTE, self-caught while writing this clause and recorded rather than
+  # quietly corrected: the first spelling was
+  #   rg -q -e 'MGVL_LIVE_PR' -A 12 "$SUBJECT" | rg -q '\[0-9\]'
+  # which ALWAYS reports the defect, because `-q` makes ripgrep exit on the
+  # first match and print NOTHING — the second rg reads an empty stream. It
+  # produced a confident, specific, FALSE claim ("used without any numeric
+  # validation") against a subject that had just been fixed. Round 30's family:
+  # a broken query is indistinguishable from a real finding, and it pointed at
+  # the alarming direction. `-q` never feeds a pipe.
+  SWEEP_WINDOW="$(rg -e 'MGVL_LIVE_PR' -A 12 "$SUBJECT")"
+
+  # POSITIVE CONTROL for the window itself, so a malformed extraction fails
+  # loudly instead of silently confirming an absence (round 30's rule for any
+  # check whose verdict authorises a conclusion).
+  if ! printf '%s' "$SWEEP_WINDOW" | rg -qF -- 'MGVL_LIVE_PR'; then
+    fail "(7) the sweep window is empty or malformed — this clause cannot see its subject, which is a broken query, NOT evidence the validation is missing"
+    SWEEP_OK=0
+  else
+    # It must be validated as a number, not merely interpolated into a message.
+    if ! printf '%s' "$SWEEP_WINDOW" | rg -q -e '\[0-9\]\+|\[\[:digit:\]\]'; then
+      fail "(7) MGVL_LIVE_PR is used without any numeric validation — an inherited non-numeric value reaches gh unchecked"
+      SWEEP_OK=0
+    fi
+    # ... and self-targeting must be REFUSED, not merely warned about. The
+    # pre-#721 file already "announced loudly" that the operator must not point
+    # this at its own PR; an announcement is not a check.
+    if ! printf '%s' "$SWEEP_WINDOW" | rg -qi -e 'fail_hard'; then
+      fail "(7) nothing REFUSES an MGVL_LIVE_PR that names the PR containing this check — the measured 331-worktree recursion stays reachable by an inherited value, with only a printed warning in front of it"
+      SWEEP_OK=0
+    fi
+  fi
+fi
+[ "$SWEEP_OK" -eq 1 ] && pass "(7) MGVL_LIVE_PR is validated (numeric, and refused when it self-targets), not merely announced"
+
+printf '\n'
+if [ "$FAILURES" -eq 0 ]; then
+  printf '=== RESULT: PASS — the verify-lane skip guard is EARNED (structured marker corroborated by ancestry), a skip is recorded as SKIP and never PASS, a skipped live clause does not exit 0, a genuine nested run still skips politely, and the sibling MGVL_LIVE_PR surface is validated rather than trusted ===\n'
+  exit 0
+fi
+printf '=== RESULT: FAIL (%d failing clause(s)) ===\n' "$FAILURES"
+exit 1

--- a/scripts/done-means/merge-gate-and-verify-lane.sh
+++ b/scripts/done-means/merge-gate-and-verify-lane.sh
@@ -80,8 +80,20 @@
 # Verdict convention matches pr-body-gate.ts: exit 2 = blocked with the reason
 # on stderr, exit 0 = allowed.
 #
-# Exit 0 only when every clause passes. Exit 3 is a harness error (missing
-# tool, unreachable gh), which is NOT a fail of the thing under test.
+# Exit 0 only when every clause passes AND nothing was skipped.
+#   0  every clause passed; the live clause ran
+#   1  at least one clause FAILED
+#   3  HARNESS-ERROR — missing tool, unreachable gh, or a POLLUTED ENVIRONMENT
+#      (an MGVL_IN_VERIFY_LANE / MGVL_LIVE_PR value that no real verify-lane run
+#      produces). Not a fail of the thing under test; the inputs are untrusted.
+#   4  every clause passed BUT the live clause was legitimately SKIPPED because
+#      this run is nested inside verify-lane. Skipped is not passed: verify-lane
+#      is UNPROVEN by this transcript. Distinct from 1 so a nested run is never
+#      misread as a regression, and non-zero so it is never misread as proof.
+#
+# Before #721 the nested/polluted paths both returned 0 with clause 9 recorded
+# PASS, so `MGVL_IN_VERIFY_LANE=anything` produced a full green in which the
+# only live proof never executed.
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -419,7 +431,13 @@ else
   # Clearing it is correct rather than a workaround: this clause spawns a
   # SYNTHETIC verify-lane against a stubbed PR #999 that runs no check and
   # cannot recurse, so the guard has nothing to protect here. Clause 9 is where
-  # nesting actually matters, and it still honours MGVL_IN_VERIFY_LANE.
+  # nesting actually matters, and it still honours MGVL_IN_VERIFY_LANE — but
+  # since #721 only when the marker is CORROBORATED by MGVL_VERIFY_LANE_PRS,
+  # never on its mere presence.
+  #
+  # Note this clearing is the DEFENSIVE use of the same variables: it BREAKS
+  # inheritance rather than trusting it, and says why in the paragraph above.
+  # That is the opposite of the #721 defect and is left as it is.
   V_OUT="$(
     PATH="$STUB_DIR:$PATH" MG_FIXTURE_DIR="$FIXTURES/no-receipt" MG_GH_BROKEN=0 \
       MGVL_VERIFY_LANE_PRS="" MGVL_IN_VERIFY_LANE="" \
@@ -451,12 +469,97 @@ else
   # exercise, and report that honestly instead of recursing. The outer run is
   # the one that proves clause 9; a nested run skipping it is not a silent pass,
   # because the reason is printed and the clause is marked SKIP-BY-GUARD.
-  if [ -n "${MGVL_IN_VERIFY_LANE:-}" ]; then
-    record 9 PASS "SKIP-BY-GUARD: already running inside verify-lane (MGVL_IN_VERIFY_LANE=${MGVL_IN_VERIFY_LANE}); re-entering would recurse without bound. The outer verify-lane run is the live proof."
+  #
+  # THE GUARD MUST BE EARNED, NOT ASSERTED (#721; family B of the 2026-08-10
+  # gate-layer audit — a gate letting its ENVIRONMENT decide the verdict).
+  # Until this fix the condition tested the variable's PRESENCE, so
+  #
+  #     MGVL_IN_VERIFY_LANE=fabricated-value bash <this file>
+  #
+  # recorded clause 9 as PASS and exited 0: a full-green transcript in which the
+  # only live proof never ran. A stale export, a CI env leak, or a hand-set
+  # value silently disabled the one clause that exercises verify-lane end to
+  # end, and the output was indistinguishable from a genuine run.
+  #
+  # This does NOT weaken the guard, and the recursion it prevents is real (331
+  # worktrees, measured above). The authoritative guard remains verify-lane's
+  # own depth counter (verify-lane.ts:287-330) — deliberately in the spawning
+  # process because a guard living in the repo cannot protect a run that checks
+  # out an older commit of that repo. THIS clause is the POLITE layer
+  # (verify-lane.ts:283-286): it exists so a genuinely nested run reports
+  # legibly instead of being refused. A polite layer that any string can
+  # trigger is not politeness, it is an off switch.
+  #
+  # verify-lane.ts:479-480 sets BOTH markers together, and both are STRUCTURED:
+  # MGVL_IN_VERIFY_LANE=`pr-<n>` and MGVL_VERIFY_LANE_PRS=<ancestry including n>.
+  # Only the real path produces that pair in agreement, so the claim is
+  # RE-DERIVED from the values instead of inferred from their presence: the
+  # marker must parse as pr-<n> AND <n> must appear in the ancestry list.
+  #
+  # Corroboration is the whole point. Validating the SHAPE alone would only
+  # replace one magic word with another — anyone reading this source could type
+  # `pr-1` and get the free pass `fabricated-value` used to get. The ancestry is
+  # maintained by the spawning process, so a fabricated marker cannot satisfy it
+  # without already knowing which PR is genuinely being verified.
+  #
+  # A marker failing either test is a POLLUTED ENVIRONMENT: exit 3
+  # (HARNESS-ERROR via fail_hard), never a pass and never an ordinary clause
+  # failure. The operator's shell is lying to their gates and needs to be told,
+  # not accommodated. #722's lesson: "I cannot trust my inputs" and "the subject
+  # regressed" are different defects with different owners.
+  MGVL_MARKER="${MGVL_IN_VERIFY_LANE:-}"
+  MGVL_SKIPPED=0
+  if [ -n "$MGVL_MARKER" ]; then
+    MGVL_PR_N="${MGVL_MARKER#pr-}"
+    if [ "$MGVL_PR_N" = "$MGVL_MARKER" ] || ! printf '%s' "$MGVL_PR_N" | rg -q '^[0-9]+$'; then
+      fail_hard "MGVL_IN_VERIFY_LANE is set to \"$MGVL_MARKER\", which is not the pr-<n> shape verify-lane produces (scripts/verify-lane.ts:479 sets MGVL_IN_VERIFY_LANE=pr-<number>).
+  This is a POLLUTED ENVIRONMENT, not a free pass. A non-empty value here used to
+  skip the ONE clause that exercises verify-lane end to end and record that skip as
+  PASS, so the run reported full green with nothing live proven (#721).
+  Clear it and re-run:  MGVL_IN_VERIFY_LANE= MGVL_VERIFY_LANE_PRS= bash $0"
+    fi
+    MGVL_ANCESTRY=",$(printf '%s' "${MGVL_VERIFY_LANE_PRS:-}" | tr -d '[:space:]'),"
+    case "$MGVL_ANCESTRY" in
+      *",$MGVL_PR_N,"*) MGVL_SKIPPED=1 ;;
+      *)
+        fail_hard "MGVL_IN_VERIFY_LANE=\"$MGVL_MARKER\" has the right shape but is NOT corroborated by MGVL_VERIFY_LANE_PRS=\"${MGVL_VERIFY_LANE_PRS:-}\" — PR $MGVL_PR_N is absent from that ancestry.
+  verify-lane sets both together (scripts/verify-lane.ts:479-480), so a marker
+  without its ancestry did not come from a real verify-lane run. Accepting the
+  shape alone would make \"pr-<n>\" the new magic word that turns the live clause
+  off, which is #721 with one extra step.
+  Clear both and re-run:  MGVL_IN_VERIFY_LANE= MGVL_VERIFY_LANE_PRS= bash $0"
+        ;;
+    esac
+  fi
+
+  if [ "$MGVL_SKIPPED" -eq 1 ]; then
+    record 9 SKIP "SKIP-BY-GUARD: genuinely nested inside verify-lane (MGVL_IN_VERIFY_LANE=${MGVL_MARKER}, corroborated by MGVL_VERIFY_LANE_PRS=${MGVL_VERIFY_LANE_PRS:-}); re-entering would recurse without bound. The OUTER verify-lane run is the live proof — THIS run proves nothing about verify-lane."
   elif [ "$CONTROL_OK" -ne 1 ]; then
     record 9 FAIL "CONTROL clause failed — refusing to bank a live verdict against a dead gh"
   else
+    # SIBLING SWEEP (#721 fixes the PATTERN, not only the reported instance).
+    # MGVL_LIVE_PR is this file's OTHER inherited variable that steers the live
+    # clause: it chooses the clause's SUBJECT. It was announced (below) but
+    # never validated, which is the same family in a quieter form — an
+    # announcement describes an input, it does not check one. An inherited or
+    # stale value silently re-aimed the live proof at an arbitrary PR, and a
+    # non-numeric value would have been handed straight to `gh`.
+    #
+    # Two validations, both refusing rather than adjusting:
+    #   (a) numeric, because everything downstream treats it as a PR number;
+    #   (b) NOT the PR that contains this check — that self-targeting is the
+    #       measured 331-worktree recursion this whole guard exists to stop,
+    #       and the operator override is precisely the route back into it.
     LIVE_PR="${MGVL_LIVE_PR:-}"
+    if [ -n "$LIVE_PR" ]; then
+      printf '%s' "$LIVE_PR" | rg -q '^[0-9]+$' \
+        || fail_hard "MGVL_LIVE_PR=\"$LIVE_PR\" is not a PR number. It selects the SUBJECT of the live clause, so an inherited or mistyped value silently re-aims the only live proof in this check. Clear it to use the purpose-made throwaway PR:  MGVL_LIVE_PR= bash $0"
+      SELF_PR="$(gh pr list --state open --json number,headRefName -q \
+        ".[] | select(.headRefName == \"$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null)\") | .number" 2>/dev/null | head -1)"
+      if [ -n "$SELF_PR" ] && [ "$SELF_PR" = "$LIVE_PR" ]; then
+        fail_hard "MGVL_LIVE_PR=$LIVE_PR is the PR that CONTAINS this check (branch $(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)). Verifying it makes verify-lane run this file, whose live clause verifies the same PR again — the unbounded recursion measured at 331 worktrees on 2026-08-08. Refusing rather than self-targeting; clear MGVL_LIVE_PR to use the purpose-made throwaway PR."
+      fi
+    fi
     CREATED_PR=""
     CREATED_BRANCH=""
 
@@ -621,15 +724,32 @@ label_for() {
   esac
 }
 
+# SKIP IS A THIRD VERDICT, NOT A FLAVOUR OF PASS (#721). A skipped clause
+# proves nothing about its subject, so it may not count toward "every clause
+# passed" and may not produce exit 0. `issue-resolution-artifacts.sh` in this
+# same directory established the convention — it counts skips and prints
+# "skipped is not passed; what they cover is unproven this run" — and this file
+# now follows it rather than laundering a skip into a green summary.
 ALL_PASS=1
+SKIPS=0
 for entry in "${CLAUSES[@]}"; do
   id="${entry%%|*}"
   rest="${entry#*|}"
   status="${rest%%|*}"
   evidence="${rest#*|}"
   printf 'CLAUSE %s (%s): %s — %s\n' "$id" "$(label_for "$id")" "$status" "$evidence"
-  [ "$status" = PASS ] || ALL_PASS=0
+  case "$status" in
+    PASS) ;;
+    SKIP) SKIPS=$((SKIPS + 1)) ;;
+    *) ALL_PASS=0 ;;
+  esac
 done
+
+if [ "$SKIPS" -gt 0 ]; then
+  printf '\nNOTE  %d clause(s) SKIPPED — skipped is not passed; what they cover is unproven this run.\n' "$SKIPS"
+  printf '      The LIVE verify-lane clause is the one that skips, so this transcript is NOT\n'
+  printf '      evidence that verify-lane works. Only an OUTER (non-nested) run proves it.\n'
+fi
 
 # Scratch fixtures are this script's own; retire them into the temp workspace
 # archive rather than deleting (AGENTS.md: the agent's cleanup verb is mv).
@@ -638,5 +758,15 @@ if mkdir -p "$ARCHIVE_DIR" 2>/dev/null; then
   mv "$SCRATCH" "$ARCHIVE_DIR/$(basename "$SCRATCH").$(date +%s)" 2>/dev/null
 fi
 
-[ "$ALL_PASS" -eq 1 ] && exit 0
+# Exit 0 means EVERY clause passed, with nothing skipped. A run whose live
+# clause was skipped exits 4 — non-zero, so no caller can mistake it for proof,
+# and distinct from 1 so a nested run is not misread as a genuine regression.
+# Before #721 this path returned 0 and the transcript was indistinguishable
+# from a run that had actually exercised verify-lane.
+if [ "$ALL_PASS" -eq 1 ] && [ "$SKIPS" -eq 0 ]; then
+  exit 0
+fi
+if [ "$ALL_PASS" -eq 1 ]; then
+  exit 4
+fi
 exit 1


### PR DESCRIPTION
## Summary

- `scripts/done-means/merge-gate-and-verify-lane.sh` clause 9 is the ONLY clause that exercises verify-lane end to end against a real PR, worktree and receipt. It skipped on the mere PRESENCE of `MGVL_IN_VERIFY_LANE` and recorded that skip as `PASS`, so `MGVL_IN_VERIFY_LANE=1 bash scripts/done-means/merge-gate-and-verify-lane.sh` exited **0 with every clause green while the live proof never executed**. A stale export or a CI env leak silently disabled the check's only live evidence, and the resulting transcript was indistinguishable from a genuine run. Family B of the 2026-08-10 gate-layer audit: a gate letting its ENVIRONMENT decide the verdict.
- The guard itself is correct and stays — the recursion it prevents is measured (331 worktrees, then 747 processes, 2026-08-08). The defect is that the guard was ASSERTED rather than EARNED.
- **The guard is now earned.** `scripts/verify-lane.ts:479-480` exports both markers together and both are structured (`MGVL_IN_VERIFY_LANE=pr-<n>`, `MGVL_VERIFY_LANE_PRS=<ancestry including n>`). The claim is now RE-DERIVED from the values instead of inferred from their presence: the marker must parse as `pr-<n>` AND `<n>` must appear in the ancestry. Shape alone is deliberately insufficient — validating spelling only would replace one magic word with another, since anyone reading the source could type `pr-1`. The ancestry is maintained by the spawning process, so a fabricated marker cannot satisfy it without already knowing which PR is genuinely under verification.
- **A skip is no longer a pass.** Clause 9 records `SKIP`, never `PASS`, and a run whose live clause was skipped exits **4** — non-zero so no caller can mistake it for proof, and distinct from 1 so a genuinely nested run is never misread as a regression. This adopts the convention `issue-resolution-artifacts.sh` already follows in the same directory ("skipped is not passed").
- **A polluted environment is exit 3 (HARNESS-ERROR)**, not an ordinary clause failure. Per #722's lesson, "I cannot trust my inputs" and "the subject regressed" are different defects with different owners; the refusal names the variable, quotes the offending value, states the expected shape, and prints the clearing command.
- **Sibling sweep — the pattern, not just the reported instance.** `MGVL_LIVE_PR`, this file's other inherited variable steering the live clause, chose the clause's SUBJECT and was announced but never validated. An announcement describes an input, it does not check one. It is now refused when non-numeric (an inherited value otherwise reached `gh` unchecked) and when it self-targets the PR containing this check — the precise route back into the measured 331-worktree recursion.
- New done-means check `scripts/done-means/721-verify-lane-guard-earned.sh` (7 clauses) drives the REAL invocation path, executing the subject with the environment under test rather than an `--explain` seam or helper function.

## Verification

- Done-means: scripts/done-means/721-verify-lane-guard-earned.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED-first, against the pre-fix subject at `afc5525` (`git checkout afc5525 -- scripts/done-means/merge-gate-and-verify-lane.sh`) — the defect reproduced live before any fix existed:

```
$ MGVL_IN_VERIFY_LANE=fabricated-value bash scripts/done-means/merge-gate-and-verify-lane.sh
CLAUSE 9 (LIVE: verify-lane runs a real PR check and posts a SHA-bearing receipt): PASS
  — SKIP-BY-GUARD: already running inside verify-lane (MGVL_IN_VERIFY_LANE=fabricated-value)
$ echo $?
0
```

Full green, exit 0, live clause never ran. The done-means check against that same pre-fix subject:

```
FAIL  (1) MGVL_IN_VERIFY_LANE=fabricated-value still exits 0 — #721 live
FAIL  (2) fabricated marker exited 0, not 3
FAIL  (3) a shape-valid marker with EMPTY ancestry exited 0
PASS  (4) genuine nested pair (pr-4242 + ancestry 4242) skips politely without recursing
FAIL  (5) a run whose live clause was SKIPPED still exits 0
FAIL  (6) the subject still records clause 9 PASS on a SKIP path
FAIL  (7) MGVL_LIVE_PR is used without any numeric validation
FAIL  (7) nothing REFUSES an MGVL_LIVE_PR that names the PR containing this check
=== RESULT: FAIL (7 failing clause(s)) ===
```

GREEN, same command against the fixed subject:

```
PASS  (1) MGVL_IN_VERIFY_LANE=fabricated-value no longer exits 0 (exit=3)
PASS  (2) fabricated marker is a HARNESS-ERROR (exit 3) naming the variable, the value, and the expected shape
PASS  (3) shape-valid marker with no matching ancestry is refused (exit 3), naming the ancestry variable
PASS  (4) genuine nested pair (pr-4242 + ancestry 4242) skips politely without recursing
PASS  (5) skipped live clause exits non-zero (4) and the summary states verify-lane is unproven this run
PASS  (6) no 'record 9 PASS "SKIP...' remains in the subject — a skip cannot be recorded as a pass
PASS  (7) MGVL_LIVE_PR is validated (numeric, and refused when it self-targets), not merely announced
=== RESULT: PASS ===  (exit 0)
```

The issue's own scenario, exported from a parent shell:

```
$ export MGVL_IN_VERIFY_LANE=1
$ bash scripts/done-means/merge-gate-and-verify-lane.sh ; echo $?
HARNESS-ERROR: MGVL_IN_VERIFY_LANE is set to "1", which is not the pr-<n> shape
verify-lane produces (scripts/verify-lane.ts:479 sets MGVL_IN_VERIFY_LANE=pr-<number>).
  This is a POLLUTED ENVIRONMENT, not a free pass. [...]
3
```

Control — the legitimate nested invocation still works and does not recurse:

```
$ MGVL_IN_VERIFY_LANE=pr-4242 MGVL_VERIFY_LANE_PRS=4242 bash .../merge-gate-and-verify-lane.sh ; echo $?
CLAUSE 9 (...): SKIP — SKIP-BY-GUARD: genuinely nested inside verify-lane [...]
NOTE  1 clause(s) SKIPPED — skipped is not passed; what they cover is unproven this run.
4
```

Two negative controls (SOP: inject a violation, confirm the check still fails), each restored afterwards:

1. Reintroduce `record 9 PASS "SKIP..."` → clause 6 FAILs, check exits 1.
2. Weaken the corroboration so any shape-valid marker is accepted — a change **invisible to clause 6's source regex** → clause 3 FAILs, check exits 1. This proves the behavioural and source clauses are independently load-bearing rather than redundant.

Ancestry-matching edge cases, verified live: `pr-42` with ancestry `142,7` is refused (exit 3 — no substring false-match), `pr-42` with `7,42` skips (exit 4), and whitespace `" 7 , 42 "` is normalised (exit 4). `MGVL_LIVE_PR="; rm -rf junk"` is refused at exit 3 before reaching `gh`.

Surrounding suite: `bunx tsc --noEmit` clean; `bash -n` parses every `scripts/done-means/*.sh`; `613-fixtures-torn-down.sh` and `637-gate-precision.sh` both exit 0. `636-neutrality.sh` FAILs on 5 tracked files — **pre-existing and byte-identical on `origin/wip/2026-08-07`** (verified by checking out the base and re-running); neither file changed here appears in its violation list. Python package is untouched by this change (shell-only diff), so its checks are not applicable.

## Critical Self-Review

- Highest-risk behavior: the exit-code contract change — a run with a skipped live clause now exits 4 where it previously exited 0. If any caller treated 0 as "passed", it would newly see a failure. Checked: `rg -l 'merge-gate-and-verify-lane'` finds only this file, the new check, a **comment-only** reference in `451-tiered-coverage.sh`, and two docs; `.github/` has no reference at all. No CI job or sibling check consumes the exit status, so the contract change breaks no caller. Second-order risk is a controller pasting an exit-4 transcript as evidence — mitigated because the summary prints an explicit NOTE that verify-lane is unproven in that run.
- Assumptions that could be wrong: (a) that `verify-lane.ts` is the only producer of these markers — verified by reading `scripts/verify-lane.ts:479-480`, the sole assignment site; (b) that the ancestry format is comma-joined PR numbers — verified at `verify-lane.ts:287-290` (the consumer splits on `,` and trims), so producer and consumer agree; (c) that the `pr-<n>` shape is stable — it is a template literal in the same file, and if it ever changes, clause 4's positive control fails loudly rather than silently admitting everything.
- Missing/weak tests: the check never exercises the genuine LIVE path end to end (a real PR + worktree + receipt), by deliberate design announced in the script's cost note — a done-means check for a guard must not itself depend on network mutation, and the live path is what an outer non-nested run proves. Consequently this PR does not re-prove clause 9's live behaviour; it proves the guard around it. Clause 6 is a source-text assertion and could be defeated by a differently-spelled reintroduction, which is exactly why clause 3 exists as an independent behavioural check — negative control 2 demonstrates that pairing works.
- Security/permission risk: net improvement. `MGVL_LIVE_PR` was previously interpolated into a `gh` invocation without validation; a non-numeric inherited value now refuses at exit 3 before reaching the command (verified with a shell-metacharacter-bearing value). No namespace, token, auth, or SQL surface is touched. No secrets are read, logged, or emitted; the refusal messages quote only the offending variable value, which is operator-supplied environment, never a credential.
- Migration/deploy risk: none. No schema, migration, service, or runtime code — the diff is two shell scripts under `scripts/done-means/`, which run only when invoked by a lane or controller. Nothing is deployed by merging this.
- Downstream client/runtime risk: none. No MCP tool, transport, schema, protocol, or client-facing surface changes, so `docs/downstream-rollout.md` classification is not-applicable; rtech-mcps, mcp2cli, and rtech-hermes consume none of this. These scripts are repo-internal verification tooling.
- Rollback/cleanup concern: revert of a two-file shell diff restores the prior behaviour exactly, with no state to unwind. The subject archives its own scratch fixtures by `mv` into the temp-workspace archive (unchanged by this PR). During verification the subject was temporarily reverted and re-injected twice; the tree was restored and confirmed clean against `HEAD` before committing.
- Fixes made before PR: the salvaged branch tip (`2da109b`) was committed UNTESTED from a parked worktree and was treated as PROPOSED, not trusted. Every factual claim in its comments was re-derived from source before acceptance — `verify-lane.ts:479-480` (marker pair), `:287-290` (ancestry parse), `:283-286` and `:293-330` (polite vs load-bearing layer). The logic was then adversarially probed for the substring false-match (`pr-42` vs ancestry `142`) and whitespace handling, both of which hold. The commit message was amended because it asserted "untested", which is no longer true. No logic defect was found requiring correction; the salvaged design is sound and is now backed by executed evidence rather than assertion.
- Known residual risk: the guard trusts that the ancestry variable is hard for an accidental environment to forge. That is true of stale exports and CI leaks — the realistic threat model, and the one #721 reported — but it is not an adversarial control: a caller who deliberately sets both variables consistently can still turn the live clause off. Making that impossible would require a secret the spawning process mints per run, which is disproportionate for a defence against environmental accident and would not survive the older-commit checkout problem that put the load-bearing guard in `verify-lane.ts` in the first place. The authoritative recursion guard remains verify-lane's own depth counter; this clause is explicitly the polite layer.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the reviewer-facing half of this family is already captured — `docs/gate-layer-audit-2026-08-10.md` files Family B (a gate letting its environment decide the verdict) with #721 as a named live member, and the operating-knowledge half belongs in the lane contract's Tightenings, which the controller harvests at merge per the ratchet rule. No new MEDIUM+ review finding surfaced in this lane that those two do not already cover.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this diff is two repo-internal shell scripts under `scripts/done-means/`; no Open Brain service, endpoint, schema, or stored data is read or written by the change, so a live smoke would exercise nothing the change affects.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no MCP tool, schema, or wire contract is touched — the change is verification tooling internal to this repo, with no fixture surface on either side.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable on every downstream axis: the diff changes two `scripts/done-means/` shell scripts and no MCP tool, transport, schema, protocol, or Python client surface. `docs/downstream-rollout.md` scopes rollout to contract-changing MCP/transport/client-facing work; nothing downstream imports, calls, or is generated from these scripts.
- Truth labels: the fix and its check are WRITTEN and verified RUNNING in this lane's clone (RED before, GREEN after, two negative controls, all executed this session). They are **not MERGED**. Worker output is PROPOSED until the controller independently re-runs `bash scripts/done-means/721-verify-lane-guard-earned.sh` before merge — this lane does not self-certify.
- Base is `wip/2026-08-07`. Closing #721 is the controller's merge-pass call, hence `Refs #721` rather than a closing keyword.

Refs #721
