### PR TITLE
feat(local-clone): fleet embedding host opt-in and launchd-safe autostart (#757)

### DIFF
--- a/docs/local-clone-dogfood.md
+++ b/docs/local-clone-dogfood.md
@@ -141,6 +141,8 @@ DB_POOL_MAX=10
 OPEN_BRAIN_RUN_MIGRATIONS=0
 
 EMBEDDING_BASE_URL=http://127.0.0.1:<local-embedding-port>/v1
+# Optional (#757): name ONE non-loopback embedding host to allow, exactly.
+# OPEN_BRAIN_EMBEDDING_HOST_ALLOW=10.71.1.11
 EMBEDDING_API_KEY=<local-only-key-if-required>
 EMBEDDING_MODEL=embeddinggemma-300m-8bit
 EMBEDDING_DIMENSIONS=768

--- a/scripts/local-clone-autostart.sh
+++ b/scripts/local-clone-autostart.sh
@@ -95,4 +95,28 @@ if ! "${BUN_BIN}" run scripts/local-clone.ts --verify; then
 fi
 
 log "preflight verified, starting launcher"
-exec "${BUN_BIN}" run scripts/local-clone.ts --start
+
+# Hand off to the launcher as a CHILD of this shell, not via exec.
+#
+# Why (measured 2026-08-25, #757): macOS Local Network privacy attributes the
+# LAN grant to the launchd job's MAIN process. With `exec`, bun became that
+# process and its fetch to the fleet embedder (10.71.1.11) was refused with
+# "Was there a typo in the url or port?", while the same fetch from a bun child
+# of this bash succeeded. That is exactly why the --verify preflight above
+# passed under launchd and --start then died on "embedding preflight failed"
+# every 30 seconds. Keeping bash as the main process keeps the grant. TERM and
+# INT are forwarded so `launchctl kickstart -k` still stops the launcher, which
+# in turn stops its server child.
+"${BUN_BIN}" run scripts/local-clone.ts --start &
+launcher_pid=$!
+forward_signal() { kill -s "$1" "${launcher_pid}" 2>/dev/null || true; }
+trap 'forward_signal TERM' TERM
+trap 'forward_signal INT' INT
+status=0
+wait "${launcher_pid}" || status=$?
+# A trapped signal returns from `wait` before the child has exited; keep
+# waiting so the exit status below is the launcher's, not the signal's.
+while kill -0 "${launcher_pid}" 2>/dev/null; do
+  wait "${launcher_pid}" || status=$?
+done
+exit "${status}"

--- a/scripts/local-clone.ts
+++ b/scripts/local-clone.ts
@@ -78,6 +78,9 @@ const CHILD_ENV_KEYS = [
   "OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES",
   "OPENBRAIN_RECOVERY_WAL_PATH",
   "OPEN_BRAIN_BIND_HOST",
+  // #757: the fleet-embedding opt-in read by `validateLocalCloneMode`; without
+  // it here the key is dropped before the child sees it (the #755 trap).
+  "OPEN_BRAIN_EMBEDDING_HOST_ALLOW",
   "OPEN_BRAIN_MAINTENANCE_ENABLED",
   "OPEN_BRAIN_RUN_MIGRATIONS",
   "OPENBRAIN_TRANSPORT",

--- a/src/local-clone-mode.test.ts
+++ b/src/local-clone-mode.test.ts
@@ -270,4 +270,76 @@ describe("validateLocalCloneMode", () => {
       ),
     ).toEqual({ enabled: true, bindHost: "127.0.0.1" });
   });
