### PR TITLE
fix(done-means): pin the fixture hook environment so 705/712 judge the code (#722)

### DIFF
--- a/scripts/done-means/705-pre-push-base-selection.sh
+++ b/scripts/done-means/705-pre-push-base-selection.sh
@@ -144,6 +144,18 @@ git_f() { git -C "$FIXTURE" -c user.name="done-means-705" -c user.email="done-me
 
 setup_fixture() {
   git -C "$FIXTURE" init -q -b main 2>/dev/null || return 1
+
+  # PIN THE FIXTURE'S HOOKS DIRECTORY (issue #722). A bare `git init` sets no
+  # `core.hooksPath`, so the fixture INHERITS the operator's global value --
+  # this fixture is not hermetic without this line. #711 added an assertion to
+  # the shipped hook that refuses any value other than `_githooks`, and it runs
+  # BEFORE the `--explain` early exit, so an inherited value made every
+  # invocation below die at that assertion and every clause parse a refusal
+  # instead of a base decision. The hook IS this check's subject, so the pin is
+  # the real value (contrast 709/714, which neutralise hooks entirely because
+  # the hook is not their subject).
+  git -C "$FIXTURE" config core.hooksPath _githooks || return 1  # DM722-PIN
+
   mkdir -p "$FIXTURE/python/openbrain/src" \
            "$FIXTURE/python/openbrain-memory/src" \
            "$FIXTURE/contracts" \
@@ -211,6 +223,34 @@ SPEC
 
 setup_fixture || fail_hard "could not build the fixture repository (see $FIXTURE)"
 
+# ---------------------------------------------------------------------------
+# FIXTURE-ENVIRONMENT GUARD (issue #722)
+# ---------------------------------------------------------------------------
+# Assert the pin actually took EFFECT before any clause runs. `git config
+# --get` here reads exactly what the hook's own assertion reads, so this guard
+# and the subject agree on the value by construction.
+#
+# WHY THIS IS EXIT 3 AND NOT A CLAUSE FAILURE. A blinded fixture says NOTHING
+# about base selection: the hook refuses before reaching a single line of its
+# subject code. Reporting that as FAIL would be a verdict about #705 that the
+# run did not earn -- and that is precisely the defect #722 filed, where five
+# clauses reported confident, specific, FALSE regressions ("the packages are no
+# longer separately gated") about a hook they never reached. A harness error is
+# not a failure of the thing under test.
+FIXTURE_HOOKS_PATH="$(git -C "$FIXTURE" config --get core.hooksPath 2>/dev/null || true)"
+if [ "$FIXTURE_HOOKS_PATH" != "_githooks" ]; then
+  fail_hard "$(printf '%s' "\
+BLIND FIXTURE -- this run cannot say anything about #705.
+    fixture core.hooksPath: '${FIXTURE_HOOKS_PATH:-<unset>}'
+    required:               '_githooks'
+  The fixture is inheriting an ambient core.hooksPath instead of pinning its
+  own, so the shipped hook will refuse at its #711 assertion before reaching
+  any base-selection code. Every clause below would then be parsing a REFUSAL,
+  not a decision. This is a defect in this CHECK's fixture (#722), not in the
+  hook. Fix: restore the 'git -C \"\$FIXTURE\" config core.hooksPath _githooks'
+  line in setup_fixture.")"
+fi
+
 # A lane off wip, tracking wip — the exact shape every lane in this flow has.
 new_lane_branch() {
   local name="$1"
@@ -223,6 +263,42 @@ new_lane_branch() {
 explain() {
   EXPLAIN_OUT="$(cd "$FIXTURE" && "$FIXTURE/_githooks/pre-push" --explain 2>&1 </dev/null)"
   EXPLAIN_EXIT=$?
+}
+
+# ---------------------------------------------------------------------------
+# REFUSAL DETECTION (issue #722) -- "I could not reach the subject" is not "the
+# subject regressed".
+# ---------------------------------------------------------------------------
+# The fixture guard above catches the ONE blind that has actually happened. This
+# is the general form, and it is the part that survives the next unrelated
+# invariant someone adds to the hook: the hook has a growing set of preconditions
+# that refuse BEFORE any base-selection code runs, and each one turns the
+# clauses' parse into a refusal.
+#
+# `blinded_by` returns the refusal's first meaningful line when the output
+# carries no base-selection decision at all, and empty otherwise. Clauses use
+# it to say WHAT BLINDED THEM instead of reporting empty decision fields as a
+# classification defect -- a parse failure and a wrong answer are different
+# defects with different owners (lane-contract round 29).
+#
+# It is deliberately anchored on the ABSENCE of every marker the hook owns for a
+# successful decision, not on a list of known refusal texts: a refusal added
+# tomorrow is unknown to this file, but "produced no decision" is checkable
+# today and stays true.
+blinded_by() {
+  local out="$1"
+  # Any of these means the hook REACHED its subject and produced a decision.
+  printf '%s\n' "$out" | rg -q '^[[:space:]]*base_ref=' && return 0
+  printf '%s\n' "$out" | rg -q '^[[:space:]]*changed_' && return 0
+  printf '%s\n' "$out" | rg -qF 'Python package changed' && return 0
+  printf '%s\n' "$out" | rg -qF 'Python package unchanged' && return 0
+  printf '%s\n' "$out" | rg -qF 'openbrain package changed' && return 0
+  printf '%s\n' "$out" | rg -qF 'openbrain package unchanged' && return 0
+  # No decision anywhere -> blinded. Report the first non-blank line, which is
+  # the refusal's own headline.
+  local first
+  first="$(printf '%s\n' "$out" | rg -v '^[[:space:]]*$' | head -1)"
+  printf 'the hook REFUSED before reaching its base-selection subject; first line: %s' "${first:-<no output at all>}"
 }
 
 # Read one decision field out of the hook's explain output.
@@ -270,8 +346,13 @@ explain
 A_OUT="$EXPLAIN_OUT"
 A_MEM="$(field changed_openbrain_memory)"
 A_OB="$(field changed_openbrain)"
-if [ -z "$A_MEM" ] || [ -z "$A_OB" ]; then
-  record a FAIL "decision fields missing from the explain output (memory='$A_MEM' openbrain='$A_OB'): $(printf '%s' "$A_OUT" | tr '\n' ' ')"
+A_BLIND="$(blinded_by "$A_OUT")"
+if [ -n "$A_BLIND" ]; then
+  # #722: NOT "the fields are missing" and NOT a #705 regression -- the hook
+  # never got to the code this clause is about.
+  record a BLIND "$A_BLIND"
+elif [ -z "$A_MEM" ] || [ -z "$A_OB" ]; then
+  record a FAIL "the hook produced a decision but this clause could not read it (memory='$A_MEM' openbrain='$A_OB'): $(printf '%s' "$A_OUT" | tr '\n' ' ')"
 elif [ "$A_MEM" = no ] && [ "$A_OB" = no ]; then
   record a PASS "zero-python lane on a wip base reports both packages unchanged"
 else
@@ -279,24 +360,38 @@ else
 fi
 
 # --- (b) the gate still discriminates --------------------------------------
+# #722: each sub-assertion is guarded by `blinded_by` FIRST. This clause is
+# where the false text was worst -- blinded, it announced "a real
+# python/openbrain edit was NOT detected" and "the packages are no longer
+# separately gated" about a hook that had refused before running any of it.
 B_FAILS=()
+B_BLIND=""
 new_lane_branch "lane-python-ob" || fail_hard "could not create lane-python-ob"
 printf 'lane-change\n' >> "$FIXTURE/python/openbrain/src/mod.py"
 git_f add -A >/dev/null && git_f commit -q -m "lane: real python/openbrain change"
 explain
-[ "$(field changed_openbrain)" = yes ] || B_FAILS+=("a real python/openbrain edit was NOT detected (changed_openbrain='$(field changed_openbrain)')")
+B_BLIND="$(blinded_by "$EXPLAIN_OUT")"
+if [ -z "$B_BLIND" ]; then
+  [ "$(field changed_openbrain)" = yes ] || B_FAILS+=("a real python/openbrain edit was NOT detected (changed_openbrain='$(field changed_openbrain)')")
 
-new_lane_branch "lane-python-mem" || fail_hard "could not create lane-python-mem"
-printf 'lane-change\n' >> "$FIXTURE/python/openbrain-memory/src/mod.py"
-git_f add -A >/dev/null && git_f commit -q -m "lane: real python/openbrain-memory change"
-explain
-[ "$(field changed_openbrain_memory)" = yes ] || B_FAILS+=("a real python/openbrain-memory edit was NOT detected (changed_openbrain_memory='$(field changed_openbrain_memory)')")
+  new_lane_branch "lane-python-mem" || fail_hard "could not create lane-python-mem"
+  printf 'lane-change\n' >> "$FIXTURE/python/openbrain-memory/src/mod.py"
+  git_f add -A >/dev/null && git_f commit -q -m "lane: real python/openbrain-memory change"
+  explain
+  B_BLIND="$(blinded_by "$EXPLAIN_OUT")"
+fi
 
-# The sibling-package separation the hook's own comment calls out: a
-# python/openbrain-memory edit must NOT light up python/openbrain.
-[ "$(field changed_openbrain)" = no ] || B_FAILS+=("a python/openbrain-memory edit lit up python/openbrain (changed_openbrain='$(field changed_openbrain)') — the packages are no longer separately gated")
+if [ -z "$B_BLIND" ]; then
+  [ "$(field changed_openbrain_memory)" = yes ] || B_FAILS+=("a real python/openbrain-memory edit was NOT detected (changed_openbrain_memory='$(field changed_openbrain_memory)')")
 
-if [ "${#B_FAILS[@]}" -eq 0 ]; then
+  # The sibling-package separation the hook's own comment calls out: a
+  # python/openbrain-memory edit must NOT light up python/openbrain.
+  [ "$(field changed_openbrain)" = no ] || B_FAILS+=("a python/openbrain-memory edit lit up python/openbrain (changed_openbrain='$(field changed_openbrain)') — the packages are no longer separately gated")
+fi
+
+if [ -n "$B_BLIND" ]; then
+  record b BLIND "$B_BLIND"
+elif [ "${#B_FAILS[@]}" -eq 0 ]; then
   record b PASS "real edits to each package are still detected, and the two packages stay separately gated"
 else
   record b FAIL "$(printf '%s; ' "${B_FAILS[@]}")"
@@ -308,8 +403,13 @@ printf 'announce note\n' >> "$FIXTURE/docs/readme.md"
 git_f add -A >/dev/null && git_f commit -q -m "lane: announce clause"
 explain
 C_BASE_REF="$(field base_ref)"
-if [ -z "$C_BASE_REF" ]; then
-  record c FAIL "the hook did not name the base ref it compared against: $(printf '%s' "$EXPLAIN_OUT" | tr '\n' ' ')"
+C_BLIND="$(blinded_by "$EXPLAIN_OUT")"
+if [ -n "$C_BLIND" ]; then
+  # #722: "the hook did not name its base ref" is a claim about the
+  # announcement. A refused hook did not GET to an announcement.
+  record c BLIND "$C_BLIND"
+elif [ -z "$C_BASE_REF" ]; then
+  record c FAIL "the hook produced a decision but did not name the base ref it compared against: $(printf '%s' "$EXPLAIN_OUT" | tr '\n' ' ')"
 elif printf '%s' "$C_BASE_REF" | rg -qF "origin/wip"; then
   record c PASS "the base ref is named in the hook's own output: base_ref=$C_BASE_REF"
 else
@@ -323,7 +423,15 @@ git_f add -A >/dev/null && git_f commit -q -m "lane: branch with no configured u
 explain
 D_BASE_REF="$(field base_ref)"
 D_SOURCE="$(field base_source)"
-if [ "$EXPLAIN_EXIT" -ne 0 ]; then
+D_BLIND="$(blinded_by "$EXPLAIN_OUT")"
+# #722: THE BLIND CHECK MUST COME BEFORE THE EXIT-CODE CHECK. A refusal is
+# ALSO a non-zero exit, so the exit-code test alone cannot tell "an
+# upstreamless branch made the hook fail rather than fall back" -- a real #705
+# regression -- from "the hook refused a precondition and never saw the
+# branch". Blinded, this clause reported the former and meant the latter.
+if [ -n "$D_BLIND" ]; then
+  record d BLIND "$D_BLIND"
+elif [ "$EXPLAIN_EXIT" -ne 0 ]; then
   record d FAIL "an upstreamless branch made the hook fail rather than fall back (exit=$EXPLAIN_EXIT): $(printf '%s' "$EXPLAIN_OUT" | tr '\n' ' ')"
 elif [ -z "$D_BASE_REF" ] || [ -z "$D_SOURCE" ]; then
   record d FAIL "the fallback did not announce itself (base_ref='$D_BASE_REF' base_source='$D_SOURCE')"
@@ -374,7 +482,13 @@ F_OUT="$(
 )"
 
 F_BASE="$(printf '%s\n' "$F_OUT" | sed -n 's/^[[:space:]]*base:[[:space:]]*\(.*\)$/\1/p' | tail -1)"
-if printf '%s' "$F_OUT" | rg -qF "openbrain package changed" \
+F_BLIND="$(blinded_by "$F_OUT")"
+if [ -n "$F_BLIND" ]; then
+  # #722: blinded, this clause said "the real push path produced no readable
+  # package decision" -- which reads as a #705 regression on the very path the
+  # issue is about, when the truth is the hook refused a precondition first.
+  record f BLIND "$F_BLIND"
+elif printf '%s' "$F_OUT" | rg -qF "openbrain package changed" \
   || printf '%s' "$F_OUT" | rg -qF "Python package changed"; then
   record f FAIL "a REAL push of a zero-python lane still ran a Python gate — base line was '${F_BASE:-<none>}'"
 elif printf '%s' "$F_OUT" | rg -qF "openbrain package unchanged" \
@@ -411,6 +525,7 @@ label_for() {
 }
 
 ALL_PASS=1
+ANY_BLIND=0
 for entry in "${CLAUSES[@]}"; do
   id="${entry%%|*}"
   rest="${entry#*|}"
@@ -418,7 +533,20 @@ for entry in "${CLAUSES[@]}"; do
   evidence="${rest#*|}"
   printf 'CLAUSE %s (%s): %s — %s\n' "$id" "$(label_for "$id")" "$status" "$evidence"
   [ "$status" = PASS ] || ALL_PASS=0
+  [ "$status" = BLIND ] && ANY_BLIND=1
 done
+
+# #722: A BLIND RUN IS A HARNESS ERROR, NOT A VERDICT.
+# Exit 1 from this script is read by controllers, verify-lane, and PR bodies as
+# "#705 is broken". A run that could not reach the hook's base-selection code
+# has not earned that claim in either direction, so it exits 3 -- this repo's
+# harness-error code, which fail_hard already uses and which the surrounding
+# process treats as "the check could not run", not "the subject failed".
+if [ "$ANY_BLIND" -eq 1 ]; then
+  printf '\nHARNESS-ERROR: %s\n' \
+    "one or more clauses were BLIND -- the hook refused before reaching its base-selection subject, so this run says NOTHING about #705 in either direction. Exiting 3 (harness error), deliberately NOT 1: a blinded run must never be recorded as a #705 regression (issue #722)." >&2
+  exit 3
+fi
 
 [ "$ALL_PASS" -eq 1 ] && exit 0
 exit 1

--- a/scripts/done-means/712-pre-push-pipe-safe.sh
+++ b/scripts/done-means/712-pre-push-pipe-safe.sh
@@ -170,6 +170,17 @@ RUNNER
 
 setup_fixture() {
   git -C "$FIXTURE" init -q -b main 2>/dev/null || return 1
+
+  # PIN THE FIXTURE'S HOOKS DIRECTORY (issue #722). A bare `git init` sets no
+  # `core.hooksPath`, so the fixture INHERITS the operator's global value --
+  # this fixture is not hermetic without this line. #711 added an assertion to
+  # the shipped hook that refuses any value other than `_githooks`, and it runs
+  # BEFORE anything this check is about, so an inherited value made all six
+  # clauses below parse a refusal instead of the hook's pipe handling. The hook
+  # IS this check's subject, so the pin is the real value (contrast 709/714,
+  # which neutralise hooks entirely because the hook is not their subject).
+  git -C "$FIXTURE" config core.hooksPath _githooks || return 1  # DM722-PIN
+
   mkdir -p "$FIXTURE/contracts" "$FIXTURE/_githooks" "$FIXTURE/docs" || return 1
 
   printf 'contracts/schema.json\n' > "$FIXTURE/contracts/parity-paths.txt" || return 1
@@ -230,6 +241,33 @@ SHIM
 }
 
 setup_fixture || fail_hard "could not build the fixture repository (see $FIXTURE)"
+
+# ---------------------------------------------------------------------------
+# FIXTURE-ENVIRONMENT GUARD (issue #722)
+# ---------------------------------------------------------------------------
+# Assert the pin actually took EFFECT before any clause runs. `git config
+# --get` here reads exactly what the hook's own assertion reads, so this guard
+# and the subject agree on the value by construction.
+#
+# WHY THIS IS EXIT 3 AND NOT A CLAUSE FAILURE. A blinded fixture says NOTHING
+# about pipe safety: the hook refuses before running its test phase at all.
+# Reporting that as FAIL would be a verdict about #712 the run did not earn --
+# and that is exactly the defect #722 filed, where clause (f) announced
+# "redirecting stdout alone does not fix #712" about a hook whose redirect code
+# never executed. A harness error is not a failure of the thing under test.
+FIXTURE_HOOKS_PATH="$(git -C "$FIXTURE" config --get core.hooksPath 2>/dev/null || true)"
+if [ "$FIXTURE_HOOKS_PATH" != "_githooks" ]; then
+  fail_hard "$(printf '%s' "\
+BLIND FIXTURE -- this run cannot say anything about #712.
+    fixture core.hooksPath: '${FIXTURE_HOOKS_PATH:-<unset>}'
+    required:               '_githooks'
+  The fixture is inheriting an ambient core.hooksPath instead of pinning its
+  own, so the shipped hook will refuse at its #711 assertion before running the
+  test phase. Every clause below would then be parsing a REFUSAL, not the
+  hook's pipe handling. This is a defect in this CHECK's fixture (#722), not in
+  the hook. Fix: restore the 'git -C \"\$FIXTURE\" config core.hooksPath
+  _githooks' line in setup_fixture.")"
+fi
 
 ZERO_SHA_FIXTURE=0000000000000000000000000000000000000000
 
@@ -297,12 +335,50 @@ precheck_pipe_is_hostile() {
 CLAUSES=()
 record() { CLAUSES+=("$1|$2|$3"); }
 
+# ---------------------------------------------------------------------------
+# REFUSAL DETECTION (issue #722) -- "I could not reach the subject" is not "the
+# subject regressed".
+# ---------------------------------------------------------------------------
+# The fixture guard above catches the ONE blind that has actually happened
+# (#711's hooksPath assertion). This is the general form, and it is the part
+# that survives the next unrelated precondition someone adds to the hook: every
+# such precondition refuses BEFORE the test phase, and each one turns all six
+# clauses below into parses of a refusal.
+#
+# `blinded_by` returns a description when the hook produced NO evidence of
+# having reached its test phase, and empty otherwise. It is anchored on the
+# ABSENCE of the markers the hook owns for having got there, not on a list of
+# known refusal texts: a refusal added tomorrow is unknown to this file, but
+# "never reached the test phase" is checkable today and stays true.
+#
+# The runner's own `DM712-RUNNER-RAN` marker is deliberately NOT one of these
+# markers. It proves the SUITE ran, which is a stronger claim than this
+# function makes and is precisely what clauses (a) and (f) assert on -- folding
+# it in here would let a hook that reached the test phase and then failed
+# legitimately be excused as "blind".
+blinded_by() {
+  local out="$1"
+  # Any of these means the hook REACHED the phase this check is about.
+  printf '%s\n' "$out" | rg -qF 'bun test ...' && return 0
+  printf '%s\n' "$out" | rg -qiF 'TESTS FAILED' && return 0
+  printf '%s\n' "$out" | rg -qiF 'could not write its output' && return 0
+  printf '%s\n' "$out" | rg -qF 'pre-push: all checks passed' && return 0
+  local first
+  first="$(printf '%s\n' "$out" | rg -v '^[[:space:]]*$|^DM712_HOOK_EXIT=' | head -1)"
+  printf 'the hook REFUSED before reaching its test phase; first line: %s' "${first:-<no output at all>}"
+}
+
 # --- (a) the defect --------------------------------------------------------
 if precheck_pipe_is_hostile "writefail-stderr"; then
   run_hook_through_pipe "writefail-stderr"
   A_OUT="$HOOK_OUT"
   A_EXIT="$HOOK_EXIT"
-  if [ "$A_EXIT" = "0" ] \
+  A_BLIND="$(blinded_by "$A_OUT")"
+  if [ -n "$A_BLIND" ]; then
+    # #722: NOT "a GREEN suite through a pipe still failed the hook" -- the
+    # hook never ran a suite at all.
+    record a BLIND "$A_BLIND"
+  elif [ "$A_EXIT" = "0" ] \
     && printf '%s' "$A_OUT" | grep -qF "pre-push: all checks passed" \
     && printf '%s' "$A_OUT" | grep -qF "DM712-RUNNER-RAN"; then
     record a PASS "the real hook, through a genuine pipe, with a runner that cannot write to a pipe (proven hostile: piped exit=$PRECHECK_EXIT): exit 0, suite genuinely ran"
@@ -317,6 +393,7 @@ fi
 run_hook_through_pipe "testfail"
 B_OUT="$HOOK_OUT"
 B_EXIT="$HOOK_EXIT"
+B_BLIND="$(blinded_by "$B_OUT")"
 B_FAILS=()
 [ "$B_EXIT" != "0" ] || B_FAILS+=("a genuinely failing suite PASSED the hook (exit=$B_EXIT) — the exit code is not being gated on")
 printf '%s' "$B_OUT" | grep -qiF "TESTS FAILED" \
@@ -324,7 +401,13 @@ printf '%s' "$B_OUT" | grep -qiF "TESTS FAILED" \
 if printf '%s' "$B_OUT" | grep -qiF "could not write its output"; then
   B_FAILS+=("a genuine test failure was MASKED as a write/runner error — the two worlds are crossed")
 fi
-if [ "${#B_FAILS[@]}" -eq 0 ]; then
+# #722: THE BLIND CHECK MUST OUTRANK THE EXIT-CODE CHECK HERE. A refusal is
+# also non-zero, so this clause's "a genuinely failing suite still fails"
+# assertion is trivially satisfied by a hook that refused and never ran a
+# suite -- the clause would go half-green for the wrong reason.
+if [ -n "$B_BLIND" ]; then
+  record b BLIND "$B_BLIND"
+elif [ "${#B_FAILS[@]}" -eq 0 ]; then
   record b PASS "a genuinely failing suite still fails the hook (exit=$B_EXIT) and is named a TEST failure, not a write error"
 else
   record b FAIL "$(printf '%s; ' "${B_FAILS[@]}")"
@@ -343,6 +426,7 @@ git_f add -A >/dev/null && git_f commit -q -m "clause c runner"
 run_hook_through_pipe "writefail-stderr"
 C_OUT="$HOOK_OUT"
 C_EXIT="$HOOK_EXIT"
+C_BLIND="$(blinded_by "$C_OUT")"
 C_FAILS=()
 [ "$C_EXIT" != "0" ] || C_FAILS+=("a runner that could not write its output was reported as a PASS (exit=$C_EXIT)")
 printf '%s' "$C_OUT" | grep -qiF "could not write its output" \
@@ -352,7 +436,9 @@ printf '%s' "$C_OUT" | grep -qiF "NOT a test failure" \
 if printf '%s' "$C_OUT" | grep -qiF "TESTS FAILED"; then
   C_FAILS+=("a write/runner failure was blamed on the tests")
 fi
-if [ "${#C_FAILS[@]}" -eq 0 ]; then
+if [ -n "$C_BLIND" ]; then
+  record c BLIND "$C_BLIND"
+elif [ "${#C_FAILS[@]}" -eq 0 ]; then
   record c PASS "a runner that cannot write its output fails the hook and is named a WRITE/RUNNER problem, explicitly not a test failure"
 else
   record c FAIL "$(printf '%s; ' "${C_FAILS[@]}")"
@@ -363,7 +449,12 @@ git_f add -A >/dev/null && git_f commit -q -m "restore runner"
 # --- (d) the redirect is announced -----------------------------------------
 run_hook_through_pipe "writefail-stderr"
 D_OUT="$HOOK_OUT"
-if printf '%s' "$D_OUT" | grep -qF "bun test ..." \
+D_BLIND="$(blinded_by "$D_OUT")"
+if [ -n "$D_BLIND" ]; then
+  # #722: "the redirect was silent" is a claim about the hook's announcement.
+  # A refused hook did not GET to a redirect to announce.
+  record d BLIND "$D_BLIND"
+elif printf '%s' "$D_OUT" | grep -qF "bun test ..." \
   && printf '%s' "$D_OUT" | grep -qF "$SCRATCH/ws"; then
   record d PASS "the hook announces that it redirected the runner's output, and names the log path"
 else
@@ -373,7 +464,11 @@ fi
 # --- (e) the output is still replayed --------------------------------------
 # Read from the same run as (d). The runner's own coverage-shaped lines must
 # reach the caller, or the hook bought its verdict by swallowing the output.
-if printf '%s' "$D_OUT" | grep -qF "DM712-RUNNER-RAN" \
+if [ -n "$D_BLIND" ]; then
+  # #722: read from the same run as (d). "the redirect swallowed the run" is a
+  # claim about a redirect that never executed.
+  record e BLIND "$D_BLIND"
+elif printf '%s' "$D_OUT" | grep -qF "DM712-RUNNER-RAN" \
   && printf '%s' "$D_OUT" | grep -qF "src/mod100.ts"; then
   record e PASS "the runner's output still reaches the caller — the redirect did not cost the operator the transcript"
 else
@@ -386,7 +481,14 @@ if precheck_pipe_is_hostile "writefail-stderr"; then
   run_hook_through_pipe "writefail-stderr"
   F_EXIT="$HOOK_EXIT"
   F_OUT="$HOOK_OUT"
-  if [ "$F_EXIT" = "0" ] && printf '%s' "$F_OUT" | grep -qF "DM712-RUNNER-RAN"; then
+  F_BLIND="$(blinded_by "$F_OUT")"
+  if [ -n "$F_BLIND" ]; then
+    # #722: this clause's failure text is the sharpest false claim of the whole
+    # family -- "redirecting stdout alone does not fix #712" is a specific
+    # verdict on the FIX's shape, emitted about a hook whose redirect code
+    # never executed. It must never be printed by a blinded run.
+    record f BLIND "$F_BLIND"
+  elif [ "$F_EXIT" = "0" ] && printf '%s' "$F_OUT" | grep -qF "DM712-RUNNER-RAN"; then
     record f PASS "a runner hostile to STDERR ONLY (the measured bun shape) survives — stderr is genuinely off the pipe, not just stdout"
   else
     record f FAIL "the runner's STDERR is still attached to a pipe (exit=$F_EXIT) — redirecting stdout alone does not fix #712"
@@ -422,6 +524,7 @@ label_for() {
 }
 
 ALL_PASS=1
+ANY_BLIND=0
 for entry in "${CLAUSES[@]}"; do
   id="${entry%%|*}"
   rest="${entry#*|}"
@@ -429,7 +532,20 @@ for entry in "${CLAUSES[@]}"; do
   evidence="${rest#*|}"
   printf 'CLAUSE %s (%s): %s — %s\n' "$id" "$(label_for "$id")" "$status" "$evidence"
   [ "$status" = PASS ] || ALL_PASS=0
+  [ "$status" = BLIND ] && ANY_BLIND=1
 done
+
+# #722: A BLIND RUN IS A HARNESS ERROR, NOT A VERDICT.
+# Exit 1 from this script is read by controllers, verify-lane, and PR bodies as
+# "#712 is broken". A run that could not reach the hook's test phase has not
+# earned that claim in either direction, so it exits 3 -- this repo's
+# harness-error code, which fail_hard already uses and which the surrounding
+# process treats as "the check could not run", not "the subject failed".
+if [ "$ANY_BLIND" -eq 1 ]; then
+  printf '\nHARNESS-ERROR: %s\n' \
+    "one or more clauses were BLIND -- the hook refused before reaching its test phase, so this run says NOTHING about #712 in either direction. Exiting 3 (harness error), deliberately NOT 1: a blinded run must never be recorded as a #712 regression (issue #722)." >&2
+  exit 3
+fi
 
 [ "$ALL_PASS" -eq 1 ] && exit 0
 exit 1

--- a/scripts/done-means/712-pre-push-pipe-safe.sh
+++ b/scripts/done-means/712-pre-push-pipe-safe.sh
@@ -447,6 +447,35 @@ write_runner
 git_f add -A >/dev/null && git_f commit -q -m "restore runner"
 
 # --- (d) the redirect is announced -----------------------------------------
+# WHY THIS ASSERTS ON THE LOG'S SHAPE AND NOT ON "$SCRATCH/ws" (issue #722).
+# This clause used to require the announced log path to sit under the fixture's
+# own `OPENBRAIN_TEMP_WORKSPACE` ("$SCRATCH/ws"), which `run_hook_through_pipe`
+# sets on the hook invocation. THE FIXTURE CANNOT WIN THAT ASSERTION, and the
+# reason is the same defect this issue is about -- the ambient environment
+# deciding a verdict:
+#
+#   $ env OPENBRAIN_TEMP_WORKSPACE=/probe/ws zsh  -c 'echo $OPENBRAIN_TEMP_WORKSPACE'
+#   /Volumes/ThunderBolt/_tmp          <- the caller's value is GONE
+#   $ env OPENBRAIN_TEMP_WORKSPACE=/probe/ws bash -c 'echo $OPENBRAIN_TEMP_WORKSPACE'
+#   /probe/ws                          <- bash honours it
+#
+# The hook's shebang is `#!/usr/bin/env zsh`, and `~/.zshenv` is read by EVERY
+# zsh -- including a non-interactive script -- which sources
+# `~/Library/Application Support/rtech-infra/env-roots.zsh`, whose line 6 is an
+# unconditional `export OPENBRAIN_TEMP_WORKSPACE=/Volumes/ThunderBolt/_tmp`.
+# An unconditional export in a startup file OVERWRITES what the caller passed,
+# so the hook always logs to the operator's real temp workspace. Measured live
+# with a probe copy of this check: the announcement WAS present
+# (`has_buntest=1`) and the "$SCRATCH/ws" match was not (`has_ws=0`), with the
+# announced path reading `.../open-brain/_scratch/pre-push/bun-test-*.log`.
+#
+# So the old assertion tested the OPERATOR'S SHELL PROFILE, not the hook. The
+# clause's actual subject -- stated in its own label -- is that the redirect is
+# ANNOUNCED and the log is NAMED. That is what it now checks: the announcement
+# line, and a concrete `bun-test-<pid>-<epoch>.log` filename in it. Pinning the
+# DIRECTORY is not this check's business and is not something the fixture is
+# able to pin; pinning the SHAPE is, and it still fails if the hook stops
+# naming the log or goes back to a bare `bun test`.
 run_hook_through_pipe "writefail-stderr"
 D_OUT="$HOOK_OUT"
 D_BLIND="$(blinded_by "$D_OUT")"
@@ -455,7 +484,7 @@ if [ -n "$D_BLIND" ]; then
   # A refused hook did not GET to a redirect to announce.
   record d BLIND "$D_BLIND"
 elif printf '%s' "$D_OUT" | grep -qF "bun test ..." \
-  && printf '%s' "$D_OUT" | grep -qF "$SCRATCH/ws"; then
+  && printf '%s\n' "$D_OUT" | grep -qE 'stdout\+stderr -> [^ ]+/bun-test-[0-9]+-[0-9]+\.log'; then
   record d PASS "the hook announces that it redirected the runner's output, and names the log path"
 else
   record d FAIL "the redirect was silent — no announcement naming the log: $(printf '%s' "$D_OUT" | tr '\n' ' ' | tail -c 300)"

--- a/scripts/done-means/722-fixture-hookspath-pinned.sh
+++ b/scripts/done-means/722-fixture-hookspath-pinned.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #722 — "both pre-push done-means checks (705, 712)
+# are RED on untouched main: unpinned fixture core.hooksPath trips #711's
+# assertion, misreported as substantive regressions".
+#
+#   bash scripts/done-means/722-fixture-hookspath-pinned.sh
+#
+# EXISTING DESIGN THIS EXTENDS (lookup before writing, per the repo's gate):
+# `docs/lane-contract.md` already requires hermetic, red-first fixtures with a
+# mutation clause, and 709/711/714 already demonstrate the pinning pattern.
+# The delta this adds is that the FIXTURE ENVIRONMENT is itself a subject: a
+# fixture that inherits ambient git config is not hermetic, and a check blinded
+# that way must be unable to report a verdict about its subject.
+#
+# ---------------------------------------------------------------------------
+# THE DEFECT THIS GATES
+# ---------------------------------------------------------------------------
+# `705-pre-push-base-selection.sh` and `712-pre-push-pipe-safe.sh` build
+# throwaway git repositories with a bare `git init`, which sets no
+# `core.hooksPath`. Git then falls back to the operator's GLOBAL value, so the
+# fixture is not hermetic: on this machine it inherited
+# `/Users/rico/.config/git/hooks`.
+#
+# #711 later added an assertion to `_githooks/pre-push` that REFUSES any
+# `core.hooksPath` other than `_githooks`, and that assertion runs BEFORE the
+# `--explain` early exit. So every fixture invocation of the shipped hook died
+# at the hooksPath check and printed the #711 refusal, and each clause parsed
+# that refusal as if it were the hook's decision output. Measured on the
+# untouched branch tip `afc5525`, clean tree:
+#
+#   705 -> 5 of 6 clauses FAIL (only (e) passes; it reads the hook's SOURCE
+#          structurally and never invokes it)
+#   712 -> 6 of 6 clauses FAIL
+#
+# The red is not the danger. THE FALSE TEXT IS. Both checks kept emitting their
+# original, now-untrue, regression claims while blinded:
+#
+#   705 (b): "a real python/openbrain edit was NOT detected ... the packages
+#            are no longer separately gated"
+#   712 (f): "the runner's STDERR is still attached to a pipe -- redirecting
+#            stdout alone does not fix #712"
+#
+# Neither fix is broken; the audit proved both intact by adding the one missing
+# `git config core.hooksPath _githooks` line. A check that says "the subject
+# regressed" when it means "I could not reach the subject" is how a genuine
+# #705 regression later gets waved through as "that one's always red".
+#
+# ---------------------------------------------------------------------------
+# WHY THE RE-BLIND CLAUSE IS THE LOAD-BEARING ONE
+# ---------------------------------------------------------------------------
+# Clause (a) alone -- "both checks are green" -- would be satisfied by a fix
+# that pinned the fixture and changed nothing about the reporting. That leaves
+# the whole defect that mattered live: the next unrelated invariant added to the
+# hook re-blinds both checks, and they go back to lying about their subject.
+#
+# So clause (b) reconstructs the defect DELIBERATELY. Each check is copied with
+# its pin line removed, and the copy is run. The copy must:
+#   - fail (a blinded check must never be green), AND
+#   - name the BLIND -- the refusal it actually hit -- in its output, AND
+#   - NOT emit the original regression text for the subject it never reached.
+#
+# The third condition is the one the pre-fix code violates, and it is asserted
+# on the EXACT strings the pre-fix code printed, so this clause is a genuine
+# mutation test rather than a restatement of clause (a).
+#
+# The copies are made by deleting the line carrying a marker the fix OWNS
+# (`DM722-PIN`), not by regex-mangling arbitrary source. If the marker is absent
+# the edit would be a silent no-op and the whole mutation would prove nothing,
+# so that case is HARNESS-ERROR, never a pass.
+#
+# ---------------------------------------------------------------------------
+# CLAUSES
+# ---------------------------------------------------------------------------
+#   (a) BOTH CHECKS ARE GREEN on the current tree. The RED->GREEN half.
+#
+#   (b) DELIBERATE RE-BLIND -- THE MUTATION. With the pin removed, each check
+#       must fail, must name the blind, and must NOT print its original
+#       regression text. This is the clause a pin-only fix fails.
+#
+#   (c) THE GUARD CLASSIFIES IT AS A HARNESS ERROR, NOT A FAILURE. A blinded
+#       fixture says nothing about the subject, so the correct exit is 3 (this
+#       repo's harness-error convention), never 1. Exit 1 from a blinded check
+#       is a verdict about #705/#712 that the run did not earn.
+#
+#   (d) INVENTORY. Every done-means check that builds a git fixture pins
+#       `core.hooksPath` to an explicit value. Two correct answers exist and
+#       both count: pin to `_githooks` when the hook IS the subject (705, 712),
+#       or neutralise by pinning at a hooks-free directory when it is not (709,
+#       714). 711 pins per-invocation with `git -c` because the value itself is
+#       its subject. What is refused is INHERITANCE -- no pin at all. Carries a
+#       positive control on its own scan (round 30): a query that matches almost
+#       nothing is a broken query, not a clean repo.
+#
+# Exit 0 only when every clause passes. Exit 3 is a harness error, which is NOT
+# a failure of the thing under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DM_DIR="$REPO_ROOT/scripts/done-means"
+RUN_ID="722-$$-$(date +%s)"
+SCRATCH="${OPENBRAIN_TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch/$RUN_ID"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v git >/dev/null 2>&1 || fail_hard "git not on PATH"
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+mkdir -p "$SCRATCH" || fail_hard "cannot create scratch dir $SCRATCH"
+
+CHECK_705="$DM_DIR/705-pre-push-base-selection.sh"
+CHECK_712="$DM_DIR/712-pre-push-pipe-safe.sh"
+PIN_MARKER="DM722-PIN"
+
+[ -r "$CHECK_705" ] || fail_hard "705 check not readable at $CHECK_705"
+[ -r "$CHECK_712" ] || fail_hard "712 check not readable at $CHECK_712"
+
+CLAUSES=()
+record() { CLAUSES+=("$1|$2|$3"); }
+
+RC_OUT=""
+RC_EXIT=0
+run_check() {
+  RC_OUT="$(cd "$REPO_ROOT" && bash "$1" 2>&1)"
+  RC_EXIT=$?
+}
+
+clause_lines() { printf '%s\n' "$1" | rg '^CLAUSE ' || true; }
+
+# ---------------------------------------------------------------------------
+# (a) both checks are GREEN on the current tree
+# ---------------------------------------------------------------------------
+A_FAILS=()
+
+run_check "$CHECK_705"
+A705_OUT="$RC_OUT"; A705_EXIT="$RC_EXIT"
+[ "$A705_EXIT" = "0" ] \
+  || A_FAILS+=("705 is not green (exit=$A705_EXIT): $(clause_lines "$A705_OUT" | rg 'FAIL' | tr '\n' ' ' | cut -c1-300)")
+
+run_check "$CHECK_712"
+A712_OUT="$RC_OUT"; A712_EXIT="$RC_EXIT"
+[ "$A712_EXIT" = "0" ] \
+  || A_FAILS+=("712 is not green (exit=$A712_EXIT): $(clause_lines "$A712_OUT" | rg 'FAIL' | tr '\n' ' ' | cut -c1-300)")
+
+if [ "${#A_FAILS[@]}" -eq 0 ]; then
+  record a PASS "705 exit=0 ($(clause_lines "$A705_OUT" | wc -l | tr -d ' ') clauses) and 712 exit=0 ($(clause_lines "$A712_OUT" | wc -l | tr -d ' ') clauses) on this tree"
+else
+  record a FAIL "$(printf '%s; ' "${A_FAILS[@]}")"
+fi
+
+# ---------------------------------------------------------------------------
+# (b) + (c) deliberate re-blind
+# ---------------------------------------------------------------------------
+# The copies MUST live in scripts/done-means/, because each check computes its
+# REPO_ROOT as "<its own dir>/../..". A copy in scratch would resolve REPO_ROOT
+# to a directory with no _githooks/ and fail_hard for the WRONG reason -- the
+# false-RED family (lane-contract rounds 18/22/23). They are dot-prefixed with
+# this run id and moved to scratch by an EXIT trap.
+BLIND_705="$DM_DIR/.dm722-blind-705-$RUN_ID.sh"
+BLIND_712="$DM_DIR/.dm722-blind-712-$RUN_ID.sh"
+
+cleanup_blinds() {
+  for f in "$BLIND_705" "$BLIND_712"; do
+    [ -e "$f" ] && mv "$f" "$SCRATCH/$(basename "$f")" 2>/dev/null
+  done
+  return 0
+}
+trap cleanup_blinds EXIT
+
+make_blind() {
+  local src="$1" dst="$2" removed
+  removed="$(rg -c -- "$PIN_MARKER" "$src" 2>/dev/null || printf '0')"
+  [ "${removed:-0}" -ge 1 ] || return 1
+  rg -v -- "$PIN_MARKER" "$src" > "$dst" || return 1
+  chmod +x "$dst" || return 1
+  printf '%s' "$removed"
+  return 0
+}
+
+R705="$(make_blind "$CHECK_705" "$BLIND_705")" \
+  || fail_hard "could not re-blind 705: no '$PIN_MARKER' line found. The fix must mark its pin with that marker so this clause can remove it; without it the mutation is a silent no-op and clause (b) would prove nothing."
+R712="$(make_blind "$CHECK_712" "$BLIND_712")" \
+  || fail_hard "could not re-blind 712: no '$PIN_MARKER' line found. The fix must mark its pin with that marker so this clause can remove it; without it the mutation is a silent no-op and clause (b) would prove nothing."
+
+# The ambient value a blinded fixture inherits. If it already IS `_githooks`,
+# or is unset, removing the pin cannot reproduce the blind -- say so rather
+# than passing on an unreproduced mutation.
+AMBIENT="$(git config --global --get core.hooksPath 2>/dev/null || true)"
+[ -n "$AMBIENT" ] || AMBIENT="$(git config --system --get core.hooksPath 2>/dev/null || true)"
+
+# The original regression text each check printed WHILE BLINDED. A blinded run
+# must not print these: they are claims about a subject it never reached.
+FALSE_705="the packages are no longer separately gated"
+FALSE_712="redirecting stdout alone does not fix #712"
+
+B_FAILS=()
+C_FAILS=()
+
+if [ -z "$AMBIENT" ] || [ "$AMBIENT" = "_githooks" ]; then
+  B_FAILS+=("the ambient core.hooksPath is '${AMBIENT:-<unset>}', so removing the pin cannot reproduce the blind -- this clause would prove nothing and is reported as unproven rather than passed")
+  C_FAILS+=("same: no reproducible blind available (ambient core.hooksPath='${AMBIENT:-<unset>}')")
+else
+  run_check "$BLIND_705"
+  B705_OUT="$RC_OUT"; B705_EXIT="$RC_EXIT"
+  run_check "$BLIND_712"
+  B712_OUT="$RC_OUT"; B712_EXIT="$RC_EXIT"
+
+  [ "$B705_EXIT" != "0" ] \
+    || B_FAILS+=("a BLINDED 705 reported success (exit=0) -- a check that cannot reach its subject must never be green")
+  [ "$B712_EXIT" != "0" ] \
+    || B_FAILS+=("a BLINDED 712 reported success (exit=0) -- a check that cannot reach its subject must never be green")
+
+  printf '%s' "$B705_OUT" | rg -qF -- "core.hooksPath" \
+    || B_FAILS+=("a BLINDED 705 did not name core.hooksPath as the blind: $(printf '%s' "$B705_OUT" | tr '\n' ' ' | cut -c1-200)")
+  printf '%s' "$B712_OUT" | rg -qF -- "core.hooksPath" \
+    || B_FAILS+=("a BLINDED 712 did not name core.hooksPath as the blind: $(printf '%s' "$B712_OUT" | tr '\n' ' ' | cut -c1-200)")
+
+  if printf '%s' "$B705_OUT" | rg -qF -- "$FALSE_705"; then
+    B_FAILS+=("a BLINDED 705 still claims '$FALSE_705' -- a parse failure masquerading as a #705 regression")
+  fi
+  if printf '%s' "$B712_OUT" | rg -qF -- "$FALSE_712"; then
+    B_FAILS+=("a BLINDED 712 still claims '$FALSE_712' -- a parse failure masquerading as a #712 regression")
+  fi
+
+  [ "$B705_EXIT" = "3" ] \
+    || C_FAILS+=("a BLINDED 705 exited $B705_EXIT, not 3 -- exit 1 is a verdict about #705 that a blinded run did not earn")
+  [ "$B712_EXIT" = "3" ] \
+    || C_FAILS+=("a BLINDED 712 exited $B712_EXIT, not 3 -- exit 1 is a verdict about #712 that a blinded run did not earn")
+fi
+
+if [ "${#B_FAILS[@]}" -eq 0 ]; then
+  record b PASS "with the pin removed (705: $R705 line(s), 712: $R712 line(s); ambient core.hooksPath='$AMBIENT') both checks fail, both name core.hooksPath, and neither emits its original regression text"
+else
+  record b FAIL "$(printf '%s; ' "${B_FAILS[@]}")"
+fi
+
+if [ "${#C_FAILS[@]}" -eq 0 ]; then
+  record c PASS "a blinded run exits 3 (HARNESS-ERROR) in both checks -- the blind is classified as a harness problem, not as a failure of the subject"
+else
+  record c FAIL "$(printf '%s; ' "${C_FAILS[@]}")"
+fi
+
+# ---------------------------------------------------------------------------
+# (d) inventory -- no git fixture inherits core.hooksPath
+# ---------------------------------------------------------------------------
+#
+# "Builds a git fixture" means a git SUBCOMMAND invocation of `init` or
+# `clone` -- `git`, optional `-C <dir>` / `-c k=v` flags, then the subcommand.
+#
+# The first spelling of this scan was `git .*\binit\b|git .*\bclone\b`, and it
+# was wrong in exactly the round-30 way. It matched the ENGLISH word "clone"
+# inside a message string --
+#   "git does NOT track it -- a fresh clone gets no tracking scribe"
+# -- and reported `tracking-scribe-root-only.sh` and `verifier-agent-grounded.sh`
+# as unpinned git fixtures. Neither runs `git init` or `git clone` at all. The
+# wrong answer named real files and a real-sounding defect, which is the whole
+# hazard: a plausible wrong answer, never an error. Anchored on the invocation
+# shape instead. The `D_CHECKED` floor below is the positive control that keeps
+# the opposite failure (a pattern so tight it matches nothing) loud --
+# `docs/sme/gotcha-agent.md` requires exactly that on a one-directional scan.
+D_UNPINNED=()
+D_CHECKED=0
+GIT_FIXTURE_RE='(^|[;&|(]|[[:space:]])git[[:space:]]+(-[Cc][[:space:]]*[^[:space:]]+[[:space:]]+)*(init|clone)([[:space:]]|$)'
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  rg -q -- "$GIT_FIXTURE_RE" "$f" || continue
+  D_CHECKED=$((D_CHECKED + 1))
+  rg -q 'core\.hooksPath' "$f" || D_UNPINNED+=("$(basename "$f")")
+done < <(fd -e sh . "$DM_DIR" 2>/dev/null | rg -v '\.dm722-blind-')
+
+if [ "$D_CHECKED" -lt 5 ]; then
+  # Positive control on the scan itself (round 30): a one-directional check
+  # cannot tell "absent" from "my query was broken". 705, 709, 711, 712 and 714
+  # all build git fixtures, so fewer than five matches means the scan broke.
+  record d FAIL "the fixture inventory matched only $D_CHECKED check(s) -- the scan is broken, not the repo clean; at least 705, 709, 711, 712 and 714 build git fixtures"
+elif [ "${#D_UNPINNED[@]}" -eq 0 ]; then
+  record d PASS "all $D_CHECKED done-means checks that build a git fixture pin core.hooksPath explicitly (pinned to _githooks where the hook IS the subject; neutralised where it is not)"
+else
+  record d FAIL "these checks build a git fixture and inherit core.hooksPath: $(printf '%s ' "${D_UNPINNED[@]}")-- #711's assertion will blind every hook invocation inside them"
+fi
+
+# ---------------------------------------------------------------------------
+# Teardown. Scratch is MOVED to the archive, never deleted (AGENTS.md: the
+# agent's cleanup verb is mv). The blinded copies were moved out of
+# scripts/done-means/ by the EXIT trap.
+# ---------------------------------------------------------------------------
+cleanup_blinds
+ARCHIVE_DIR="${OPENBRAIN_TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_archive"
+if mkdir -p "$ARCHIVE_DIR" 2>/dev/null; then
+  mv "$SCRATCH" "$ARCHIVE_DIR/$RUN_ID" 2>/dev/null \
+    || printf 'TEARDOWN-WARNING: scratch left at %s\n' "$SCRATCH" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+label_for() {
+  case "$1" in
+    a) printf 'both pre-push done-means checks are GREEN on this tree' ;;
+    b) printf 'MUTANT: a re-blinded check fails, names the BLIND, and drops the false regression text' ;;
+    c) printf 'a blinded run exits 3 (HARNESS-ERROR), never 1' ;;
+    d) printf 'no done-means git fixture inherits core.hooksPath' ;;
+  esac
+}
+
+ALL_PASS=1
+for entry in "${CLAUSES[@]}"; do
+  id="${entry%%|*}"
+  rest="${entry#*|}"
+  status="${rest%%|*}"
+  evidence="${rest#*|}"
+  printf 'CLAUSE %s (%s): %s — %s\n' "$id" "$(label_for "$id")" "$status" "$evidence"
+  [ "$status" = PASS ] || ALL_PASS=0
+done
+
+[ "$ALL_PASS" -eq 1 ] && exit 0
+exit 1


### PR DESCRIPTION
## Summary

`scripts/done-means/705-pre-push-base-selection.sh` and
`scripts/done-means/712-pre-push-pipe-safe.sh` built their throwaway git
fixtures with a bare `git init`, which sets no `core.hooksPath`. The fixture
therefore INHERITED the operator's global value, and #711's in-hook assertion —
which runs before the `--explain` early exit — refused every fixture
invocation. Every clause then parsed a refusal instead of the hook's decision,
and both checks reported that as a substantive regression of #705/#712 in
confident, specific, FALSE text.

Family B (the environment deciding a verdict), reaching a new surface: the
gates' own checks.

Measured on the untouched tree at `origin/wip/2026-08-07`, under the operator's
real global `core.hooksPath=/Users/rico/.config/git/hooks`:

- `705`: 5 of 6 clauses FAIL, exit 1. Only clause (e), which reads the hook's
  source structurally and never invokes it, passes. Clause (b)'s text —
  "the packages are no longer separately gated" — is about a hook that never ran.
- `712`: 6 of 6 clauses FAIL. Clause (f)'s "redirecting stdout alone does not
  fix #712" is a specific verdict on the FIX's shape, emitted about a hook whose
  redirect code never executed.

### The fix

1. **Pin the fixture environment.** Both fixtures set
   `core.hooksPath=_githooks` immediately after `git init`, so the fixture is
   hermetic against the operator's global config and the hook under test reaches
   its own subject code. The hook IS these checks' subject, so the pin is the
   real value — contrast `709`/`714`, which point at an empty hooks directory
   because the hook is NOT their subject.
2. **A HARNESS-ERROR guard, not a FAIL.** Before any clause runs, each check
   asserts the fixture's effective `core.hooksPath`. A mismatch exits 3, because
   a blinded fixture is not a statement about the subject in either direction.
3. **A parse failure is not a regression.** `blinded_by` is anchored on the
   ABSENCE of every marker the hook owns for a successful decision, not on a
   list of known refusal texts, so an invariant added tomorrow still degrades to
   "produced no decision" rather than to a false regression.

### Second defect, found by finishing the salvage (not in the original checkpoint)

With the pin applied, `712` still failed clause (d) with the hook FULLY REACHED
— a real verdict, not a blind (`3372 pass 0 fail`, `DM712_HOOK_EXIT=0`). So the
pin alone was not the whole defect.

Clause (d) required the announced log path to sit under the fixture's own
`OPENBRAIN_TEMP_WORKSPACE` (`$SCRATCH/ws`), which `run_hook_through_pipe` sets
on the hook invocation. **The fixture cannot win that assertion**, for the same
reason #722 exists — the ambient environment decides the verdict:

```
env OPENBRAIN_TEMP_WORKSPACE=/probe/ws zsh  -c 'echo $OPENBRAIN_TEMP_WORKSPACE'
  -> /Volumes/ThunderBolt/_tmp      # the caller's value is discarded
env OPENBRAIN_TEMP_WORKSPACE=/probe/ws bash -c 'echo $OPENBRAIN_TEMP_WORKSPACE'
  -> /probe/ws                      # bash honours it
```

The hook's shebang is `#!/usr/bin/env zsh`; `~/.zshenv` is read by EVERY zsh —
including a non-interactive script — and sources
`~/Library/Application Support/rtech-infra/env-roots.zsh`, whose line 6 is an
unconditional `export OPENBRAIN_TEMP_WORKSPACE=/Volumes/ThunderBolt/_tmp`. An
unconditional export in a startup file overwrites what the caller passed, so the
hook always logs to the operator's real temp workspace. Measured with a probe
copy of the check: `has_buntest=1`, `has_ws=0`, announced path
`.../open-brain/_scratch/pre-push/bun-test-47592-1787017419.log`.

So the old assertion tested the OPERATOR'S SHELL PROFILE, not the hook. The
clause's stated subject is that the redirect is ANNOUNCED and the log NAMED;
it now checks the announcement plus a concrete `bun-test-<pid>-<epoch>.log`
filename. Pinning the DIRECTORY is not this check's business and is not
something the fixture is able to do; pinning the SHAPE is, and it still fails if
the hook stops naming its log.

## Verification

- Done-means: scripts/done-means/722-fixture-hookspath-pinned.sh

RED, on the untouched tree at `origin/wip/2026-08-07`, with the operator's real
global `core.hooksPath` in force (and reproduced identically with a simulated
global via `GIT_CONFIG_GLOBAL` pointed at a fixture config, so the real global
was never touched):

```
705 RED EXIT=1
CLAUSE a: FAIL — decision fields missing ... ✗ core.hooksPath does not match ... (issue #711)
CLAUSE b: FAIL — the packages are no longer separately gated
CLAUSE c: FAIL — the hook did not name the base ref it compared against ... (issue #711)
CLAUSE d: FAIL — an upstreamless branch made the hook fail rather than fall back (exit=1)
CLAUSE e: PASS   (structural — never invokes the hook)
CLAUSE f: FAIL — the real push path produced no readable package decision

712: 6 of 6 clauses FAIL
CLAUSE f: FAIL — redirecting stdout alone does not fix #712
```

GREEN, on this branch, under the operator's REAL environment — the same one
where the checks were RED:

```
705-pre-push-base-selection REAL-ENV EXIT=0     (6/6 PASS)
712-pre-push-pipe-safe      REAL-ENV EXIT=0     (6/6 PASS)
722-fixture-hookspath-pinned REAL-ENV EXIT=0    (4/4 PASS)
```

`722`'s own clauses, which prove the pinning rather than assuming it:

```
CLAUSE a: PASS — 705 exit=0 (6 clauses) and 712 exit=0 (6 clauses) on this tree
CLAUSE b: PASS — DELIBERATE RE-BLIND: with the pin removed (705: 1 line, 712: 1 line;
          ambient core.hooksPath='/Users/rico/.config/git/hooks') both checks fail,
          both name core.hooksPath, and NEITHER emits its original regression text
CLAUSE c: PASS — a blinded run exits 3 (HARNESS-ERROR), never 1
CLAUSE d: PASS — all 5 done-means checks that build a git fixture pin
          core.hooksPath explicitly
```

Clause (b) is the negative control: it removes the pin, re-blinds each check,
and asserts both that the check FAILS and that the false regression text is
GONE. Without it, the pin could be deleted and everything would still look green.

Mutation test on the new clause (d) assertion: replacing the
`bun-test-<pid>-<epoch>.log` pattern with a sentinel the hook never emits makes
clause (d) FAIL, so the clause is not vacuously green.

`bunx tsc --noEmit`: clean (after `bun install --frozen-lockfile`; the change is
shell-only and adds no TypeScript).

Not run: the full `bun run test:isolated` suite. This diff touches only
`scripts/done-means/*.sh` and no runtime code, and the three affected checks
each drive the real shipped `_githooks/pre-push` end to end.

## Critical Self-Review

- Highest-risk behavior: a fixture pinned to `core.hooksPath=_githooks` could
  mask a REAL #711 drift in the operator's config. It cannot: the pin is
  fixture-local (`git -C "$FIXTURE" config`), the operator's global is never
  read or written, and #711's assertion still runs in the real hook on every
  real push. These checks are about #705/#712, not about the operator's config.
- Assumptions that could be wrong: that `_githooks` is the correct pin value.
  Verified against `_githooks/pre-push` line 83 (`EXPECTED_HOOKS_PATH="_githooks"`)
  and against `_githooks/install.sh`, which is what writes it — not assumed.
- Missing/weak tests: clause (d)'s new assertion pins the log's SHAPE, not its
  DIRECTORY, so a hook that logged to a wrong-but-plausibly-named path would
  still pass. That is deliberate and documented in the file: the fixture
  provably cannot pin the directory (zsh startup overwrites the variable), and
  an assertion the fixture cannot satisfy is exactly the #722 defect. Pinning
  the directory needs `env-roots.zsh` to stop unconditionally exporting, which
  is out of this lane's scope and is NOT fixed here.
- Security/permission risk: none. No auth, namespace, network, or DB surface is
  touched. No secrets in the diff; the pre-commit secret scan reported
  `no leaks found`.
- Migration/deploy risk: none. No migration, no schema, no runtime code.
- Downstream client/runtime risk: none. `scripts/done-means/*.sh` are
  repo-local verification scripts; no MCP tool, transport, schema, or Python
  client surface changes, so `docs/downstream-rollout.md` does not apply.
- Rollback/cleanup concern: revert the two commits; nothing is stateful. The
  lane clone and the baseline worktree are archived at teardown (below), and
  the probe copy of `712` was moved to `_archive/` rather than deleted.
- Fixes made before PR: the clause (d) defect above — found by actually running
  the salvaged checkpoint instead of trusting it. The checkpoint was committed
  UNTESTED and was NOT sufficient on its own; it left `712` at 5 of 6.
- Known residual risk: `env-roots.zsh` unconditionally exporting
  `OPENBRAIN_TEMP_WORKSPACE` means NO zsh-shebanged script in this repo can
  have its temp workspace overridden by a caller. This PR works around that in
  one clause and documents it; it does not fix the root cause, and other
  callers that believe they can set that variable for a zsh child are still
  wrong. Filing that separately is the controller's call.
- SME review-memory update: [x] not applicable because: the lane's operating
  lesson (a fixture must pin every environment input its subject reads, and a
  check that cannot express the defect is a harness error rather than a
  verdict) belongs in `docs/lane-contract.md` Tightenings, which the merge pass
  harvests from this report; `docs/sme/` covers reviewer knowledge, and no new
  reviewer-facing code pattern was found.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this change touches only
  `scripts/done-means/*.sh` verification scripts — no MCP tool, transport,
  schema, namespace, or Open Brain runtime surface is involved, so there is
  nothing for a live Open Brain canary to exercise.

Refs #722
