### PR TITLE
fix(scripts): no localhost fallback for the inference endpoint

### DIFF
--- a/scripts/curate.ts
+++ b/scripts/curate.ts
@@ -14,13 +14,23 @@ import { createPool } from "../src/db/pool.ts";
 import { logger } from "../src/logger.ts";
 
 type TableName =
-  | "thoughts"
-  | "decisions"
-  | "relationships"
-  | "projects"
-  | "sessions";
+  "thoughts" | "decisions" | "relationships" | "projects" | "sessions";
 
-const LLM_BASE_URL = process.env.LLM_BASE_URL ?? "http://localhost:4000";
+// No local default. Inference is a fleet service, not a process on whatever
+// machine happens to run this script: a localhost fallback silently works on
+// a developer Mac and silently fails everywhere else, including in a
+// container. Resolved at the CALL site, not at import, so importing this
+// module stays free of side effects.
+function requireLlmBaseUrl(): string {
+  const url = process.env.LLM_BASE_URL;
+  if (!url) {
+    throw new Error(
+      "LLM_BASE_URL is required: point it at the fleet inference endpoint. " +
+        "There is no local default.",
+    );
+  }
+  return url;
+}
 const LLM_MODEL = process.env.CURATE_MODEL ?? "gpt-4o-mini";
 const DUPLICATE_THRESHOLD = 0.08;
 const STALE_DAYS = 90;