+  // #757 (Rico ruling 2026-08-25): the embedding provider moved to the fleet AI
+  // box, so clone mode takes ONE named non-loopback embedding host by explicit
+  // opt-in. Unset or empty must behave exactly as before.
+  it("refuses a fleet embedding host when the opt-in is unset", () => {
+    expect(() =>
+      validateLocalCloneMode(
+        validCloneEnv({ EMBEDDING_BASE_URL: "http://10.71.1.11:8080/v1" }),
+      ),
+    ).toThrow("literal loopback");
+  });
+
+  it("accepts the exact embedding host named by the opt-in", () => {
+    expect(
+      validateLocalCloneMode(
+        validCloneEnv({
+          EMBEDDING_BASE_URL: "http://10.71.1.11:8080/v1",
+          OPEN_BRAIN_EMBEDDING_HOST_ALLOW: "10.71.1.11",
+        }),
+      ),
+    ).toEqual({ enabled: true, bindHost: "127.0.0.1" });
+  });
+
+  it("refuses an embedding host the opt-in does not name", () => {
+    expect(() =>
+      validateLocalCloneMode(
+        validCloneEnv({
+          EMBEDDING_BASE_URL: "http://10.71.1.12:8080/v1",
+          OPEN_BRAIN_EMBEDDING_HOST_ALLOW: "10.71.1.11",
+        }),
+      ),
+    ).toThrow("OPEN_BRAIN_EMBEDDING_HOST_ALLOW host");
+  });
+
+  it("still accepts a loopback embedding host while the opt-in is set", () => {
+    expect(
+      validateLocalCloneMode(
+        validCloneEnv({ OPEN_BRAIN_EMBEDDING_HOST_ALLOW: "10.71.1.11" }),
+      ),
+    ).toEqual({ enabled: true, bindHost: "127.0.0.1" });
+  });
+
+  it.each([
+    "http://10.71.1.11",
+    "10.71.1.11:8080",
+    "10.71.1.11/v1",
+    "10.71.1.11 ",
+  ])("rejects an opt-in value that is not a bare hostname: %s", (configured) => {
+    expect(() =>
+      validateLocalCloneMode(
+        validCloneEnv({
+          EMBEDDING_BASE_URL: "http://10.71.1.11:8080/v1",
+          OPEN_BRAIN_EMBEDDING_HOST_ALLOW: configured,
+        }),
+      ),
+    ).toThrow("OPEN_BRAIN_EMBEDDING_HOST_ALLOW");
+  });
+
+  it("treats an empty opt-in as unset", () => {
+    expect(() =>
+      validateLocalCloneMode(
+        validCloneEnv({
+          EMBEDDING_BASE_URL: "http://10.71.1.11:8080/v1",
+          OPEN_BRAIN_EMBEDDING_HOST_ALLOW: "",
+        }),
+      ),
+    ).toThrow("literal loopback");
+    expect(
+      validateLocalCloneMode(
+        validCloneEnv({ OPEN_BRAIN_EMBEDDING_HOST_ALLOW: "" }),
+      ),
+    ).toEqual({ enabled: true, bindHost: "127.0.0.1" });
+  });
 });

--- a/src/local-clone-mode.ts
+++ b/src/local-clone-mode.ts
@@ -153,7 +153,33 @@ export function validateLocalCloneMode(
   }
   const embeddingHost =
     embeddingUrl.hostname === "[::1]" ? "::1" : embeddingUrl.hostname;
