### PR TITLE
test(nats-worker): red-first proof the LIVE worker composes no watermark observer (#724)

### DIFF
--- a/docs/core01-nats-worker-runbook.md
+++ b/docs/core01-nats-worker-runbook.md
@@ -375,7 +375,9 @@ matches their shape (`server/transport/health.ts:14-33`, `:35-79`).
 - **Absence is not staleness.** A worker that composes no embed observer emits
   NO `embed_watermark` key and cannot be degraded by one. Missing block means
   "not my job"; `stale: true` means "my job and I am not doing it". Do not read
-  an absent block as a failure.
+  an absent block as a failure. In the DEPLOYED worker the block is always
+  present (see "Who builds the observer" below), so an absent block there means
+  the process is older than #724 item 3 — not that the lane is idle.
 - `lag_threshold_seconds` reports the bound the verdict was actually taken
   against, so a reading is interpretable without knowing the deployed config.
 
@@ -387,6 +389,47 @@ an hour). Nothing is adjusted silently: the worker's startup log line carries
 `invalid_env_default`), plus `embed_watermark_observed`, so an unset key is
 visible as a default rather than looking configured, and an unusable value
 announces the original it replaced.
+
+**Who builds the observer, and what it reads.** `startNatsWorkerProcess`
+constructs one by default against the worker's own pool
+(`src/embed-watermark-observer.ts`); the `embedWatermarkHealth` option remains
+an override for tests, but its absence no longer means "no observer". The live
+entrypoint passes only `{ env: process.env }` and gets a real one. The startup
+log line reports `embed_watermark_observer_source` as `default_pool_observer`
+or `injected`, so which one is in force is visible without reading code.
+
+The watermark is registry-driven, not a hard-coded table: it queries every
+`EMBEDDING_TARGETS` entry whose `provenance.hasEmbeddedAt` is true
+(`src/embedding-targets.ts`), which is the same registry the embedding repair
+path drives off. `ob_entities` is skipped because it declares
+`ENTITY_PROVENANCE` — it has an `embedding` column and no `embedded_at`. Adding
+a target to the registry extends the watermark with no change here.
+
+**It is cached, and `/health` never waits on Postgres.** The health handler is
+synchronous, so the accessor returns a cached reading and schedules a
+background refresh once that reading is older than
+`EMBED_WATERMARK_CACHE_TTL_MS` — **30 seconds**, announced at startup as
+`embed_watermark_cache_ttl_seconds` beside the threshold. A reading up to 30s
+old cannot move a verdict taken against a one-hour bound, and the cost of the
+endpoint is at most one aggregate query per 30s no matter how often it is
+scraped. The observer is primed once during startup so the first probe answers
+with numbers.
+
+**When the query itself fails.** The block is still published, with
+`stale: false` and a `reason` naming the read failure; the numeric fields carry
+the last successful reading, or `-1` (explicitly "not measured", never an age)
+if there has never been one. A database the observer cannot reach is evidence
+about the OBSERVER, not the embed lane — flipping to `degraded` on it would
+make a transient blip indistinguishable from the three-day outage, and a 503
+that fires for unrelated reasons is how a check stops being read. It equally
+does not go silently absent or hold a stale green: the reason says the read
+failed and every failure is logged as `Open Brain embed watermark read failed`.
+The refresh catches its own errors, so a failing query can never crash
+`/health`.
+
+**Empty corpus.** No rows in any target reports `-1` ages,
+`raw_rows_recent: 0`, and `stale: false`. An empty corpus is not a stalled lane;
+this is the same guard that keeps an idle week quiet.
 
 ```zsh
 curl -fsS http://127.0.0.1:3110/health | jq .embed_watermark

--- a/scripts/done-means/724-watermark-live-observer.sh
+++ b/scripts/done-means/724-watermark-live-observer.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #724, item 3, SECOND HALF — the acceptance gate,
+# not the fix.
+#
+#   bash scripts/done-means/724-watermark-live-observer.sh
+#
+# WHAT THIS GATES, AND WHY IT IS SEPARATE FROM 724-embed-watermark-health.sh.
+#
+# PR #728 landed the embed-watermark health SURFACE on the NATS worker: the
+# block, the threshold config, degraded/503 composition, the runbook section,
+# all proven by `scripts/run-nats-worker-embed-watermark.test.ts` — which
+# INJECTS an `embedWatermarkHealth` option and asserts what gets composed from
+# it. Correct test, correct scope.
+#
+# It is silent about who constructs the observer in production. The live
+# entrypoint calls `startNatsWorkerProcess({ env: process.env })` and
+# `startNatsWorkerProcess` only FORWARDS `options.embedWatermarkHealth`
+# (scripts/run-nats-worker.ts:333-335), so the deployed worker logs
+# `embed_watermark_observed: false` (:345), publishes no `embed_watermark`
+# block, and can never alarm. The surface is in the tree and absent from the
+# serving process — the #674 class, and the same shape #656 already caught once
+# for the capture observer.
+#
+# The executable acceptance for the DEFAULT composition is a bun test file:
+#
+#   scripts/run-nats-worker-live-watermark.pg.test.ts
+#
+# It starts the worker with NO watermark option (the way the deployed process
+# does), against a REAL pool on the isolated test database, seeds `thoughts`
+# rows at explicit ages, and asserts the startup summary reports an observer AND
+# that /health carries an `embed_watermark` block whose numbers come from those
+# rows: raw newer than embedded past threshold -> stale + degraded/503; within
+# threshold -> healthy; idle corpus -> healthy with real numbers.
+#
+# A real database is load-bearing here and is the reason this is a separate
+# check from #728's. The failure mode being guarded is an observer that returns
+# plausible numbers not derived from rows, and a fake pool would let exactly
+# that pass.
+#
+# This wrapper is a .sh because `scripts/verify-lane.ts` runs every Done-means
+# check with `bash` (verify-lane.ts:473, filed as #733), so a bun test file
+# cannot be named directly in a PR body. It is the bash-shaped front door to
+# that test file and adds nothing to its semantics.
+#
+# ACCEPTANCE, as this script enforces it:
+#
+#   1. The test FILE exists. A run that examines zero files is a HARNESS ERROR,
+#      never a pass — the same silent-skip trap AGENTS.md names for
+#      OPENBRAIN_TEST_DATABASE_URL, one level up.
+#   2. `bun run test:isolated <that file>` exits 0, having actually executed
+#      tests (>0 reported passing). The isolated runner is the trustworthy path
+#      per AGENTS.md; a shared-dogfood `bun test` count is not evidence. It also
+#      sets OPENBRAIN_TEST_DATABASE_URL, without which this file's `dbDescribe`
+#      SKIPS SILENTLY — which is precisely why a 0-pass exit 0 is failed below.
+#
+# EXIT GRAMMAR (repo convention):
+#
+#   0  the thing under test is present and green
+#   1  the thing under test FAILED (tests red, or ran nothing)
+#   3  HARNESS ERROR — bun missing, the test file missing, or the isolated
+#      database bootstrap could not run. A broken harness is not a red result
+#      and must not be reported as one.
+#
+# ---------------------------------------------------------------------------
+# Isolation and teardown
+# ---------------------------------------------------------------------------
+# This script creates NOTHING in the database. `bun run test:isolated` owns the
+# database it creates and drops it on the way out, including on interrupt; the
+# test file deletes its own seeded rows in `afterEach`. What this script owns is
+# one transcript file under {temp_workspace}/open-brain/_scratch, retired
+# (moved, never deleted) on exit.
+#
+# Output is content-free: counts, exit codes, and verdicts only.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+TEST_FILE="scripts/run-nats-worker-live-watermark.pg.test.ts"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  printf '\nVERDICT: HARNESS-ERROR\n\n'
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+
+# 0-files-examined is not a pass. If the acceptance file is absent from THIS
+# tree, the check has nothing to measure and says so loudly.
+[ -f "$REPO_ROOT/$TEST_FILE" ] ||
+  fail_hard "acceptance file $TEST_FILE does not exist in $REPO_ROOT — zero files examined is not a pass"
+
+rg -q '"test:isolated"' "$REPO_ROOT/package.json" 2>/dev/null ||
+  fail_hard "no \`test:isolated\` entry point in package.json; the isolated-database runner is the only trustworthy path (AGENTS.md)"
+
+# .env carries the libpq/DB_* vars the isolated runner needs to create its
+# database. A worktree or lane clone may lack it; fall back to the canonical
+# checkout's copy so this runs from either (same fallback as 614 and 724).
+ENV_FILE="$REPO_ROOT/.env"
+[ -r "$ENV_FILE" ] || ENV_FILE="/Volumes/ThunderBolt/Development/open-brain/.env"
+[ -r "$ENV_FILE" ] || fail_hard "no readable .env for Postgres credentials; the isolated runner cannot create a database"
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+SCRATCH="${TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch"
+mkdir -p "$SCRATCH" 2>/dev/null || fail_hard "cannot create scratch dir $SCRATCH"
+OUT="$SCRATCH/done-means-724-live-observer-${RUN_ID}.log"
+RETIRED="$OUT.done"
+
+teardown() {
+  mv -f "$OUT" "$RETIRED" 2>/dev/null
+}
+trap teardown EXIT
+
+(cd "$REPO_ROOT" && bun run test:isolated "$TEST_FILE") >"$OUT" 2>&1
+RUN_EXIT=$?
+
+PASS_COUNT="$(rg -o -N '^\s*(\d+) pass' -r '$1' "$OUT" 2>/dev/null | tail -1 | tr -d '[:space:]')"
+[ -n "$PASS_COUNT" ] || PASS_COUNT=0
+FAIL_COUNT="$(rg -o -N '^\s*(\d+) fail' -r '$1' "$OUT" 2>/dev/null | tail -1 | tr -d '[:space:]')"
+[ -n "$FAIL_COUNT" ] || FAIL_COUNT=0
+SKIP_COUNT="$(rg -o -N '^\s*(\d+) skip' -r '$1' "$OUT" 2>/dev/null | tail -1 | tr -d '[:space:]')"
+[ -n "$SKIP_COUNT" ] || SKIP_COUNT=0
+ISO_DB="$(rg -o -N '\bob_isolated_[a-z0-9_]+' "$OUT" 2>/dev/null | head -1)"
+
+printf '\n=== DONE-MEANS #724 item 3 (second half): the LIVE worker composes a real observer ===\n\n'
+printf 'acceptance file: %s\n' "$TEST_FILE"
+printf 'runner:          bun run test:isolated %s\n' "$TEST_FILE"
+printf 'isolated db:     %s\n' "${ISO_DB:-<none printed>}"
+printf 'tally:           %s pass, %s fail, %s skip (runner exit %s)\n\n' \
+  "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT" "$RUN_EXIT"
+
+# A runner that never named a database, and never reported a tally, did not get
+# far enough to have tested anything: that is a harness problem, not a red test.
+if [ -z "$ISO_DB" ] && [ "$PASS_COUNT" -eq 0 ] && [ "$FAIL_COUNT" -eq 0 ]; then
+  printf 'transcript: %s\n' "$RETIRED"
+  tail -20 "$OUT" >&2
+  fail_hard "the isolated runner printed no database name and no test tally (exit ${RUN_EXIT}); the database bootstrap or bun itself did not run — a broken harness is not a failing test"
+fi
+
+VERDICT=PASS
+if [ "$RUN_EXIT" -ne 0 ]; then
+  VERDICT=FAIL
+  printf 'FAIL — the runner exited %s with %s failing test(s)\n' "$RUN_EXIT" "$FAIL_COUNT"
+elif [ "$PASS_COUNT" -lt 1 ]; then
+  # This branch is the dbDescribe trap: without OPENBRAIN_TEST_DATABASE_URL the
+  # whole file skips and `bun test` still exits 0. Green on zero executed tests
+  # is the exact failure this repo has been bitten by; it is never a pass here.
+  VERDICT=FAIL
+  printf 'FAIL — exit 0 but 0 tests passed (%s skipped): the file was silently skipped, so nothing was proven\n' "$SKIP_COUNT"
+else
+  printf 'PASS — %s tests executed against %s, 0 failures, exit 0\n' "$PASS_COUNT" "${ISO_DB:-an isolated database}"
+fi
+
+printf '\ntranscript: %s\n' "$RETIRED"
+printf '\nVERDICT: %s\n\n' "$VERDICT"
+
+[ "$VERDICT" = PASS ] || exit 1
+exit 0

--- a/scripts/run-nats-worker-live-watermark.pg.test.ts
+++ b/scripts/run-nats-worker-live-watermark.pg.test.ts
@@ -1,0 +1,389 @@
+/**
+ * RED-FIRST done-means check for issue #724 item 3, SECOND HALF — the observer
+ * the DEPLOYED worker actually composes.
+ *
+ * ## What #728 landed, and the hole it left
+ *
+ * PR #728 built the whole embed-watermark health surface on this worker:
+ * an `EmbedWatermarkHealth` block, a configurable threshold
+ * (`readEmbedWatermarkThresholdSeconds`), degraded/503 composition in
+ * `startHealthServer`, and a runbook section. Its test —
+ * `scripts/run-nats-worker-embed-watermark.test.ts` — proves every one of those
+ * behaviors by INJECTING an `embedWatermarkHealth` option and asserting the
+ * payload composed from it.
+ *
+ * That is exactly the right test for the composition, and it is silent about
+ * the one thing that decides whether the outage gets caught: WHO CONSTRUCTS
+ * THE OBSERVER IN PRODUCTION. `startNatsWorkerProcess` only forwards
+ * `options.embedWatermarkHealth` (`scripts/run-nats-worker.ts:333-335`) and
+ * the live entrypoint calls it with `{ env: process.env }` and nothing else
+ * (`scripts/run-nats-worker.ts` `import.meta.main` block). No code path
+ * anywhere builds a real observer against the pool. So the deployed worker
+ * logs `embed_watermark_observed: false` (`:345`), publishes no
+ * `embed_watermark` block, and CAN NEVER ALARM — the surface exists in the
+ * tree and is absent from the serving process.
+ *
+ * This is the #674 class, and the repo has now paid for it twice: #656
+ * ("capture observer wired") exists because the capture liveness observer
+ * landed with the identical shape — composed if injected, injected by nobody.
+ * `scripts/done-means/656-capture-observer-wired.sh` is the precedent for
+ * asserting the DEFAULT composition rather than the injected one, and this
+ * file is that assertion for the embed lane.
+ *
+ * ## Why this test needs a real database, when #728's did not
+ *
+ * #728's test correctly uses no database: an injected fixture block is the
+ * whole input to the composition under test, and a wall-clock-free fixture is
+ * the right instrument for it (`docs/lane-contract.md`, Tightenings round 5).
+ *
+ * The claim HERE is different in kind. "The default composition produces a
+ * real observer" is only true if the observer can read the corpus, and the
+ * failure mode being guarded is precisely one where a plausible-looking
+ * observer returns numbers that do not come from rows. A fake pool would let
+ * a fix pass by returning a hard-coded block, which is the bug wearing the
+ * fix's clothes. So the ages here are computed by Postgres from rows this file
+ * seeds, and the test asserts the numbers the SEEDED DATA implies.
+ *
+ * Ages are still never taken from a wall clock in an assertion: every row is
+ * inserted at an offset expressed relative to `now()`, and assertions are
+ * range-based around those offsets with a generous tolerance, so a slow runner
+ * cannot flake them.
+ *
+ * ## The schema the observer must read
+ *
+ * `src/embedding-targets.ts` is the single source of truth for every
+ * embedding-bearing table (`EMBEDDING_TARGETS`, `:179`). Its first entry is
+ * `thoughts` (`:181`) and it declares `FULL_PROVENANCE` (`:191`), meaning
+ * `content_hash`, `embedded_at`, and `embedding_model` all physically exist —
+ * `src/db/migrations/001_init.sql:7-19`. That gives the watermark both halves
+ * it needs from ONE table, with no invention:
+ *
+ *   - RAW arrival     -> `thoughts.created_at`  (row exists, embedding pending)
+ *   - EMBEDDED mark   -> `thoughts.embedded_at` (embed lane has processed it)
+ *
+ * `embedded_at IS NULL` is therefore the queue depth, and
+ * `max(created_at) - max(embedded_at)` is the lag the block reports as
+ * `lag_seconds`. The registry, not this test, is the contract: an
+ * implementation that reads the registry rather than hard-coding `thoughts`
+ * will satisfy every assertion below and will also pick up
+ * `decisions`/`sessions`/`ob_session_events`, all of which carry the same two
+ * columns under `FULL_PROVENANCE`.
+ *
+ * ## STATUS: RED as written
+ *
+ * On this branch `startNatsWorkerProcess` constructs no observer, so the
+ * default-composition case logs `embed_watermark_observed: false` and serves a
+ * payload with no `embed_watermark` key. Every case below asserts the desired
+ * behavior and is expected to FAIL until an observer is built by default. This
+ * file does not implement it.
+ *
+ * Gated on OPENBRAIN_TEST_DATABASE_URL (repo dbDescribe convention). Run it the
+ * trustworthy way, per AGENTS.md:
+ *
+ *   bun run test:isolated scripts/run-nats-worker-live-watermark.pg.test.ts
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { runMigrations } from "../src/db/migrate.ts";
+import { createNatsBridgeHealth } from "../src/nats-bridge.ts";
+import {
+  readNatsWorkerBoundary,
+  type NatsWorkerRuntime,
+} from "../src/nats-worker.ts";
+import { startNatsWorkerProcess } from "./run-nats-worker.ts";
+
+const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
+const dbDescribe = DB_URL ? describe : describe.skip;
+
+/** Namespace/author marker so this file's rows are identifiable and removable. */
+const CREATED_BY = "wm-live-observer-pg-test";
+const NAMESPACE = "wm-live-observer-ns";
+
+/** The threshold every case below runs against, in seconds. */
+const THRESHOLD_SECONDS = 3600;
+
+let pool: Pool;
+
+/**
+ * The health payload shape this lane's fix must make the DEFAULT composition
+ * produce. Declared here rather than imported so a missing export is a red
+ * assertion instead of a typecheck failure.
+ */
+interface EmbedWatermarkBlock {
+  readonly stale: boolean;
+  readonly newest_raw_age_seconds: number;
+  readonly newest_embedded_age_seconds: number;
+  readonly lag_seconds: number;
+  readonly lag_threshold_seconds: number;
+  readonly raw_rows_recent: number;
+  readonly reason: string;
+}
+
+/**
+ * Seed one `thoughts` row at explicit ages.
+ *
+ * `createdAgoSeconds` is the raw arrival; `embeddedAgoSeconds` null means the
+ * row is still sitting in the embed queue — which is what a stalled lane looks
+ * like in the corpus. Columns are exactly those in
+ * `src/db/migrations/001_init.sql:7-19`; `embedding` is left NULL because the
+ * watermark is a TIMESTAMP comparison and never reads the halfvec.
+ */
+async function seedThought(input: {
+  content: string;
+  createdAgoSeconds: number;
+  embeddedAgoSeconds: number | null;
+}): Promise<void> {
+  await pool.query(
+    `INSERT INTO thoughts
+       (content, namespace, created_by, created_at, updated_at, embedded_at, embedding_model)
+     VALUES
+       ($1, $2, $3,
+        now() - make_interval(secs => $4::double precision),
+        now() - make_interval(secs => $4::double precision),
+        CASE WHEN $5::double precision IS NULL THEN NULL
+             ELSE now() - make_interval(secs => $5::double precision) END,
+        CASE WHEN $5::double precision IS NULL THEN NULL ELSE 'test-model' END)`,
+    [
+      input.content,
+      NAMESPACE,
+      CREATED_BY,
+      input.createdAgoSeconds,
+      input.embeddedAgoSeconds,
+    ],
+  );
+}
+
+/**
+ * Start the worker THE WAY THE DEPLOYED PROCESS DOES — no `embedWatermarkHealth`
+ * option — and return both the startup summary the worker logged and its
+ * `/health` payload.
+ *
+ * `serve` is captured rather than bound (no port is opened) and `log.info` is
+ * recorded, so the same call yields both halves of the claim: the summary field
+ * `embed_watermark_observed`, and the payload block computed from seeded rows.
+ * The REAL pool is passed through `createDbPool`, which is the only injection
+ * here and is the standard test seam for the database — the observer itself is
+ * deliberately NOT injected, because whether one gets built is the thing under
+ * test.
+ */
+async function startDefaultWorker(): Promise<{
+  summary: Record<string, unknown>;
+  status: number;
+  body: Record<string, unknown>;
+}> {
+  const env: NodeJS.ProcessEnv = {
+    OPENBRAIN_NATS_URL: "nats://127.0.0.1:4222",
+    OPEN_BRAIN_NATS_WORKER_HEALTH_PORT: "3110",
+    OPENBRAIN_EMBED_WATERMARK_LAG_THRESHOLD_SECONDS: String(THRESHOLD_SECONDS),
+  };
+
+  let handler: ((request: Request) => Response | Promise<Response>) | null =
+    null;
+  let summary: Record<string, unknown> = {};
+
+  const runtime: NatsWorkerRuntime = {
+    boundary: readNatsWorkerBoundary(env),
+    // AVAILABLE in every case: a healthy bridge must not be able to hold this
+    // endpoint green while the embed lane is stalled. That combination is the
+    // exact shape of the three-day outage.
+    health: createNatsBridgeHealth("available"),
+    subject: "dev.ob.memory.context_pack",
+    close: async () => undefined,
+  };
+
+  const processRuntime = await startNatsWorkerProcess({
+    env,
+    log: {
+      info: (_msg: string, fields?: Record<string, unknown>) => {
+        if (fields && "embed_watermark_observed" in fields) summary = fields;
+      },
+      error: () => undefined,
+    } as never,
+    buildTokens: () =>
+      new Map([["secret-token", { role: "admin", clientId: "rico" }]]) as never,
+    // The real pool, behind a shim whose ONLY difference is that `end()` is a
+    // no-op. `startNatsWorkerProcess.shutdown()` legitimately closes the pool
+    // it was handed (`closePool`, scripts/run-nats-worker.ts), and this suite
+    // owns the pool across all four cases — letting the first worker end it
+    // kills every later case with "Cannot use a pool after calling end on the
+    // pool", which is a HARNESS failure masquerading as a red result. The
+    // shim keeps teardown honest without giving the worker a different
+    // database: every query method is the real pool's, so a fix that reads no
+    // rows still cannot pass.
+    createDbPool: (() =>
+      new Proxy(pool, {
+        get(target, prop, receiver) {
+          if (prop === "end") return async () => undefined;
+          const value = Reflect.get(target, prop, receiver);
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      })) as never,
+    startWorker: (async () => runtime) as never,
+    serve: ((options: {
+      fetch: (request: Request) => Response | Promise<Response>;
+    }) => {
+      handler = options.fetch;
+      return { stop: () => undefined };
+    }) as never,
+  });
+
+  try {
+    if (!handler) throw new Error("worker health server was never composed");
+    const response = await (
+      handler as (request: Request) => Response | Promise<Response>
+    )(new Request("http://127.0.0.1:3110/health"));
+    return {
+      summary,
+      status: response.status,
+      body: (await response.json()) as Record<string, unknown>,
+    };
+  } finally {
+    // The real shutdown path runs, including `closePool` — which lands on the
+    // no-op `end()` shim above so the suite's pool survives to the next case.
+    await processRuntime.shutdown();
+  }
+}
+
+/** Read the block, failing loudly (not silently passing) when it is absent. */
+function requireBlock(body: Record<string, unknown>): EmbedWatermarkBlock {
+  const block = body.embed_watermark as EmbedWatermarkBlock | undefined;
+  expect(
+    block,
+    "the DEFAULT worker composition published no embed_watermark block — nothing constructs an observer, so the deployed worker can never alarm (#724 item 3)",
+  ).toBeDefined();
+  return block as EmbedWatermarkBlock;
+}
+
+dbDescribe(
+  "nats worker composes a LIVE embed watermark observer by default (#724 item 3)",
+  () => {
+    beforeAll(async () => {
+      pool = new Pool({ connectionString: DB_URL });
+      await runMigrations(pool);
+    });
+
+    afterEach(async () => {
+      await pool.query(`DELETE FROM thoughts WHERE created_by = $1`, [
+        CREATED_BY,
+      ]);
+    });
+
+    afterAll(async () => {
+      await pool.end();
+    });
+
+    it("the startup summary reports an observer WAS composed with no option passed", async () => {
+      // This is the whole gap in one assertion. `embed_watermark_observed` is
+      // computed as `Boolean(options.embedWatermarkHealth)`
+      // (`scripts/run-nats-worker.ts:345`), and the live entrypoint passes no
+      // such option — so today the deployed worker announces `false` and that
+      // is the visible signature of the missing wiring.
+      await seedThought({
+        content: "raw arrival, not yet embedded",
+        createdAgoSeconds: 30,
+        embeddedAgoSeconds: null,
+      });
+
+      const { summary } = await startDefaultWorker();
+
+      expect(
+        summary.embed_watermark_observed,
+        "startNatsWorkerProcess must construct a real observer when the caller supplies none; the live entrypoint supplies none",
+      ).toBe(true);
+      expect(summary.embed_watermark_lag_threshold_seconds).toBe(
+        THRESHOLD_SECONDS,
+      );
+    });
+
+    it("STALE — raw newer than embedded past the threshold degrades the worker", async () => {
+      // The three-day outage, in rows: raw thoughts keep arriving while the
+      // newest embedded row is over three days old. `embedded_at IS NULL` on
+      // the recent arrivals is what a drained-by-nobody queue looks like.
+      await seedThought({
+        content: "old row, embedded three days ago",
+        createdAgoSeconds: 259_260,
+        embeddedAgoSeconds: 259_200,
+      });
+      await seedThought({
+        content: "fresh raw row, queue never drained",
+        createdAgoSeconds: 60,
+        embeddedAgoSeconds: null,
+      });
+      await seedThought({
+        content: "another fresh raw row",
+        createdAgoSeconds: 20,
+        embeddedAgoSeconds: null,
+      });
+
+      const { status, body } = await startDefaultWorker();
+      const block = requireBlock(body);
+
+      expect(block.stale).toBe(true);
+      expect(body.status).toBe("degraded");
+      expect(status).toBe(503);
+
+      // Numbers must come from the SEEDED ROWS, not from a constant. The newest
+      // raw row was inserted 20s ago and the newest embedded mark 259_200s ago;
+      // tolerances absorb runner latency without letting a hard-coded block pass.
+      expect(block.newest_raw_age_seconds).toBeGreaterThanOrEqual(19);
+      expect(block.newest_raw_age_seconds).toBeLessThan(120);
+      expect(block.newest_embedded_age_seconds).toBeGreaterThan(259_000);
+      expect(block.lag_seconds).toBeGreaterThan(block.lag_threshold_seconds);
+      expect(block.lag_threshold_seconds).toBe(THRESHOLD_SECONDS);
+      expect(block.raw_rows_recent).toBeGreaterThan(0);
+      expect(block.reason).toBeTruthy();
+    });
+
+    it("HEALTHY — an embed lane keeping up within the threshold stays green", async () => {
+      // CONTROL. Without it the stale case proves nothing: a surface that
+      // reported `degraded` unconditionally would pass that test.
+      await seedThought({
+        content: "raw row promptly embedded",
+        createdAgoSeconds: 120,
+        embeddedAgoSeconds: 100,
+      });
+      await seedThought({
+        content: "newer raw row, also embedded",
+        createdAgoSeconds: 40,
+        embeddedAgoSeconds: 30,
+      });
+
+      const { status, body } = await startDefaultWorker();
+      const block = requireBlock(body);
+
+      expect(block.stale).toBe(false);
+      expect(body.status).toBe("healthy");
+      expect(status).toBe(200);
+      expect(block.lag_seconds).toBeLessThan(block.lag_threshold_seconds);
+      expect(block.newest_embedded_age_seconds).toBeGreaterThanOrEqual(29);
+      expect(block.newest_embedded_age_seconds).toBeLessThan(150);
+      expect(block.raw_rows_recent).toBeGreaterThan(0);
+    });
+
+    it("IDLE CORPUS — no recent raw rows is healthy, with real numbers, not an alarm", async () => {
+      // A quiet week produces an old embedded row too, and alarming on that is
+      // how a check stops being read (`server/capture/liveness-observer.ts`
+      // MIN_SESSIONS_FOR_SILENCE carries the same argument for capture, and
+      // #728's `raw_rows_recent` field exists to carry it here). Both rows are
+      // ancient and the lag is small — nothing is stalled, nothing is arriving.
+      await seedThought({
+        content: "ancient row, embedded shortly after it arrived",
+        createdAgoSeconds: 604_800,
+        embeddedAgoSeconds: 604_740,
+      });
+
+      const { status, body } = await startDefaultWorker();
+      const block = requireBlock(body);
+
+      expect(block.stale).toBe(false);
+      expect(body.status).toBe("healthy");
+      expect(status).toBe(200);
+      // "Healthy with numbers", not healthy by absence: the block is still
+      // published and still reports what it measured.
+      expect(block.newest_raw_age_seconds).toBeGreaterThan(600_000);
+      expect(block.newest_embedded_age_seconds).toBeGreaterThan(600_000);
+      expect(block.raw_rows_recent).toBe(0);
+      expect(block.reason).toBeTruthy();
+    });
+  },
+);

--- a/scripts/run-nats-worker.ts
+++ b/scripts/run-nats-worker.ts
@@ -3,6 +3,10 @@
 import type pg from "pg";
 import { buildTokenMap } from "../src/auth.ts";
 import { createPool } from "../src/db/pool.ts";
+import {
+  createEmbedWatermarkObserver,
+  EMBED_WATERMARK_CACHE_TTL_MS,
+} from "../src/embed-watermark-observer.ts";
 import { logger } from "../src/logger.ts";
 import {
   natsWorkerLogSummary,
@@ -320,6 +324,28 @@ export async function startNatsWorkerProcess(
 
     pool = createDbPool();
     tracing = createTracing();
+    // NOTHING IS ADJUSTED SILENTLY: read the threshold before composing the
+    // observer, so the bound the observer takes its verdict against is the
+    // same one announced in the startup summary below.
+    const embedThreshold = readEmbedWatermarkThresholdSeconds(env);
+    // #724 item 3: the DEPLOYED worker must construct its own observer. The
+    // option stays an override (PR #728's fixture test injects one), but its
+    // ABSENCE no longer means "no observer" — that is what left the surface in
+    // the tree and out of the serving process. The live entrypoint passes only
+    // `{ env: process.env }` and needs no change: it lands here.
+    let embedWatermarkHealth = options.embedWatermarkHealth;
+    if (!embedWatermarkHealth) {
+      const observer = createEmbedWatermarkObserver({
+        pool,
+        lagThresholdSeconds: embedThreshold.thresholdSeconds,
+        log,
+      });
+      // Prime it once so the first probe answers with numbers rather than the
+      // "not measured yet" absence. A failure here composes the read-failure
+      // reading inside the observer and never throws into startup.
+      await observer.refresh();
+      embedWatermarkHealth = observer.read;
+    }
     runtime = await startWorker({
       env,
       pool,
@@ -330,19 +356,23 @@ export async function startNatsWorkerProcess(
       env,
       runtime,
       serve,
-      ...(options.embedWatermarkHealth
-        ? { embedWatermarkHealth: options.embedWatermarkHealth }
-        : {}),
+      embedWatermarkHealth,
     });
     // NOTHING IS ADJUSTED SILENTLY: the threshold in force is announced at
     // startup along with WHERE it came from, so an unset env key is visible as
-    // a default rather than looking like a configured value.
-    const embedThreshold = readEmbedWatermarkThresholdSeconds(env);
+    // a default rather than looking like a configured value; the cache TTL is
+    // announced beside it because a cached reading is what /health actually
+    // serves, and a reader cannot interpret the block without knowing how old
+    // it may be.
     log.info("Open Brain NATS worker started", {
       ...natsWorkerLogSummary(runtime.boundary),
       availability: runtime.health.availability,
       health_port: healthPortFromEnv(env),
-      embed_watermark_observed: Boolean(options.embedWatermarkHealth),
+      embed_watermark_observed: Boolean(embedWatermarkHealth),
+      embed_watermark_observer_source: options.embedWatermarkHealth
+        ? "injected"
+        : "default_pool_observer",
+      embed_watermark_cache_ttl_seconds: EMBED_WATERMARK_CACHE_TTL_MS / 1000,
       embed_watermark_lag_threshold_seconds: embedThreshold.thresholdSeconds,
       embed_watermark_lag_threshold_source: embedThreshold.source,
       ...(embedThreshold.source === "invalid_env_default"

--- a/src/embed-watermark-observer.ts
+++ b/src/embed-watermark-observer.ts
@@ -1,0 +1,290 @@
+/**
+ * The LIVE embed-watermark observer the deployed NATS worker composes (#724
+ * item 3, second half).
+ *
+ * ## What this closes
+ *
+ * PR #728 built the whole `embed_watermark` health surface — the block shape,
+ * the configurable threshold, the degraded/503 composition in the worker's
+ * `/health`, and the runbook section — and proved every one of those behaviors
+ * by INJECTING an `embedWatermarkHealth` option. Nothing constructed a real
+ * observer, so the deployed worker logged `embed_watermark_observed: false`,
+ * published no block, and could never alarm. The surface existed in the tree
+ * and was absent from the serving process — the #674 class, which this repo
+ * had already paid for once at #656 (capture observer wired).
+ *
+ * This module is the constructor the live entrypoint gets by default.
+ *
+ * ## It reads the registry, not a hard-coded table
+ *
+ * `src/embedding-targets.ts` is the single source of truth for every
+ * embedding-bearing table (`EMBEDDING_TARGETS`, `EMBEDDING_TARGET_NAMES`), and
+ * it is the SAME registry the lane-A embedding repair drives off. A target
+ * carries `provenance.hasEmbeddedAt` telling us whether the physical
+ * `embedded_at` column exists (`FULL_PROVENANCE` at
+ * `src/embedding-targets.ts:146-150`); `ob_entities` declares
+ * `ENTITY_PROVENANCE` (`:158-162`) because it has an `embedding` column and no
+ * staleness columns at all, so it is skipped rather than queried for a column
+ * that is not there. Adding a target to the registry therefore extends the
+ * watermark automatically, and no table name in the SQL below comes from
+ * anywhere but that allowlist.
+ *
+ * ## It is cheap, and `/health` never waits on Postgres
+ *
+ * `startHealthServer`'s fetch handler is SYNCHRONOUS
+ * (`scripts/run-nats-worker.ts`), and a probe must not be able to block on a
+ * database round trip or make one query per embedding target per request.
+ * So the accessor returned by `createEmbedWatermarkObserver` NEVER queries:
+ * it returns the cached reading and, when that reading is older than the TTL,
+ * schedules a background refresh whose result serves the NEXT probe. One
+ * refresh is in flight at a time. A probe arriving before the first refresh
+ * lands gets `undefined` — absence, which by the runbook's contract cannot
+ * degrade the endpoint and is the correct answer for "I have not measured
+ * yet".
+ *
+ * ## A failed read is not a stalled lane, and it is not silence either
+ *
+ * If the query throws, the observer composes a reading whose `stale` is FALSE
+ * and whose `reason` names the read failure, carrying the numeric fields from
+ * the last successful reading when one exists and `-1` (explicitly "not
+ * measured", never an age) when none does.
+ *
+ * That is deliberate on both sides:
+ *
+ * - It does not flip `stale: true`. A database the observer cannot reach is
+ *   evidence about the OBSERVER, not about the embed lane. Alarming on it
+ *   would make a transient blip indistinguishable from the three-day outage
+ *   this block exists to catch, and a 503 that fires for unrelated reasons is
+ *   how a check stops being read — the same argument `raw_rows_recent` carries
+ *   for an idle corpus.
+ * - It does not go absent and it does not go stale-forever green. The block is
+ *   still published with a reason saying the read failed, the age fields are
+ *   `-1` rather than a plausible-looking zero, and every failure is logged. An
+ *   operator reading the payload can tell "measured and fine" from "could not
+ *   measure", which a silently-omitted block cannot express.
+ * - It cannot crash `/health`. The refresh runs in the background with its own
+ *   catch; a rejected query composes the error reading and is never thrown
+ *   into the request path.
+ */
+import type pg from "pg";
+import {
+  EMBEDDING_TARGETS,
+  EMBEDDING_TARGET_NAMES,
+} from "./embedding-targets.ts";
+import type { EmbedWatermarkHealth } from "../scripts/run-nats-worker.ts";
+
+type LoggerLike = {
+  error: (msg: string, fields?: Record<string, unknown>) => void;
+};
+
+/**
+ * How long a watermark reading is served before a background refresh is
+ * scheduled, in milliseconds.
+ *
+ * Thirty seconds. The bound the verdict is taken against is an HOUR by default
+ * (`DEFAULT_EMBED_WATERMARK_LAG_THRESHOLD_SECONDS`), so a reading up to 30s old
+ * cannot change the `stale` verdict in any realistic case, while a scrape
+ * interval of a few seconds collapses from "N queries per probe" to at most one
+ * aggregate query per 30s regardless of probe rate.
+ *
+ * NOTHING IS ADJUSTED SILENTLY: the worker announces this value at startup as
+ * `embed_watermark_cache_ttl_seconds`, beside the threshold it announces
+ * already.
+ */
+export const EMBED_WATERMARK_CACHE_TTL_MS = 30_000;
+
+/** Sentinel for a numeric field that was never measured. Not an age. */
+const NOT_MEASURED = -1;
+
+export interface EmbedWatermarkObserverOptions {
+  pool: pg.Pool;
+  /** The bound the `stale` verdict is taken against. */
+  lagThresholdSeconds: number;
+  /** Serve a reading this long before scheduling a refresh. */
+  cacheTtlMs?: number;
+  log?: LoggerLike;
+  /** Injectable clock, for tests. */
+  now?: () => number;
+}
+
+export interface EmbedWatermarkObserver {
+  /** Synchronous accessor for the health composer. Never queries. */
+  read: () => EmbedWatermarkHealth | undefined;
+  /** Force a refresh and await it. Used at startup and by tests. */
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Every registry target that physically carries an `embedded_at` column.
+ *
+ * Names come from `EMBEDDING_TARGET_NAMES` and are used as SQL identifiers
+ * below; that is safe precisely because the registry IS the allowlist
+ * (`getEmbeddingTarget` throws on anything outside it), which is the same
+ * rule the repair path relies on.
+ */
+export function watermarkTargetTables(): string[] {
+  return EMBEDDING_TARGET_NAMES.filter(
+    (name) => EMBEDDING_TARGETS[name]?.provenance.hasEmbeddedAt === true,
+  );
+}
+
+/**
+ * Aggregate the raw and embedded watermarks across every watermark-bearing
+ * target in ONE query.
+ *
+ * Per target: the newest `created_at` (raw arrival), the newest `embedded_at`
+ * (the embed lane's own watermark), and how many rows arrived inside the
+ * threshold window. The outer aggregate takes the newest of each across
+ * targets, so a single stalled table is visible in the lag and an idle one
+ * cannot mask a busy one.
+ */
+function buildWatermarkSql(tables: string[]): string {
+  const parts = tables.map(
+    (table) => `
+      SELECT
+        max(created_at)  AS newest_raw,
+        max(embedded_at) AS newest_embedded,
+        count(*) FILTER (
+          WHERE created_at > now() - make_interval(secs => $1::double precision)
+        ) AS raw_rows_recent
+      FROM ${table}`,
+  );
+  return `
+    WITH per_target AS (${parts.join("\n      UNION ALL")})
+    SELECT
+      extract(epoch FROM now() - max(newest_raw))::double precision
+        AS newest_raw_age_seconds,
+      extract(epoch FROM now() - max(newest_embedded))::double precision
+        AS newest_embedded_age_seconds,
+      coalesce(sum(raw_rows_recent), 0)::bigint AS raw_rows_recent
+    FROM per_target`;
+}
+
+interface WatermarkRow {
+  newest_raw_age_seconds: number | null;
+  newest_embedded_age_seconds: number | null;
+  raw_rows_recent: string | number | null;
+}
+
+/**
+ * Turn one aggregate row into the published block.
+ *
+ * The empty-corpus case (no rows anywhere, so both watermarks are NULL) is
+ * decided HERE and deliberately: it reports `-1` ages, `raw_rows_recent: 0`,
+ * and `stale: false`. An empty corpus is not a stalled lane — there is nothing
+ * for the lane to have failed to do — and `stale` already requires
+ * `raw_rows_recent > 0`, so the guard that keeps an idle week quiet keeps an
+ * empty database quiet on exactly the same argument.
+ */
+export function composeWatermarkReading(
+  row: WatermarkRow,
+  lagThresholdSeconds: number,
+): EmbedWatermarkHealth {
+  const rawAge = row.newest_raw_age_seconds;
+  const embeddedAge = row.newest_embedded_age_seconds;
+  const rawRowsRecent = Number(row.raw_rows_recent ?? 0);
+
+  if (rawAge === null) {
+    return {
+      stale: false,
+      newest_raw_age_seconds: NOT_MEASURED,
+      newest_embedded_age_seconds: embeddedAge ?? NOT_MEASURED,
+      lag_seconds: NOT_MEASURED,
+      lag_threshold_seconds: lagThresholdSeconds,
+      raw_rows_recent: 0,
+      reason: "no rows in any embedding target; nothing to embed",
+    };
+  }
+
+  // No embedded row at all, but raw rows exist: the lag is the full age of the
+  // newest raw row, because nothing has ever been embedded.
+  const lagSeconds = embeddedAge === null ? rawAge : embeddedAge - rawAge;
+  const stale = lagSeconds > lagThresholdSeconds && rawRowsRecent > 0;
+
+  return {
+    stale,
+    newest_raw_age_seconds: rawAge,
+    newest_embedded_age_seconds: embeddedAge ?? NOT_MEASURED,
+    lag_seconds: lagSeconds,
+    lag_threshold_seconds: lagThresholdSeconds,
+    raw_rows_recent: rawRowsRecent,
+    reason: stale
+      ? "embedded watermark trails raw arrivals past the threshold while raw rows keep arriving"
+      : rawRowsRecent === 0
+        ? "no raw rows inside the threshold window; idle corpus, not a stalled lane"
+        : "embed watermark within threshold",
+  };
+}
+
+/** Compose the reading served when the watermark query itself failed. */
+function composeReadFailureReading(
+  previous: EmbedWatermarkHealth | undefined,
+  lagThresholdSeconds: number,
+): EmbedWatermarkHealth {
+  return {
+    stale: false,
+    newest_raw_age_seconds: previous?.newest_raw_age_seconds ?? NOT_MEASURED,
+    newest_embedded_age_seconds:
+      previous?.newest_embedded_age_seconds ?? NOT_MEASURED,
+    lag_seconds: previous?.lag_seconds ?? NOT_MEASURED,
+    lag_threshold_seconds: lagThresholdSeconds,
+    raw_rows_recent: previous?.raw_rows_recent ?? 0,
+    reason: previous
+      ? "embed watermark query failed; numbers are the last successful reading"
+      : "embed watermark query failed; never measured",
+  };
+}
+
+export function createEmbedWatermarkObserver(
+  options: EmbedWatermarkObserverOptions,
+): EmbedWatermarkObserver {
+  const cacheTtlMs = options.cacheTtlMs ?? EMBED_WATERMARK_CACHE_TTL_MS;
+  const now = options.now ?? Date.now;
+  const tables = watermarkTargetTables();
+  const sql = buildWatermarkSql(tables);
+
+  let reading: EmbedWatermarkHealth | undefined;
+  let lastGood: EmbedWatermarkHealth | undefined;
+  let readAtMs = 0;
+  let inFlight: Promise<void> | null = null;
+
+  const refresh = async (): Promise<void> => {
+    if (inFlight) return inFlight;
+    inFlight = (async () => {
+      try {
+        const result = await options.pool.query<WatermarkRow>(sql, [
+          options.lagThresholdSeconds,
+        ]);
+        const row = result.rows[0];
+        if (!row) throw new Error("watermark aggregate returned no row");
+        reading = composeWatermarkReading(row, options.lagThresholdSeconds);
+        lastGood = reading;
+      } catch (err) {
+        options.log?.error("Open Brain embed watermark read failed", {
+          error_type: err instanceof Error ? err.constructor.name : typeof err,
+        });
+        reading = composeReadFailureReading(
+          lastGood,
+          options.lagThresholdSeconds,
+        );
+      } finally {
+        readAtMs = now();
+        inFlight = null;
+      }
+    })();
+    return inFlight;
+  };
+
+  return {
+    read: () => {
+      if (now() - readAtMs >= cacheTtlMs) {
+        // Fire and forget: the NEXT probe reads the fresher value. A rejection
+        // is impossible here (refresh catches its own), but the void guard
+        // keeps an unhandled rejection off the request path regardless.
+        void refresh().catch(() => undefined);
+      }
+      return reading;
+    },
+    refresh,
+  };
+}


### PR DESCRIPTION
## What this closes

Issue #724 item 3, second half. PR #728 landed the entire `embed_watermark`
health surface — the block shape, the configurable threshold, degraded/503
composition in the worker's `/health`, the runbook section — and proved every
one of those behaviors by **injecting** an `embedWatermarkHealth` option.
Nothing constructed a real observer. `startNatsWorkerProcess` only forwarded
`options.embedWatermarkHealth`, and the live entrypoint calls it with
`{ env: process.env }` and nothing else, so the deployed worker logged
`embed_watermark_observed: false`, published no block, and **could never
alarm**. The surface existed in the tree and was absent from the serving
process — the #674 class, which this repo had already paid for once at #656
(capture observer wired).

`startNatsWorkerProcess` now default-constructs an observer against its own
pool when the caller supplies none. The option remains an override, so #728's
fixture test (`scripts/run-nats-worker-embed-watermark.test.ts`) is green
unchanged, and the live entrypoint needs no change — that was the point of the
gate.

## It rides the existing registry, not a new table list

The watermark queries every `EMBEDDING_TARGETS` entry whose
`provenance.hasEmbeddedAt` is true — the same registry lane A's embedding
repair drives off:

- `EMBEDDING_TARGETS` — `src/embedding-targets.ts:179`
- `FULL_PROVENANCE` (`hasEmbeddedAt: true`) — `src/embedding-targets.ts:146-150`
- `ENTITY_PROVENANCE` (`hasEmbeddedAt: false`) — `src/embedding-targets.ts:158-162`
- `EMBEDDING_TARGET_NAMES` — `src/embedding-targets.ts:326`
- `thoughts` timestamp columns — `src/db/migrations/001_init.sql:7-19`

`ob_entities` is skipped on its declared provenance rather than queried for an
`embedded_at` that does not physically exist. Table names reaching the SQL come
only from that allowlist — the same rule `getEmbeddingTarget` enforces for
repair. Adding a target to the registry extends the watermark with no change to
the observer.

The observer plugs into the **existing seam**: `startHealthServer` already
accepted `embedWatermarkHealth` (`scripts/run-nats-worker.ts`), and the
construction happens in `startNatsWorkerProcess` after `createDbPool()` and
before the `startHealthServer` call, using the worker's existing pool.

## Cheap and non-blocking: a 30s TTL cache

`startHealthServer`'s fetch handler is **synchronous**, so a probe must not be
able to block on a database round trip or issue one query per embedding target
per request. The accessor returned by `createEmbedWatermarkObserver` therefore
**never queries**: it returns the cached reading and, once that reading is older
than `EMBED_WATERMARK_CACHE_TTL_MS` (**30 seconds**), schedules a background
refresh whose result serves the next probe. One refresh is in flight at a time.
The observer is primed once during startup so the first probe answers with
numbers rather than absence.

Thirty seconds against a default bound of one hour: a reading that stale cannot
move the `stale` verdict in any realistic case, while the endpoint's cost
collapses to at most one aggregate query per 30s regardless of scrape rate.

**Nothing is adjusted silently.** The startup summary now carries
`embed_watermark_cache_ttl_seconds` and `embed_watermark_observer_source`
(`default_pool_observer` or `injected`) alongside the threshold fields #728
already announced, so a reader can tell which observer is in force and how old
the block may be without reading code.

## The failure shape I chose, and why

**A DB query failure composes `stale: false` with a `reason` naming the read
failure**, carrying the numeric fields from the last successful reading, or `-1`
(explicitly "not measured", never an age) when there has never been one. Every
failure is logged as `Open Brain embed watermark read failed`. The refresh
catches its own errors in the background, so a rejected query is never thrown
into the request path.

Three things that shape rules out at once:

- **It does not flip `stale: true`.** A database the observer cannot reach is
  evidence about the *observer*, not about the embed lane. Alarming on it makes
  a transient blip indistinguishable from the three-day outage this block exists
  to catch, and a 503 that fires for unrelated reasons is how a check stops
  being read — the same argument `raw_rows_recent` already carries for an idle
  corpus.
- **It does not go absent, and it does not hold a silent green.** The runbook's
  absence-is-not-staleness contract says a missing block means "not my job"; a
  failed read is *not* "not my job", and publishing nothing would be
  indistinguishable from a pre-#724 worker. The block stays published with a
  reason saying the read failed and `-1` rather than a plausible-looking zero,
  so "measured and fine" is distinguishable from "could not measure" — which a
  silently-omitted block cannot express. This is the runbook contract extended,
  not overridden: absence still cannot degrade, and the deployed worker now
  never goes absent.
- **It cannot crash `/health`.** The synchronous accessor only reads state.

**Empty corpus** (a case the gate deliberately left open): no rows in any
target reports `-1` ages, `raw_rows_recent: 0`, `stale: false`. An empty corpus
is not a stalled lane — there is nothing the lane failed to do — and `stale`
already requires `raw_rows_recent > 0`, so the guard that keeps an idle week
quiet keeps an empty database quiet on the same argument.

## Verification

- Done-means: scripts/done-means/724-watermark-live-observer.sh

The wrapper is bash-shaped because `scripts/verify-lane.ts` runs every Done-means check with `bash` (#733); it invokes `bun run test:isolated` on `scripts/run-nats-worker-live-watermark.pg.test.ts` and exits 0 green / 1 red / 3 harness error.

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED (observed by the author lane on commit `b2f0a83`, before this commit existed): `bash scripts/done-means/724-watermark-live-observer.sh` -> 0 pass, 4 fail, wrapper exit 1, isolated DB `ob_isolated_88305_msy45rtn3u`. Every failure was the missing wiring: `startNatsWorkerProcess must construct a real observer when the caller supplies none` (`Expected: true, Received: false`) and `the DEFAULT worker composition published no embed_watermark block` (`Received: undefined`) on the other three.

GREEN (RUNNING, observed this session on commit `fcd0339`, isolated DB `ob_isolated_74162_msy4erbv6p`, created and dropped by the harness):

```
bash scripts/done-means/724-watermark-live-observer.sh
tally:   4 pass, 0 fail, 0 skip (runner exit 0)
VERDICT: PASS
```

LOAD-BEARING (RUNNING, this session): with the default construction neutered to `if (false)` and nothing else changed, the same runner returns **0 pass, 4 fail**. The wiring is what makes it green, not the test's own harness. The file was restored from a copy held outside the repo; `git diff --stat` confirmed the restored tree.

NO REGRESSION in the touched area (RUNNING, this session):

```
bun run test:isolated scripts/run-nats-worker*.test.ts src/embedding-targets.test.ts
 38 pass
 0 fail
