### PR TITLE
fix(provider): guard refusals say "git guard", not "Codex"

### DIFF
--- a/python/openbrain-provider/src/openbrain_provider/policy_safety.py
+++ b/python/openbrain-provider/src/openbrain_provider/policy_safety.py
@@ -495,13 +495,13 @@ def _branch_block_reason(cwd: Path) -> str | None:
         )
     except (OSError, subprocess.SubprocessError):
         return (
-            "Codex git guard: unable to verify the current branch; commit/push is "
+            "git guard: unable to verify the current branch; commit/push is "
             "blocked until branch state is readable."
         )
     branch = completed.stdout.strip()
     if branch in ("main", "master"):
         return (
-            f"Codex git guard: current branch is {branch}; do not commit or push "
+            f"git guard: current branch is {branch}; do not commit or push "
             "from a protected branch."
         )
     return None
@@ -515,7 +515,7 @@ def _git_history_block_reason(command: str, command_cwd: str) -> str | None:
         if not _GIT_MUTATES_HISTORY.search(command):
             return None
         return (
-            "Codex git guard: unable to verify the current branch; commit/push is "
+            "git guard: unable to verify the current branch; commit/push is "
             "blocked until branch state is readable."
         )
     if any(
@@ -523,7 +523,7 @@ def _git_history_block_reason(command: str, command_cwd: str) -> str | None:
         for mutator in mutators
     ):
         return (
-            "Codex git guard: do not commit or push directly to main/master "
+            "git guard: do not commit or push directly to main/master "
             "without explicit approval."
         )
     for mutator in mutators:
