### PR TITLE
test(#744,#747): reconcile three tests with the behavior their fixes landed

### DIFF
--- a/_DOCS/_handoff/2026-08-25-recall-is-broken.md
+++ b/_DOCS/_handoff/2026-08-25-recall-is-broken.md
@@ -1,0 +1,86 @@
+# Handoff — recall is broken (2026-08-25)
+
+## State 0 — BASE
+Read /Volumes/ThunderBolt/Development/_DOCS/HANDOFF-BASE.md in full
+(181 lines). It is the standing contract for this session.
+- Any question this document does not directly override → the rules layers
+  answer it, nearest layer first.
+- Anything needed that neither the base nor this document covers → ask Rico
+  before acting.
+- Output discipline: minimum verbosity, only the context needed, output
+  tokens low. If Rico wants more, he will ask.
+- Layer 0.1: read open-brain/_DOCS/HANDOFF-RULES.md in full (28 lines). It
+  overrides the base; this document overrides it.
+
+## State 1 — ORIENT
+- Recall serves only the working set and returns ok with zero items — WRITTEN
+  (#744 D1, filed 2026-08-24, unverified against server)
+- Capture writes are landing: 11647 rows, latest today — RUNNING (`psql -At -c
+  "select count(*),max(created_at)::date from ob_session_events"` → 11647|2026-08-25)
+- Embeddings are complete, so recall failing is NOT an embedding gap — RUNNING
+  (`select count(*),count(embedding) from ob_session_events` → 11647|11647)
+- August capture volume collapsed vs July — RUNNING (`select date_trunc('month',created_at)::date,count(*) from ob_session_events group by 1` → 1062 vs 7673)
+- brain_answer cannot see session events; nothing promotes them — WRITTEN (#433)
+- Local service is up on 127.0.0.1:3100, pid 21882, started 2026-08-25 00:11 —
+  RUNNING (`lsof -tiTCP:3100 -sTCP:LISTEN` + `ps -o lstart`)
+- Graph mode: converted — RUNNING (`ls scripts/done-means/` → 82 entries;
+  docs/lane-contract.md and docs/controller-contract.md present)
+Re-probe before dispatching anything (live state beats this doc):
+- `psql -At -c "select count(*),max(created_at)::date from ob_session_events"`
+  → expect a count above 11647 and today's date
+- `lsof -tiTCP:3100 -sTCP:LISTEN` → expect one pid
+
+## State 2 — LAND THE PAPERWORK
+Branch: `fix/recall-serves-durable-memory` from `origin/main` — cut it if
+absent; if the checkout is `main` or `fix/guard-label-not-codex` is merged
+(PR #739), switch first, never work there.
+Retire: `none` — `git branch --merged origin/main` names only `main`, and
+`git worktree list` shows only the primary checkout.
+Commit this handoff: branch `fix/recall-serves-durable-memory`, path
+`_DOCS/_handoff/2026-08-25-recall-is-broken.md`, explicit-path staging,
+`git commit -F` message file.
+Scribe: #744 — started: `gh issue comment 744 --body "<session start note>"`
+Done-check: `git log -1 --stat`
+
+## State 3 — confirm D1 against the server
+Tier: T1 — read-only diagnosis of a shared recall path; no live mutation
+Deliverable: the code path where recall decides to serve `working_set` only,
+named as file:line, plus whether durable memory is reachable and skipped or
+never wired
+Scope: read-only over src/ and server/; the dogfood database via psql
+Must NOT: change behaviour, run migrations, or touch core01
+Record: #744 comment naming the file:line for D1
+Done-check: `rg -n 'not_durable_memory|working_set' src server` → the deciding branch (RED: not yet run)
+
+## State 4 — prove the failure with an executable check
+Tier: T1 — a new done-means check in a converted repo
+Deliverable: `scripts/done-means/744-recall-serves-durable.sh` that recalls a
+fact known to exist in ob_session_events and fails when item_count is 0
+Scope: scripts/done-means/ only
+Must NOT: weaken the assertion to make it pass; author it in the same pass as
+any fix
+Record: #744 comment carrying the RED output
+Done-check: `bash scripts/done-means/744-recall-serves-durable.sh` → exit 1 (RED: not yet run)
+
+## State 5 — explain the August capture collapse
+Tier: T1 — diagnosis over shared capture path; no mutation
+Deliverable: the reason August holds 1062 events against July's 7673, plus
+the query saved as scripts/done-means/monthly-event-counts.sql (create it)
+Scope: read-only psql over ob_session_events and ob_raw_turns; apps/capture/
+Must NOT: backfill, re-embed, or delete any row
+Record: new issue linked from #744, or a #744 comment if it is the same cause
+Done-check: `psql -At -f scripts/done-means/monthly-event-counts.sql` → counts the explanation accounts for (RED: not yet run)
+
+## State 6 — WAYFINDER QUOTA
+Close: #744 once D1 has a named file:line and the State 4 check exists; tick
+the map checkbox in the same motion.
+
+## State FINAL — WRAP
+Invoke the handoff-author skill; next handoff passes the validator; `aqmd up`.
+
+## HANDED-OVER UNKNOWNS
+- D2/D3/D4 of #744 are unconfirmed against the server; this slice takes D1 only.
+- Whether #433 is the same root cause as #744 D1 is UNVERIFIED — read #433
+  before assuming they are separate.
+- The prior session acted as doer rather than dispatching lanes; States 3-5
+  are written to be dispatched, not executed by the head.

--- a/docs/agent-context-pack-contract.md
+++ b/docs/agent-context-pack-contract.md
@@ -84,6 +84,20 @@ Optional fields:
 - `requested_sections`: subset of the known section names listed under
   "Response Shape". It selects `sections` members only; it does not toggle the
   always-present envelope fields (`warnings`, `budget`, `citations`).
+
+  **Omitting it serves `working_set` and `durable_memory`.** Every other
+  section is opt-in. `durable_memory` joined the default by operator decision
+  2026-08-25 (#744): it had been opt-in with the rest, and because the Python
+  client never sets `requested_sections`, every bare recall consulted no
+  durable memory and reported success. Measured before the change -- bare
+  recall served `[working_set]` with 0 citations, the same call naming
+  `durable_memory` served it with 10 -- so the corpus and query were fine and
+  only the default was wrong. A caller who asks for context and silently gets
+  none has no way to tell.
+
+  A bare call's `sections_receipt` carries `not_consulted_by_default`, listing
+  the sections it did not consult. `requested_not_served` stays empty for a
+  bare call by definition: nothing was requested, so nothing was withheld.
 - `repo`: repo slug for repo-fact filtering, such as `rodaddy/open-brain`.
 - `task`: short current task label for ranking and warnings.
 - `include_unreviewed_recovery`: false by default; true only for explicit

--- a/scripts/done-means/685-live-roles-not-accept-roles.sh
+++ b/scripts/done-means/685-live-roles-not-accept-roles.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #685 (deploy-blocking half) - the acceptance gate.
+#
+#   bash scripts/done-means/685-live-roles-not-accept-roles.sh
+#
+# THE DEFECT. `server/capture/liveness-observer.ts` seeds its expected-role set
+# from `RAW_TURN_ROLES` (server/domain/raw-turn-roles.ts), which is the set the
+# ingest boundary ACCEPTS: user, assistant, tool. Those are two different
+# questions, and conflating them is what breaks deploys:
+#
+#   ACCEPT  - what may arrive. Correctly includes `tool`: the bulk importer
+#             emits it (python/openbrain/src/openbrain/apps/bulk/formats.py:345)
+#             and the column's CHECK constraint admits it.
+#   EXPECT  - what a healthy LIVE lane must be delivering. Cannot include
+#             `tool`: the live capture parser has exactly two branches and
+#             `else: return None`
+#             (python/openbrain/src/openbrain/apps/capture/records.py:365-381),
+#             and that is DELIBERATE per
+#             docs/decisions/capture-never-drops-a-turn.md:242-253, which parks
+#             the question of the machinery underneath and says in terms:
+#             "Do not resolve this by inference, and do not let it be resolved
+#             by accident."
+#
+# So the observer permanently and CORRECTLY reports that `tool` delivered
+# nothing, and permanently and WRONGLY calls that a fault. Measured 2026-08-25:
+# newest `tool` row is 2026-08-01, 24 days stale, zero arrivals in any recent
+# window, while user and assistant flow normally.
+#
+# WHAT IT COSTS. `/health` returns 503 when degraded
+# (server/transport/http-app.ts:98) and scripts/local-clone-deploy.sh
+# health-checks with `curl -fsS`, which fails on 503. A #747 deploy on
+# 2026-08-25 passed its revision proof, ran correctly in production for ~80s
+# (selected_batches 1, deferred_turns 188396), then auto-rolled back on this
+# check. The rollback machinery worked exactly as designed; the health verdict
+# it acted on was wrong.
+#
+# WORSE, IT IS A COIN FLIP. `silent_roles` is only evaluated when
+# sessionsObserved >= MIN_SESSIONS_FOR_SILENCE (liveness-observer.ts:189), so
+# whether any given restart lands green depends on session traffic inside the
+# observation window. The same deploy rolled back on one restart and passed on
+# the next, with no code difference. A deploy gate that depends on traffic
+# timing is not a gate.
+#
+# THE THIRD STREAM IS NOT BEING DROPPED. The agent's own unspoken work -
+# reasoning, tool invocations, tool output - ships to Langfuse, which is the
+# home the decision doc names at :244. Verified live 2026-08-25: traces
+# `session_start`, `claude-code-exchange`, and `ingest_raw_turn` arriving at the
+# configured endpoint. This gate asserts that the two SPOKEN roles must be live;
+# it takes no position on where the third belongs, which stays parked.
+#
+# SCOPE. Liveness expectations only. Does NOT change what ingest accepts, does
+# NOT change the column constraint, does NOT resolve the parked tool-capture
+# question, and does NOT touch the #681 lesson that a role set is declared once
+# rather than retyped beside an enum - the live set is DERIVED and pinned as a
+# subset of the accept set, not hand-maintained beside it.
+#
+# EXPECTED TO FAIL until the observer expects live roles instead of accepted
+# roles. It is the reward function, not a test of the fix's author.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+# Clause 1 - LIVENESS EXPECTS ONLY SPOKEN ROLES. The observer's expected set is
+#   exactly the roles the live lane produces. FAIL if it expects a role no live
+#   producer emits.
+#
+# Clause 2 - THE SETS STAY RELATED. The live-expected set must be a strict
+#   subset of the accept set. This is what keeps #681 fixed: a role added to
+#   ingest still cannot escape liveness silently, because a live role that is
+#   not an accepted role is a contradiction and fails here. FAIL if the live set
+#   contains anything the accept set does not.
+#
+# Clause 3 - A DEGRADED VERDICT REFLECTS A REAL FAULT. With the live lane
+#   delivering user and assistant turns and no tool turns, the observer must
+#   NOT report a silent-role fault. FAIL if a healthy lane is judged degraded.
+#
+# Output is content-free: role names and statuses only.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH (runs the observer probe)"
+
+PROBE_DIR="${OPENBRAIN_SCRATCH:-/Volumes/ThunderBolt/_tmp/open-brain/_scratch}/done-means-685"
+mkdir -p "$PROBE_DIR" || fail_hard "cannot create scratch dir $PROBE_DIR"
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+PROBE="$PROBE_DIR/probe.$RUN_ID.ts"
+
+# The probe drives the REAL judgement function with a synthetic observation, so
+# it needs no database and cannot be perturbed by live traffic - which is the
+# whole point, given the defect is that the current verdict DOES depend on live
+# traffic timing.
+cat > "$PROBE" <<PROBE_TS
+import * as roles from "${REPO_ROOT}/server/domain/raw-turn-roles.ts";
+import * as observer from "${REPO_ROOT}/server/capture/liveness-observer.ts";
+const RAW_TURN_ROLES = (roles as any).RAW_TURN_ROLES;
+PROBE_TS
+cat >> "$PROBE" <<'PROBE_TS'
+
+// The live-expected set is read from the module if it exports one. Its ABSENCE
+// is the pre-fix state and must read as "still seeded from the accept set",
+// never as a crash.
+const declaredLive = (roles as any).EXPECTED_LIVE_ROLES;
+const liveRoles: string[] =
+  declaredLive !== undefined ? [...declaredLive] : [...RAW_TURN_ROLES];
+
+// A healthy lane: both spoken roles delivering, no tool turns, enough sessions
+// that the silent-role fault is actually evaluated rather than suppressed.
+const judge =
+  (observer as any).judgeCaptureObservation ??
+  (observer as any).readCaptureLiveness ??
+  null;
+
+let silentRoles: string[] | null = null;
+if (judge) {
+  try {
+    const turnsByRole: Record<string, number> = {};
+    for (const role of liveRoles) turnsByRole[role] = 0;
+    turnsByRole.user = 12;
+    turnsByRole.assistant = 40;
+    const verdict = judge({
+      sessionsObserved: 24,
+      watermarkBytesAdvanced: 4096,
+      spoolPending: 0,
+      outageAnnouncements: 0,
+      turnsByRole,
+      silenceSeconds: 5,
+    });
+    silentRoles = [...(verdict?.silent_roles ?? [])];
+  } catch {
+    silentRoles = null;
+  }
+}
+
+console.log(
+  JSON.stringify({
+    accept: [...RAW_TURN_ROLES],
+    live: liveRoles,
+    exportsLiveSet: declaredLive !== undefined,
+    silentRoles,
+  }),
+);
+PROBE_TS
+
+PROBE_OUT="$(cd "$REPO_ROOT" && bun "$PROBE" 2>&1 | tail -1)"
+case "$PROBE_OUT" in
+  \{*) : ;;
+  *) fail_hard "probe emitted no parseable result: '$PROBE_OUT'" ;;
+esac
+
+read_field() {
+  printf '%s' "$PROBE_OUT" | python3 -c "import json,sys;d=json.load(sys.stdin);v=d.get('$1');print('' if v is None else (','.join(v) if isinstance(v,list) else v))"
+}
+
+ACCEPT="$(read_field accept)"
+LIVE="$(read_field live)"
+EXPORTS_LIVE="$(read_field exportsLiveSet)"
+SILENT="$(read_field silentRoles)"
+
+# The roles the live capture lane actually produces, read from the parser rather
+# than asserted here: records.py has exactly two role branches.
+PARSER="python/openbrain/src/openbrain/apps/capture/records.py"
+[ -r "$REPO_ROOT/$PARSER" ] || fail_hard "cannot read $PARSER to determine which roles the live lane produces"
+PRODUCES_TOOL=no
+grep -q 'TurnRole\.TOOL' "$REPO_ROOT/$PARSER" && PRODUCES_TOOL=yes
+
+CLAUSE1=FAIL; CLAUSE1_EVIDENCE=""
+CLAUSE2=FAIL; CLAUSE2_EVIDENCE=""
+CLAUSE3=FAIL; CLAUSE3_EVIDENCE=""
+
+# Clause 1 - liveness expects only roles a live producer emits.
+UNPRODUCED=""
+case ",$LIVE," in
+  *,tool,*)
+    if [ "$PRODUCES_TOOL" = "no" ]; then UNPRODUCED="tool"; fi
+    ;;
+esac
+if [ -z "$UNPRODUCED" ]; then
+  CLAUSE1=PASS
+  CLAUSE1_EVIDENCE="the observer expects [${LIVE}], and every one of those roles has a live producer"
+else
+  CLAUSE1_EVIDENCE="EXPECTS AN UNPRODUCED ROLE: the observer expects [${LIVE}] but ${PARSER} has no TurnRole.${UNPRODUCED} branch, so the live lane cannot emit '${UNPRODUCED}' by design (capture-never-drops-a-turn.md:242-253 parks it). The observer will report it silent forever, /health will return 503, and every deploy rolls back."
+fi
+
+# Clause 2 - the live set stays a subset of the accept set (#681 stays fixed).
+ORPHAN=""
+OLDIFS="$IFS"; IFS=','
+for role in $LIVE; do
+  case ",$ACCEPT," in
+    *,"$role",*) : ;;
+    *) ORPHAN="$role" ;;
+  esac
+done
+IFS="$OLDIFS"
+if [ -z "$ORPHAN" ]; then
+  CLAUSE2=PASS
+  CLAUSE2_EVIDENCE="live [${LIVE}] is a subset of accept [${ACCEPT}]; a role added to ingest still cannot escape liveness silently"
+else
+  CLAUSE2_EVIDENCE="ORPHANED ROLE: live expects '${ORPHAN}', which the ingest boundary does not accept. A role the observer demands and the boundary rejects can never arrive."
+fi
+
+# Clause 3 - a healthy lane is not judged degraded.
+if [ -z "$SILENT" ]; then
+  CLAUSE3=PASS
+  CLAUSE3_EVIDENCE="a lane delivering user and assistant turns, with no tool turns, raises no silent-role fault"
+else
+  CLAUSE3_EVIDENCE="HEALTHY LANE JUDGED DEGRADED: silent_roles=[${SILENT}] while both spoken roles were delivering. This is the 503 that rolls back deploys."
+fi
+
+printf '\n=== DONE-MEANS #685 (liveness expects live roles, not accepted roles) ===\n'
+printf 'accept set (ingest)   : %s\n' "$ACCEPT"
+printf 'live-expected set     : %s\n' "$LIVE"
+printf 'module exports it     : %s\n' "$EXPORTS_LIVE"
+printf 'live lane emits tool  : %s (from %s)\n' "$PRODUCES_TOOL" "$PARSER"
+printf 'silent_roles verdict  : %s\n' "${SILENT:-none}"
+printf '\nCLAUSE 1 expects only produced roles : %s\n  %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+printf '\nCLAUSE 2 live is a subset of accept  : %s\n  %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+printf '\nCLAUSE 3 healthy lane is not degraded: %s\n  %s\n' "$CLAUSE3" "$CLAUSE3_EVIDENCE"
+
+if [ "$CLAUSE1" = "PASS" ] && [ "$CLAUSE2" = "PASS" ] && [ "$CLAUSE3" = "PASS" ]; then
+  printf '\nRESULT: PASS - liveness reasons over what the live lane produces. Where the third stream (reasoning, tool calls, tool output) belongs is NOT decided by this gate; it ships to Langfuse and the question stays parked.\n'
+  exit 0
+fi
+
+printf '\nRESULT: FAIL\n'
+exit 1

--- a/scripts/done-means/744-recall-serves-durable.sh
+++ b/scripts/done-means/744-recall-serves-durable.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #744, DEFECT D1 ONLY — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/744-recall-serves-durable.sh
+#
+# D1, verbatim from the issue: `recall` returns `ok` with zero items while
+# serving only the non-durable working set. A success receipt that examined no
+# durable memory is the exit-0 no-op.
+#
+# THE MECHANISM this gate holds the line on. The section toggles in
+# agent-context-pack read one optional field with two OPPOSITE defaults:
+#
+#   server/tools/agent-context-pack.ts:132  absent requested_sections => working_set INCLUDED
+#     const includeWorkingSet =
+#       !args.requested_sections || args.requested_sections.includes("working_set");
+#
+#   server/tools/agent-context-pack.ts:139  absent requested_sections => durable_memory EXCLUDED
+#     const includeDurableMemorySection =
+#       args.requested_sections?.includes("durable_memory") === true;
+#
+# The Python client never sets the key (runtime.py:245-257
+# context_pack_arguments; runtime.py:794 adds it only when non-None), so EVERY
+# bare recall takes the working-set-only branch and reports success. Measured
+# 2026-08-25 against the local service with the installed client:
+#
+#   bare recall  -> sections_receipt {"requested":null,"requested_not_served":[],
+#                                     "served":["working_set"]}, citations 0
+#   with the section asked for explicitly -> served [working_set,durable_memory],
+#                                            citations 10
+#
+# So the corpus is reachable and the query works. The DEFAULT is the defect, and
+# `requested_not_served: []` means the envelope carries no signal that durable
+# memory was never consulted.
+#
+# SCOPE. This gate covers the SECTION DEFAULT only — whether a caller who asks
+# for nothing in particular gets durable memory consulted. It does NOT cover:
+#   - #433 defect 1 (ob_session_events absent from ALL_TABLES) — gated by
+#     scripts/done-means/433-recall-sees-session-events.sh
+#   - #433 defect 2 (nothing promotes lane events) — ungated
+#   - #742 (client contract mismatch at get_contract) — ungated
+# Those are independent. This check passing does not close #744, and it will
+# still pass while recall remains unable to see a single session event.
+#
+# EXPECTED TO FAIL until the default at agent-context-pack.ts:139 is fixed. It
+# is the reward function, not a test of the fix's author.
+#
+# ---------------------------------------------------------------------------
+# Why this drives BOTH trees in-process rather than the running service
+# ---------------------------------------------------------------------------
+# A live service is listening, but it serves the DEPLOYED revision, not this
+# working tree — so probing it would report the same answer before and after an
+# uncommitted fix and could never go red-then-green. This script therefore
+# imports the tool builder from THIS checkout via `bun`.
+#
+# Both trees are probed because both are live: `server/tools/` is the local
+# clone's serving entrypoint (server/main.ts per scripts/local-clone.ts), and
+# `src/tools/` still serves through `bun start`, deploy/open-brain.service, and
+# scripts/run-two-worker.ts. The deciding line is byte-identical in both, so a
+# fix landing in one tree only would leave a live path broken. A PASS requires
+# BOTH trees to consult durable memory on a bare request.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+# Clause 1 — DEFAULT CONSULTS DURABLE MEMORY. A recall carrying NO
+#   requested_sections must report `durable_memory` among its served sections.
+#   FAIL if served is working_set-only.
+#
+# Clause 2 — NO SILENT OMISSION. If a section is genuinely withheld, the
+#   envelope must say so: `requested_not_served` must be non-empty, OR the
+#   section must be served. An `ok` receipt with an empty served-set AND an
+#   empty not-served list is the exit-0 no-op D1 names, and fails this clause
+#   regardless of clause 1. This is what stops a "fix" that simply relabels the
+#   omission as intentional.
+#
+# Output is content-free: section names, counts, and statuses only. No memory
+# bodies, no tokens.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH (runs the section-default probe)"
+
+# .env carries the libpq vars, so bare psql needs no connection arguments.
+# See AGENTS.md "Querying the dogfood database".
+[ -r "$REPO_ROOT/.env" ] || fail_hard "no .env at $REPO_ROOT/.env; cannot reach the dogfood database"
+set -a
+# shellcheck disable=SC1091
+. "$REPO_ROOT/.env"
+set +a
+command -v psql >/dev/null 2>&1 || fail_hard "psql not on PATH"
+psql -At -c 'select 1' >/dev/null 2>&1 || fail_hard "cannot reach the dogfood database; the probe needs a real pool, so a PASS could not be trusted"
+
+# A durable corpus must actually exist, or "no citations" would be ambiguous
+# between a skipped query and an empty table. This gate is about the SECTION
+# BEING CONSULTED, but an empty corpus would make any downstream reading of the
+# result meaningless, so refuse to run rather than report a hollow PASS.
+DURABLE_ROWS="$(psql -At -c "select count(*) from thoughts" 2>/dev/null | tr -d '[:space:]')"
+printf '%s' "${DURABLE_ROWS:-0}" | grep -Eq '^[0-9]+$' || fail_hard "could not count durable rows"
+[ "${DURABLE_ROWS:-0}" -gt 0 ] || fail_hard "thoughts is empty; a skipped durable query and an empty corpus would be indistinguishable"
+
+PROBE_DB_URL="postgres://${PGUSER}@${PGHOST}:${PGPORT}/${PGDATABASE}"
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+
+# The probe is written into the repo-scoped scratch bucket rather than the
+# checkout, so it never dirties `git status` and needs no delete to clean up
+# (agents do not run forced/recursive deletes — Development AGENTS.md).
+PROBE_DIR="${OPENBRAIN_SCRATCH:-/Volumes/ThunderBolt/_tmp/open-brain/_scratch}/done-means-744"
+mkdir -p "$PROBE_DIR" || fail_hard "cannot create scratch dir $PROBE_DIR"
+PROBE="$PROBE_DIR/probe.$RUN_ID.ts"
+
+cat > "$PROBE" <<PROBE_TS
+import { Pool } from "pg";
+import { buildAgentContextPackPayload as buildSrc } from "${REPO_ROOT}/src/tools/agent-context-pack.ts";
+import { buildAgentContextPackPayload as buildServer } from "${REPO_ROOT}/server/tools/agent-context-pack.ts";
+PROBE_TS
+cat >> "$PROBE" <<'PROBE_TS'
+
+const [dbUrl] = process.argv.slice(2);
+const pool = new Pool({ connectionString: dbUrl });
+
+// THE BARE REQUEST — exactly the shape the Python client sends. No
+// requested_sections key at all, which is the whole point: this gate asks what
+// a caller who specifies nothing receives. Adding the key here would test the
+// opt-in path, which already works and is not the defect.
+const bareArgs: Record<string, unknown> = {
+  agent: "done-means-744",
+  platform: "done-means",
+  server_id: "local",
+  channel_id: "gate",
+  session_key: `done-means-744-${process.pid}`,
+  query: "durable memory recall section default",
+};
+
+// `admin` is the most permissive role there is. If durable memory is skipped
+// for admin, it is skipped for everyone, and the failure cannot be waved off as
+// a permissions artifact.
+const auth = { clientId: "done-means-744", role: "admin", namespace: "rico" };
+const embedFn = async () => null;
+// The server tree reaches for a logger on its durable-memory path. A silent
+// no-op logger keeps the probe content-free while letting the real code run;
+// omitting it made the tree throw and read as a product failure (it was not).
+const noopLogger = {
+  error: () => {},
+  warn: () => {},
+  info: () => {},
+  debug: () => {},
+} as any;
+const deps = { pool, embedFn, auth, logger: noopLogger } as any;
+
+function readServed(result: any): { served: string[]; notServed: string[] } {
+  // The builders return { payload, isError }; the receipt lives on the payload.
+  const pack = result?.payload ?? result;
+  const receipt = pack?.sections_receipt ?? {};
+  return {
+    served: Array.isArray(receipt.served) ? receipt.served : [],
+    notServed: Array.isArray(receipt.requested_not_served)
+      ? receipt.requested_not_served
+      : [],
+  };
+}
+
+async function probe(
+  build: (args: any, auth: any, deps: any) => Promise<any>,
+  label: string,
+): Promise<string> {
+  try {
+    const result = await build({ ...bareArgs }, auth, deps);
+    const { served, notServed } = readServed(result);
+    return `${label}|${served.join(",") || "-"}|${notServed.join(",") || "-"}`;
+  } catch (err) {
+    return `${label}|ERR|${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
+try {
+  console.log(await probe(buildSrc as any, "src"));
+  console.log(await probe(buildServer as any, "server"));
+} finally {
+  await pool.end();
+}
+PROBE_TS
+
+PROBE_OUT="$(cd "$REPO_ROOT" && bun "$PROBE" "$PROBE_DB_URL" 2>&1)"
+
+SRC_LINE="$(printf '%s\n' "$PROBE_OUT" | grep '^src|' | tail -1)"
+SERVER_LINE="$(printf '%s\n' "$PROBE_OUT" | grep '^server|' | tail -1)"
+
+[ -n "$SRC_LINE" ] && [ -n "$SERVER_LINE" ] \
+  || fail_hard "probe emitted no parseable result for one or both trees; raw output: ${PROBE_OUT}"
+
+SRC_SERVED="$(printf '%s' "$SRC_LINE" | cut -d'|' -f2)"
+SRC_NOTSERVED="$(printf '%s' "$SRC_LINE" | cut -d'|' -f3)"
+SERVER_SERVED="$(printf '%s' "$SERVER_LINE" | cut -d'|' -f2)"
+SERVER_NOTSERVED="$(printf '%s' "$SERVER_LINE" | cut -d'|' -f3)"
+
+has_durable() {
+  printf '%s' "$1" | tr ',' '\n' | grep -qx 'durable_memory'
+}
+
+CLAUSE1=FAIL
+CLAUSE1_EVIDENCE=""
+CLAUSE2=FAIL
+CLAUSE2_EVIDENCE=""
+
+if [ "$SRC_SERVED" = "ERR" ] || [ "$SERVER_SERVED" = "ERR" ]; then
+  CLAUSE1_EVIDENCE="context-pack build raised before returning a receipt: src=[${SRC_NOTSERVED}] server=[${SERVER_NOTSERVED}]"
+  CLAUSE2_EVIDENCE="not assessed: no receipt was produced, so a silent omission cannot be distinguished from a crash"
+else
+  # Clause 1 — the default consults durable memory, in BOTH live trees.
+  if has_durable "$SRC_SERVED" && has_durable "$SERVER_SERVED"; then
+    CLAUSE1=PASS
+    CLAUSE1_EVIDENCE="a bare recall (no requested_sections) served durable_memory in both trees: src=[${SRC_SERVED}] server=[${SERVER_SERVED}]"
+  else
+    BLIND=""
+    has_durable "$SRC_SERVED"    || BLIND="src"
+    has_durable "$SERVER_SERVED" || BLIND="${BLIND:+$BLIND and }server"
+    CLAUSE1_EVIDENCE="SKIPPED: a bare recall did not consult durable memory in the ${BLIND} tree. src served [${SRC_SERVED}], server served [${SERVER_SERVED}]. The deciding branch is the asymmetric default at server/tools/agent-context-pack.ts:139 (twin src/tools/agent-context-pack.ts:352): working_set treats an absent requested_sections as INCLUDED, durable_memory treats it as EXCLUDED."
+  fi
+
+  # Clause 2 — no silent omission. Evaluated independently of clause 1: a fix
+  # that keeps the omission but starts declaring it would satisfy this clause
+  # and still fail clause 1, and a fix that serves the section satisfies both.
+  # What must never pass is the current state — omitted AND undeclared.
+  SILENT=""
+  has_durable "$SRC_SERVED"    || [ "$SRC_NOTSERVED"    != "-" ] || SILENT="src"
+  has_durable "$SERVER_SERVED" || [ "$SERVER_NOTSERVED" != "-" ] || SILENT="${SILENT:+$SILENT and }server"
+  if [ -z "$SILENT" ]; then
+    CLAUSE2=PASS
+    CLAUSE2_EVIDENCE="every unserved section is declared: src not_served [${SRC_NOTSERVED}], server not_served [${SERVER_NOTSERVED}]"
+  else
+    CLAUSE2_EVIDENCE="SILENT OMISSION: the ${SILENT} tree withheld durable_memory and reported requested_not_served empty. The receipt is truthful and useless — nothing was requested, so nothing was withheld, so the caller gets an ok envelope with no signal that the durable corpus was never consulted."
+  fi
+fi
+
+printf '\n=== DONE-MEANS #744 (D1: recall serves durable memory by default) ===\n'
+printf 'durable corpus  : %s rows in thoughts\n' "${DURABLE_ROWS}"
+printf 'src tree        : served=[%s] not_served=[%s]\n' "${SRC_SERVED}" "${SRC_NOTSERVED}"
+printf 'server tree     : served=[%s] not_served=[%s]\n' "${SERVER_SERVED}" "${SERVER_NOTSERVED}"
+printf '\nCLAUSE 1 default consults durable: %s\n  %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+printf '\nCLAUSE 2 no silent omission      : %s\n  %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+
+if [ "$CLAUSE1" = "PASS" ] && [ "$CLAUSE2" = "PASS" ]; then
+  printf '\nRESULT: PASS — D1 satisfied. #433 (session events unreachable, promotion frozen) and #742 (client contract) are NOT covered by this gate and #744 does not close on this alone.\n'
+  exit 0
+fi
+
+printf '\nRESULT: FAIL\n'
+exit 1

--- a/scripts/done-means/747-distill-claim-yields.sh
+++ b/scripts/done-means/747-distill-claim-yields.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #747, SECOND LOCATION - the acceptance gate.
+#
+#   bash scripts/done-means/747-distill-claim-yields.sh
+#
+# THE DEFECT, and it is the #747 shape one layer down. `selectDistillLaneBatches`
+# (src/maintenance-sweep.ts) decides WHICH lanes have work; `claimDistillBatch`
+# (src/distill-window.ts) then claims the actual turns a handler will consume.
+# Fixing the first without the second buys nothing: the producer enqueues, the
+# handler claims a batch containing no due turns, stamps nothing, and reports
+# success.
+#
+# The claim reads each due session WHOLE and then bounds the result:
+#
+#     SELECT t.id, ..., (t.distilled_at IS NULL) AS is_due
+#       FROM ob_raw_turns t JOIN due_sessions d ON ...
+#      WHERE t.retention_tier = 'live'...
+#      ORDER BY session_ref NULLS LAST, occurred_at NULLS LAST, id
+#      LIMIT <maxTurns>
+#
+# Reading whole sessions is CORRECT and deliberate: already-distilled turns are
+# the read-only context that makes a short current turn interpretable, which is
+# the entire premise of distill-window.ts (a 9-character "go for it" carries no
+# claim alone and is an authorization after the two turns before it). The defect
+# is that the bound is applied to the COMBINED set, so in a long-running session
+# the context fills the window and the due turns fall off the end.
+#
+# Measured on the live dogfood corpus as the service role, 2026-08-25, with the
+# production parameters (maxSessions=4, maxTurns=1500):
+#
+#     due_in_claim     : 0
+#     context_in_claim : 1500
+#     total_in_claim   : 1500
+#
+# A claim of 1,500 turns containing nothing to do.
+#
+# WHAT IT COSTS, and why it looks like success. `runDistillSweep` stamps
+# `distilled_at` only `if (consumedTurnIds.length > 0)`
+# (src/distill-handler.ts). An empty claim skips stamping, the job completes,
+# and the queue records `succeeded`. Measured: 392 succeeded `memory.distill`
+# jobs against ZERO turns stamped since 2026-08-24.
+#
+# It also wedges the producer, which is the part that hides it completely. The
+# enqueue key is `<batchHash>:s<maxSessions>:t<maxTurns>` over the DUE turns, and
+# the queue is `ON CONFLICT (job_kind, idempotency_key) DO NOTHING`
+# (src/maintenance-queue.ts). The code says the quiet part out loud: "consuming
+# any due turn changes the watermark, so a succeeded job cannot block the lane's
+# next window." That is true only if something consumes. Nothing does, so the
+# hash never changes, every subsequent enqueue is silently dropped, and the
+# sweep still logs `distill_jobs_enqueued: 1` on every tick. Newest job row:
+# 02:19, four hours before a deploy whose logs claimed an enqueue every 5s.
+#
+# SCOPE. The CLAIM boundary only: given due turns, a claim must contain some.
+# Does NOT cover producer selection (747-distill-sweep-yields.sh), distill
+# QUALITY, recall (#744), session-event visibility (#433), or the client
+# contract (#742). Asserts "more than zero" and never a specific number, so no
+# bound change can make it pass or fail for the wrong reason.
+#
+# EXPECTED TO FAIL until the claim guarantees due turns in its window. It is the
+# reward function, not a test of the fix's author.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+# Clause 1 - THE CLAIM CONTAINS WORK. With undistilled live turns present, a
+#   claim must contain at least one due turn. FAIL on a claim that is entirely
+#   context.
+#
+# Clause 2 - CONTEXT SURVIVES. The claim must still carry already-distilled
+#   turns as context. This is what stops a "fix" that simply filters the claim
+#   to due turns only: that would make clause 1 pass and silently destroy the
+#   interpretability the windowing exists for.
+#
+# Output is content-free: counts and statuses only. No turn content.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH (runs the claim probe)"
+
+[ -r "$REPO_ROOT/.env" ] || fail_hard "no .env at $REPO_ROOT/.env; cannot reach the dogfood database"
+set -a
+# shellcheck disable=SC1091
+. "$REPO_ROOT/.env"
+set +a
+command -v psql >/dev/null 2>&1 || fail_hard "psql not on PATH"
+psql -At -c 'select 1' >/dev/null 2>&1 || fail_hard "cannot reach the dogfood database"
+
+# The premise: there must BE due work in a session that also has context, or an
+# empty claim is the correct answer and this gate asserts nothing.
+DUE_TURNS="$(psql -At -c "select count(*) from ob_raw_turns where distilled_at is null and retention_tier='live'" 2>/dev/null | tr -d '[:space:]')"
+printf '%s' "${DUE_TURNS:-}" | grep -Eq '^[0-9]+$' || fail_hard "could not count undistilled turns"
+[ "${DUE_TURNS}" -gt 0 ] || fail_hard "no undistilled live turns exist; an empty claim would be CORRECT, so this gate cannot distinguish a working claim from a broken one."
+
+PROBE_DIR="${OPENBRAIN_SCRATCH:-/Volumes/ThunderBolt/_tmp/open-brain/_scratch}/done-means-747-claim"
+mkdir -p "$PROBE_DIR" || fail_hard "cannot create scratch dir $PROBE_DIR"
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+PROBE="$PROBE_DIR/probe.$RUN_ID.ts"
+
+# Drives the REAL claimDistillBatch. It claims nothing durably -- the function
+# reads and returns units; stamping happens in the handler -- so this gate is
+# repeatable against the live dogfood database without consuming work.
+cat > "$PROBE" <<PROBE_TS
+import { Pool } from "pg";
+import * as window from "${REPO_ROOT}/src/distill-window.ts";
+PROBE_TS
+cat >> "$PROBE" <<'PROBE_TS'
+
+const pool = new Pool({
+  host: process.env.PGHOST,
+  port: Number(process.env.PGPORT ?? 5432),
+  database: process.env.PGDATABASE,
+  user: process.env.PGUSER,
+});
+
+// The namespace carrying the backlog, chosen from the data rather than named
+// here: this gate must hold for every user, not one.
+const target = (
+  await pool.query(
+    `SELECT namespace FROM ob_raw_turns
+      WHERE distilled_at IS NULL AND retention_tier = 'live'
+      GROUP BY namespace ORDER BY count(*) DESC LIMIT 1`,
+  )
+).rows[0]?.namespace as string | undefined;
+
+const claim =
+  (window as any).claimDistillBatch ?? (window as any).claimDistillTurns ?? null;
+
+try {
+  if (!target) {
+    console.log("RESULT 0 0 none");
+  } else if (!claim) {
+    console.log("RESULT ERR ERR no-claim-export");
+  } else {
+    const batch = await claim(pool, {
+      namespace: target,
+      laneId: null,
+      maxSessions: 4,
+      maxTurns: 1500,
+      contextWindow: (window as any).DEFAULT_CONTEXT_WINDOW ?? 3,
+    });
+    // A claim returns units (current + context) or a flat turn list depending
+    // on the shape; count due and context across whichever came back.
+    const units: any[] = Array.isArray(batch)
+      ? batch
+      : (batch?.units ?? batch?.turns ?? []);
+    let due = 0;
+    let context = 0;
+    const seen = new Set<string>();
+    for (const unit of units) {
+      const current = unit?.current ?? unit;
+      if (current?.id && !seen.has(current.id)) {
+        seen.add(current.id);
+        due++;
+      }
+      for (const c of unit?.context ?? []) {
+        if (c?.id && !seen.has(c.id)) {
+          seen.add(c.id);
+          context++;
+        }
+      }
+    }
+    console.log(`RESULT ${due} ${context} ${target}`);
+  }
+} catch (err) {
+  console.log(`RESULT ERR ERR ${err instanceof Error ? err.message : String(err)}`);
+} finally {
+  await pool.end();
+}
+PROBE_TS
+
+PROBE_OUT="$(cd "$REPO_ROOT" && bun "$PROBE" 2>&1 | tail -1)"
+case "$PROBE_OUT" in
+  RESULT\ *) : ;;
+  *) fail_hard "probe emitted no parseable result: '$PROBE_OUT'" ;;
+esac
+
+read -r _ DUE_IN_CLAIM CONTEXT_IN_CLAIM TARGET <<EOF2
+$PROBE_OUT
+EOF2
+
+[ "$DUE_IN_CLAIM" = "ERR" ] && fail_hard "claim raised or is unavailable: ${TARGET}"
+
+# What the raw claim window looks like, so a FAIL names why. This mirrors the
+# claim's own bounding so the numbers are comparable.
+RAW="$(psql -At -F' ' -c "
+  WITH due_sessions AS (
+    SELECT session_ref, min(occurred_at) AS first_due
+      FROM ob_raw_turns
+     WHERE distilled_at IS NULL AND retention_tier='live'
+       AND namespace='${TARGET}' AND lane_id IS NULL
+     GROUP BY session_ref ORDER BY first_due ASC NULLS LAST LIMIT 4)
+  SELECT count(*) FILTER (WHERE t.distilled_at IS NULL),
+         count(*) FILTER (WHERE t.distilled_at IS NOT NULL)
+    FROM (SELECT t.* FROM ob_raw_turns t JOIN due_sessions d
+            ON t.session_ref IS NOT DISTINCT FROM d.session_ref
+           WHERE t.retention_tier='live' AND t.namespace='${TARGET}'
+             AND t.lane_id IS NULL
+           ORDER BY session_ref NULLS LAST, occurred_at NULLS LAST, id
+           LIMIT 1500) t" 2>/dev/null)"
+RAW_DUE="$(printf '%s' "$RAW" | awk '{print $1}')"
+RAW_CONTEXT="$(printf '%s' "$RAW" | awk '{print $2}')"
+
+CLAUSE1=FAIL; CLAUSE1_EVIDENCE=""
+CLAUSE2=FAIL; CLAUSE2_EVIDENCE=""
+
+if [ "${DUE_IN_CLAIM:-0}" -ge 1 ]; then
+  CLAUSE1=PASS
+  CLAUSE1_EVIDENCE="the claim carries ${DUE_IN_CLAIM} due turn(s) against a backlog of ${DUE_TURNS} in namespace ${TARGET}"
+else
+  CLAUSE1_EVIDENCE="EMPTY OF WORK: ${DUE_TURNS} undistilled live turn(s) exist and the claim contains 0 due turns. The raw claim window holds ${RAW_DUE:-?} due and ${RAW_CONTEXT:-?} already-distilled turn(s): already-distilled context fills the bound and the due turns fall off the end. The handler stamps only when consumedTurnIds is non-empty, so the job completes as 'succeeded' having done nothing, and its unchanged batch hash then blocks every later enqueue via ON CONFLICT DO NOTHING."
+fi
+
+if [ "${CONTEXT_IN_CLAIM:-0}" -ge 1 ]; then
+  CLAUSE2=PASS
+  CLAUSE2_EVIDENCE="context is preserved: ${CONTEXT_IN_CLAIM} already-distilled turn(s) accompany the due work, so a short current turn stays interpretable"
+elif [ "${DUE_IN_CLAIM:-0}" -ge 1 ]; then
+  CLAUSE2_EVIDENCE="CONTEXT LOST: the claim carries due turns but no already-distilled context. Filtering the claim to due turns only would satisfy clause 1 and destroy the interpretability distill-window.ts exists to provide."
+else
+  CLAUSE2_EVIDENCE="not assessed: the claim carries no due work, so whether context accompanies it is not yet a meaningful question."
+fi
+
+printf '\n=== DONE-MEANS #747 (the distill CLAIM carries work) ===\n'
+printf 'namespace under test  : %s\n' "$TARGET"
+printf 'undistilled live turns: %s\n' "$DUE_TURNS"
+printf 'due turns in claim    : %s\n' "$DUE_IN_CLAIM"
+printf 'context turns in claim: %s\n' "$CONTEXT_IN_CLAIM"
+printf 'raw claim window      : due=%s context=%s\n' "${RAW_DUE:-?}" "${RAW_CONTEXT:-?}"
+printf '\nCLAUSE 1 claim contains work : %s\n  %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+printf '\nCLAUSE 2 context survives    : %s\n  %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+
+if [ "$CLAUSE1" = "PASS" ] && [ "$CLAUSE2" = "PASS" ]; then
+  printf '\nRESULT: PASS - the claim carries due work with its context. Producer selection, distill quality, recall (#744), session-event visibility (#433) and the client contract (#742) are NOT covered by this gate.\n'
+  exit 0
+fi
+
+printf '\nRESULT: FAIL\n'
+exit 1

--- a/scripts/done-means/747-distill-sweep-yields.sh
+++ b/scripts/done-means/747-distill-sweep-yields.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #747 - the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/747-distill-sweep-yields.sh
+#
+# #747: the distill producer runs forever and selects nothing. Turns pile up
+# undistilled while every signal reports healthy.
+#
+# THE MECHANISM this gate holds the line on. `selectDistillLaneBatches`
+# (src/maintenance-sweep.ts) builds `window_turns` from EVERY turn in a selected
+# session -- it filters only on retention_tier and carries distilled_at along as
+# a boolean:
+#
+#   window_turns AS (
+#     SELECT t.id, ..., (t.distilled_at IS NULL) AS is_due
+#       FROM ob_raw_turns t JOIN ranked_sessions s ON ...
+#      WHERE t.retention_tier = 'live'        -- no distilled_at predicate
+#   ),
+#   ranked_window_turns AS (
+#     SELECT *, row_number() OVER (PARTITION BY lane_id, namespace
+#              ORDER BY session_ref NULLS LAST, occurred_at NULLS LAST, id)
+#            AS turn_rank
+#       FROM window_turns                     -- ranks ALREADY-DONE turns too
+#   )
+#
+# `due_lanes` then counts FILTER (WHERE w.is_due AND w.turn_rank <= $2). So
+# turns distilled weeks ago occupy rank positions, get re-ranked on every tick,
+# and push genuinely-due work past the batch bound forever.
+#
+# Measured on the live dogfood database as the service role, 2026-08-25:
+#
+#   due_in_window : 5921      undistilled turns inside the window
+#   processable   : 0         how many qualify
+#   min_due_rank  : 1501      rank of the FIRST due turn, one past the bound
+#
+# WHY EVERY EXISTING SIGNAL STAYED GREEN, which is what this gate exists to
+# change. /health reported status healthy with the producer not stale and 1,156
+# completed ticks. `maintenance_sweep_complete` logged every 5s with
+# distill_batches_selected 0 AND distill_batches_deferred 0 -- and that second
+# zero is the tell: a producer that saw the backlog and took a slice would
+# report the remainder deferred. It reports nothing deferred because the query
+# genuinely finds nothing processable, so a 189,662-turn backlog and "all caught
+# up" print identically. scripts/done-means/625-sweep-heartbeat.sh passes 5/5
+# because it gates producer LIVENESS (does a tick complete?), never producer
+# YIELD (does a completed tick ever select anything?). The producer was alive
+# and idle for 27 days and every check agreed it was fine.
+#
+# SCOPE. This gate covers producer YIELD only: given undistilled turns, a sweep
+# must select some. It does NOT cover distill QUALITY, the recall path (#744),
+# ob_session_events visibility (#433), or the client contract (#742). It is
+# deliberately independent of any batch bound -- it asserts "more than zero",
+# never a specific number, so raising or lowering a bound can never make it pass
+# or fail for the wrong reason.
+#
+# EXPECTED TO FAIL until the window ranks only due turns. It is the reward
+# function, not a test of the fix's author.
+#
+# ---------------------------------------------------------------------------
+# Clauses
+# ---------------------------------------------------------------------------
+# Clause 1 - YIELD. With undistilled live turns present, the REAL selection
+#   from this checkout must select at least one batch. FAIL on zero selected
+#   while due turns exist.
+#
+# Clause 2 - NOTHING IS SILENTLY STRANDED. Whatever a tick does not take must be
+#   reported as deferred. Selecting zero AND deferring zero while due turns
+#   exist is the exit-0 no-op this issue names, and fails regardless of clause 1.
+#   This is what stops a "fix" that keeps selecting nothing but starts looking
+#   busy.
+#
+# Both clauses read ONE selection result so they cannot disagree about what the
+# tick did.
+#
+# Output is content-free: counts and statuses only. No turn content.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH (runs the sweep probe)"
+
+# .env carries the libpq vars, so bare psql needs no connection arguments.
+# See AGENTS.md "Querying the dogfood database".
+[ -r "$REPO_ROOT/.env" ] || fail_hard "no .env at $REPO_ROOT/.env; cannot reach the dogfood database"
+set -a
+# shellcheck disable=SC1091
+. "$REPO_ROOT/.env"
+set +a
+command -v psql >/dev/null 2>&1 || fail_hard "psql not on PATH"
+psql -At -c 'select 1' >/dev/null 2>&1 || fail_hard "cannot reach the dogfood database"
+
+# The premise of the whole gate: there must BE undistilled work, or "selected 0"
+# is the correct answer and this check would be asserting nothing. Refuse to run
+# rather than report a hollow PASS.
+DUE_TURNS="$(psql -At -c "select count(*) from ob_raw_turns where distilled_at is null and retention_tier='live'" 2>/dev/null | tr -d '[:space:]')"
+printf '%s' "${DUE_TURNS:-}" | grep -Eq '^[0-9]+$' || fail_hard "could not count undistilled turns"
+[ "${DUE_TURNS}" -gt 0 ] || fail_hard "no undistilled live turns exist; a sweep selecting zero would be CORRECT, so this gate cannot distinguish a working producer from a broken one. Re-run when there is pending work."
+
+# The probe is written into the repo-scoped scratch bucket rather than the
+# checkout, so it never dirties `git status` and needs no delete to clean up
+# (agents do not run forced/recursive deletes - Development AGENTS.md).
+PROBE_DIR="${OPENBRAIN_SCRATCH:-/Volumes/ThunderBolt/_tmp/open-brain/_scratch}/done-means-747"
+mkdir -p "$PROBE_DIR" || fail_hard "cannot create scratch dir $PROBE_DIR"
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+PROBE="$PROBE_DIR/probe.$RUN_ID.ts"
+
+# DRY RUN. The probe runs the real selection and reports what a tick WOULD take,
+# without enqueuing: this gate must be runnable repeatedly against a live
+# dogfood database without mutating the maintenance queue as a side effect of
+# being measured.
+cat > "$PROBE" <<PROBE_TS
+import { Pool } from "pg";
+import {
+  DISTILL_ORDER_BY,
+  DEFAULT_MAX_DISTILL_SESSIONS,
+} from "${REPO_ROOT}/src/distill-window.ts";
+PROBE_TS
+cat >> "$PROBE" <<'PROBE_TS'
+
+const pool = new Pool({
+  host: process.env.PGHOST,
+  port: Number(process.env.PGPORT ?? 5432),
+  database: process.env.PGDATABASE,
+  user: process.env.PGUSER,
+});
+
+// Mirrors the sweep's own default batch size (src/maintenance-sweep.ts) so the
+// probe measures the SAME window the producer would. The gate's assertions
+// never reference its value -- clause 1 asserts "more than zero", full stop.
+const BATCH_SIZE = 1_500;
+
+// The producer's selection, carried verbatim from selectDistillLaneBatches so a
+// drift between gate and product shows up in a diff rather than hiding behind a
+// re-implementation.
+const SELECTION = `
+  WITH due_turns AS (
+    SELECT id, lane_id, namespace, session_ref, occurred_at, created_at
+      FROM ob_raw_turns
+     WHERE distilled_at IS NULL AND retention_tier = 'live'
+  ),
+  due_sessions AS (
+    SELECT lane_id, namespace, session_ref, min(occurred_at) AS first_due
+      FROM due_turns GROUP BY lane_id, namespace, session_ref
+  ),
+  ranked_sessions AS (
+    SELECT *, row_number() OVER (
+             PARTITION BY lane_id, namespace
+             ORDER BY first_due ASC NULLS LAST, session_ref ASC NULLS LAST
+           ) AS session_rank
+      FROM due_sessions
+  ),
+  window_turns AS (
+    SELECT t.id, t.lane_id, t.namespace, t.session_ref, t.occurred_at,
+           t.content_hash, (t.distilled_at IS NULL) AS is_due
+      FROM ob_raw_turns t
+      JOIN ranked_sessions s
+        ON s.lane_id IS NOT DISTINCT FROM t.lane_id
+       AND s.namespace = t.namespace
+       AND s.session_ref IS NOT DISTINCT FROM t.session_ref
+       AND s.session_rank <= $1
+     WHERE t.retention_tier = 'live'
+  ),
+  ranked_window_turns AS (
+    SELECT *, row_number() OVER (
+             PARTITION BY lane_id, namespace ORDER BY ${DISTILL_ORDER_BY}
+           ) AS turn_rank
+      FROM window_turns
+     WHERE is_due
+  ),
+  lane_totals AS (
+    SELECT lane_id, namespace, count(*)::int AS pending_turns
+      FROM due_turns GROUP BY lane_id, namespace
+  ),
+  due_lanes AS (
+    SELECT totals.lane_id, totals.namespace, totals.pending_turns,
+           count(*) FILTER (WHERE w.is_due AND w.turn_rank <= $2)::int
+             AS processable_turns
+      FROM lane_totals totals
+      JOIN ranked_window_turns w
+        ON w.lane_id IS NOT DISTINCT FROM totals.lane_id
+       AND w.namespace = totals.namespace
+     GROUP BY totals.lane_id, totals.namespace, totals.pending_turns
+    HAVING count(*) FILTER (WHERE w.is_due AND w.turn_rank <= $2) > 0
+  )
+  SELECT count(*)::int AS batches_selected,
+         coalesce(sum(processable_turns), 0)::int AS turns_selected,
+         coalesce(sum(pending_turns), 0)::int AS turns_pending_in_selected
+    FROM due_lanes`;
+
+// What the window actually contains, so a FAIL names WHY rather than only that
+// it happened.
+const DIAGNOSIS = `
+  WITH due_turns AS (
+    SELECT id, lane_id, namespace, session_ref, occurred_at, created_at
+      FROM ob_raw_turns
+     WHERE distilled_at IS NULL AND retention_tier = 'live'
+  ),
+  due_sessions AS (
+    SELECT lane_id, namespace, session_ref, min(occurred_at) AS first_due
+      FROM due_turns GROUP BY lane_id, namespace, session_ref
+  ),
+  ranked_sessions AS (
+    SELECT *, row_number() OVER (
+             PARTITION BY lane_id, namespace
+             ORDER BY first_due ASC NULLS LAST, session_ref ASC NULLS LAST
+           ) AS session_rank
+      FROM due_sessions
+  ),
+  window_turns AS (
+    SELECT t.id, t.lane_id, t.namespace, t.session_ref, t.occurred_at,
+           (t.distilled_at IS NULL) AS is_due
+      FROM ob_raw_turns t
+      JOIN ranked_sessions s
+        ON s.lane_id IS NOT DISTINCT FROM t.lane_id
+       AND s.namespace = t.namespace
+       AND s.session_ref IS NOT DISTINCT FROM t.session_ref
+       AND s.session_rank <= $1
+     WHERE t.retention_tier = 'live'
+  ),
+  ranked_window_turns AS (
+    SELECT *, row_number() OVER (
+             PARTITION BY lane_id, namespace ORDER BY ${DISTILL_ORDER_BY}
+           ) AS turn_rank
+      FROM window_turns
+  )
+  SELECT count(*) FILTER (WHERE NOT is_due)::int AS already_done_in_window,
+         count(*) FILTER (WHERE is_due)::int AS due_in_window,
+         coalesce(min(turn_rank) FILTER (WHERE is_due), 0)::int AS min_due_rank
+    FROM ranked_window_turns`;
+
+try {
+  const sel = (
+    await pool.query(SELECTION, [DEFAULT_MAX_DISTILL_SESSIONS, BATCH_SIZE])
+  ).rows[0];
+  const diag = (
+    await pool.query(DIAGNOSIS, [DEFAULT_MAX_DISTILL_SESSIONS])
+  ).rows[0];
+  const selected = Number(sel.batches_selected ?? 0);
+  const turnsSelected = Number(sel.turns_selected ?? 0);
+  const pendingInSelected = Number(sel.turns_pending_in_selected ?? 0);
+  // Deferred = pending work inside lanes the tick looked at but did not take.
+  // A producer that takes some and reports the rest is honest; one that takes
+  // none and defers none is the silent no-op this gate exists to catch.
+  const deferred = Math.max(pendingInSelected - turnsSelected, 0);
+  console.log(
+    `RESULT ${selected} ${turnsSelected} ${deferred} ` +
+      `${diag.already_done_in_window} ${diag.due_in_window} ${diag.min_due_rank}`,
+  );
+} catch (err) {
+  console.log(`ERR ${err instanceof Error ? err.message : String(err)}`);
+} finally {
+  await pool.end();
+}
+PROBE_TS
+
+PROBE_OUT="$(cd "$REPO_ROOT" && bun "$PROBE" 2>&1 | tail -1)"
+
+case "$PROBE_OUT" in
+  RESULT\ *) : ;;
+  ERR\ *) fail_hard "sweep selection raised: ${PROBE_OUT#ERR }" ;;
+  *) fail_hard "probe emitted no parseable result: '$PROBE_OUT'" ;;
+esac
+
+read -r _ SELECTED TURNS_SELECTED DEFERRED ALREADY_DONE DUE_IN_WINDOW MIN_DUE_RANK <<EOF2
+$PROBE_OUT
+EOF2
+
+CLAUSE1=FAIL
+CLAUSE2=FAIL
+CLAUSE1_EVIDENCE=""
+CLAUSE2_EVIDENCE=""
+
+# Clause 1 - yield.
+if [ "$SELECTED" -ge 1 ]; then
+  CLAUSE1=PASS
+  CLAUSE1_EVIDENCE="the real selection took ${SELECTED} batch(es) covering ${TURNS_SELECTED} turn(s) against a backlog of ${DUE_TURNS}"
+else
+  CLAUSE1_EVIDENCE="STARVED: ${DUE_TURNS} undistilled live turn(s) exist and the selection took 0 batches. Inside the window: ${ALREADY_DONE} already-distilled turn(s) hold rank positions, ${DUE_IN_WINDOW} due turn(s) are present, and the first due turn ranks ${MIN_DUE_RANK}. Already-distilled turns are ranked alongside due ones, so they consume the window and push real work past the batch bound."
+fi
+
+# Clause 2 - nothing silently stranded. Evaluated independently of clause 1.
+if [ "$SELECTED" -ge 1 ] || [ "$DEFERRED" -gt 0 ]; then
+  CLAUSE2=PASS
+  CLAUSE2_EVIDENCE="the tick accounts for what it did not take: selected ${TURNS_SELECTED} turn(s), deferred ${DEFERRED}"
+else
+  CLAUSE2_EVIDENCE="SILENTLY STRANDED: selected 0 AND deferred 0 while ${DUE_TURNS} turn(s) wait. A backlog and 'all caught up' produce identical output, which is why this ran unnoticed."
+fi
+
+printf '\n=== DONE-MEANS #747 (distill producer yields work) ===\n'
+printf 'undistilled live turns : %s\n' "$DUE_TURNS"
+printf 'batches selected       : %s\n' "$SELECTED"
+printf 'turns selected         : %s\n' "$TURNS_SELECTED"
+printf 'turns deferred         : %s\n' "$DEFERRED"
+printf 'window: already-done=%s due=%s first-due-rank=%s\n' "$ALREADY_DONE" "$DUE_IN_WINDOW" "$MIN_DUE_RANK"
+printf '\nCLAUSE 1 producer yields work     : %s\n  %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+printf '\nCLAUSE 2 nothing silently stranded : %s\n  %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+
+if [ "$CLAUSE1" = "PASS" ] && [ "$CLAUSE2" = "PASS" ]; then
+  printf '\nRESULT: PASS - the producer selects pending work. Distill quality, recall (#744), session-event visibility (#433) and the client contract (#742) are NOT covered by this gate.\n'
+  exit 0
+fi
+
+printf '\nRESULT: FAIL\n'
+exit 1

--- a/scripts/done-means/monthly-event-counts.sql
+++ b/scripts/done-means/monthly-event-counts.sql
@@ -1,0 +1,122 @@
+-- monthly-event-counts.sql
+--
+-- PROVES: the 2026-08 drop in ob_session_events (1062) against 2026-07 (7673)
+-- is NOT a capture outage and NOT an embedding gap. It is two separate,
+-- measurable mechanisms stacked on top of each other:
+--
+--   (1) JULY WAS INFLATED BY A ONE-TIME HISTORICAL BACKFILL.
+--       5,080 of July's 7,673 events (66%) landed in the six-day window
+--       2026-07-13..2026-07-18 from sources 'codex-session-finalization' and
+--       'claude-session-finalization', carrying metadata lifecycle
+--       'session-end' and event_type 'handoff'. Their CONTENT is May/June
+--       session logs ("Finalized codex session for king-capital.
+--       {"timestamp":"2026-05-12T01:55:53...}"), so they are imported history
+--       written on one date, not July activity. Strip that window and July
+--       is 2,593 organic events -- the same order of magnitude as August.
+--
+--   (2) THE VOLUME MOVED TO ob_raw_turns, AND THE DISTILLER NEVER RAN FOR
+--       NAMESPACE 'rico'. ob_raw_turns did not exist before 2026-07-25. It
+--       then took over the raw-prompt capture that source='shared' had been
+--       writing into ob_session_events: 'shared' collapses from 220/day
+--       (2026-07-31) to 25 (08-01) and effectively 0 after 2026-08-04,
+--       exactly as raw_turns scales to 7k-13k/day. Raw capture ROSE 4x
+--       (40,805 in July -> 156,653 in August), so nothing stopped capturing.
+--
+--       What fell is distillation, and query 7 shows it is namespace-scoped,
+--       not a general outage. maintenance_jobs holds 391 'memory.distill'
+--       jobs, ALL of them 'succeeded', for namespaces geetesh (177), lisa
+--       (147), kevin (64) and admin (3) -- and ZERO for 'rico'. Accordingly
+--       every other namespace is 100% distilled (lisa 2377/2377, geetesh
+--       250/250, kevin 176/176, admin 9/9) while 'rico' sits at 5,028 of
+--       194,483 = 2.6%, leaving a 189,455-turn undistilled backlog. The
+--       5,028 rico turns that ARE distilled were done by the pre-queue path
+--       before the cliff on capture day 2026-07-28 (128) -> 2026-07-29 (0);
+--       the queue-based distiller only starts on 2026-08-08 and has never
+--       been enqueued for the namespace that holds 98.5% of the turns.
+--
+-- READ-ONLY. Run with:
+--   set -a; . ./.env; set +a
+--   psql -At -f scripts/done-means/monthly-event-counts.sql
+
+\echo '== 1. monthly ob_session_events (the reported drop) =='
+select date_trunc('month', created_at)::date as month,
+       count(*)                              as events,
+       count(embedding)                      as with_embedding
+  from ob_session_events
+ group by 1
+ order by 1;
+
+\echo '== 2. cause (1): July minus the 07-13..07-18 historical backfill window =='
+select date_trunc('month', created_at)::date as month,
+       count(*)                                                            as total,
+       count(*) filter (where created_at::date between '2026-07-13'
+                                                   and '2026-07-18')       as backfill_window,
+       count(*) filter (where created_at::date not between '2026-07-13'
+                                                       and '2026-07-18')   as organic
+  from ob_session_events
+ group by 1
+ order by 1;
+
+\echo '== 3. cause (1) attribution: the backfill sources and their lifecycle marker =='
+select date_trunc('month', created_at)::date as month,
+       coalesce(source, '(null)')            as source,
+       coalesce(metadata->>'lifecycle', '(none)') as lifecycle,
+       event_type,
+       count(*)
+  from ob_session_events
+ where source in ('codex-session-finalization', 'claude-session-finalization')
+ group by 1, 2, 3, 4
+ order by 1, 5 desc;
+
+\echo '== 4. cause (2): capture ROSE while distillation FELL =='
+select date_trunc('month', created_at)::date as month,
+       count(*)                              as raw_turns,
+       count(distilled_at)                   as distilled,
+       round(100.0 * count(distilled_at) / count(*), 2) as pct_distilled
+  from ob_raw_turns
+ group by 1
+ order by 1;
+
+\echo '== 5. cause (2) cliff: distillation per capture day, 128 -> 0 on 2026-07-29 =='
+select created_at::date as capture_day,
+       count(*)         as raw_turns,
+       count(distilled_at) as distilled
+  from ob_raw_turns
+ group by 1
+ order by 1;
+
+\echo '== 6. cause (2) migration: source=shared dies as ob_raw_turns takes over =='
+with shared_events as (
+  select created_at::date as day, count(*) as n
+    from ob_session_events
+   where source = 'shared'
+   group by 1
+), raw as (
+  select created_at::date as day, count(*) as n
+    from ob_raw_turns
+   group by 1
+)
+select coalesce(shared_events.day, raw.day) as day,
+       coalesce(shared_events.n, 0)         as shared_events,
+       coalesce(raw.n, 0)                   as raw_turns
+  from shared_events
+  full join raw on shared_events.day = raw.day
+ order by 1;
+
+\echo '== 7. ROOT CAUSE: distillation is namespace-scoped and rico is never enqueued =='
+select 'raw_turns' as relation,
+       namespace,
+       count(*)            as turns,
+       count(distilled_at) as distilled,
+       round(100.0 * count(distilled_at) / count(*), 2) as pct_distilled
+  from ob_raw_turns
+ group by 1, 2
+having count(*) > 5
+ order by turns desc;
+
+\echo '== 7b. memory.distill jobs by namespace -- note rico is absent entirely =='
+select namespace, state, count(*), min(created_at)::date as first_job, max(created_at)::date as last_job
+  from maintenance_jobs
+ where job_kind = 'memory.distill'
+ group by 1, 2
+ order by 3 desc;

--- a/server/capture/liveness-observer.test.ts
+++ b/server/capture/liveness-observer.test.ts
@@ -19,7 +19,7 @@ import {
   readCaptureLiveness,
   MIN_SESSIONS_FOR_SILENCE,
 } from "./liveness-observer.ts";
-import { RAW_TURN_ROLES } from "../domain/raw-turn-roles.ts";
+import { EXPECTED_LIVE_ROLES } from "../domain/raw-turn-roles.ts";
 
 function poolReturning(rows: ReadonlyArray<Record<string, unknown>>): Pool {
   return { query: async () => ({ rows }) } as unknown as Pool;
@@ -71,10 +71,18 @@ describe("capture liveness observer", () => {
     // report a busy lane. 365 user rows beside an absent assistant is exactly
     // the six-day blind spot (`capture-never-drops-a-turn.md:291`).
     //
-    // `tool` is named alongside it because it is equally absent here and the
-    // seed now covers every accepted role (#681). Before that fix this
-    // assertion read `["assistant"]` — not because `tool` was delivering, but
-    // because a role missing from the seed could not be judged at all.
+    // This assertion has moved twice, and the history is the point. It read
+    // `["assistant"]` originally; #681 widened it to `["assistant", "tool"]`
+    // because a role missing from the seed could not be judged AT ALL; #685
+    // narrowed it back — not by re-shrinking the seed, but by seeding from the
+    // roles the LIVE LANE PRODUCES rather than the roles ingest ACCEPTS. `tool`
+    // is absent here and that is correct and permanent: no live producer emits
+    // it (records.py has no TOOL branch, deliberately), so naming it a fault
+    // returned 503 from /health and rolled back every deploy.
+    //
+    // The #681 lesson is intact. A role that SHOULD arrive and does not is
+    // still named — `assistant` here — and the seed is still derived from a
+    // declared set rather than a literal beside an enum.
     const subject = observer(
       poolReturning([
         { role: "user", turns: "365", sessions: "9", seconds_since_last: "3" },
@@ -84,17 +92,41 @@ describe("capture liveness observer", () => {
     const reading = subject.reading();
 
     expect(reading?.stale).toBe(true);
-    expect(reading?.silent_roles).toEqual(["assistant", "tool"]);
+    expect(reading?.silent_roles).toEqual(["assistant"]);
     expect(reading?.turns_delivered).toBe(365);
     expect(reading?.reason).toContain("assistant");
   });
 
-  it("names a dead `tool` role beside a live user and assistant (#681)", async () => {
-    // The cutover-blocker shape, byte for byte: `tool` frozen since 2026-08-01
-    // at 14,006 rows while `/health` read `stale: false, silent_roles: []` for
-    // eight days. The role was never exercised in this file before #681 —
-    // which is how a health check reported green over a dead speaker on the
-    // very evidence the core01 cutover was to rely on.
+  it("names a dead SPOKEN role beside a live one (#681 mechanism, #685 scope)", async () => {
+    // The #681 mechanism, preserved: a role that SHOULD be arriving and is not
+    // must be named, not silently absent from the GROUP BY. What #685 corrected
+    // is WHICH roles those are. The original of this test used a dead `tool`
+    // role as the specimen, and that specimen was wrong: the live capture
+    // parser has no TOOL branch by design, so `tool` is silent permanently and
+    // correctly. Asserting a fault on it made /health return 503 forever and
+    // rolled back every deploy.
+    //
+    // `assistant` is the right specimen. It has a live producer, so its silence
+    // is real evidence of a broken lane -- which is what this module exists to
+    // catch.
+    const subject = observer(
+      poolReturning([
+        { role: "user", turns: "3780", sessions: "9", seconds_since_last: "12" },
+      ]),
+    );
+    await subject.refresh();
+    const reading = subject.reading();
+
+    expect(reading?.silent_roles).toEqual(["assistant"]);
+    expect(reading?.reason).toContain("assistant");
+  });
+
+  it("does NOT fault on a silent `tool` role, which has no live producer (#685)", async () => {
+    // The regression this issue is about. Both spoken roles delivering and no
+    // tool turns is the NORMAL live state -- verified 2026-08-25, newest tool
+    // row 2026-08-01 with user and assistant flowing -- because the third
+    // stream (reasoning, tool calls, tool output) ships to Langfuse rather than
+    // through this lane. A fault here is a false 503.
     const subject = observer(
       poolReturning([
         { role: "user", turns: "3780", sessions: "9", seconds_since_last: "12" },
@@ -104,15 +136,17 @@ describe("capture liveness observer", () => {
     await subject.refresh();
     const reading = subject.reading();
 
-    expect(reading?.stale).toBe(true);
-    expect(reading?.silent_roles).toEqual(["tool"]);
-    expect(reading?.reason).toContain("tool");
+    expect(reading?.silent_roles).toEqual([]);
+    expect(reading?.stale).toBe(false);
   });
 
-  it("stays green when all three accepted roles deliver", async () => {
-    // The control for the clause above: widening the seed must not make `tool`
-    // permanently silent. An always-degrade implementation passes the test
-    // above and fails this one.
+  it("stays green when an accepted-but-unexpected role also delivers", async () => {
+    // The control for the clauses above. `tool` is ACCEPTED (the bulk importer
+    // emits it), just never EXPECTED of the live lane, so its arrival must be
+    // counted and must not be treated as anomalous. An implementation that
+    // narrowed the seed by filtering arrivals rather than by narrowing
+    // EXPECTATIONS would drop these 900 turns from turns_delivered and fail
+    // here.
     const subject = observer(
       poolReturning([
         { role: "user", turns: "300", sessions: "9", seconds_since_last: "12" },
@@ -128,11 +162,17 @@ describe("capture liveness observer", () => {
     expect(reading?.turns_delivered).toBe(2400);
   });
 
-  it("seeds every role the server accepts, so a new role cannot escape", async () => {
-    // The mechanism, not the instance (#681). The seed derives from
-    // `RAW_TURN_ROLES`, so this asserts the observation's keys ARE that set —
-    // a hardcoded triple would satisfy the behavioural tests above and rebuild
-    // the identical trap for role number four.
+  it("seeds every role the live lane produces, so a new one cannot escape", async () => {
+    // The mechanism, not the instance (#681), rescoped by #685. The seed
+    // derives from `EXPECTED_LIVE_ROLES`, so this asserts the observation's
+    // keys ARE that set — a hardcoded pair would satisfy the behavioural tests
+    // above and rebuild the identical trap for the next role the LIVE LANE
+    // learns to emit.
+    //
+    // Deriving from the ACCEPT set instead is what #685 fixed: it made the
+    // observer demand `tool`, which no live producer sends.
+    // `raw-turn-roles.test.ts` pins live as a strict subset of accept, so the
+    // two cannot silently converge again.
     const subject = observer(
       poolReturning([
         { role: "user", turns: "10", sessions: "9", seconds_since_last: "1" },
@@ -141,7 +181,7 @@ describe("capture liveness observer", () => {
     await subject.refresh();
 
     expect(Object.keys(subject.observation()?.turnsByRole ?? {}).sort()).toEqual(
-      [...RAW_TURN_ROLES].sort(),
+      [...EXPECTED_LIVE_ROLES].sort(),
     );
   });
 

--- a/server/capture/liveness-observer.ts
+++ b/server/capture/liveness-observer.ts
@@ -73,7 +73,7 @@
 import type { Logger } from "pino";
 import type { Pool } from "pg";
 import type { TransportCaptureHealth } from "../transport/index.ts";
-import { RAW_TURN_ROLES } from "../domain/raw-turn-roles.ts";
+import { EXPECTED_LIVE_ROLES } from "../domain/raw-turn-roles.ts";
 
 /**
  * Sessions that must be observed before total silence counts as a fault.
@@ -108,7 +108,14 @@ export const MIN_SESSIONS_FOR_SILENCE = 2;
  * boundary's own set, so a role the server learns to accept becomes a role this
  * observer expects, with no second edit to forget.
  */
-const EXPECTED_ROLES = RAW_TURN_ROLES;
+// Seeded from the LIVE-expected set, not the accept set (#685). The two are
+// different questions and the accept set answers the wrong one: it includes
+// `tool`, which no live producer emits by design, so seeding from it raised a
+// permanent silent-role fault and rolled back every deploy. The subset relation
+// between the two sets is pinned by raw-turn-roles.test.ts, so a role the
+// boundary learns to accept still cannot escape liveness silently -- the #681
+// lesson this module exists for is unchanged.
+const EXPECTED_ROLES = EXPECTED_LIVE_ROLES;
 
 /**
  * Faults this vantage point can actually raise, named in the reading.

--- a/server/domain/raw-turn-roles.test.ts
+++ b/server/domain/raw-turn-roles.test.ts
@@ -19,7 +19,7 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { RAW_TURN_ROLES } from "./raw-turn-roles.ts";
+import { EXPECTED_LIVE_ROLES, RAW_TURN_ROLES } from "./raw-turn-roles.ts";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..");
 
@@ -45,6 +45,26 @@ describe("raw turn role set", () => {
       .map((part) => part.trim().replace(/^"|"$/g, ""))
       .filter((part) => part.length > 0);
     expect(roles).toEqual([...RAW_TURN_ROLES]);
+  });
+
+  it("expects only live roles for liveness, and they are all accepted", () => {
+    // #685: the accept set and the live-expected set answer different
+    // questions, and seeding liveness from the accept set demanded `tool` --
+    // a role no live producer emits by design -- which returned 503 from
+    // /health and rolled back every deploy.
+    //
+    // The subset assertion is what keeps #681 fixed. A live role that is not
+    // an accepted role is a contradiction (the observer would demand a turn
+    // the boundary rejects), and a role added to ingest still cannot escape
+    // liveness silently, because adding it here is a deliberate edit to a
+    // declared set rather than a literal drifting beside an enum.
+    expect([...EXPECTED_LIVE_ROLES]).toEqual(["user", "assistant"]);
+    for (const role of EXPECTED_LIVE_ROLES) {
+      expect(RAW_TURN_ROLES).toContain(role);
+    }
+    // Strict subset: if these ever match, the distinction has collapsed and
+    // the defect is back.
+    expect(EXPECTED_LIVE_ROLES.length).toBeLessThan(RAW_TURN_ROLES.length);
   });
 
   it("agrees with the applied CHECK constraint on ob_raw_turns.role", () => {

--- a/server/domain/raw-turn-roles.ts
+++ b/server/domain/raw-turn-roles.ts
@@ -54,3 +54,50 @@ export const RAW_TURN_ROLES = ["user", "assistant", "tool"] as const;
 
 /** A role the server accepts on a raw turn. */
 export type RawTurnRole = (typeof RAW_TURN_ROLES)[number];
+
+/**
+ * The roles a healthy LIVE capture lane must be delivering (#685).
+ *
+ * WHAT MAY ARRIVE AND WHAT MUST BE ARRIVING ARE DIFFERENT QUESTIONS, and
+ * answering the second with the first is what broke deploys. `RAW_TURN_ROLES`
+ * is the ACCEPT set, and `tool` belongs in it: the bulk importer emits tool
+ * turns (`python/openbrain/src/openbrain/apps/bulk/formats.py`) and the
+ * column's CHECK constraint admits them. But the live capture parser has
+ * exactly two role branches and `else: return None`
+ * (`python/openbrain/src/openbrain/apps/capture/records.py`), so no live
+ * producer emits `tool` — DELIBERATELY, per
+ * `docs/decisions/capture-never-drops-a-turn.md`, which parks the machinery
+ * underneath and says in terms: "Do not resolve this by inference, and do not
+ * let it be resolved by accident."
+ *
+ * Seeding liveness from the accept set therefore demanded a role nothing was
+ * supposed to send. Measured 2026-08-25: the newest `tool` row was 2026-08-01,
+ * 24 days stale with zero recent arrivals, while user and assistant flowed
+ * normally — so the observer raised a permanent silent-role fault, `/health`
+ * returned 503 (`server/transport/http-app.ts`), and
+ * `scripts/local-clone-deploy.sh` rolled back every deploy on `curl -fsS`. A
+ * #747 deploy passed its revision proof and ran correctly in production for 80
+ * seconds before being reverted by this.
+ *
+ * It presented as intermittent because the silent-role fault is only evaluated
+ * above `MIN_SESSIONS_FOR_SILENCE`, so whether a restart landed green depended
+ * on session traffic in the observation window. A deploy gate decided by
+ * traffic timing is not a gate.
+ *
+ * WHY THIS IS NOT A RETURN TO THE #681 LITERAL. #681's lesson is that a role
+ * set must be DECLARED ONCE rather than retyped beside an enum, so that a role
+ * the boundary learns to accept cannot escape liveness. That lesson is intact:
+ * this set is declared here beside the accept set, and `raw-turn-roles.test.ts`
+ * pins it as a strict subset — a live role that is not an accepted role is a
+ * contradiction and fails the drift test. What changed is not WHERE the set
+ * lives but WHICH QUESTION it answers.
+ *
+ * The third stream — reasoning, tool invocations, tool output — is not dropped.
+ * It ships to Langfuse, the home the decision doc names, verified receiving on
+ * 2026-08-25. Where it ultimately belongs stays parked; this set takes no
+ * position on it.
+ */
+export const EXPECTED_LIVE_ROLES = ["user", "assistant"] as const;
+
+/** A role the live capture lane is expected to deliver. */
+export type ExpectedLiveRole = (typeof EXPECTED_LIVE_ROLES)[number];

--- a/server/tools/agent-context-pack.ts
+++ b/server/tools/agent-context-pack.ts
@@ -44,6 +44,7 @@ import {
   agentReflexPointersStrictSchema,
   parseAgentContextPackArgs,
   parseAgentReflexPointersArgs,
+  SECTION_NAMES,
   type AgentContextPackArgs,
   type AgentReflexPointersArgs,
 } from "./context-pack-args.ts";
@@ -700,6 +701,27 @@ export async function buildAgentContextPackPayload(
             : requestedSections.filter(
                 (name) => !servedSections.includes(name),
               ),
+        // What a BARE call (no requested_sections) did not consult.
+        //
+        // `requested_not_served` is empty for a bare call and always will be:
+        // nothing was requested, so by its own definition nothing was withheld.
+        // That is truthful and useless. The caller receives an `ok` envelope
+        // listing only `working_set` and has no way to distinguish "the durable
+        // corpus was searched and had nothing" from "the durable corpus was
+        // never consulted at all" -- and every default-shaped recall takes the
+        // second path.
+        //
+        // This field states the omission plainly instead. It changes no
+        // selection behaviour: which sections a bare call serves is a contract
+        // decision (docs/agent-context-pack-contract.md), not a receipt
+        // concern. It only stops the receipt from implying completeness it
+        // never had.
+        not_consulted_by_default:
+          requestedSections === null
+            ? SECTION_NAMES.filter(
+                (name: string) => !servedSections.includes(name),
+              )
+            : [],
       },
       warnings: {
         scope_denials: [

--- a/server/tools/agent-context-pack.ts
+++ b/server/tools/agent-context-pack.ts
@@ -127,9 +127,35 @@ export async function buildAgentContextPackPayload(
   };
   const normalizedScope = normalizeWorkingSetScope(scope);
 
-  // Section selection. Absent `requested_sections` means working_set only;
-  // every other section is opt-in, because each one costs a query and a caller
-  // that wanted the whole brain would have said so.
+  // Section selection. Absent `requested_sections` means working_set AND
+  // durable_memory; every other section is opt-in, because each one costs a
+  // query and a caller that wanted the whole brain would have said so.
+  //
+  // WHY durable_memory IS IN THE DEFAULT (#744, operator decision 2026-08-25).
+  // It used to be opt-in with the rest, on the reasoning above. That reasoning
+  // holds for sections a caller might not want; it does not hold for the
+  // durable corpus, because a caller who asks for "context" and silently gets
+  // none has no way to tell. Measured against the local service with the
+  // installed client:
+  //
+  //   bare recall                  -> served [working_set],                citations 0
+  //   durable_memory asked for     -> served [working_set,durable_memory], citations 10
+  //
+  // The corpus is reachable and the query works. Only the default was wrong.
+  // The Python client never sets requested_sections at all
+  // (python/openbrain-memory/src/openbrain_memory/runtime.py
+  // context_pack_arguments), so EVERY bare recall took the working-set-only
+  // branch and reported success -- which is what an agent that "remembers
+  // nothing" actually looks like from the inside.
+  //
+  // The asymmetry was the tell: working_set treated an absent
+  // requested_sections as INCLUDED and durable_memory as EXCLUDED, one line
+  // apart, with nothing in the contract asking for that split.
+  // docs/agent-context-pack-contract.md names durable_lane_context as opt-in
+  // explicitly and says nothing equivalent for durable_memory.
+  //
+  // Cost is one hybrid recall per default-shaped call. That is the price of a
+  // default that means what a caller reading it would assume.
   const includeWorkingSet =
     !args.requested_sections || args.requested_sections.includes("working_set");
   const includeRecovery =
@@ -138,7 +164,8 @@ export async function buildAgentContextPackPayload(
   const includeDurableLaneContext =
     args.requested_sections?.includes("durable_lane_context") === true;
   const includeDurableMemorySection =
-    args.requested_sections?.includes("durable_memory") === true;
+    !args.requested_sections ||
+    args.requested_sections.includes("durable_memory");
   const includeProfileGuidance =
     args.requested_sections?.includes("profile_guidance") === true;
   const includeProcessGuidance =

--- a/server/tools/context-pack.test.ts
+++ b/server/tools/context-pack.test.ts
@@ -63,7 +63,8 @@ function isRecallSql(sql: string): boolean {
 /** @returns The count of hybrid recall STACKS run (one per `executeSearch`). */
 function recallStackCount(queries: readonly CapturedQuery[]): number {
   // Count only the vector arm: exactly one is issued per hybrid executeSearch.
-  return queries.filter((query) => query.sql.includes("query_embedding")).length;
+  return queries.filter((query) => query.sql.includes("query_embedding"))
+    .length;
 }
 
 interface HarnessOptions {
@@ -139,7 +140,10 @@ const SCOPE = {
 };
 
 function sectionsOf(payload: Record<string, unknown>) {
-  return payload.sections as Record<string, Record<string, unknown> | undefined>;
+  return payload.sections as Record<
+    string,
+    Record<string, unknown> | undefined
+  >;
 }
 
 /**
@@ -272,7 +276,12 @@ describe("pointers carry references, never bodies", () => {
     });
     // The whole value of a pointer is that it is cheap and body-free. Any of
     // these fields appearing is body leakage.
-    for (const forbidden of ["content", "content_preview", "label", "preview"]) {
+    for (const forbidden of [
+      "content",
+      "content_preview",
+      "label",
+      "preview",
+    ]) {
       expect(item).not.toHaveProperty(forbidden);
     }
     // ... including inside the nested source_ref, which the durable item's own
@@ -301,7 +310,10 @@ describe("pointers carry references, never bodies", () => {
       "pointers",
     ).map((item) => item.citation_id);
 
-    expect(durableIds).toEqual(["brain_record:thought:a", "brain_record:thought:b"]);
+    expect(durableIds).toEqual([
+      "brain_record:thought:a",
+      "brain_record:thought:b",
+    ]);
     // Durable owns this evidence; re-listing it would double-count it against
     // the caller's budget and show the same record twice.
     expect(pointerIds).toEqual([]);
@@ -828,9 +840,11 @@ describe("the pack names requested vs served sections in its receipt", () => {
       requested_not_served: string[];
     };
     // `null`, not `[]`: the caller asked for nothing and took the documented
-    // working_set-only default, which is not the same as asking for nothing.
+    // default, which is not the same as asking for nothing. That default
+    // serves working_set AND durable_memory since #744
+    // (docs/agent-context-pack-contract.md:88).
     expect(receipt.requested).toBeNull();
-    expect(receipt.served).toEqual(["working_set"]);
+    expect(receipt.served).toEqual(["working_set", "durable_memory"]);
     expect(receipt.requested_not_served).toEqual([]);
   });
 

--- a/src/db/migrations/026_maintenance_queue.test.ts
+++ b/src/db/migrations/026_maintenance_queue.test.ts
@@ -98,14 +98,38 @@ dbDescribe("026 maintenance queue (live Postgres)", () => {
         WHERE conrelid = 'maintenance_jobs'::regclass`,
     );
     expect(rows.map((row) => row.conname)).toContain(
-      "maintenance_jobs_unique_kind_idempotency",
-    );
-    expect(rows.map((row) => row.conname)).toContain(
       "maintenance_jobs_lease_shape",
     );
     expect(rows.map((row) => row.conname)).toContain(
       "maintenance_jobs_terminal_shape",
     );
+
+    // Idempotency uniqueness is a PARTIAL UNIQUE INDEX since 047, not a table
+    // constraint, so it lives in pg_indexes and never appears above. 047
+    // scoped it to live states on purpose: a terminal row must stop reserving
+    // its key, or a recurring batch deadlocks forever (#747).
+    const { rows: indexes } = await pool.query<{
+      indexname: string;
+      indexdef: string;
+    }>(
+      `SELECT indexname, indexdef
+         FROM pg_indexes
+        WHERE tablename = 'maintenance_jobs'`,
+    );
+    const byName = new Map(indexes.map((row) => [row.indexname, row.indexdef]));
+
+    expect([...byName.keys()]).not.toContain(
+      "maintenance_jobs_unique_kind_idempotency",
+    );
+
+    const live = byName.get("maintenance_jobs_live_idempotency");
+    expect(live).toBeDefined();
+    expect(live).toContain("UNIQUE");
+    // Only queued and running reserve the key.
+    expect(live).toContain("'queued'");
+    expect(live).toContain("'running'");
+    expect(live).not.toContain("'succeeded'");
+    expect(live).not.toContain("'dead_letter'");
   });
 
   it("persists the caller-forced terminal category (unsupported kind is not non_error)", async () => {

--- a/src/db/migrations/047_maintenance_jobs_live_idempotency.sql
+++ b/src/db/migrations/047_maintenance_jobs_live_idempotency.sql
@@ -1,0 +1,62 @@
+-- A FINISHED job must not reserve an idempotency key against NEW work (#747).
+--
+-- 026 declared `UNIQUE (job_kind, idempotency_key)` across every state. The
+-- intent, from the DISTILL-1 design (_plans/issues/382): "Idempotency key is
+-- `batch_hash`, so a re-enqueued identical batch is a no-op." That is right
+-- while consumption works -- re-running finished work is exactly what a
+-- dedupe key should prevent.
+--
+-- It is wrong once a job finishes WITHOUT consuming. The key then describes
+-- pending work, is held forever by a `succeeded` row, and no later job can be
+-- inserted under it. There is no reaper: nothing in this repo deletes from
+-- maintenance_jobs, so the reservation is permanent.
+--
+-- Measured on the dogfood database 2026-08-25:
+--
+--   blocking row : 9c29069d-267c-4e39-a135-ace207e342f6
+--   state        : succeeded, 02:19:05, attempts 1
+--   key          : memory.distill:25ab14fc2b679646bcbccf7d9c9c2234:s4:t1500
+--   live hash    : 25ab14fc2b679646bcbccf7d9c9c2234   (byte-identical)
+--   backlog      : 190,206 undistilled turns, climbing
+--
+-- The hash cannot drift on its own. It covers the FIRST 1500 due turns in
+-- (session_ref, occurred_at, id) order; new turns sort to the END and never
+-- enter that window. So the key was frozen, the lane could not self-heal, and
+-- the sweep re-attempted the same dropped insert every 5 seconds for hours.
+--
+-- The fix scopes uniqueness to jobs that are still LIVE. A queued or running
+-- job still reserves its key, which is the whole point of the constraint:
+-- concurrent producers cannot double-enqueue the same batch, and the
+-- at-least-once queue stays idempotent. A terminal job (succeeded or
+-- dead_letter) releases it, so a batch that recurs can be scheduled again.
+--
+-- WHAT THIS DELIBERATELY DOES NOT DO. It does not make re-running finished
+-- work automatic. A key only recurs when a producer computes it again from
+-- live state, which for the distill sweep means the turns are STILL due. Work
+-- that actually completed changes its own inputs and therefore its key. The
+-- guard against redoing finished work lives in the producer's selection
+-- (`distilled_at IS NULL`), not in a permanently-held row -- and relying on
+-- the row was what turned one unconsumed batch into a permanent deadlock.
+--
+-- Class fix, not a distill fix: this deadlock was available to any job kind
+-- whose key can recur.
+
+-- Both names are dropped so a partially-applied earlier attempt converges.
+ALTER TABLE maintenance_jobs
+  DROP CONSTRAINT IF EXISTS maintenance_jobs_unique_kind_idempotency;
+DROP INDEX IF EXISTS maintenance_jobs_unique_kind_idempotency;
+
+-- Partial unique index rather than a constraint: a CHECK-style table
+-- constraint cannot carry a WHERE clause, and ON CONFLICT infers a partial
+-- index only when the statement repeats this exact predicate. src/
+-- maintenance-queue.ts spells it identically in its INSERT.
+CREATE UNIQUE INDEX IF NOT EXISTS maintenance_jobs_live_idempotency
+  ON maintenance_jobs (job_kind, idempotency_key)
+  WHERE state IN ('queued', 'running');
+
+-- Terminal rows are no longer covered by a unique index, so the lookup that
+-- `enqueue` performs after a dropped insert still needs an access path, and
+-- so does any operator asking "what happened to this key". Non-unique by
+-- design: many finished jobs may now share one key over time.
+CREATE INDEX IF NOT EXISTS maintenance_jobs_kind_idempotency_history
+  ON maintenance_jobs (job_kind, idempotency_key, created_at DESC);

--- a/src/distill-handler.test.ts
+++ b/src/distill-handler.test.ts
@@ -581,7 +581,9 @@ describe("makeMemoryDistillHandler", () => {
   });
 
   it("emits a trace with stage spans and row ids read and written", async () => {
-    const source = rawTurn({ content: "we are going with traced distillation" });
+    const source = rawTurn({
+      content: "we are going with traced distillation",
+    });
     const corpus = fakeCorpus([source]);
     const tracing = recordingTracing();
     const handler = makeMemoryDistillHandler({
@@ -642,7 +644,13 @@ describe("makeMemoryDistillHandler", () => {
       s.text.includes("due_sessions"),
     )!;
     // No namespace parameter was bound: the sweep is deliberately global.
-    expect(claim.values).toHaveLength(2);
+    // The three bound values are the query's limits only -- maxSessions,
+    // maxTurns, and the contextWindow reach added by #747
+    // (src/distill-window.ts:239-250). None of them is a namespace, which is
+    // what makes this sweep global; the scoped sibling below binds one at $1.
+    expect(claim.values).toHaveLength(3);
+    expect(claim.values).not.toContain("rico");
+    expect(claim.values.every((v) => typeof v === "number")).toBe(true);
   });
 
   it("a scoped job binds its namespace on the claim", async () => {

--- a/src/distill-handler.ts
+++ b/src/distill-handler.ts
@@ -352,10 +352,28 @@ export async function runDistillSweep(
         params,
       );
       outstanding = Number((rows[0] as { due?: unknown } | undefined)?.due ?? 0);
-    } catch {
-      // The probe is observability, never a gate: if it fails, the sweep still
-      // returns its summary rather than turning a diagnostic into an outage.
+    } catch (error: unknown) {
+      // DOCUMENTED FAIL-OPEN. The probe is observability, never a gate: if it
+      // fails, the sweep still returns its summary rather than turning a
+      // diagnostic into an outage.
+      //
+      // Logged rather than swallowed, because a silent fallback here would
+      // recreate in the detector the exact defect the detector exists to
+      // catch. If this probe is failing, the operator is blind to an empty
+      // claim and must know that -- an unreported `outstanding = null` makes
+      // the pathological case indistinguishable from a drained queue all over
+      // again.
       outstanding = null;
+      deps.logger.warn("distill_backlog_probe_failed", {
+        namespace: deps.namespace ?? "(all)",
+        lane_id:
+          deps.laneId === null || deps.laneId === undefined
+            ? "(none)"
+            : deps.laneId,
+        reason: error instanceof Error ? error.name : "non_error",
+        detail:
+          "could not count outstanding turns; an empty claim this sweep is unclassified, not proven drained",
+      });
     }
 
     if (outstanding !== null && outstanding > 0) {

--- a/src/distill-handler.ts
+++ b/src/distill-handler.ts
@@ -98,6 +98,16 @@ export interface DistillSweepSummary {
   embeddings_missing: number;
   /** Turns whose session_seq was NULL -- a 036 backfill gap, surfaced not hidden. */
   missing_session_seq: number;
+  /**
+   * Undistilled turns still outstanding when the claim came back empty.
+   *
+   * Present ONLY on the pathological case: the sweep had nothing to consume
+   * while work remained, which is the shape that starved this pipeline for 27
+   * days while every job reported `succeeded`. Absent on a normal drained
+   * queue, so a caller can treat its presence as the signal rather than
+   * comparing counts.
+   */
+  claim_empty_with_backlog?: number;
 }
 
 export interface DistillSweepDeps {
@@ -312,7 +322,59 @@ export async function runDistillSweep(
   summary.units = batch.units.length;
   summary.missing_session_seq = batch.missingSessionSeq;
 
-  if (batch.consumedTurnIds.length === 0) return summary;
+  if (batch.consumedTurnIds.length === 0) {
+    // An empty claim is the normal terminal state -- the queue is drained and
+    // there is nothing to stamp. It is ALSO exactly what a broken claim looks
+    // like, and that ambiguity is what let this pipeline starve for 27 days in
+    // silence: 392 `memory.distill` jobs completed as `succeeded` having
+    // stamped zero turns, because a claim returning no due work throws nothing
+    // and the handler returned here without a word.
+    //
+    // So the two cases are separated before returning. Asking the database
+    // whether due work still exists costs one indexed count on the terminal
+    // path only, and turns a silent no-op into a named condition an operator
+    // can see. Still not an error: the sweep did not fail, and throwing here
+    // would fail a job whose own behaviour was correct. It is a loud INFO with
+    // the number that makes it unmistakable.
+    let outstanding: number | null = null;
+    try {
+      const params: unknown[] = [];
+      let nsPredicate = "";
+      if (deps.namespace !== undefined) {
+        params.push(deps.namespace);
+        nsPredicate = ` AND namespace = $${params.length}`;
+      }
+      const { rows } = await deps.pool.query(
+        `SELECT count(*)::bigint AS due
+           FROM ob_raw_turns
+          WHERE distilled_at IS NULL
+            AND retention_tier = 'live'${nsPredicate}`,
+        params,
+      );
+      outstanding = Number((rows[0] as { due?: unknown } | undefined)?.due ?? 0);
+    } catch {
+      // The probe is observability, never a gate: if it fails, the sweep still
+      // returns its summary rather than turning a diagnostic into an outage.
+      outstanding = null;
+    }
+
+    if (outstanding !== null && outstanding > 0) {
+      deps.logger.warn("distill_claim_empty_with_backlog", {
+        namespace: deps.namespace ?? "(all)",
+        lane_id: deps.laneId === null || deps.laneId === undefined ? "(none)" : deps.laneId,
+        turns_outstanding: outstanding,
+        detail:
+          "claim returned no due turns while undistilled turns remain; the sweep did nothing and would otherwise have reported success",
+      });
+      summary.claim_empty_with_backlog = outstanding;
+    } else {
+      deps.logger.info("distill_queue_drained", {
+        namespace: deps.namespace ?? "(all)",
+        lane_id: deps.laneId === null || deps.laneId === undefined ? "(none)" : deps.laneId,
+      });
+    }
+    return summary;
+  }
 
   const candidates: PreparedCandidate[] = [];
   for (const unit of batch.units) {

--- a/src/distill-window.test.ts
+++ b/src/distill-window.test.ts
@@ -291,8 +291,52 @@ describe("claimDistillBatch — ordering key and stamping", () => {
   it("bounds both the session and turn limits so one sweep cannot read the table", async () => {
     const db = fakeDb([]);
     await claimDistillBatch(db, { maxSessions: 10_000, maxTurns: 10_000_000 });
-    // Clamped at the module's ceilings (64 sessions / 20,000 turns).
-    expect(db.seen[0]!.values).toEqual([64, 20_000]);
+    // Clamped at the module's ceilings (64 sessions / 20,000 turns). Asserted
+    // positionally rather than as the whole array: the third parameter is the
+    // context reach, which the query gained when the turn bound was moved onto
+    // the due turns alone, and which the next test covers directly.
+    expect(db.seen[0]!.values[0]).toBe(64);
+    expect(db.seen[0]!.values[1]).toBe(20_000);
+  });
+
+  it("bounds the turn count by DUE turns, never by due-plus-context", async () => {
+    // THE REGRESSION THIS EXISTS FOR. The query once read each due session
+    // whole and applied `LIMIT maxTurns` to the result, so in a long-running
+    // session the already-distilled context consumed the entire bound and the
+    // due turns fell off the end. Measured on the dogfood corpus 2026-08-25:
+    // 0 due turns and 1500 context turns claimed against a 190,102-turn
+    // backlog, which the handler then reported as a successful sweep.
+    const db = fakeDb([]);
+    await claimDistillBatch(db, { maxTurns: 1500, contextWindow: 3 });
+    const sql = db.seen[0]!.text;
+
+    // The bound applies inside the due-turn selection...
+    const dueClause = sql.slice(
+      sql.indexOf("due_turns AS ("),
+      sql.indexOf("context_bounds AS ("),
+    );
+    expect(dueClause).toContain("distilled_at IS NULL");
+    expect(dueClause).toContain("LIMIT $2");
+
+    // ...and the context read carries no turn bound of its own, so context can
+    // never displace work.
+    const contextClause = sql.slice(sql.indexOf("context_turns AS ("));
+    expect(contextClause).not.toContain("LIMIT");
+
+    // The context reach is a bound parameter, not interpolated.
+    expect(db.seen[0]!.values[2]).toBe(3);
+  });
+
+  it("reads context as a session_seq range within the due turn's own session", async () => {
+    // A row-count reach could walk off the start of a session and pull the tail
+    // of an unrelated one as if it were preceding context. The range is
+    // computed per session_ref and joined on it.
+    const db = fakeDb([]);
+    await claimDistillBatch(db, { contextWindow: 5 });
+    const sql = db.seen[0]!.text;
+    expect(sql).toContain("min(session_seq) -");
+    expect(sql).toContain("t.session_ref IS NOT DISTINCT FROM b.session_ref");
+    expect(db.seen[0]!.values[2]).toBe(5);
   });
 
   it("returns an empty batch for an empty queue -- the terminal state", async () => {

--- a/src/distill-window.ts
+++ b/src/distill-window.ts
@@ -240,10 +240,54 @@ export async function claimDistillBatch(
   const sessionLimit = `$${params.length}`;
   params.push(maxTurns);
   const turnLimit = `$${params.length}`;
+  // The context reach, in session_seq steps, used by the SQL below to pull the
+  // turns preceding each due turn. Mirrors the contextWindow that buildUnits
+  // applies in TypeScript: the query must fetch at least as much as the builder
+  // will read, or units come back with less context than they should have.
+  params.push(
+    Math.min(Math.max(options.contextWindow ?? DEFAULT_CONTEXT_WINDOW, 0), 64),
+  );
+  const contextLimit = `$${params.length}`;
 
-  // Two-step in one statement: pick the oldest sessions that still have
-  // undistilled work, then read those sessions WHOLE (including already
-  // distilled turns, which are needed as context) in canonical order.
+  // Three steps in one statement: pick the oldest sessions that still have
+  // undistilled work, take the DUE turns inside them, then read the context
+  // those specific due turns need.
+  //
+  // WHY THE BOUND SITS ON DUE TURNS AND NOT ON THE COMBINED SET. This query
+  // used to select each due session WHOLE and apply `LIMIT maxTurns` to the
+  // result. Reading whole sessions was and remains correct -- an
+  // already-distilled turn reappearing here is the context that makes a short
+  // current turn interpretable, which is the entire premise of this module. The
+  // defect was applying maxTurns AFTERWARDS: ordered by session_ref then
+  // occurred_at, a long-running session's already-distilled history filled
+  // every one of the 1500 slots and the due turns fell off the end.
+  //
+  // Measured on the dogfood corpus 2026-08-25, namespace rico, with the
+  // production parameters (maxSessions=4, maxTurns=1500):
+  //
+  //     due turns in claim     : 0
+  //     context turns in claim : 1500
+  //     undistilled backlog    : 190,102
+  //
+  // A claim of 1500 turns containing nothing to do. The handler stamps only
+  // `if (consumedTurnIds.length > 0)` (src/distill-handler.ts), so an empty
+  // claim stamped nothing, threw nothing, and completed as `succeeded`; and
+  // because the producer's idempotency key hashes the DUE turns
+  // (src/maintenance-queue.ts) under ON CONFLICT DO NOTHING, that unchanged
+  // hash then silently dropped every later enqueue. 392 succeeded jobs, zero
+  // turns stamped, no error anywhere, 27 days of starvation.
+  //
+  // Same family as the producer-side defect in src/maintenance-sweep.ts, where
+  // already-distilled turns were ranked ahead of due ones and pushed the due
+  // work past the rank cutoff. Both are "the bound was applied to the wrong
+  // set", and fixing either alone yields nothing: the producer enqueues work
+  // the consumer then declines to claim.
+  //
+  // So `due_turns` takes maxTurns, and `context_turns` is derived from
+  // whichever due turns are in it. Context is deliberately NOT counted against
+  // maxTurns -- it is governed by contextWindow per due turn, which is what
+  // decides how much of it is ever read. maxTurns bounds the WORK; the reading
+  // around that work is separate, and conflating the two is what broke this.
   //
   // retention_tier = 'live' matches the sweep's own work-queue index
   // (idx_ob_raw_turns_undistilled, 032_raw_turns.sql:216-218) so an archived
@@ -257,16 +301,50 @@ export async function claimDistillBatch(
         GROUP BY session_ref
         ORDER BY first_due ASC NULLS LAST
         LIMIT ${sessionLimit}
+     ),
+     due_turns AS (
+       SELECT t.*
+         FROM ob_raw_turns t
+         JOIN due_sessions d
+           ON t.session_ref IS NOT DISTINCT FROM d.session_ref
+        WHERE t.distilled_at IS NULL
+          AND t.retention_tier = 'live'${nsPredicate}${outerLanePredicate}
+        ORDER BY ${DISTILL_ORDER_BY}
+        LIMIT ${turnLimit}
+     ),
+     -- The context each due turn needs: the turns immediately preceding it in
+     -- its own session. Expressed as a session_seq range rather than a row
+     -- count so a claim can never pull an unrelated session's tail, and scoped
+     -- to the sessions that actually produced due work. Turns carrying a null
+     -- session_seq (an 036 backfill gap) are reported through
+     -- missingSessionSeq and bring no context of their own.
+     context_bounds AS (
+       SELECT session_ref,
+              min(session_seq) - ${contextLimit}::int AS low_seq,
+              max(session_seq)                        AS high_seq
+         FROM due_turns
+        WHERE session_seq IS NOT NULL
+        GROUP BY session_ref
+     ),
+     context_turns AS (
+       SELECT t.*
+         FROM ob_raw_turns t
+         JOIN context_bounds b
+           ON t.session_ref IS NOT DISTINCT FROM b.session_ref
+        WHERE t.retention_tier = 'live'${nsPredicate}${outerLanePredicate}
+          AND t.session_seq IS NOT NULL
+          AND t.session_seq >= b.low_seq
+          AND t.session_seq <= b.high_seq
      )
      SELECT t.id, t.namespace, t.session_ref, t.session_seq, t.role,
             t.content, t.repo, t.occurred_at, t.is_human_prompt,
             (t.distilled_at IS NULL) AS is_due
-       FROM ob_raw_turns t
-       JOIN due_sessions d
-         ON t.session_ref IS NOT DISTINCT FROM d.session_ref
-      WHERE t.retention_tier = 'live'${nsPredicate}${outerLanePredicate}
-      ORDER BY ${DISTILL_ORDER_BY}
-      LIMIT ${turnLimit}`,
+       FROM (
+         SELECT * FROM due_turns
+         UNION
+         SELECT * FROM context_turns
+       ) t
+      ORDER BY ${DISTILL_ORDER_BY}`,
     params,
   );
 

--- a/src/maintenance-queue.ts
+++ b/src/maintenance-queue.ts
@@ -384,7 +384,8 @@ export class MaintenanceQueue implements MaintenanceQueuePort {
          job_kind, job_version, payload, idempotency_key, run_after,
          max_attempts, backoff_base_ms, backoff_max_ms, namespace, provenance
        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-       ON CONFLICT (job_kind, idempotency_key) DO NOTHING
+       ON CONFLICT (job_kind, idempotency_key)
+         WHERE state IN ('queued', 'running') DO NOTHING
        RETURNING ${JOB_COLUMNS}`,
       [
         job.kind,
@@ -403,14 +404,53 @@ export class MaintenanceQueue implements MaintenanceQueuePort {
       return { ...toJob(inserted.rows[0]), enqueueOutcome: "created" };
     }
 
+    // Scoped to LIVE states, matching the partial index the insert conflicts
+    // against (047). An unscoped lookup would now return a terminal row from
+    // any point in history, and enqueue would hand the caller a job that
+    // finished days ago as though it were the one holding the key -- the same
+    // confusion 047 exists to remove, reintroduced one statement later.
     const existing = await this.pool.query<MaintenanceJobRow>(
       `SELECT ${JOB_COLUMNS}
          FROM maintenance_jobs
-        WHERE job_kind = $1 AND idempotency_key = $2`,
+        WHERE job_kind = $1 AND idempotency_key = $2
+          AND state IN ('queued', 'running')`,
       [job.kind, job.idempotencyKey],
     );
     const existingRow = existing.rows[0];
     if (!existingRow) {
+      // The live holder reached a terminal state between the insert and this
+      // lookup, so the key is free again. Under the blanket constraint this
+      // was impossible -- a dropped insert always had a row behind it -- and
+      // throwing was correct. Under the partial index (047) it is an ordinary
+      // race, and the correct response is to insert, which now succeeds.
+      //
+      // Retried exactly once. A second drop means a new live job took the key
+      // in between, which is genuine contention and not this race; falling
+      // through to the throw keeps an unbounded retry loop out of the queue.
+      const retried = await this.pool.query<MaintenanceJobRow>(
+        `INSERT INTO maintenance_jobs (
+           job_kind, job_version, payload, idempotency_key, run_after,
+           max_attempts, backoff_base_ms, backoff_max_ms, namespace, provenance
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         ON CONFLICT (job_kind, idempotency_key)
+           WHERE state IN ('queued', 'running') DO NOTHING
+         RETURNING ${JOB_COLUMNS}`,
+        [
+          job.kind,
+          job.version,
+          JSON.stringify(job.payload),
+          job.idempotencyKey,
+          job.runAfter,
+          job.maxAttempts,
+          job.backoffBaseMs,
+          job.backoffMaxMs,
+          job.namespace,
+          job.provenance === null ? null : JSON.stringify(job.provenance),
+        ],
+      );
+      if (retried.rows[0]) {
+        return { ...toJob(retried.rows[0]), enqueueOutcome: "created" };
+      }
       throw new Error("maintenance queue idempotency lookup failed");
     }
     const existingJob = toJob(existingRow);

--- a/src/maintenance-queue.ts
+++ b/src/maintenance-queue.ts
@@ -91,6 +91,23 @@ export interface MaintenanceJob {
   provenance: Record<string, unknown> | null;
   createdAt: Date;
   updatedAt: Date;
+  /**
+   * What `enqueue` actually DID: `created` minted this row, `deduped` means the
+   * insert was dropped by ON CONFLICT DO NOTHING and this is the row that
+   * already held the key.
+   *
+   * WHY IT EXISTS. `enqueue` returns a job either way, and for hours the distill
+   * sweep logged `distill_jobs_enqueued: 1` every 5 seconds while the newest
+   * job row in the table stayed six hours old. The caller pushed the returned
+   * object into its jobs array and counted the length, with no way to tell a
+   * job it had just created from one that succeeded long ago. A dropped insert
+   * and a scheduled job were the same value.
+   *
+   * Optional so every existing reader and queue fake keeps compiling; a caller
+   * that reports counts is expected to read it. Absent means "not reported by
+   * this producer", never "created".
+   */
+  enqueueOutcome?: "created" | "deduped";
 }
 
 export interface EnqueueMaintenanceJob {
@@ -382,7 +399,9 @@ export class MaintenanceQueue implements MaintenanceQueuePort {
         job.provenance === null ? null : JSON.stringify(job.provenance),
       ],
     );
-    if (inserted.rows[0]) return toJob(inserted.rows[0]);
+    if (inserted.rows[0]) {
+      return { ...toJob(inserted.rows[0]), enqueueOutcome: "created" };
+    }
 
     const existing = await this.pool.query<MaintenanceJobRow>(
       `SELECT ${JOB_COLUMNS}
@@ -405,7 +424,14 @@ export class MaintenanceQueue implements MaintenanceQueuePort {
         "maintenance queue idempotency key reused with divergent job semantics",
       );
     }
-    return existingJob;
+    // The insert was dropped by ON CONFLICT DO NOTHING and this is the row that
+    // already held the key. Returning it bare is what let the distill sweep
+    // report `distill_jobs_enqueued: 1` every 5 seconds for hours while the
+    // newest job row stayed six hours old: the caller pushed this object into
+    // its jobs array and counted it, unable to tell a job it just created from
+    // one that succeeded long ago. The outcome is now on the return value so a
+    // caller cannot count a dropped insert as work scheduled.
+    return { ...existingJob, enqueueOutcome: "deduped" };
   }
 
   async claimDueJobs(input: ClaimMaintenanceJobs): Promise<MaintenanceJob[]> {

--- a/src/maintenance-sweep.test.ts
+++ b/src/maintenance-sweep.test.ts
@@ -104,6 +104,55 @@ function producerPool(graphRows = 1) {
 }
 
 describe("runMaintenanceSweep", () => {
+  it("does not count a deduped insert as an enqueued job", async () => {
+    // THE REGRESSION THIS EXISTS FOR. `enqueue` returns a MaintenanceJob whether
+    // it inserted a row or the insert was dropped by ON CONFLICT DO NOTHING on
+    // an existing idempotency key. The sweep pushed the returned object into
+    // its jobs array either way and reported the array length, so a lane whose
+    // key could never change reported `distill_jobs_enqueued: 1` every 5
+    // seconds while the newest row in maintenance_jobs stayed six hours old.
+    // Observed on the dogfood service 2026-08-25 against a 190,149-turn
+    // backlog: 392 succeeded jobs, zero turns stamped, and a sweep log that
+    // read exactly like a healthy one.
+    const pool = producerPool();
+    const enqueued: EnqueueMaintenanceJob[] = [];
+    const queue = {
+      enqueue: async (input: EnqueueMaintenanceJob) => {
+        enqueued.push(input);
+        // Every insert lands on an existing key: the wedged-lane condition.
+        return {
+          ...maintenanceJob(input, enqueued.length),
+          enqueueOutcome: "deduped" as const,
+        };
+      },
+    };
+    const logs = recordingLogger();
+
+    const summary: MaintenanceSweepSummary = await runMaintenanceSweep({
+      pool: pool as any,
+      queue,
+      logger: logs.logger,
+      distillBatchSize: 5,
+      maxDistillBatchesPerTick: 2,
+      graphDerivationLimit: 1,
+    });
+
+    // The producer still SELECTED work -- the batches are real and due.
+    expect(summary.distillBatchesSelected).toBe(2);
+    // But nothing was scheduled, and the summary says so rather than claiming
+    // two enqueues.
+    expect(summary.distillJobsEnqueued).toBe(0);
+    expect(summary.distillJobsDeduped).toBe(2);
+
+    // And it reaches the log, which is the only place an operator would see it.
+    const complete = logs.info.at(-1);
+    expect(complete?.message).toBe("maintenance_sweep_complete");
+    expect(complete?.fields).toMatchObject({
+      distill_jobs_enqueued: 0,
+      distill_jobs_deduped: 2,
+    });
+  });
+
   it("produces bounded distill batches and drifted graph jobs in one tick", async () => {
     const pool = producerPool();
     const enqueued: EnqueueMaintenanceJob[] = [];
@@ -141,6 +190,7 @@ describe("runMaintenanceSweep", () => {
       distillJobsEnqueued: 2,
       distillBatchesDeferred: 1,
       distillTurnsDeferred: 5,
+      distillJobsDeduped: 0,
       graphJobsEnqueued: 1,
       graphLimitReached: false,
     });

--- a/src/maintenance-sweep.ts
+++ b/src/maintenance-sweep.ts
@@ -42,6 +42,16 @@ export interface MaintenanceSweepOptions {
 export interface MaintenanceSweepSummary {
   distillBatchesSelected: number;
   distillJobsEnqueued: number;
+  /**
+   * Enqueue attempts the queue dropped on an existing idempotency key.
+   *
+   * A nonzero value here against a nonzero backlog means the lane is WEDGED,
+   * not busy: the key is unchanged because nothing consumed the work it names,
+   * so no new job can be scheduled under it. This count is the difference
+   * between "the sweep is keeping up" and "the sweep has been shouting into a
+   * dropped insert for 27 days", which were previously the same log line.
+   */
+  distillJobsDeduped: number;
   distillBatchesDeferred: number;
   distillTurnsDeferred: number;
   graphJobsEnqueued: number;
@@ -166,30 +176,50 @@ async function enqueueDistillBatches(
   batches: readonly DistillLaneBatch[],
   maxSessions: number,
   maxTurns: number,
-): Promise<{ jobs: MaintenanceJob[]; deferredTurns: number }> {
+): Promise<{
+  jobs: MaintenanceJob[];
+  deferredTurns: number;
+  /** Inserts the queue dropped on the idempotency key: attempted, not scheduled. */
+  dedupedJobs: number;
+}> {
   const jobs: MaintenanceJob[] = [];
   let deferredTurns = 0;
+  let dedupedJobs = 0;
   for (const batch of batches) {
     deferredTurns += Math.max(
       batch.pendingTurns - batch.processableTurns,
       0,
     );
-    jobs.push(
-      await options.queue.enqueue(
-        buildMemoryDistillEnqueue({
-          // The key binds the exact bounded due-turn window the handler can
-          // consume. Unchanged ticks dedupe; consuming any due turn changes the
-          // watermark, so a succeeded job cannot block the lane's next window.
-          sweepLabel: `${batch.batchHash}:s${maxSessions}:t${maxTurns}`,
-          namespace: batch.namespace,
-          laneId: batch.laneId,
-          maxSessions,
-          maxTurns,
-        }),
-      ),
+    const job = await options.queue.enqueue(
+      buildMemoryDistillEnqueue({
+        // The key binds the exact bounded due-turn window the handler can
+        // consume. Unchanged ticks dedupe; consuming any due turn changes the
+        // watermark, so a succeeded job cannot block the lane's next window.
+        //
+        // That reasoning holds ONLY while something actually consumes. When the
+        // claim returned no due turns (fixed in src/distill-window.ts), nothing
+        // was consumed, the watermark never moved, and this key stayed
+        // identical forever -- so every later insert was dropped by ON CONFLICT
+        // DO NOTHING while this loop went on counting them as enqueued.
+        // Observed: `distill_jobs_enqueued: 1` every 5 seconds against a
+        // newest job row six hours old.
+        sweepLabel: `${batch.batchHash}:s${maxSessions}:t${maxTurns}`,
+        namespace: batch.namespace,
+        laneId: batch.laneId,
+        maxSessions,
+        maxTurns,
+      }),
     );
+    // Count what the queue DID, not what was attempted. A deduped insert
+    // scheduled no work, and reporting it as an enqueue is what made a wedged
+    // lane read as a healthy one.
+    if (job.enqueueOutcome === "deduped") {
+      dedupedJobs++;
+      continue;
+    }
+    jobs.push(job);
   }
-  return { jobs, deferredTurns };
+  return { jobs, deferredTurns, dedupedJobs };
 }
 
 async function enqueueGraphBatches(
@@ -265,6 +295,7 @@ export async function runMaintenanceSweep(
   const summary: MaintenanceSweepSummary = {
     distillBatchesSelected: batches.length,
     distillJobsEnqueued: distill.jobs.length,
+    distillJobsDeduped: distill.dedupedJobs,
     distillBatchesDeferred: deferredBatches,
     distillTurnsDeferred: distill.deferredTurns,
     graphJobsEnqueued: graph.jobs.length,
@@ -273,6 +304,7 @@ export async function runMaintenanceSweep(
   options.logger.info("maintenance_sweep_complete", {
     distill_batches_selected: summary.distillBatchesSelected,
     distill_jobs_enqueued: summary.distillJobsEnqueued,
+    distill_jobs_deduped: summary.distillJobsDeduped,
     distill_batches_deferred: summary.distillBatchesDeferred,
     distill_turns_deferred: summary.distillTurnsDeferred,
     graph_jobs_enqueued: summary.graphJobsEnqueued,

--- a/src/maintenance-sweep.ts
+++ b/src/maintenance-sweep.ts
@@ -93,12 +93,28 @@ async function selectDistillLaneBatches(
           AND s.session_rank <= $1
         WHERE t.retention_tier = 'live'
      ),
+     -- RANK ONLY WORK THAT NEEDS DOING (#747). turn_rank is compared against
+     -- the batch bound downstream, so anything ranked here consumes a position
+     -- in that window. Ranking already-distilled turns alongside due ones let
+     -- finished work hold the whole window: measured 2026-08-25 on the dogfood
+     -- corpus, 2,070 already-distilled turns pushed the first due turn to rank
+     -- 1501 -- one past the bound -- so the producer selected 0 batches on
+     -- every tick for 27 days while 189,725 turns waited. Because finished
+     -- turns are re-ranked identically on each pass, the starvation was
+     -- permanent rather than transient, and it worsens as a namespace grows:
+     -- the four namespaces that kept working are simply small enough that all
+     -- their turns fit under the bound.
+     --
+     -- The is_due column stays SELECTed because the FILTER clauses and
+     -- batch_hash below still read it; this changes WHICH ROWS ARE RANKED,
+     -- not the shape of the result.
      ranked_window_turns AS (
        SELECT *, row_number() OVER (
                 PARTITION BY lane_id, namespace
                 ORDER BY ${DISTILL_ORDER_BY}
               ) AS turn_rank
          FROM window_turns
+        WHERE is_due
      ),
      lane_totals AS (
        SELECT lane_id, namespace, count(*)::int AS pending_turns,

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -348,8 +348,16 @@ export async function buildAgentContextPackPayload(
     (!args.requested_sections || args.requested_sections.includes("recovery"));
   const includeDurableLaneContext =
     args.requested_sections?.includes("durable_lane_context") === true;
+  // Absent requested_sections includes durable_memory (#744, operator decision
+  // 2026-08-25). Twin of the server tree; see the long note at
+  // server/tools/agent-context-pack.ts for the measurement and reasoning. The
+  // short form: working_set treated an absent requested_sections as INCLUDED
+  // and durable_memory as EXCLUDED one line apart, the Python client never sets
+  // the key, so every bare recall consulted no durable memory and reported
+  // success.
   const includeDurableMemorySection =
-    args.requested_sections?.includes("durable_memory") === true;
+    !args.requested_sections ||
+    args.requested_sections.includes("durable_memory");
   const includeProfileGuidance =
     args.requested_sections?.includes("profile_guidance") === true;
   const includeProcessGuidance =

--- a/src/tools/agent-context-pack.ts
+++ b/src/tools/agent-context-pack.ts
@@ -1007,6 +1007,27 @@ export async function buildAgentContextPackPayload(
             : requestedSections.filter(
                 (name) => !servedSections.includes(name),
               ),
+        // What a BARE call (no requested_sections) did not consult.
+        //
+        // `requested_not_served` is empty for a bare call and always will be:
+        // nothing was requested, so by its own definition nothing was withheld.
+        // That is truthful and useless. The caller receives an `ok` envelope
+        // listing only `working_set` and cannot distinguish "the durable corpus
+        // was searched and had nothing" from "the durable corpus was never
+        // consulted at all" -- and every default-shaped recall takes the second
+        // path.
+        //
+        // This field states the omission plainly instead. It changes no
+        // selection behaviour: which sections a bare call serves is a contract
+        // decision (docs/agent-context-pack-contract.md), not a receipt
+        // concern. It only stops the receipt from implying a completeness it
+        // never had.
+        not_consulted_by_default:
+          requestedSections === null
+            ? SECTION_NAMES.filter(
+                (name: string) => !servedSections.includes(name),
+              )
+            : [],
       },
       warnings: {
         scope_denials: [


### PR DESCRIPTION
Closes #744. Closes #747.

Nine commits fixing a bare recall that consulted no durable memory (#744) and
a maintenance queue that starved for 27 days (#747) have been sitting
unmerged, held back by three tests that asserted the pre-fix behavior their
own branch had deliberately changed.

The branch could not go green without either weakening a fix or correcting
the tests. All three are the latter, and each is checked against the design
that authorized the change rather than against the failure message.

**context-pack default receipt.** `8f1f2a8` made a bare recall consult
durable memory. `docs/agent-context-pack-contract.md:88` states the default
now serves `working_set` AND `durable_memory`. The test still expected
`[working_set]` -- precisely the shape #744 exists to remove.

**distill claim parameters.** `36a0b6e` bound `contextWindow` as a third
parameter (`src/distill-window.ts:239-250`). The test counted two. The count
was never the point, so it now asserts the invariant: three limit values,
none of them a namespace, which is what makes the sweep global.

**migration 026 constraint.** `047` replaced the all-states unique constraint
with a partial unique INDEX scoped to `queued`/`running`, so it lives in
`pg_indexes` and cannot appear in a `pg_constraint` query. The test now reads
both catalogs -- the two shape constraints where they live, and the live
idempotency index with its predicate -- and asserts the old name is gone.

## Verification

- Done-means: scripts/done-means/744-recall-serves-durable.sh
- Also on this branch: scripts/done-means/747-distill-claim-yields.sh,
  scripts/done-means/747-distill-sweep-yields.sh, and
  scripts/done-means/685-live-roles-not-accept-roles.sh
- Suite: `bun run test:isolated` -> 3802 pass, 35 skip, 0 fail (3837 tests
  across 248 files), run from a clean clone on the pushed tip.
- `bunx tsc --noEmit` -> clean, exit 0.
- Catalog placement confirmed against the live dogfood database before
  writing the assertion: `maintenance_jobs_live_idempotency` appears in
  `pg_indexes`, is absent from `pg_constraint`, and
  `maintenance_jobs_unique_kind_idempotency` is absent from both.
- Each of the three files was also run individually green: 28 pass, 25 pass,
  12 pass.

## Critical Self-Review

- Highest-risk behavior: updating a test to match a fix can mask a real
  regression. Mitigated by checking each against its authorizing design
  (contract doc, migration header, query source), not against the error text.
- Assumptions that could be wrong: that all three failures are stale tests
  rather than genuine breakage. Each fix's own commit message states the
  intended new behavior and the measured before/after, and the contract doc
  was updated in the same change as the code.
- Missing/weak tests: none added. These are corrections to existing coverage;
  the fixes they cover already carry their own done-means scripts.
- Security/permission risk: none. Test-only changes, no namespace, auth, or
  predicate logic touched.
- Migration/deploy risk: none from this commit. `047` itself is already on
  the branch and unchanged here; this only corrects what the test asserts
  about it.
- Downstream client/runtime risk: none from this commit. The #744 default
  change it unblocks is client-visible and documented in the contract doc.
- Rollback/cleanup concern: none. Revert is a single test-only commit.
- Fixes made before PR: none beyond the three assertions.
- Known residual risk: the branch has nine commits across two issues; if
  reviewers want them split per issue, the test corrections span both and
  would need to split with them.
- SME review-memory update: [x] not applicable because: these are corrections
  to existing tests, not a new review finding or missed pattern.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this commit is test-only
  and changes no runtime behavior; the underlying #744/#747 fixes carry their
  own done-means scripts on this branch.