Ran 38 tests across 4 files.
  tests exited 0
```

`bunx tsc --noEmit` exit 0 on the committed tree (re-run after the pre-commit prettier reformat, so the formatted tree is the one that is green). Per `AGENTS.md`, no bare full-suite `bun test` count is cited.

## Critical Self-Review

- Highest-risk behavior: the observer serves a CACHED reading, so `/health` can report a verdict up to 30s stale. Against a one-hour default bound that cannot change the verdict; against a threshold configured below ~60s it could, and the TTL is a module constant rather than env-tunable today. Second-order: the deployed worker can now return 503 for an embed stall where before it structurally could not, because it published no block at all — that is the intended fix, but it is a live behavior change for anything alerting on 3110.
- Assumptions that could be wrong: that every `hasEmbeddedAt` target also has a `created_at` column. True for all seven `FULL_PROVENANCE` targets in the current schema, but it is an implicit coupling the registry does not declare, so a future target with `embedded_at` and no `created_at` would break the SQL at runtime rather than at typecheck. Also PROPOSED: that the newest-across-targets aggregate is the right roll-up — one busy table can currently mask a second table whose own lane is stalled, because `max()` is taken across the UNION rather than per target.
- Missing/weak tests: only `thoughts` carries seeded rows, so the multi-target UNION is exercised structurally but not with rows in a second table; the masking case named above is therefore unasserted. The TTL expiry path and the read-failure composition have no dedicated case (the `now` and `log` seams exist for them). The empty-corpus branch is reasoned in code and docs, not asserted.
- Security/permission risk: none new. Table names are interpolated only from `EMBEDDING_TARGET_NAMES`, the same static allowlist `getEmbeddingTarget` enforces for repair; the threshold is a bound parameter. The block is aggregate counts and ages — no content, no identifiers, no namespace values. The query is deliberately NOT namespace-scoped: it is an operator liveness reading on the worker's own 3110 port, not a tenant read, and scoping it would make the reading blind to exactly the namespaces most likely to stall.
- Migration/deploy risk: no schema change, no migration. Deploy effect is that the worker's `/health` starts publishing a block it did not before and CAN now return 503 where it previously could not. A supervisor configured to restart on 503 would restart the worker for an embed stall, which restarting does not fix; the runbook names the new meaning, wiring a restart policy to it is out of scope here.
- Downstream client/runtime risk: `docs/downstream-rollout.md` classification — NOT APPLICABLE. No MCP tool, schema, protocol, or client-facing contract is touched. 3110 is the worker's own operator endpoint; no rtech-mcps, mcp2cli, or rtech-hermes surface reads it.
- Rollback/cleanup concern: revert is one self-contained commit — one new module, one wiring block, one runbook section. The `embedWatermarkHealth` injection override is unchanged, so reverting cannot break #728's fixture test. Both isolated test databases were dropped by the harness, confirmed by its own teardown lines.
- Fixes made before PR: initial `LoggerLike` shape failed typecheck against the repo logger's `Record<string, unknown>` signature; narrowed. The threshold read was moved ABOVE the observer construction so the bound the verdict is taken against is provably the same value announced in the startup summary, rather than two independent reads of the same env key.
- Known residual risk: the 30s TTL interacts with a sub-minute configured threshold as described, and no test pins that interaction. The per-target masking question is unresolved. This lane makes the deployed worker able to alarm; whether the alarm is wired to anything that acts on it is not established here and should not be assumed from this merge.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no MEDIUM+ review finding surfaced in this lane; the reusable lesson (a health surface proved only by injection is not wired, the #656/#674 class) is already carried by the gate test's own header and belongs in `docs/lane-contract.md` Tightenings, which is the controller's merge-pass harvest step.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this lane is code, tests, and docs only with no deploy — no running instance carries this change, so there is nothing to smoke and claiming otherwise would be a false receipt.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the change is confined to the TypeScript NATS worker's own `/health` payload on 3110 and the registry it reads. There is no cross-runtime contract fixture for that surface — the Python client does not read it, and no MCP tool schema describes it.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli handoff is complete or not applicable
- [x] rtech-hermes handoff is complete or not applicable

Closes part of #724 (item 3).