@@ -544,15 +544,15 @@ def _shell_safety_block_reason(command: str, command_cwd: str) -> str | None:
         The refusal text, or None.
     """
     if _GIT_RESET_HARD.search(command):
-        return "Codex git guard: `git reset --hard` needs explicit user approval."
+        return "git guard: `git reset --hard` needs explicit user approval."
     if _GIT_CHECKOUT_DISCARD.search(command):
         return (
-            "Codex git guard: `git checkout --` can discard work and needs "
+            "git guard: `git checkout --` can discard work and needs "
             "explicit user approval."
         )
     if _GIT_SWITCH_PROTECTED.search(command):
         return (
-            "Codex git guard: do not switch to main/master for work; use a "
+            "git guard: do not switch to main/master for work; use a "
             "focused work branch."
         )
     if _CLAUDE_WORKTREE.search(command):
@@ -562,7 +562,7 @@ def _shell_safety_block_reason(command: str, command_cwd: str) -> str | None:
         )
     if _GH_PR_MERGE.search(command) and _GH_MERGE_AUTOMATIC.search(command):
         return (
-            "Codex merge guard: do not use `gh pr merge --admin/--auto`. Inspect "
+            "merge guard: do not use `gh pr merge --admin/--auto`. Inspect "
             "checks and merge deliberately."
         )
 

--- a/python/openbrain-provider/tests/fixtures/ts_gate_parity/recorded.json
+++ b/python/openbrain-provider/tests/fixtures/ts_gate_parity/recorded.json
@@ -763,7 +763,7 @@
         "command": "git reset --hard origin/main"
       }
     },
-    "stdout": "{\"decision\":\"block\",\"reason\":\"Codex git guard: `git reset --hard` needs explicit user approval.\"}\n",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"git guard: `git reset --hard` needs explicit user approval.\"}\n",
     "stderr": "",
     "status": 0
   },
@@ -790,7 +790,7 @@
         "command": "git checkout main"
       }
     },
-    "stdout": "{\"decision\":\"block\",\"reason\":\"Codex git guard: do not switch to main/master for work; use a focused work branch.\"}\n",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"git guard: do not switch to main/master for work; use a focused work branch.\"}\n",
     "stderr": "",
     "status": 0
   },
@@ -817,7 +817,7 @@
         "command": "gh pr merge --admin 12"
       }
     },
-    "stdout": "{\"decision\":\"block\",\"reason\":\"Codex merge guard: do not use `gh pr merge --admin/--auto`. Inspect checks and merge deliberately.\"}\n",
+    "stdout": "{\"decision\":\"block\",\"reason\":\"merge guard: do not use `gh pr merge --admin/--auto`. Inspect checks and merge deliberately.\"}\n",
     "stderr": "",
     "status": 0
   },

--- a/scripts/done-means/745-guard-label-not-codex.sh
+++ b/scripts/done-means/745-guard-label-not-codex.sh
@@ -1,0 +1,28 @@
+#!/opt/homebrew/bin/bash
+# DONE-MEANS check for PR #745: the provider's git and merge guard refusals
+# are labelled for every runtime, not for Codex alone.
+#
+#   bash scripts/done-means/745-guard-label-not-codex.sh
+#
+# The guard in python/openbrain-provider/src/openbrain_provider/policy_safety.py
+# fires for Claude and Codex lanes alike; a refusal that opens with "Codex git
+# guard:" tells a Claude lane the wrong thing about who refused it. GREEN when
+# no refusal string carries the "Codex " prefix and the plain "git guard:" /
+# "merge guard:" labels are present in both the source and the recorded
+# ts_gate_parity fixture.
+#
+# Exit grammar: 0 pass, 1 the label is still Codex-specific, 3 harness error.
+set -u
+cd "$(git rev-parse --show-toplevel)" || exit 3
+SRC=python/openbrain-provider/src/openbrain_provider/policy_safety.py
+FIX=python/openbrain-provider/tests/fixtures/ts_gate_parity/recorded.json
+[ -f "$SRC" ] && [ -f "$FIX" ] || { echo "HARNESS: $SRC or $FIX missing"; exit 3; }
+rc=0
+for f in "$SRC" "$FIX"; do
+  stale=$(rg -c 'Codex (git|merge) guard:' "$f" || true)
+  plain=$(rg -c '(^|[^a-zA-Z])(git|merge) guard:' "$f" || true)
+  if [ "${stale:-0}" -ne 0 ]; then echo "FAIL: $f still has ${stale} Codex-labelled guard refusal(s)"; rc=1; fi
+  if [ "${plain:-0}" -eq 0 ]; then echo "FAIL: $f has no plain guard label"; rc=1; fi
+done
+[ "$rc" -eq 0 ] && echo "PASS: guard refusals are labelled for every runtime in $SRC and $FIX"
+exit "$rc"


### PR DESCRIPTION
The PreToolUse policy gate runs for every runtime, Claude included. A refusal
labelled "Codex git guard" in a Claude session reads as a misroute and sends the
agent looking for a routing fault that does not exist. This renames the refusal
prefixes in `policy_safety.py` to name the guard that actually fired -- "git
guard" and "merge guard" -- and updates the recorded parity fixture to match.

Rebased onto current `main` (2026-08-28). The branch previously carried three
commits that have since landed on `main` independently:

- `3cdcc1c fix(memory): capture adopts the lane scope` -- landed as #741 (`6065390`)
- `dc989d5 feat(gate): enforce one-compaction session handoff` -- superseded on `main`
- `f0fa355 fix(gate): make the compaction sprint advisory, never blocking` -- superseded on `main`

Those three produced all 19 rebase conflicts across four files. Replaying only
this branch's own intent onto `main` applies clean with no conflicts, so the PR
is now the single rename commit it was always about: 2 files, 11 lines.

## Verification

- Done-means: scripts/done-means/745-guard-label-not-codex.sh

`scripts/done-means/745-guard-label-not-codex.sh` asserts that no refusal in `policy_safety.py` or the recorded `ts_gate_parity` fixture opens with `Codex git guard:` / `Codex merge guard:` and that the plain `git guard:` / `merge guard:` labels are present. RED at origin/main fee8e11b: `FAIL: ... still has 8 Codex-labelled guard refusal(s)` and 3 in the fixture, exit 1. GREEN on this branch: `PASS: guard refusals are labelled for every runtime`, exit 0. Exit grammar: `0` pass, `1` the label is still Codex-specific, `3` harness error.

- `uv run pytest -q` (python/openbrain-provider) -> 646 passed, 1 skipped
- `uv run ruff check src tests` -> All checks passed!
- `uv run mypy src` -> Success: no issues found in 19 source files
- `git rebase` replay of `c97aaeb` onto `origin/main` -> clean, 0 conflicts

## Critical Self-Review

- Highest-risk behavior: the refusal strings are asserted verbatim in the
  `ts_gate_parity/recorded.json` fixture, so a rename that misses the fixture
  makes the guard pass its own tests while emitting the old label. Both sides
  are changed in the same commit and the parity test is in the 646 that pass.
- Assumptions that could be wrong: that nothing outside this repo matches on the
  literal prefix `Codex git guard`. Downstream hook consumers read the
  `decision` field rather than the reason text, but an operator-side log filter
  or alerting rule keyed to the old string would go quiet rather than fail loudly.
- Missing/weak tests: the done-means check pins the label text, not each guard branch; a per-branch prefix test in `test_guard.py` is the natural follow-up.
- Security/permission risk: none. Only the human-readable reason text changes;
  the block/allow decision, the matched command patterns, and the branch
  predicates are untouched.
- Migration/deploy risk: none in-repo. The provider is installed via
  `uv tool install`, so a host still running the previously installed copy keeps
  emitting the old label until it is reinstalled -- cosmetic, not a behavior split.
- Downstream client/runtime risk: no MCP tool, schema, transport, or Python
  client surface is touched, so `docs/downstream-rollout.md` does not apply here.
- Rollback/cleanup concern: single commit, two files, revert is clean.
- Fixes made before PR: dropped the three already-landed commits during the
  rebase rather than resolving 19 conflicts against work `main` already has.
- Known residual risk: an operator-side log filter keyed to the old `Codex git guard` string goes quiet rather than failing loudly.
- SME review-memory update: [x] not applicable because: a string rename with no new reviewer-lane failure pattern.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this change touches only local PreToolUse refusal text and makes no Open Brain service call.