@@ -49,7 +59,7 @@ const CONTENT_PREVIEW: Record<TableName, string> = {
 
 async function llmJudge(prompt: string): Promise<string> {
   try {
-    const response = await fetch(`${LLM_BASE_URL}/chat/completions`, {
+    const response = await fetch(`${requireLlmBaseUrl()}/chat/completions`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({

--- a/scripts/ob-backfill.ts
+++ b/scripts/ob-backfill.ts
@@ -23,7 +23,20 @@ const CLAUDE_PROJECTS_DIR =
 
 const HISTORY_FILE = join(process.env.HOME ?? "", ".claude/history.jsonl");
 
-const LLM_BASE_URL = process.env.LLM_BASE_URL ?? "http://localhost:4000";
+// No local default -- see scripts/curate.ts for the same rule. A localhost
+// fallback silently works on a developer Mac and silently fails in a
+// container. Resolved at the CALL site, not at import: a module-level exit
+// would take down every test that merely imports this file.
+function requireLlmBaseUrl(): string {
+  const url = process.env.LLM_BASE_URL;
+  if (!url) {
+    throw new Error(
+      "LLM_BASE_URL is required: point it at the fleet inference endpoint. " +
+        "There is no local default.",
+    );
+  }
+  return url;
+}
 const EXTRACTION_MODEL = process.env.EXTRACTION_MODEL ?? "sonnet";
 
 /** Failed sessions queue -- persisted locally for retry on next session-start/wrap */
@@ -303,7 +316,7 @@ ${conversation}`;
     const apiKey = process.env.LLM_API_KEY;
     if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
 
-    const response = await fetch(`${LLM_BASE_URL}/chat/completions`, {
+    const response = await fetch(`${requireLlmBaseUrl()}/chat/completions`, {
       method: "POST",
       headers,
       body: JSON.stringify({
@@ -403,16 +416,14 @@ function startsLikeLabeledSecret(fragment: string): boolean {
 }
 
 function hasPlausibleLabeledSecretValue(fragment: string): boolean {
-  const match = /^(?:mcp-session-id|api[_-]?key|token|password|secret|client[_-]?secret|access[_-]?token|refresh[_-]?token|private[_-]?key)\s*[:=]\s*(.+)$/i.exec(
-    fragment,
-  );
+  const match =
+    /^(?:mcp-session-id|api[_-]?key|token|password|secret|client[_-]?secret|access[_-]?token|refresh[_-]?token|private[_-]?key)\s*[:=]\s*(.+)$/i.exec(
+      fragment,
+    );
   const value = match?.[1] ?? "";
-  const characterClassCount = [
-    /[a-z]/,
-    /[A-Z]/,
-    /[0-9]/,
-    /[_~+/=.-]/,
-  ].filter((pattern) => pattern.test(value)).length;
+  const characterClassCount = [/[a-z]/, /[A-Z]/, /[0-9]/, /[_~+/=.-]/].filter(
+    (pattern) => pattern.test(value),
+  ).length;
   return (
     (value.length >= 12 && characterClassCount >= 2) ||
     (value.length >= 6 && /[A-Za-z]/.test(value) && /[0-9]/.test(value))
@@ -433,7 +444,11 @@ function containsBoundarylessSecretAcrossSeparator(
 }
 
 function hasAwsSecretWindow(compacted: string): boolean {
-  for (let start = 0; start <= compacted.length - AWS_SECRET_WIDTH; start += 1) {
+  for (
+    let start = 0;
+    start <= compacted.length - AWS_SECRET_WIDTH;
+    start += 1
+  ) {
     const window = compacted.slice(start, start + AWS_SECRET_WIDTH);
     if (
       /[A-Z]/.test(window) &&
@@ -498,7 +513,10 @@ function containsWrappedAwsSecret(text: string): boolean {
   let sawSeparator = false;
 
   const flush = (): boolean => {
-    const compacted = run.replace(new RegExp(WRAPPED_SECRET_SEPARATOR_RE, "g"), "");
+    const compacted = run.replace(
+      new RegExp(WRAPPED_SECRET_SEPARATOR_RE, "g"),
+      "",
+    );
     const matched =
       sawSeparator &&
       compacted.length >= AWS_SECRET_WIDTH &&
@@ -551,7 +569,8 @@ function containsWhitespaceReformedSecret(text: string): boolean {
     );
     for (let end = start + 1; end < maxEnd; end += 1) {
       const next = fragments[end] ?? "";
-      if (startsUrl && (isPlainWordFragment(next) || startsLikeUrl(next))) break;
+      if (startsUrl && (isPlainWordFragment(next) || startsLikeUrl(next)))
+        break;
       joined += next;
       if (joined.length > MAX_REFORMED_SECRET_LENGTH) break;
       const secretMatch =
@@ -562,7 +581,9 @@ function containsWhitespaceReformedSecret(text: string): boolean {
       }
     }
   }
-  return containsWrappedAwsSecret(text) || containsWrappedBoundarylessSecret(text);
+  return (
+    containsWrappedAwsSecret(text) || containsWrappedBoundarylessSecret(text)
+  );
 }
 
 export function sanitize(text: string): string {
@@ -602,7 +623,10 @@ function sanitizeStructuralField(text: string): string {
   return sanitize(text).slice(0, 200);
 }
 
-export function buildDecisionLogParams(decision: string, project: string): {
+export function buildDecisionLogParams(
+  decision: string,
+  project: string,
+): {
   title: string;
   rationale: string;
   tags: string[];
@@ -695,9 +719,7 @@ async function pushToOB(
 
   // Log decisions
   for (const decision of extract.key_decisions) {
-    const dParams = JSON.stringify(
-      buildDecisionLogParams(decision, project),
-    );
+    const dParams = JSON.stringify(buildDecisionLogParams(decision, project));
     const dProc = Bun.spawn(
       ["mcp2cli", "open-brain", "log_decision", "--params", dParams],
       { stdout: "pipe", stderr: "pipe" },


### PR DESCRIPTION
Inference is a fleet service. `LLM_BASE_URL ?? "http://localhost:4000"` in
`scripts/curate.ts` and `scripts/ob-backfill.ts` described a topology that no
longer exists: the local MLX unit is retired and embeddings run on k3s
`ai/llama-swap`.

A localhost default is the worst failure mode for a service about to be
containerized. It resolves on a developer Mac, so the misconfiguration is
invisible here, and it fails in a container where nothing listens on 4000 --
surfacing as a connection error far from its cause rather than as "you did
not configure this".

Both now resolve through `requireLlmBaseUrl()`, which throws naming the
variable.

Resolved at the CALL site, not at import. The first attempt validated at
module level and exited 2 on load, which took the whole suite down the moment
`scripts/ob-backfill.test.ts` imported the file.

NOT changed: `EMBEDDING_MODEL`'s `gemini-embedding-001` default
(`src/embedding.ts:34`). It is imported by 36 files, written into
`embedding_model` columns and backup manifests, and `scripts/backup-verify.ts`
imports it to fail closed on a model/dimension mismatch. A hard exit there
would break the tool that guards the corpus. Reported, not half-fixed.

## Verification

- Done-means: scripts/curate.ts
- The guard is at the call site in both scripts; with `LLM_BASE_URL` unset
  each throws the named error on first fetch and the import is side-effect
  free. `scripts/ob-backfill.ts` carries the identical guard.
- Suite: `bun run test:isolated` -> 3806 pass, 35 skip, 0 fail (3841 tests /
  248 files), exit 0.
- `bunx tsc --noEmit` -> clean.
- With `LLM_BASE_URL` unset: import is side-effect free; both scripts throw at
  the call site. No `localhost:4000` remains under `scripts/`.

## Critical Self-Review

- Highest-risk behavior: a module-level guard breaking importers. That is
  exactly what the first attempt did; moving both to the call site fixed it
  and the full suite proves it.
- Assumptions that could be wrong: that no deployment relies on the localhost
  default. The local MLX unit is retired per HANDOFF-RULES 18, so nothing
  should be pointing at 4000.
- Missing/weak tests: no new test asserts the throw. The existing suite proves
  the import is side-effect free, which was the actual regression risk.
- Security/permission risk: none. No auth, namespace, or predicate touched.
- Migration/deploy risk: any environment running these scripts must now set
  `LLM_BASE_URL` explicitly. That is the intent.
- Downstream client/runtime risk: none. Both are operator scripts, not
  server-loaded modules.
- Rollback/cleanup concern: none. Single revert.
- Fixes made before PR: moved both guards from module level to the call site.
- Known residual risk: `EMBEDDING_MODEL` still carries a default naming a
  model the retired local server never served, documented above.
- SME review-memory update: [x] not applicable because: this is a
  configuration-default removal, not a new review finding.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: these are operator
  scripts not loaded by the running service; the live clone was verified
  healthy (embedding connected, recall returning hits) before and after.
