### PR TITLE
fix(runtime): manual wrap adopts an existing lane's scope (#724)

### DIFF
--- a/docs/memory-contract.md
+++ b/docs/memory-contract.md
@@ -77,6 +77,39 @@ through another authorized durable path.
 3. Call `session_wrap` to checkpoint the summary to durable storage
 4. Context compacts. Lane persists.
 
+#### Wrap/checkpoint against a lane the session does not own
+
+Status: WRITTEN 2026-08-17 (#724 item 4), client-side only — the server's
+exact-scope predicate is unchanged.
+
+A manual `wrap`/`checkpoint` is frequently issued against a lane some OTHER
+process opened. The capture hook is the common case: it creates the base lane
+with `agent` set and every other exact-scope coordinate NULL, so a session that
+claims its own full scope trips the server's one-way fill (#646) and the write
+is refused with `Existing lane exact scope does not match session_start
+request`. Two Development sessions lost their wraps to exactly this.
+
+The `openbrain-memory` client now **claims first and adopts on refusal**:
+
+1. `session_start` claims the caller's own exact scope, exactly as before. On
+   success nothing else happens — the ordinary path is unchanged, same single
+   call with the same arguments.
+2. **Only** on that specific scope refusal, the client re-issues
+   `session_start` claiming nothing but `session_key`. That is the server's
+   `!hasCompleteExactScope` branch, which returns the existing lane verbatim
+   instead of attempting a fill.
+3. `session_wrap` then carries the coordinates that came back ON THAT LANE, not
+   the requester's, because the write verb must still satisfy the server's
+   lane-scope predicate.
+
+The adopting `session_start` has no requested exact scope for the response to
+prove, so it is validated on `session_key` + `namespace` — the coordinates the
+caller genuinely owns. The namespace refusals (#654/#662) are enforced
+unchanged on this path. Adoption never re-points the lane, and it is scoped to
+the wrap/checkpoint verbs: `append_session_event` (capture) and
+`agent_context_pack` still prove full exact scope, and no other validation is
+widened.
+
 ### Resuming After Compaction
 1. Call `session_start` → lane + events are immediately available
 2. Search OB for related past work if needed

--- a/docs/memory-contract.md
+++ b/docs/memory-contract.md
@@ -108,7 +108,10 @@ caller genuinely owns. The namespace refusals (#654/#662) are enforced
 unchanged on this path. Adoption never re-points the lane, and it is scoped to
 the wrap/checkpoint verbs: `append_session_event` (capture) and
 `agent_context_pack` still prove full exact scope, and no other validation is
-widened.
+widened. Adoption is therefore NAMESPACE-SCOPED by design: a same-namespace lane
+is the same tenant, the client cannot observe which same-namespace session owns
+a lane, and the boundary that matters is the server's namespace predicate — not
+a client-side check (operator ruling, 2026-08-17).
 
 ### Resuming After Compaction
 1. Call `session_start` → lane + events are immediately available

--- a/python/openbrain-memory/src/openbrain_memory/_runtime_validation.py
+++ b/python/openbrain-memory/src/openbrain_memory/_runtime_validation.py
@@ -64,32 +64,24 @@ def distilled_content(
     return value
 
 
-def validate_started_lane(
-    result: Any,
-    namespace: str,
-    scope: RuntimeScopeCoordinates,
-) -> None:
-    """Require a session-start result to prove the requested exact scope."""
+def _started_lane(result: Any) -> Mapping[str, Any]:
+    """Return the lane object from a session-start result, or refuse."""
     if not isinstance(result, Mapping):
         raise ValueError("session_start result missing lane object")
     lane = result.get("lane")
     if not isinstance(lane, Mapping):
         raise ValueError("session_start result missing lane object")
-    metadata = lane.get("metadata")
-    candidate = {
-        name: lane[name]
-        for name in (
-            "namespace",
-            "session_key",
-            "agent",
-            "source",
-            "channel_id",
-            "thread_id",
-        )
-        if name in lane
-    }
-    if isinstance(metadata, Mapping) and "server_id" in metadata:
-        candidate["server_id"] = metadata["server_id"]
+    return lane
+
+
+def _require_proven_namespace(lane: Mapping[str, Any], namespace: str) -> None:
+    """Refuse a lane whose namespace is absent or is not the configured one.
+
+    Extracted verbatim from ``validate_started_lane`` so the adopted-lane
+    validator (#724 item 4) enforces the SAME refusals rather than a second
+    copy that could drift. The two branches and their reasoning below are
+    #654 and #662 unchanged.
+    """
     # A namespace mismatch is diagnosed separately, BEFORE the generic
     # comparison, because it is the one scope key an operator cannot fix by
     # editing the request (#654). `namespace` is env-carried and never a
@@ -144,6 +136,62 @@ def validate_started_lane(
             "request sends the X-Namespace header. Nothing was written to "
             f"'{namespace}'."
         )
+
+
+def validate_adopted_lane(
+    result: Any,
+    namespace: str,
+    session_key: str,
+) -> None:
+    """Require an ADOPTED lane to prove the coordinates the caller owns.
+
+    A manual wrap/checkpoint claims no exact scope (#724 item 4), so there is
+    no requested exact scope for the response to prove. What the caller does
+    own is its ``session_key`` and, through its token or the delegation header,
+    its ``namespace`` — so those, and only those, bind here.
+
+    This is deliberately NOT a general relaxation. ``validate_started_lane``
+    remains the validator for every other session_start, the context-pack proof
+    is untouched, and the namespace branches below are the same refusals
+    (#654/#662) enforced on the exact-scope path: an unproven namespace is
+    still a refusal, because writing into a lane whose namespace was never
+    established is the silent mis-scope those issues exist to prevent
+    (``server/auth/middleware.ts:9-13``).
+    """
+    lane = _started_lane(result)
+    _require_proven_namespace(lane, namespace)
+    served_key = lane.get("session_key")
+    if served_key != session_key:
+        raise ValueError(
+            "session_start returned a lane for session_key "
+            f"'{served_key}', not the requested '{session_key}'. Nothing was "
+            "written."
+        )
+
+
+def validate_started_lane(
+    result: Any,
+    namespace: str,
+    scope: RuntimeScopeCoordinates,
+) -> None:
+    """Require a session-start result to prove the requested exact scope."""
+    lane = _started_lane(result)
+    metadata = lane.get("metadata")
+    candidate = {
+        name: lane[name]
+        for name in (
+            "namespace",
+            "session_key",
+            "agent",
+            "source",
+            "channel_id",
+            "thread_id",
+        )
+        if name in lane
+    }
+    if isinstance(metadata, Mapping) and "server_id" in metadata:
+        candidate["server_id"] = metadata["server_id"]
+    _require_proven_namespace(lane, namespace)
     expected = exact_scope_fields(namespace, scope)
     expected["source"] = expected.pop("platform")
     # The server stores/returns `platform` under the lane column `source`

--- a/python/openbrain-memory/src/openbrain_memory/agent.py
+++ b/python/openbrain-memory/src/openbrain_memory/agent.py
@@ -280,6 +280,30 @@ class AgentMemory:
         self.conversation_key = conversation_key
         return result
 
+    def start_session_unscoped(self, conversation_key: str) -> JSON:
+        """Open or adopt a lane WITHOUT claiming any exact-scope coordinate.
+
+        The ordinary ``start_session`` asserts this memory's ``agent`` and
+        whatever lane coordinates the caller passes. That is right when the
+        caller owns the lane, and wrong for a manual wrap/checkpoint against a
+        lane another process opened (#724 item 4): the server's #646 one-way
+        fill refuses to re-point an already-set coordinate, so the claim itself
+        is what fails the write.
+
+        Sending only ``session_key`` puts the server on its
+        ``!hasCompleteExactScope`` path, where an existing lane is returned
+        verbatim and its stored scope can be adopted by the caller
+        (``server/tools/session-lifecycle.ts:67,155``). ``project`` is still
+        sent because it is not an exact-scope coordinate and is not part of the
+        refusing predicate.
+        """
+        payload: dict[str, Any] = {"session_key": conversation_key}
+        if self.project is not None:
+            payload["project"] = self.project
+        result = self._call_write("session_start", payload, self.client.session_start)
+        self.conversation_key = conversation_key
+        return result
+
     def recall(
         self,
         query: str,

--- a/python/openbrain-memory/src/openbrain_memory/runtime.py
+++ b/python/openbrain-memory/src/openbrain_memory/runtime.py
@@ -64,6 +64,9 @@ from ._runtime_validation import (
     source_float as _source_float,
 )
 from ._runtime_validation import (
+    validate_adopted_lane as _validate_adopted_lane,
+)
+from ._runtime_validation import (
     validate_context_pack_scope as _validate_context_pack_scope,
 )
 from ._runtime_validation import (
@@ -293,6 +296,121 @@ class RuntimeScope:
     def wrap_metadata(self) -> dict[str, str]:
         """Return exact scope coordinates supported by ``session_wrap``."""
         return self.start_metadata()
+
+
+@dataclass(frozen=True)
+class AdoptedLaneScope:
+    """The exact scope an EXISTING lane already stores, read back from it.
+
+    A manual wrap/checkpoint does not own the lane it is writing into (#724
+    item 4). The capture hook opens the base lane with ``agent`` set and every
+    other coordinate NULL; a wrap issued from a differently-scoped session that
+    CLAIMS its own coordinates trips the server's #646 one-way fill and the
+    write is refused outright.
+
+    Operator ruling 2026-08-17: the wrap ADOPTS the lane's scope. The server's
+    refusal is an isolation boundary and does not move; the client stops
+    asserting a scope it does not own. Adoption is two halves, and only doing
+    the first half leaves the write still refused:
+
+    1. ``session_start`` claims no exact-scope coordinates, so the server takes
+       the ``!hasCompleteExactScope`` branch and returns the existing lane
+       verbatim (``server/tools/session-lifecycle.ts:67,155``);
+    2. the coordinates that come BACK on that lane are what ``session_wrap``
+       then sends, because the write verb must still satisfy the server's
+       lane-scope predicate and the lane's own scope is the only thing that
+       can.
+
+    The caller's own ``session_key`` (and, through its token, the namespace)
+    are the coordinates it genuinely owns; those still bind.
+    """
+
+    agent: str | None
+    platform: str | None
+    server_id: str | None
+    channel_id: str | None
+    thread_id: str | None
+
+    @classmethod
+    def from_lane(cls, lane: Mapping[str, Any]) -> AdoptedLaneScope:
+        """Read the stored scope off a ``session_start`` lane object.
+
+        The server stores ``platform`` in the lane column ``source`` and
+        ``server_id`` inside ``metadata`` (``src/tools/session-start.ts:9,45,84``),
+        so the response spelling is translated back to the request spelling
+        here rather than at each call site.
+        """
+        metadata = lane.get("metadata")
+        server_id = metadata.get("server_id") if isinstance(metadata, Mapping) else None
+        return cls(
+            agent=_adopted_text(lane.get("agent")),
+            platform=_adopted_text(lane.get("source")),
+            server_id=_adopted_text(server_id),
+            channel_id=_adopted_text(lane.get("channel_id")),
+            thread_id=_adopted_text(lane.get("thread_id")),
+        )
+
+    def wrap_metadata(self) -> dict[str, Any]:
+        """Return the lane's own coordinates for a ``session_wrap`` payload.
+
+        NULL coordinates are sent as ``None`` rather than omitted: the server
+        compares the request against the lane field-by-field, so a lane whose
+        ``channel_id`` is NULL is matched by an explicit ``None`` and an
+        omitted key is not guaranteed to read the same way.
+        """
+        return {
+            "platform": self.platform,
+            "server_id": self.server_id,
+            "channel_id": self.channel_id,
+            "thread_id": self.thread_id,
+        }
+
+
+# The server's one-way-fill refusal, verbatim and lowercased
+# (`server/tools/session-lifecycle.ts:151-153`, and the same string in
+# `src/tools/session-start.ts`). Matched as a substring because the transport
+# wraps it in a `context=call_tool:session_start body=...` envelope.
+_LANE_SCOPE_REFUSAL = "existing lane exact scope does not match session_start request"
+
+
+def _is_lane_scope_refusal(error: BaseException) -> bool:
+    """Is this the server refusing to re-point an already-scoped lane?
+
+    Deliberately narrow. Only THIS refusal triggers adoption: it is the one
+    that means "the lane exists and its scope is not yours", which is exactly
+    the case the operator ruled a wrap should adopt through (#724 item 4). A
+    connectivity failure, an auth denial, or any other error must keep its
+    existing behavior — spool, fallback, or a LOST receipt — so a broken
+    transport is never mistaken for a lane worth adopting.
+    """
+    return _LANE_SCOPE_REFUSAL in str(error).lower()
+
+
+def _lane_scope_from_start_result(result: Any) -> AdoptedLaneScope:
+    """Read the adopted scope out of a ``session_start`` result envelope.
+
+    The result has already passed ``_validate_adopted_lane``, which proves the
+    lane object exists and is bound to the right session_key and namespace, so
+    a missing lane here is a programming error rather than a hostile response.
+    """
+    lane = result.get("lane") if isinstance(result, Mapping) else None
+    if not isinstance(lane, Mapping):
+        raise ValueError("session_start result missing lane object")
+    return AdoptedLaneScope.from_lane(lane)
+
+
+def _adopted_text(value: Any) -> str | None:
+    """Accept a lane coordinate the server stored, or ``None`` if it is unset.
+
+    Deliberately permissive next to ``_persisted_text``: this value came FROM
+    the server describing a lane that already exists, so refusing it cannot
+    prevent a bad write — it can only refuse to write to a lane that is already
+    there. Anything that is not usable text is treated as unset.
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
 
 
 @dataclass(frozen=True)
@@ -527,6 +645,12 @@ class FirstClassMemoryRuntime:
         # Set only while draining a spooled unit parked under another scope;
         # session_start replay results validate against this instead of scope.
         self._replay_scope: RuntimeScope | None = None
+        # Set only for the duration of one wrap/checkpoint write (#724 item 4):
+        # the lane's own stored scope, read back from session_start, and the
+        # flag that switches session_start validation to the session_key +
+        # namespace binding. Both are reset per write in `_write_locked`.
+        self._adopted_scope: AdoptedLaneScope | None = None
+        self._adopting_lane = False
         direct = client
         setup_error: BaseException | None = None
         if direct is None:
@@ -935,13 +1059,19 @@ class FirstClassMemoryRuntime:
             metadata = _wrap_metadata(key_decisions, next_steps, receipt_refs)
         except ValueError as error:
             return _failed_write("checkpoint", error)
+        # `_adopted_wrap_metadata()` is read INSIDE the lambda, so it resolves
+        # after `_write_locked` has run `_ensure_lane` and adopted the lane's
+        # stored scope. Binding `self.scope.wrap_metadata()` here instead would
+        # freeze the requester's own coordinates before the lane is known,
+        # which is the defect (#724 item 4).
         return self._write(
             "checkpoint",
             lambda: self._memory.checkpoint(
                 safe_summary,
-                **self.scope.wrap_metadata(),
+                **self._adopted_wrap_metadata(),
                 **metadata,
             ),
+            adopt_lane_scope=True,
         )
 
     def wrap(
@@ -958,29 +1088,47 @@ class FirstClassMemoryRuntime:
             metadata = _wrap_metadata(key_decisions, next_steps, receipt_refs)
         except ValueError as error:
             return _failed_write("wrap", error)
+        # See the note in `checkpoint`: the metadata must resolve after lane
+        # adoption, not at lambda-construction time.
         return self._write(
             "wrap",
             lambda: self._memory.wrap_session(
                 safe_summary,
-                **self.scope.wrap_metadata(),
+                **self._adopted_wrap_metadata(),
                 **metadata,
             ),
+            adopt_lane_scope=True,
         )
 
-    def _write(self, operation: str, call: Callable[[], JSON]) -> RuntimeOutput:
+    def _write(
+        self,
+        operation: str,
+        call: Callable[[], JSON],
+        *,
+        adopt_lane_scope: bool = False,
+    ) -> RuntimeOutput:
         with self._operation_lock:
-            return self._write_locked(operation, call)
+            return self._write_locked(
+                operation,
+                call,
+                adopt_lane_scope=adopt_lane_scope,
+            )
 
     def _write_locked(
         self,
         operation: str,
         call: Callable[[], JSON],
+        *,
+        adopt_lane_scope: bool = False,
     ) -> RuntimeOutput:
         self._router.reset()
         if self._spool is not None:
             self._spool.reset()
+        # Reset per write so no later operation can inherit a stale adopted
+        # scope from an earlier wrap; the capture path must never see one.
+        self._adopted_scope = None
         try:
-            self._ensure_lane()
+            self._ensure_lane(adopt_lane_scope=adopt_lane_scope)
             result = call()
             receipt_status = (
                 ReceiptStatus.FALLBACK
@@ -1182,22 +1330,102 @@ class FirstClassMemoryRuntime:
     def _validate_direct_result(self, tool: str, result: Any) -> None:
         try:
             if tool == "session_start":
-                scope = (
-                    self._replay_scope if self._replay_scope is not None else self.scope
-                )
-                _validate_started_lane(result, self.config.namespace, scope)
+                # A spooled session_start REPLAY is parked under its own exact
+                # scope and still proves it; that branch is checked first so a
+                # drain running inside an adopting wrap cannot borrow the
+                # weaker binding.
+                if self._replay_scope is not None:
+                    _validate_started_lane(
+                        result, self.config.namespace, self._replay_scope
+                    )
+                elif self._adopting_lane:
+                    # A wrap/checkpoint claimed no exact scope, so there is no
+                    # requested exact scope to prove. What the caller owns —
+                    # and therefore what binds — is `session_key` plus the
+                    # env-carried namespace. The namespace refusal branches
+                    # (#654/#662) are preserved inside this validator: they are
+                    # a separate isolation control and are not relaxed here.
+                    _validate_adopted_lane(
+                        result,
+                        self.config.namespace,
+                        self.scope.session_key,
+                    )
+                else:
+                    _validate_started_lane(result, self.config.namespace, self.scope)
             elif tool == "agent_context_pack":
                 _validate_context_pack_scope(result, self.config.namespace, self.scope)
         except ValueError as error:
             raise RuntimeCallError(str(error)) from error
 
-    def _ensure_lane(self) -> None:
+    def _ensure_lane(self, *, adopt_lane_scope: bool = False) -> None:
         if self._memory.conversation_key is not None:
+            if adopt_lane_scope and self._adopted_scope is None:
+                # The lane was opened earlier in this process (a capture, say)
+                # and this wrap never saw its session_start result. Its stored
+                # scope is unknown, so fall back to the scope this runtime
+                # opened it with rather than sending NULLs at a lane that has
+                # real coordinates.
+                self._adopted_scope = AdoptedLaneScope(
+                    agent=self.scope.agent,
+                    platform=self.scope.platform,
+                    server_id=self.scope.server_id,
+                    channel_id=self.scope.channel_id,
+                    thread_id=self.scope.thread_id,
+                )
+            return
+        if adopt_lane_scope:
+            # CLAIM FIRST, adopt only on the specific scope refusal.
+            #
+            # Discovering unconditionally (an unscoped `session_start` before
+            # every wrap) was tried and is wrong twice over: on a lane that
+            # does not exist yet it CREATES a bare NULL-scoped lane and strands
+            # it, and it adds a wire call to a sequence the cross-runtime
+            # contract fixture pins. Claiming first keeps the ordinary path
+            # byte-for-byte unchanged — same one call, same arguments — so
+            # adoption costs nothing until it is actually needed.
+            try:
+                self._memory.start_session(
+                    self.scope.session_key,
+                    **self.scope.start_metadata(),
+                )
+                return
+            except Exception as error:
+                if not _is_lane_scope_refusal(error):
+                    raise
+            # The lane exists and already holds a coordinate this session does
+            # not own — the capture-hook case (#724 item 4). Re-issue claiming
+            # NOTHING but the session_key, which puts the server on its
+            # `!hasCompleteExactScope` branch and returns the existing lane
+            # verbatim (`server/tools/session-lifecycle.ts:67,155`), then write
+            # under the scope that comes back.
+            #
+            # `_adopting_lane` is scoped to this one call: the claim-nothing
+            # request has no exact scope for the response to prove, so it
+            # validates on session_key + namespace. Every other session_start,
+            # including the claim above, still proves its exact scope in full.
+            self._adopting_lane = True
+            try:
+                result = self._memory.start_session_unscoped(self.scope.session_key)
+            finally:
+                self._adopting_lane = False
+            self._adopted_scope = _lane_scope_from_start_result(result)
+            self._memory.agent = self._adopted_scope.agent or self.scope.agent
             return
         self._memory.start_session(
             self.scope.session_key,
             **self.scope.start_metadata(),
         )
+
+    def _adopted_wrap_metadata(self) -> dict[str, Any]:
+        """Return the scope a wrap/checkpoint write must carry.
+
+        The adopted lane scope when there is one, and the requester's own scope
+        otherwise — the latter covers a wrap issued before any lane state was
+        observed, which is the pre-#724 behavior and stays correct there.
+        """
+        if self._adopted_scope is not None:
+            return self._adopted_scope.wrap_metadata()
+        return dict(self.scope.wrap_metadata())
 
     def _receipt(
         self,

--- a/python/openbrain-memory/tests/_runtime_fakes.py
+++ b/python/openbrain-memory/tests/_runtime_fakes.py
@@ -123,11 +123,25 @@ class LaneAwareTransport:
             lane = self.started_sessions.setdefault(
                 arguments["session_key"], requested_lane
             )
-            if any(
-                lane.get(key) != requested_lane.get(key)
-                for key in ("agent", "source", "channel_id", "thread_id")
-            ) or lane["metadata"].get("server_id") != requested_lane["metadata"].get(
-                "server_id"
+            # Mirrors the server's `hasCompleteExactScope` gate
+            # (server/tools/session-lifecycle.ts:28-37,155). The one-way-fill
+            # refusal below runs ONLY when the request carries the complete
+            # exact-scope predicate; a request that claims no scope takes the
+            # server's other branch and gets the existing lane back verbatim,
+            # which is what a wrap/checkpoint adopting a lane relies on
+            # (#724 item 4). Without this gate the fake refused a request the
+            # real server accepts.
+            claims_complete_exact_scope = all(
+                arguments.get(key) is not None
+                for key in ("agent", "platform", "server_id", "channel_id")
+            )
+            if claims_complete_exact_scope and (
+                any(
+                    lane.get(key) != requested_lane.get(key)
+                    for key in ("agent", "source", "channel_id", "thread_id")
+                )
+                or lane["metadata"].get("server_id")
+                != requested_lane["metadata"].get("server_id")
             ):
                 return self._tool_error(
                     json_body["id"],
@@ -443,15 +457,21 @@ class StartThenFailClient:
         if self.fail_start:
             raise ConnectionError("session start failed with token=secret-value")
         self.started = True
+        # Every exact-scope coordinate is read with `.get()`, matching the
+        # server's own schema, where all of them are `.optional()`
+        # (server/tools/session-lifecycle.ts:120-127). A wrap/checkpoint
+        # discovering a lane to adopt sends only `session_key` (#724 item 4),
+        # and subscripting here turned that legitimate request into a KeyError
+        # inside the fake rather than a response.
         return {
             "lane": {
                 "namespace": "bilby",
                 "session_key": arguments["session_key"],
-                "agent": arguments["agent"],
-                "source": arguments["platform"],
-                "channel_id": arguments["channel_id"],
+                "agent": arguments.get("agent"),
+                "source": arguments.get("platform"),
+                "channel_id": arguments.get("channel_id"),
                 "thread_id": arguments.get("thread_id"),
-                "metadata": {"server_id": arguments["server_id"]},
+                "metadata": {"server_id": arguments.get("server_id")},
             }
         }
 

--- a/python/openbrain-memory/tests/test_runtime.py
+++ b/python/openbrain-memory/tests/test_runtime.py
@@ -568,34 +568,14 @@ def test_fresh_checkpoint_and_wrap_are_immediately_recallable() -> None:
         )
 
 
-def test_checkpoint_first_lane_denies_hostile_same_namespace_claim() -> None:
-    transport = LaneAwareTransport()
-    owner = FirstClassMemoryRuntime(
-        runtime_config(), runtime_scope(), transport=transport
-    )
-    hostile = FirstClassMemoryRuntime(
-        runtime_config(),
-        RuntimeScope(
-            agent="bilby",
-            platform="discord",
-            server_id="hostile-guild",
-            channel_id="channel-2",
-            thread_id="thread-3",
-            session_key="repo/session-4",
-        ),
-        transport=transport,
-    )
-
-    assert owner.checkpoint("owner summary").receipt.status is ReceiptStatus.SAVED
-    denied = hostile.wrap("hostile summary")
-
-    assert denied.receipt.status is ReceiptStatus.LOST
-    assert transport.started_sessions["repo/session-4"]["metadata"] == {
-        "server_id": "guild-1"
-    }
-    assert transport.started_sessions["repo/session-4"]["current_context_md"] == (
-        "owner summary"
-    )
+# RETIRED 2026-08-17 (operator ruling, Rico):
+# test_checkpoint_first_lane_denies_hostile_same_namespace_claim was removed, not lost.
+# With wrap-adopts-lane-scope (#724 item 4), the client provably cannot distinguish
+# the capture hook's lane from another same-namespace session's lane -- the wire
+# sequences are identical, so there is nothing observable to assert on. Same namespace
+# is same tenant; the real boundary is the server's namespace predicate, and
+# AGENTS.md Coding Standards already state that client-side convenience checks are
+# not security controls.
 
 
 def test_same_session_key_with_different_scope_is_denied_by_transport_boundary() -> (

--- a/python/openbrain-memory/tests/test_runtime_wrap_lane_adoption.py
+++ b/python/openbrain-memory/tests/test_runtime_wrap_lane_adoption.py
@@ -1,0 +1,170 @@
+"""Manual wrap/checkpoint must ADOPT an existing capture lane's stored scope.
+
+RED-FIRST (#724 item 4). Measured failure, 2026-08-17: a manual
+`openbrain-memory --event wrap` (and `--event checkpoint`) against a session
+whose lane was created by the capture hook fails with
+
+    Existing lane exact scope does not match session_start request
+
+The chain, verified in source:
+
+* the capture hook opens the BASE lane with `agent='openbrain-capture'` and
+  every other exact-scope field NULL
+  (`python/openbrain/src/openbrain/config.py:517`);
+* the client runtime makes `session_start` claim the CALLER's own full exact
+  scope — `RuntimeScope.start_metadata()` via `_ensure_lane()`
+  (`src/openbrain_memory/runtime.py:1194-1200`);
+* the server's #646 one-way fill refuses to re-point an already-set `agent`
+  and returns the refusal above
+  (`server/tools/session-lifecycle.ts:61-100,151-166`).
+
+Operator ruling 2026-08-17: **wrap adopts the lane's existing scope.** The
+server's refusal is an isolation boundary and MUST NOT change; the client is
+what has to stop claiming a scope it does not own. Validation of a wrap/
+checkpoint lane binds on `session_key` + `namespace` — the coordinates the
+caller genuinely owns — not on the requester's exact scope.
+
+Modeled on `tests/test_runtime_ingest.py`, which drives the same
+`execute_json` + `LaneAwareTransport` + `request_payload` fake-transport path;
+`LaneAwareTransport` already reproduces the server's one-way-fill refusal
+verbatim (`tests/_runtime_fakes.py:120-136`), so no new fake is introduced.
+
+Status: PROPOSED behavior. On current code these tests are RED with the
+scope-mismatch error, which is the proof the check can fail.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from openbrain_memory.cli import execute_json
+
+from ._runtime_fakes import LaneAwareTransport, request_payload, tool_calls
+
+CAPTURE_AGENT = "openbrain-capture"
+SESSION_KEY = "session"
+
+
+def _capture_hook_lane(session_key: str = SESSION_KEY) -> dict[str, Any]:
+    """The lane shape the capture hook actually creates.
+
+    `agent` set, every other exact-scope coordinate NULL — the 2009-lane class
+    #646 was measured against.
+    """
+    return {
+        "namespace": "bilby",
+        "session_key": session_key,
+        "agent": CAPTURE_AGENT,
+        "source": None,
+        "channel_id": None,
+        "thread_id": None,
+        "project": None,
+        "current_context_md": None,
+        "metadata": {"server_id": None},
+    }
+
+
+def _transport_with_capture_lane() -> LaneAwareTransport:
+    transport = LaneAwareTransport()
+    transport.started_sessions[SESSION_KEY] = _capture_hook_lane()
+    return transport
+
+
+def _wrap_request(operation: str) -> dict[str, Any]:
+    """A manual wrap/checkpoint from a session scoped as a DIFFERENT agent.
+
+    `request_payload` supplies `agent='bilby'`, `platform='discord'`,
+    `server_id='guild'`, `channel_id='channel'` — i.e. a full exact scope that
+    disagrees with the capture lane's `agent` and fills its NULL fields. That
+    disagreement is the whole defect.
+    """
+    return request_payload(
+        operation,
+        distilled=True,
+        summary=(
+            "Lane B authored the red-first proof for #724 item 4; no fix applied."
+        ),
+    )
+
+
+@pytest.mark.parametrize("operation", ["wrap", "checkpoint"])
+def test_wrap_adopts_an_existing_capture_lane_scope(operation: str) -> None:
+    """Post-fix: the write lands instead of failing on scope mismatch."""
+    transport = _transport_with_capture_lane()
+
+    output = execute_json(_wrap_request(operation), transport=transport)
+
+    receipt = output["receipt"]
+    assert receipt["operation"] == operation
+    assert receipt["status"] == "saved", receipt.get("error")
+    assert receipt["durable"] is True
+
+
+@pytest.mark.parametrize("operation", ["wrap", "checkpoint"])
+def test_wrap_session_start_binds_on_session_key_and_namespace_only(
+    operation: str,
+) -> None:
+    """Post-fix: session_start for a wrap claims no exact-scope coordinates.
+
+    The caller owns `session_key` (and, through its token, the namespace). It
+    does NOT own `agent`/`platform`/`server_id`/`channel_id` for a lane another
+    process opened, so it must not assert them — asserting them is what trips
+    the server's one-way fill.
+    """
+    transport = _transport_with_capture_lane()
+
+    execute_json(_wrap_request(operation), transport=transport)
+
+    starts = [
+        call["params"]["arguments"]
+        for call in tool_calls(transport)
+        if call["params"]["name"] == "session_start"
+    ]
+    assert starts, "wrap did not reach session_start"
+    claimed = starts[-1]
+    assert claimed["session_key"] == SESSION_KEY
+    for owned_by_the_lane in ("agent", "platform", "server_id", "channel_id"):
+        assert claimed.get(owned_by_the_lane) is None, (
+            f"session_start for a {operation} claimed {owned_by_the_lane!r}, "
+            "which belongs to the existing lane"
+        )
+
+
+@pytest.mark.parametrize("operation", ["wrap", "checkpoint"])
+def test_wrap_writes_under_the_lanes_stored_scope(operation: str) -> None:
+    """Post-fix: the write verb carries the LANE's scope, not the requester's.
+
+    Adoption is not "send nothing" — the wrap/checkpoint tool call still has to
+    satisfy the server's lane-scope predicate, and the only scope that can
+    satisfy it is the one already stored on the lane.
+    """
+    transport = _transport_with_capture_lane()
+
+    execute_json(_wrap_request(operation), transport=transport)
+
+    writes = [
+        call["params"]["arguments"]
+        for call in tool_calls(transport)
+        if call["params"]["name"] == "session_wrap"
+    ]
+    assert writes, f"{operation} did not reach session_wrap"
+    sent = writes[-1]
+    assert sent["agent"] == CAPTURE_AGENT
+    assert sent.get("platform") is None
+    assert sent.get("server_id") is None
+    assert sent.get("channel_id") is None
+
+
+def test_capture_lane_scope_is_not_rewritten_by_a_wrap() -> None:
+    """Adoption must never re-point the lane — the isolation boundary holds."""
+    transport = _transport_with_capture_lane()
+
+    execute_json(_wrap_request("wrap"), transport=transport)
+
+    lane = transport.started_sessions[SESSION_KEY]
+    assert lane["agent"] == CAPTURE_AGENT
+    assert lane["source"] is None
+    assert lane["channel_id"] is None
+    assert lane["metadata"]["server_id"] is None

--- a/scripts/done-means/724-wrap-lane-adoption.sh
+++ b/scripts/done-means/724-wrap-lane-adoption.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #724 — the wrap-lane adoption acceptance gate.
+#
+#   bash scripts/done-means/724-wrap-lane-adoption.sh
+#
+# The executable acceptance for wrap-lane adoption in the Python runtime is a
+# pytest file:
+#
+#   python/openbrain-memory/tests/test_runtime_wrap_lane_adoption.py
+#
+# This wrapper exists because `scripts/verify-lane.ts` runs every Done-means
+# check with `bash` (verify-lane.ts:473, filed as #733), so a Done-means that is
+# a pytest file cannot be named directly in a PR body. This script is the
+# bash-shaped front door to that test file and adds nothing to its semantics.
+#
+# ACCEPTANCE, as this script enforces it:
+#
+#   1. The test FILE exists. A run that examines zero files is a HARNESS ERROR,
+#      never a pass — the same silent-skip trap AGENTS.md names for
+#      OPENBRAIN_TEST_DATABASE_URL, one level up.
+#   2. `uv run pytest <that file> -q` exits 0, having actually executed tests
+#      (>0 reported passing). Exit 0 with a 0-test collection is NOT a pass.
+#
+# EXIT GRAMMAR (repo convention):
+#
+#   0  the thing under test is present and green
+#   1  the thing under test FAILED (tests red, or ran nothing)
+#   3  HARNESS ERROR — `uv` missing, dependencies unavailable, or the test file
+#      absent. A broken harness is not a red result and must not be reported as
+#      one.
+#
+# ---------------------------------------------------------------------------
+# Isolation and teardown
+# ---------------------------------------------------------------------------
+# This script creates NOTHING in the database; the test file is transport-fake
+# based. What it owns is one transcript file under {temp_workspace}/open-brain/
+# _scratch, retired (moved, never deleted) on exit.
+#
+# Output is content-free: counts, exit codes, and verdicts only.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+PKG_DIR="python/openbrain-memory"
+TEST_FILE="tests/test_runtime_wrap_lane_adoption.py"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  printf '\nVERDICT: HARNESS-ERROR\n\n'
+  exit 3
+}
+
+command -v uv >/dev/null 2>&1 || fail_hard "uv not on PATH"
+
+[ -d "$REPO_ROOT/$PKG_DIR" ] ||
+  fail_hard "python package dir $PKG_DIR does not exist in $REPO_ROOT"
+
+# 0-files-examined is not a pass. If the acceptance file is absent from THIS
+# tree, the check has nothing to measure and says so loudly.
+[ -f "$REPO_ROOT/$PKG_DIR/$TEST_FILE" ] ||
+  fail_hard "acceptance file $PKG_DIR/$TEST_FILE does not exist in $REPO_ROOT — zero files examined is not a pass"
+
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+SCRATCH="${TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch"
+mkdir -p "$SCRATCH" 2>/dev/null || fail_hard "cannot create scratch dir $SCRATCH"
+OUT="$SCRATCH/done-means-724-wrap-${RUN_ID}.log"
+
+teardown() {
+  mv -f "$OUT" "$OUT.done" 2>/dev/null
+}
+trap teardown EXIT
+
+(cd "$REPO_ROOT/$PKG_DIR" && uv run pytest "$TEST_FILE" -q) >"$OUT" 2>&1
+RUN_EXIT=$?
+
+PASS_COUNT="$(rg -o -N '(\d+) passed' -r '$1' "$OUT" 2>/dev/null | tail -1 | tr -d '[:space:]')"
+[ -n "$PASS_COUNT" ] || PASS_COUNT=0
+FAIL_COUNT="$(rg -o -N '(\d+) failed' -r '$1' "$OUT" 2>/dev/null | tail -1 | tr -d '[:space:]')"
+[ -n "$FAIL_COUNT" ] || FAIL_COUNT=0
+ERR_COUNT="$(rg -o -N '(\d+) error' -r '$1' "$OUT" 2>/dev/null | tail -1 | tr -d '[:space:]')"
+[ -n "$ERR_COUNT" ] || ERR_COUNT=0
+
+printf '\n=== DONE-MEANS #724: wrap-lane adoption in the Python runtime ===\n\n'
+printf 'acceptance file: %s/%s\n' "$PKG_DIR" "$TEST_FILE"
+printf 'runner:          uv run pytest %s -q\n' "$TEST_FILE"
+printf 'tally:           %s passed, %s failed, %s error(s) (runner exit %s)\n\n' \
+  "$PASS_COUNT" "$FAIL_COUNT" "$ERR_COUNT" "$RUN_EXIT"
+
+# uv exit 2 is a usage/collection error; pytest 3 is internal error, 4 usage,
+# 5 no-tests-collected. None of those are a failing test — they are a harness
+# that never got far enough to measure anything.
+if [ "$RUN_EXIT" -ge 2 ] && [ "$FAIL_COUNT" -eq 0 ]; then
+  tail -20 "$OUT" >&2
+  printf 'transcript: %s.done\n' "$OUT.done"
+  fail_hard "the runner exited ${RUN_EXIT} with no failing test reported — uv/pytest could not resolve dependencies or collect the file; a broken harness is not a failing test"
+fi
+
+VERDICT=PASS
+if [ "$RUN_EXIT" -ne 0 ]; then
+  VERDICT=FAIL
+  printf 'FAIL — the runner exited %s with %s failing test(s)\n' "$RUN_EXIT" "$FAIL_COUNT"
+elif [ "$PASS_COUNT" -lt 1 ]; then
+  VERDICT=FAIL
+  printf 'FAIL — exit 0 but 0 tests passed: the file was silently skipped, so nothing was proven\n'
+else
+  printf 'PASS — %s tests executed, 0 failures, exit 0\n' "$PASS_COUNT"
+fi
+
+printf '\ntranscript: %s.done\n' "$OUT.done"
+printf '\nVERDICT: %s\n\n' "$VERDICT"
+
+[ "$VERDICT" = PASS ] || exit 1
+exit 0


### PR DESCRIPTION
Refs #724 (item 4 — manual wrap adopts the hook-owned lane's scope).

A manual `openbrain-memory --event wrap` (and `--event checkpoint`) against a
lane the capture hook opened failed with `Existing lane exact scope does not
match session_start request`. Two Development sessions lost their wraps to it,
and it is the collateral symptom that led to discovering the nats-worker
outage.

The capture hook creates the base lane with `agent` set and every other
exact-scope coordinate NULL. The client made `session_start` claim the CALLER's
own full exact scope, which trips the server's #646 one-way fill, and
`session_wrap` was never reached at all.

**The server does not change.** `server/` and `src/` carry zero modifications in
this PR — the exact-scope predicate is an isolation boundary. Operator ruling
2026-08-17: the client stops asserting a scope it does not own.

## What changed

Claim first, adopt only on that one refusal:

1. `session_start` claims the caller's own exact scope, exactly as before. On
   success nothing else happens — same single call, same arguments — so the
   ordinary path is byte-for-byte unchanged and adoption costs nothing until it
   is actually needed.
2. Only on the specific scope refusal, `session_start` is re-issued claiming
   nothing but `session_key`. That is the server's `!hasCompleteExactScope`
   branch (`server/tools/session-lifecycle.ts:67,155`), which returns the
   existing lane verbatim rather than attempting a fill.
3. `session_wrap` then carries the coordinates that came back ON THAT LANE, not
   the requester's, because the write verb must still satisfy the server's
   lane-scope predicate. Adoption is not merely "send fewer fields on start".

Discovering unconditionally (an unscoped `session_start` before every wrap) was
tried first and is wrong twice over: on a lane that does not exist yet it
CREATES a bare NULL-scoped lane and permanently strands it, and it adds a wire
call to the sequence the cross-runtime contract fixture pins. Both were
observed as real test failures before the approach was changed.

`validate_adopted_lane` binds the adopting start on `session_key` + `namespace`
— the coordinates the caller genuinely owns — because there is no requested
exact scope for the response to prove. The namespace refusals (#654/#662) are
extracted into `_require_proven_namespace` and enforced unchanged on BOTH
paths, rather than copied into a second block that could drift.

Nothing else is widened: capture (`append_session_event`) and the context-pack
exact-scope proof are untouched, and the adopting flag is scoped to the single
discovery call so a spooled `session_start` replay still proves its own parked
scope.

Two fidelity gaps in the test fakes are corrected, both toward the real server:
`LaneAwareTransport` now mirrors the `hasCompleteExactScope` gate (it carried
only the refusal half of that server branch, so it refused a request the real
server accepts), and `StartThenFailClient` reads exact-scope coordinates with
`.get()`, matching the server schema where all of them are `.optional()`.

## RESOLVED BY RULING

Operator ruling (Rico, 2026-08-17): `test_checkpoint_first_lane_denies_hostile_same_namespace_claim` is RETIRED (commit `d7f5c06`) because the client provably cannot distinguish the capture hook lane from another same-namespace session lane — the wire sequences are identical — same namespace is the same tenant, the server namespace predicate is the real boundary, and AGENTS.md Coding Standards already state that client-side convenience checks are not security controls. A comment at the former test site records the retirement, and `docs/memory-contract.md` now states that wrap/checkpoint adoption is namespace-scoped by design.

## Downstream rollout (`docs/downstream-rollout.md`)

This is a **client behavior change** in `python/openbrain-memory/`, with no MCP
tool, schema, or protocol change.

- **rtech-mcps / mcp2cli** — N/A. No tool, schema, or transport contract moved;
  the server is byte-identical and `mcp2cli` speaks to it, not to this client.
- **rtech-hermes Python runtime/plugin** — N/A for correctness, but it is a
  consumer of this package. Its wraps only reach the new code path when a
  `session_start` is refused for scope, which today means its wrap was failing
  outright; the change strictly converts that failure into a write.
- **Live Hermes agent canary** — the isolation question is settled by the ruling
  above; the real canary is the one the issue
  actually asks for: a manual `openbrain-memory --event wrap` from a
  Development session against a capture-hook-owned lane, which is the exact
  call that has never produced a wrap receipt (`receipts.json` shows zero wrap
  receipts ever). That is a RUNNING check and has not been performed — this PR
  is verified against fake transports only.
- **Package version bump / republish** — not done in this PR; the controller
  should decide whether this rides an existing release lane.

## Verification

- Done-means: scripts/done-means/724-wrap-lane-adoption.sh
- RED (commit `dd5de5a`, observed live this session):
  `cd python/openbrain-memory && uv run pytest tests/test_runtime_wrap_lane_adoption.py -q`
  -> `6 failed, 1 passed in 0.09s`, headline failure
  `AssertionError: Open Brain tool returned an error context=call_tool:session_start body=existing lane exact scope does not match session_start request`
- GREEN (this commit): same command -> `7 passed in 0.06s`
- Full package (commit `d7f5c06`): `uv run pytest -q` -> `585 passed, 14 skipped in 7.11s`,
  zero failures. Baseline on `dd5de5a` was `6 failed, 580 passed, 14 skipped`.
- `uv run mypy src/openbrain_memory` -> `Success: no issues found in 17 source files` (re-run on `d7f5c06`)
- `uv run ruff check src tests` -> `All checks passed!` (re-run on `d7f5c06`)
- `uv run ruff format --check src tests` -> 9 files would be reformatted, which
  is the UNCHANGED pre-existing baseline on `dd5de5a` (measured by stashing);
  the one file this PR touched that drifted was formatted back.
- TypeScript: not run to completion in this clone — `bunx tsc --noEmit` stops on
  `Cannot find type definition file for 'bun-types'` because the fresh clone has
  no `bun install`. This PR modifies zero TypeScript files, so this is stated as
  a gap rather than a pass.

## Critical Self-Review

- Highest-risk behavior: the adopting `session_start`/`session_wrap` pair, which
  deliberately writes into a lane using coordinates the caller did not supply.
  If the adopted scope were read from the wrong object the wrap would land on a
  lane the session never intended to touch.
- Assumptions that could be wrong: that the server's `!hasCompleteExactScope`
  branch returns an existing lane verbatim with no fill. Read directly in
  `server/tools/session-lifecycle.ts:67,155` this session, but never exercised
  against the RUNNING service — every check here is against fake transports.
  Also assumed: the refusal string is stable, since `_is_lane_scope_refusal`
  matches it as a substring; a server-side reword would silently disable
  adoption and restore the original failure.
- Missing/weak tests: no test covers the fallback branch where a wrap runs on a
  lane opened earlier in the same process (`conversation_key` already set) — it
  reuses the requester's scope and is reasoned about, not proven. No test
  exercises adoption through the spool/replay drain. No live-service test at
  all.
- Security/permission risk: this is the PR's central risk and it is the
  RESOLVED BY RULING section above, stated in full rather than buried. The
  namespace boundary is untouched and still fails closed (#654/#662 preserved
  verbatim via `_require_proven_namespace`), but the intra-namespace exact-scope
  assertion is genuinely weakened for the wrap/checkpoint verbs. That was not
  resolved on implementer authority: the operator ruled on 2026-08-17 that
  same-namespace is same-tenant and the server namespace predicate is the
  boundary.
- Migration/deploy risk: low. No schema, no migration, no server change. A
  client older than this change keeps its current behavior, which is the
  failure being fixed, not a new break.
- Downstream client/runtime risk: classified in the Downstream rollout section.
  Nothing was verified against a live downstream runtime.
- Rollback/cleanup concern: revert is the single commit; there is no persisted
  state to unwind. Worth noting that a wrap which already adopted has written
  durable content under the lane's scope, which is correct and is not undone by
  a revert.
- Fixes made before PR: two approaches were built and discarded on evidence
  rather than shipped — unconditional discovery (stranded fresh lanes with NULL
  scope; broke the pinned contract fixture) and a COALESCE-fill fake (unneeded
  once claim-first landed, and reverted to keep the fake diff minimal). The
  ruff import-order error and the one formatting drift were fixed.
- Known residual risk: nothing in this PR has been observed against the RUNNING
  service, so the end-to-end claim the issue actually cares about — a real
  manual wrap producing a real wrap receipt — is UNVERIFIED. Every green result
  above is a fake-transport result.
- SME review-memory update: [x] not applicable because: the lesson is now a recorded operator ruling captured in docs/memory-contract.md and at the retired test site, not a review-swarm pattern.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this lane was verified against fake transports only; the live manual-wrap canary is named above as an outstanding RUNNING check and is not performed in this PR.



## Contract Parity

- Contract parity: [x] runtime-specific because: this PR changes only the Python lifecycle runtime's manual wrap/checkpoint path (the only manual-wrap surface currently in use); clients/ts is deliberately unchanged and its port of the ruled adoption behavior is filed as #736 — no shared contract fixtures encode the old client-side refusal, so none required updating here.

