### PR TITLE
docs(handoff): rules 19-21 and the k3s cutover run

### DIFF
--- a/_DOCS/HANDOFF-RULES.md
+++ b/_DOCS/HANDOFF-RULES.md
@@ -86,3 +86,23 @@ only when a session actually needed it.
     `10.71.1.11:8080` and the local MLX unit are dead; point nothing at them.
     The ingress has shown ~1-minute `503 no available server` windows
     (rtech-infra#1110); the clone rides through them.
+19. Branch is not tree. `rg` for a symbol in a checkout answers for the branch
+    CHECKED OUT, not for `main`, and an empty result reads as "main lacks
+    this" when it means "this branch lacks it". Twice on 2026-08-25 that
+    produced a confident wrong claim that external-embedder support was
+    stranded on the deploy branch; it was already merged. Ask git, not the
+    filesystem: `git show origin/main:<path>`, and settle "is it merged" by
+    CONTENT (`git diff origin/main <ref> -- <paths>`, empty = identical), not
+    by `git cherry`, which compares patch-ids and marks a squash-merged
+    commit as unmerged.
+20. A required-config guard goes at the CALL site, never at module level. A
+    top-level `process.exit()` on missing env fires on IMPORT, so any test
+    that imports the module takes the whole suite down with it -- observed
+    2026-08-26 in `scripts/ob-backfill.ts`, suite exit 2, zero tests
+    meaningful. Resolve through a `requireX()` the caller invokes.
+21. The k3s Postgres is `10.71.20.167:5432` (CNPG cluster `general`, PG 18.4,
+    pgvector 0.8.6, database `open_brain`, credentials in Vaultwarden under
+    "PostgreSQL - general open_brain"). The Mac's kubeconfig for the cluster
+    is `~/.kube/config-rtech-k3s` -- the DEFAULT context is a dead
+    `docker-desktop` and will make every `kubectl` call fail; export
+    KUBECONFIG before probing.

--- a/_DOCS/_handoff/2026-08-26-k3s-cutover.md
+++ b/_DOCS/_handoff/2026-08-26-k3s-cutover.md
@@ -1,0 +1,98 @@
+# Handoff — Open Brain leaves the Mac: restore to k3s, cut src/, containerize (2026-08-26)
+
+## State 0 — BASE
+Read /Volumes/ThunderBolt/Development/_DOCS/HANDOFF-BASE.md in full
+(181 lines). It is the standing contract for this session.
+- Any question this document does not directly override → the rules layers
+  answer it, nearest layer first.
+- Anything needed that neither the base nor this document covers → ask Rico
+  before acting.
+- Output discipline: minimum verbosity, pony/minimal-correct, output tokens
+  low. Rico will ask for more.
+- Layer 0.1: read open-brain/_DOCS/HANDOFF-RULES.md in full. Rules 19, 20, 21
+  are new (PR #767, unmerged): branch-is-not-tree, call-site guards, and the
+  k3s Postgres + kubeconfig trap.
+- Graph run, T2: live data, a live service, an external surface. The lane
+  chain is strictly sequential — each lane reads the previous lane's output.
+- Workers: Luna max via codex:codex-rescue, or Opus 5 low with a reason.
+
+## State 1 — ORIENT
+- Backup of the Mac corpus EXISTS and VERIFIES — RUNNING (`bun run scripts/backup-verify.ts --dir /Volumes/ThunderBolt/open-brain-local/backups/local-20260826-cutover` → exit 0, status passed, embedding model/dimension EQUAL)
+- Source `open_brain_local_20260724`: 4824 MB, 202,976 raw turns, 26,453 thoughts; dump 1.82 GB, 42 tables with data — RUNNING (`psql`, `pg_restore --list`)
+- Target `10.71.20.167:5432` db `open_brain` EMPTY, CNPG `general`, PG 18.4, pgvector 0.8.6, 3/3 healthy — RUNNING (`KUBECONFIG=~/.kube/config-rtech-k3s kubectl get cluster -n databases`)
+- Live clone still serves the MAC database at `127.0.0.1` — RUNNING (`curl -s http://10.71.1.20:3100/health` → revision ad3b59c, db connected, embedding connected)
+- Embedder external and correct: llama-swap returns 768-dim, model `embed-gemma-dense` — RUNNING (`curl https://llama-swap.rodaddy.live/v1/embeddings`)
+- `server/main.ts` imports 6 things from `src/` (2 are `import type`); 21 non-test server files import 28 distinct `src/` modules out of 145 — WRITTEN (`rg` census this session)
+- `src/index.ts` is the DOCUMENTED ROLLBACK and is still what `package.json:8` and `deploy/open-brain.service:10` start — WRITTEN (`_plans/463-server-rewrite-charter.md`, LAW-0 state WRITTEN, cutover NOT STARTED)
+- Open PRs: #765 (#744/#747 unblock, CI green, 13 pass), #766 (no localhost inference default), #767 (rules 19-21). #745 and #739 are older and not this run's — MERGED-pending
+- Mac checkout is dirty on `sprint/standards-fmt` (#750, ON HOLD by Rico) — leave it — WRITTEN
+- Graph mode: converted — RUNNING (`ls scripts/done-means/*.sh` → 61)
+Re-probe before dispatching:
+- `KUBECONFIG=~/.kube/config-rtech-k3s kubectl get cluster general -n databases`
+- `curl -s -m 5 http://10.71.1.20:3100/health`
+- `gh pr checks 765` and `766`
+
+## State 2 — LAND THE PAPERWORK
+Branch: `docs/handoff-rules-19-21` in the clean clone at
+`/Volumes/ThunderBolt/_tmp/open-brain/_scratch/clone-20260825` (rule 17: the
+Mac checkout is dirty and refuses every push). `git -C <clone>` is the form
+that satisfies the git guard; a `cd X && git push` compound is refused.
+Retire: none merged yet. Once #765/#766/#767 merge, delete their branches.
+Merge order: #767 (rules, docs-only), #765, #766.
+Scribe: #762 — started: `gh issue comment 762 --body-file <file>`
+Done-check: `gh pr list --state open` no longer lists 765, 766, 767.
+
+## State 3 — L2: restore the corpus to k3s and prove parity
+Tier: T2 — the data moves
+Deliverable: `open_brain` on 10.71.20.167 holding the corpus, with a parity receipt
+Scope: `pg_restore` from the verified set; credentials from Vaultwarden
+("PostgreSQL - general open_brain"); a parity script under `scripts/`
+Must NOT: touch or drop the Mac database; skip the parity check; point the
+live clone at the new host in this lane
+Record: #762
+Done-check: `psql -h 10.71.20.167 -U open_brain -At -c 'select count(*) from ob_raw_turns'` → 202976 (RED: not yet run)
+
+## State 4 — L3: cut server/ free of src/
+Tier: T2 — restructures the live entrypoint's dependencies
+Deliverable: `server/main.ts` runs with zero runtime imports from `src/`
+Scope: the 28 modules named in State 1; move them under `server/` with owned
+boundaries per `_plans/463-server-rewrite-charter.md` §2 (behavior frozen)
+Must NOT: change behavior; delete anything from `src/` in this lane; break the
+`src/index.ts` rollback
+Record: #463, #674
+Done-check: `rg -c 'from "\.\./src/' server/ -g '!*.test.ts'` → 0 hits (RED: not yet run)
+
+## State 5 — L4: flip the entrypoint and containerize
+Tier: T2 — changes what runs
+Deliverable: a Dockerfile over `server/main.ts`; `package.json` and
+`deploy/open-brain.service` naming it
+Scope: `Dockerfile`, `package.json`, `deploy/`, `.dockerignore`
+Must NOT: delete `src/` (it is the rollback until the image is proven serving)
+Record: #674, #675, #762
+Done-check: `curl -s <image>/health` → db connected true, embedding connected true (RED: not yet run)
+
+## State 6 — L5: retire src/
+Tier: T2 — deletion
+Deliverable: `src/` removed after a reachability audit
+Scope: `src/`, `package.json`, any script entrypoint still naming it
+Must NOT: delete on static reachability alone — charter §1.6 requires an
+export/reachability audit across `src/`, `scripts/`, package entrypoints, and
+tests, each deletion proven by red contract tests first
+Record: #463
+Done-check: `bun run test:isolated` → 0 fail with `src/` absent (RED: not yet run)
+
+## State FINAL — WRAP
+Invoke the handoff-author skill; next handoff passes the validator; `aqmd up`.
+
+## HANDED-OVER UNKNOWNS
+- Neither tenant on 10.71.20.167 is backed up: its `backup.sh` enumerates only
+  the bootstrap database. Open Brain gets no daily dump until that enumerates
+  databases at run time. Rico's call whether that gates the restore.
+- `EMBEDDING_MODEL` still defaults to `gemini-embedding-001` (src/embedding.ts:34),
+  a model the retired local server never served. 36 importers, written into
+  `embedding_model` columns and backup manifests, and backup-verify imports it
+  to fail closed on mismatch — so it needs its own change, not a one-liner.
+- Whether the live clone cuts over to k3s before or after the container exists.
+  L2 proves the data; L5 proves the image. Rico picks the order.
+- The dreaming work is explicitly LATER (Rico, this session). Not in this run.
+- #745 and #739 are open PRs from earlier sessions, unrelated to this run.


### PR DESCRIPTION
Two lessons from the cutover session, plus the next session's handoff.

**Rule 19 — branch is not tree.** Searching a checkout answers for the branch
CHECKED OUT, not for `main`. That produced two confidently wrong claims this
session: external-embedder support was reported stranded on the deploy branch
when `main` had carried it all along. `git cherry` agreed, because it compares
patch-ids and a squash-merged commit has a different one. Settle "is it
merged" by content diff.

**Rule 20 — required-config guards go at the CALL site.** A module-level
`process.exit()` on missing env fires on IMPORT, so the first version of the
`LLM_BASE_URL` guard took the entire suite down (exit 2, nothing meaningful
ran) the moment a test imported the file.

**Rule 21 — the k3s Postgres and its kubeconfig trap.** `10.71.20.167:5432`,
CNPG `general`, pgvector 0.8.6. The Mac's DEFAULT kubectl context is a dead
`docker-desktop`, which is why an earlier probe concluded no cluster database
existed while it was running; `~/.kube/config-rtech-k3s` is the one that works.

The handoff charts the cutover as a sequential T2 chain and passes the
validator (98 lines).

## Verification

- Done-means: not applicable because: docs-only change adding handoff rules
  and a handoff document; no behavior to gate. The handoff validator below is
  the executable check that applies.
- `_ob/skills/handoff-author/scripts/validate-handoff.sh` -> PASS, 98 lines,
  validator 2026-08-22.4.
- Docs-only: no source file touched, so the suite is unaffected.

## Critical Self-Review

- Highest-risk behavior: none. Two markdown files.
- Assumptions that could be wrong: that rules 19-21 generalize. Each is
  written from a specific failure this session with its receipt.
- Missing/weak tests: not applicable, docs-only.
- Security/permission risk: none. Rule 21 names a host and a Vaultwarden
  entry title; no credential is in the text.
- Migration/deploy risk: none.
- Downstream client/runtime risk: none.
- Rollback/cleanup concern: none.
- Fixes made before PR: seven validator failures corrected (missing graph-mode
  bullet, unbackticked branch, missing scribe command, four multi-line
  done-checks that broke the RED-receipt parser).
- Known residual risk: the handoff asserts a lane ordering Rico may want
  changed; that question is listed in HANDED-OVER UNKNOWNS.
- SME review-memory update: [x] not applicable because: these are handoff
  rules, captured in _DOCS/HANDOFF-RULES.md which is their home.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: docs-only change with no
  runtime effect.