-  requireLiteralLoopback(embeddingHost, "EMBEDDING_BASE_URL");
+  // Fleet embedding opt-in (Rico, 2026-08-25, #757): the embedding provider
+  // moved off this machine to the fleet AI box, so clone mode accepts ONE
+  // explicitly named host alongside loopback. Exact string equality only -- no
+  // wildcard, no CIDR, no substring, no name resolution -- and every other
+  // clone-mode guard stays loopback-locked, exactly as the bind-host opt-in
+  // above does.
+  // Read the RAW value, not the trimmed one: surrounding whitespace means the
+  // operator wrote something other than a bare hostname, and trimming it away
+  // would silently accept a value this guard exists to refuse.
+  const allowedEmbeddingHost = env.OPEN_BRAIN_EMBEDDING_HOST_ALLOW;
+  if (allowedEmbeddingHost === undefined || allowedEmbeddingHost === "") {
+    requireLiteralLoopback(embeddingHost, "EMBEDDING_BASE_URL");
+  } else {
+    if (/[:/\s]/.test(allowedEmbeddingHost)) {
+      throw new Error(
+        "Local clone mode requires OPEN_BRAIN_EMBEDDING_HOST_ALLOW to be a bare hostname",
+      );
+    }
+    if (
+      !LOOPBACK_HOSTS.has(embeddingHost) &&
+      embeddingHost !== allowedEmbeddingHost
+    ) {
+      throw new Error(
+        "Local clone mode requires EMBEDDING_BASE_URL to be a literal loopback address or the OPEN_BRAIN_EMBEDDING_HOST_ALLOW host",
+      );
+    }
+  }
 
   const database = requireValue(env, "DB_NAME");
   if (!database.startsWith("open_brain_local_")) {


### PR DESCRIPTION
Closes part of #757.

Two commits, both scoped to local-clone mode. Neither touches the hosted service or any MCP contract.

## What changed

**`b2643ed` — clone-mode opt-in `OPEN_BRAIN_EMBEDDING_HOST_ALLOW`.** Local clone mode refuses a non-loopback `EMBEDDING_BASE_URL` by default, which is correct: a dogfood clone silently embedding against an arbitrary host is the failure the guard exists to prevent. This adds a single named-host escape hatch. The operator sets `OPEN_BRAIN_EMBEDDING_HOST_ALLOW=<host>` and only that exact host is accepted; everything else still refuses as before. The key is added to `CHILD_ENV_KEYS` so the launcher actually passes it through to the spawned process, and `docs/local-clone-dogfood.md` gains the one line describing it.

**`7c3eb1b` — the autostart script runs the launcher as a child instead of `exec`ing it.** Under launchd, `scripts/local-clone.ts --verify` reached the fleet embedding host and passed, then `--start` died every 30 seconds on "Local clone embedding preflight failed". Root cause: macOS Local Network privacy attributes the grant to the launchd job's **main process**. When bash `exec`s bun, bun *becomes* the main process and its outbound request to a LAN address is refused with a misleading `Was there a typo in the url or port?`. Keeping bash as the main process and running bun as its child inherits the grant and the same fetch returns 200. The script now spawns the launcher, forwards `SIGTERM`/`SIGINT` to it, and exits with the child's status so launchd still sees an accurate exit code.

## Why this host

Measured on #757 against 1000 stored rows: `embed-gemma-dense` on the fleet host produces cosine p50 **0.974** against the existing stored vectors — the same embedding space, so no re-embedding is required. `embed-qwen3-4b` scores cosine **~0** (a different space, 2560-wide), which would mean re-embedding all 178,282 vectors plus altering nine `halfvec(768)` columns and their indexes. Gemma-dense now; Qwen is its own issue if anyone wants it.

## Verification

- Done-means: src/local-clone-mode.test.ts
- `bunx tsc --noEmit` → clean, exit 0.
- `bunx oxlint --deny-warnings src/local-clone-mode.ts src/local-clone-mode.test.ts scripts/local-clone.ts` → clean, exit 0.
- `/opt/homebrew/bin/bash -n scripts/local-clone-autostart.sh` → clean, exit 0.
- `bun test src/local-clone-mode.test.ts scripts/local-clone.test.ts` → 69 pass, 1 skip, 0 fail, 105 assertions.
- Pre-push hook ran the full suite on these two commits: 3407 pass, 531 skip, 0 fail across 248 files; gitleaks clean.
- RUNNING, not merely merged: the local clone currently serves this exact code as `ad3b59c` (cherry-picked here as `7c3eb1b`), reports `embedding.connected=true` with embedder `embed-gemma-dense`, and the fleet host's llama-swap log shows `POST /v1/embeddings` arriving from the Mini at ~20 ms. Process tree confirms bash is the launchd main process with bun as its child.

## Critical Self-Review

- Highest-risk behavior: the launchd Local Network attribution. The fix depends on macOS granting the Local Network entitlement to the job's main process (bash) and that grant being inherited by the bun child. This was proven by two throwaway probe plists — `exec`'d bun fails the fetch, bun-as-child returns 200 — but it is an OS privacy behavior, not a documented API contract, so it can change under a macOS update.
- Assumptions that could be wrong: that TCC continues to grant Local Network access to bash. If Apple later gates bash the same way it gates bun, the clone will start failing the embedding preflight again under launchd with the identical misleading error. That is the first thing to check if this regresses; the probe plists reproduce it in about ten seconds.
- Missing/weak tests: the allowlist logic has RED-first cases in `src/local-clone-mode.test.ts` (exact-host accept, non-allowlisted host still refused, unset variable preserves the old refusal). Signal forwarding in the autostart script is proven with a dummy child rather than against launchd itself — there is no unit-testable seam for the TCC behavior, so that half rests on the live probes and the running deployment, not on an automated test.
- Security/permission risk: this widens a deliberate network guard, which is the whole point of the change, so it is opt-in and single-valued. The variable names exactly one host; it is not a list, not a CIDR, and not a wildcard, and an unset variable leaves the previous loopback-only behavior untouched. It applies only in local clone mode and has no effect on the hosted service.
- Migration/deploy risk: no schema change and no re-embedding — `embed-gemma-dense` lands in the same vector space as the stored data (cos p50 0.974), so existing rows stay valid. The env change is the deploy. Already RUNNING on the local clone as `ad3b59c`, with `EMBEDDING_BASE_URL` and `EMBEDDING_MODEL` switched and backups written beside each env file.
- Downstream client/runtime risk: none identified. No MCP tool, schema, transport, or Python client path is touched, so `docs/downstream-rollout.md` does not apply — this is a local-clone launcher and a clone-mode env guard only.
- Rollback/cleanup concern: restore `local-clone.env` from `local-clone.env.bak-20260825-1103` and redeploy `8f1f2a8`. That reverts both the host and the launcher in one step. The local MLX embedding unit is still loaded and running, so the previous provider is available immediately without a reinstall.
- Fixes made before PR: the autostart commit itself is the fix found after the first deploy attempt — the allowlist alone passed `--verify` and still could not `--start` under launchd, which is what exposed the `exec` problem. `OPEN_BRAIN_EMBEDDING_HOST_ALLOW` was also added to `CHILD_ENV_KEYS` after the first run showed the launcher was not forwarding it to the child.
- Known residual risk: the fleet host is now a hard dependency of local embedding. If it is down, local tests that embed fail with network errors rather than skipping, and the clone's preflight refuses to start. Separately, the fleet host carries an ungrouped `embed-qwen3-4b` test entry whose implicit exclusive group would evict the pinned concurrent group if anyone requested it; harmless today, but it should be grouped or removed before anything relies on it.
- SME review-memory update: [x] not applicable because: no review finding was produced — this is an author-side gate on a two-commit local-clone change, and the launchd/TCC lesson is recorded in `_DOCS/_handoff/2026-08-25-embedding-tn01-cutover.md` rather than as a reviewer lane pattern.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: no Open Brain tool, schema, or namespace behavior changes here; the live evidence that matters is the clone's own `/health` embedding status, cited under Verification.
