### PR TITLE
fix(verify-lane): install the PR head's dependencies before running the check

### DIFF
--- a/docs/lane-contract.md
+++ b/docs/lane-contract.md
@@ -87,6 +87,57 @@ Every lane, no exceptions:
 
 Newest first. Every entry: what changed, and the observation that forced it.
 
+### 2026-08-26 (round 34) — harvest of the verify-lane deps-at-head lane (PR #776, #775)
+
+- **verify-lane installed dependencies at `origin/main` and then verified the
+  PR head, so the first dependency-adding PR could not get a receipt.**
+  `lane-bootstrap.ts` cuts the verification worktree from `origin/main` and
+  runs `bun install --frozen-lockfile` THERE; verify-lane then hard-resets the
+  same worktree onto the PR head and never reinstalled. The SOURCE moved and
+  `node_modules` did not. Measured twice on #771, which adds `oxlint`: the
+  check died on `MISSING TOOL: .../node_modules/.bin/oxlint` and NO receipt was
+  posted, while a second install in that same worktree made the identical check
+  pass. Fixed by reinstalling when `package.json`/`bun.lock` differ between the
+  bootstrap ref and the head. `git diff --quiet` answers 0 for "same" and 1 for
+  "differs", so it cannot go through `capture()` (which throws on any non-zero
+  status); every OTHER status fails closed rather than being read as
+  "unchanged", because reading a broken comparison as "unchanged" reintroduces
+  the original defect exactly when git cannot compare.
+- **A test that shells out to git MUST pin `--git-dir` and `--work-tree` on
+  every call, and MUST assert `git init` succeeded before any other git call.**
+  A bare `-C <fixture>` does not fail when the fixture is not a repository — it
+  walks UP to the first enclosing one and operates there. One `mkdtempSync`
+  fixture came back without a `.git` (init did not take, nothing checked), so
+  the fixture's own `base` and `docs only` commits were authored into the
+  surrounding worktree as `verify-lane test <test@example.invalid>`, deleting
+  every tracked file in it, and the fixture's `git config` calls wrote
+  `core.bare=true`, the test identity, and `commit.gpgsign=false` into the
+  CLONE's `.git/config` (the controller restored it). Proven directly rather
+  than argued: against a non-repo directory, `git -C <d> rev-parse HEAD`
+  returns the enclosing worktree's HEAD while the pinned form returns
+  `fatal: not a git repository`. Recovery used `git update-ref` plus a mixed
+  reset, because the guard correctly refuses `git reset --hard` — the guard was
+  right and the workaround is the supported path, not a bypass.
+- **Test scratch is repo-relative `_scratch/`, never a hardcoded Mac path.**
+  Both the test and the done-means check defaulted to
+  `/Volumes/ThunderBolt/_tmp` when `OPENBRAIN_TEMP_WORKSPACE`/`DEV_TMP` were
+  unset. That is the operator's machine, so CI failed in both `check` and
+  `db-integration` with `EACCES: permission denied, mkdir '/Volumes'` on the
+  Linux runner. The repo already had the right shape
+  (`src/operator-doctor.test.ts:29`): a `_scratch/<name>/` directory resolved
+  from the repo root, already excluded by `.gitignore:119`. A fixture that
+  requires one machine's volume layout gates nothing in CI, which is where the
+  check most needs to run. Keeping the fixture inside the repo also bounds the
+  escape above — the worst a stray git call can reach is a directory the repo
+  already ignores.
+- **A check that can mutate the repository it verifies is a worse defect than
+  the one it gates.** Proving such a check is not "it exited 0": it is
+  `git config --list --local` and `git status --short` of the ENCLOSING repo,
+  before and after, plus confirming HEAD is unchanged and no fixture path shows
+  up as untracked. The escape above passed its own clauses green while
+  corrupting the branch it ran on; only inspecting the enclosing repo caught
+  it.
+
 ### 2026-08-26 (round 33) — harvest of the plans lane (PR #772) and the L1 lint-gate lane (PR #771)
 
 - **A docs-only PR still carries an executable done-means.** The merge gate

--- a/docs/sme/entries/2026-08-26-a-test-fixture-that-shells-out-to-git-escapes-into-the-enclosing-repository.md
+++ b/docs/sme/entries/2026-08-26-a-test-fixture-that-shells-out-to-git-escapes-into-the-enclosing-repository.md
@@ -1,0 +1,75 @@
+---
+lane: gotcha-agent
+order: 75
+---
+## [2026-08-26] A test fixture that shells out to git escapes into the enclosing repository
+
+**Provenance:** PR #776, issue #775. Severity: HIGH. Status: open.
+**Scope:** `scripts/*.test.ts`, `scripts/done-means/*.sh`, any test or check
+that builds a throwaway git repository.
+
+A done-means check and its unit test both built a scratch git repository and
+then drove it with `spawnSync("git", args, { cwd: fixture })` and
+`git -C "$FIXTURE"`. Both spellings look scoped and neither is: when the target
+directory is NOT a repository, git does not fail — it walks UP the directory
+tree to the first enclosing `.git` and operates on THAT.
+
+One `mkdtempSync` fixture came back without a `.git` directory. `git init` had
+not taken and nothing checked its exit code, so every subsequent call in the
+fixture's setup resolved to the surrounding worktree. The fixture's own commits
+— `base` and `docs only` — were authored into the branch under development as
+`verify-lane test <test@example.invalid>`, and because the fixture commits a
+tree containing only `package.json`, `bun.lock`, and `README.md`, the commit
+DELETED every other tracked file in the worktree. The setup's `git config`
+calls landed in the enclosing repository too, writing `core.bare=true`, the
+test identity, and `commit.gpgsign=false` into the clone's `.git/config`.
+
+The check reported all clauses PASS while doing this. Its assertions were about
+git's diff behavior on the fixture, which remained true; nothing in the check
+looked at the repository it was running inside. The corruption was found only
+because the branch was pushed and the diff was inspected.
+
+Two properties make this dangerous rather than merely annoying. First, the
+failure is silent and delayed: a fixture that fails to initialize produces no
+error, and the damage surfaces later as "why did my branch delete everything".
+Second, moving fixtures into the repo's own `_scratch/` (correct for CI
+portability — a hardcoded `/Volumes/...` default failed the Linux runner with
+`EACCES: permission denied, mkdir '/Volumes'`) puts the fixture strictly INSIDE
+the repository, which makes the upward walk shorter and guaranteed to find a
+target.
+
+The fix is two mechanical rules, both fail-closed. Pin `--git-dir <fixture>/.git`
+and `--work-tree <fixture>` on every call, which makes the walk impossible —
+git errors instead of finding a parent. And assert `git init` succeeded on BOTH
+its exit code and the resulting `.git` before any other git call runs, since an
+unchecked init is what enables the escape at all. Verified directly against a
+non-repo directory nested in the worktree:
+
+```
+git --git-dir <d>/.git --work-tree <d> rev-parse HEAD
+  -> fatal: not a git repository
+git -C <d> rev-parse HEAD
+  -> 365ae45          # the ENCLOSING worktree's HEAD
+```
+
+### Review Questions
+
+- **Does any test or check run git with a bare `cwd` or `-C` against a
+  directory it created?** That is the escape. Require `--git-dir` and
+  `--work-tree` on every invocation; `-C` alone scopes nothing when the target
+  is not a repository.
+- **Is `git init`'s success asserted, or assumed?** An init that silently did
+  not take converts every following call into an operation on the enclosing
+  repo. Check the exit code AND that `.git` exists before proceeding.
+- **Does the check inspect the repository it is running INSIDE?** A check that
+  can mutate its host must prove it did not: `git status --short`,
+  `git rev-parse HEAD`, and `git config --list --local` of the enclosing repo,
+  before and after. Green clauses are not evidence here — this one was green
+  throughout.
+- **Where does the fixture root come from?** Repo-relative `_scratch/`
+  (gitignored, `src/operator-doctor.test.ts:29`), never a hardcoded absolute
+  path. A `/Volumes/...` or `/Users/...` default is a test that only runs on one
+  machine, and it will fail CI rather than gate it.
+- **Would a stray write land somewhere the repo ignores?** Fixtures inside
+  `_scratch/` bound the blast radius even when the other rules are followed;
+  fixtures outside the repo do not.

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -2092,3 +2092,75 @@ resolves from the symbolic `HEAD`. **A seam added to make a gate testable is not
 the path that runs in production.** When a check drives a convenience entry
 point, at least one clause must drive the real invocation shape — for a pre-push
 hook, a genuine stdin range with a zero remote SHA.
+
+## [2026-08-26] A test fixture that shells out to git escapes into the enclosing repository
+
+**Provenance:** PR #776, issue #775. Severity: HIGH. Status: open.
+**Scope:** `scripts/*.test.ts`, `scripts/done-means/*.sh`, any test or check
+that builds a throwaway git repository.
+
+A done-means check and its unit test both built a scratch git repository and
+then drove it with `spawnSync("git", args, { cwd: fixture })` and
+`git -C "$FIXTURE"`. Both spellings look scoped and neither is: when the target
+directory is NOT a repository, git does not fail — it walks UP the directory
+tree to the first enclosing `.git` and operates on THAT.
+
+One `mkdtempSync` fixture came back without a `.git` directory. `git init` had
+not taken and nothing checked its exit code, so every subsequent call in the
+fixture's setup resolved to the surrounding worktree. The fixture's own commits
+— `base` and `docs only` — were authored into the branch under development as
+`verify-lane test <test@example.invalid>`, and because the fixture commits a
+tree containing only `package.json`, `bun.lock`, and `README.md`, the commit
+DELETED every other tracked file in the worktree. The setup's `git config`
+calls landed in the enclosing repository too, writing `core.bare=true`, the
+test identity, and `commit.gpgsign=false` into the clone's `.git/config`.
+
+The check reported all clauses PASS while doing this. Its assertions were about
+git's diff behavior on the fixture, which remained true; nothing in the check
+looked at the repository it was running inside. The corruption was found only
+because the branch was pushed and the diff was inspected.
+
+Two properties make this dangerous rather than merely annoying. First, the
+failure is silent and delayed: a fixture that fails to initialize produces no
+error, and the damage surfaces later as "why did my branch delete everything".
+Second, moving fixtures into the repo's own `_scratch/` (correct for CI
+portability — a hardcoded `/Volumes/...` default failed the Linux runner with
+`EACCES: permission denied, mkdir '/Volumes'`) puts the fixture strictly INSIDE
+the repository, which makes the upward walk shorter and guaranteed to find a
+target.
+
+The fix is two mechanical rules, both fail-closed. Pin `--git-dir <fixture>/.git`
+and `--work-tree <fixture>` on every call, which makes the walk impossible —
+git errors instead of finding a parent. And assert `git init` succeeded on BOTH
+its exit code and the resulting `.git` before any other git call runs, since an
+unchecked init is what enables the escape at all. Verified directly against a
+non-repo directory nested in the worktree:
+
+```
+git --git-dir <d>/.git --work-tree <d> rev-parse HEAD
+  -> fatal: not a git repository
+git -C <d> rev-parse HEAD
+  -> 365ae45          # the ENCLOSING worktree's HEAD
+```
+
+### Review Questions
+
+- **Does any test or check run git with a bare `cwd` or `-C` against a
+  directory it created?** That is the escape. Require `--git-dir` and
+  `--work-tree` on every invocation; `-C` alone scopes nothing when the target
+  is not a repository.
+- **Is `git init`'s success asserted, or assumed?** An init that silently did
+  not take converts every following call into an operation on the enclosing
+  repo. Check the exit code AND that `.git` exists before proceeding.
+- **Does the check inspect the repository it is running INSIDE?** A check that
+  can mutate its host must prove it did not: `git status --short`,
+  `git rev-parse HEAD`, and `git config --list --local` of the enclosing repo,
+  before and after. Green clauses are not evidence here — this one was green
+  throughout.
+- **Where does the fixture root come from?** Repo-relative `_scratch/`
+  (gitignored, `src/operator-doctor.test.ts:29`), never a hardcoded absolute
+  path. A `/Volumes/...` or `/Users/...` default is a test that only runs on one
+  machine, and it will fail CI rather than gate it.
+- **Would a stray write land somewhere the repo ignores?** Fixtures inside
+  `_scratch/` bound the blast radius even when the other rules are followed;
+  fixtures outside the repo do not.

--- a/scripts/done-means/775-verify-lane-installs-head-deps.sh
+++ b/scripts/done-means/775-verify-lane-installs-head-deps.sh
@@ -30,13 +30,16 @@
 # ---------------------------------------------------------------------------
 # Four clauses
 # ---------------------------------------------------------------------------
-# CLAUSE 1 — THE STEP EXISTS, BETWEEN THE RESET AND THE CHECK.
-#   Position is the whole fix. A reinstall placed before the hard reset would
-#   install origin/main's deps twice and change nothing; one placed after
-#   run-check would be too late. This clause reads the byte offsets of the
-#   `checkout-head` step line, the `deps-at-head` step, and the `run-check`
-#   note out of scripts/verify-lane.ts and requires that strict ordering,
-#   rather than merely asserting the string is present somewhere.
+# CLAUSE 1 — THE FIX IS PROVEN BY MUTATION, NOT BY BYTE OFFSETS.
+#   The earlier version of this clause located strings in verify-lane.ts by
+#   byte offset and asserted their order. That is structural, and a mutant that
+#   kept the strings while ignoring `diff.status` passed all four clauses
+#   (review round 1). So the status handling now lives INSIDE the exported
+#   `decideDepsAtHead()`, and this clause proves the test can actually kill a
+#   mutant: it copies the repo's verify-lane.ts to a scratch path, flips the
+#   fail-closed comparison (`!== 0 && !== 1` -> a condition that never fires),
+#   points the unit suite at the mutant, and REQUIRES the suite to fail. A
+#   green suite against a mutant means the suite proves nothing.
 #
 # CLAUSE 2 — BOTH PATHS ANNOUNCE THEMSELVES (nothing is adjusted silently).
 #   The unit suite drives decideDepsAtHead() both ways and asserts a
@@ -62,7 +65,17 @@
 #   the fix reintroduces the original defect whenever git cannot compare. This
 #   clause asserts verify-lane rejects any status outside {0, 1}.
 #
-# Exit 0 only when all four clauses pass. Exit 3 is a harness error (missing
+# CLAUSE 5 — NEGATIVE CONTROL: THE FIXTURES CANNOT TOUCH ANOTHER REPOSITORY.
+#   A check that can mutate the repository it verifies is a worse defect than
+#   the one it gates, and this check's own fixtures corrupted the branch under
+#   development while being authored. So it is proven, not asserted: a
+#   throwaway VICTIM repository is created, its `.git/config` and HEAD are
+#   hashed, the fixture work is then run with `GIT_DIR` deliberately POINTED AT
+#   THE VICTIM, and the victim's config and HEAD must be byte-identical
+#   afterwards. If the environment fence or the `--git-dir` pinning ever
+#   regresses, this clause goes red instead of a branch getting eaten.
+#
+# Exit 0 only when all five clauses pass. Exit 3 is a harness error (missing
 # tool / unreadable repo), which is NOT a fail of the thing under test.
 set -uo pipefail
 
@@ -86,32 +99,57 @@ CLAUSE1=FAIL; CLAUSE1_EVIDENCE=""
 CLAUSE2=FAIL; CLAUSE2_EVIDENCE=""
 CLAUSE3=FAIL; CLAUSE3_EVIDENCE=""
 CLAUSE4=FAIL; CLAUSE4_EVIDENCE=""
+# Repo-relative, matching src/operator-doctor.test.ts and this check's own unit
+# test: `_scratch/<name>/` under the repo root, already excluded by
+# .gitignore:119. The previous fallback hardcoded the operator's Mac
+# (`/Volumes/ThunderBolt/_tmp`), so CI died on `EACCES: permission denied,
+# mkdir '/Volumes'` — a Linux runner cannot create that path, and a done-means
+# check that only runs on one machine's volume layout gates nothing in CI.
+#
+# Keeping the fixture INSIDE the repo also bounds the escape guarded against
+# below: the worst a stray git call can reach is a directory the repo already
+# ignores.
+SCRATCH_BASE="$REPO_ROOT/_scratch/verify-lane-deps"
+mkdir -p "$SCRATCH_BASE" || fail_hard "cannot create scratch dir at $SCRATCH_BASE"
+
+CLAUSE5=FAIL; CLAUSE5_EVIDENCE=""
+
+# Pre-declared so the EXIT trap can reference them before they are assigned.
+MUTANT_DIR=""
+VICTIM=""
+FIXTURE=""
 
 # ---------------------------------------------------------------------------
-# CLAUSE 1 — the step sits between the hard reset and run-check.
+# CLAUSE 1 — mutation: flip the fail-closed branch, the unit suite MUST fail.
 # ---------------------------------------------------------------------------
-# `rg -bo` gives a byte offset per match; first match of each anchor is enough
-# because each appears once in main()'s linear flow.
-offset_of() {
-  rg -bo --no-filename "$1" "$SCRIPT" 2>/dev/null | head -n 1 | cut -d: -f1
-}
+# Structural checks (byte offsets of strings) cannot tell a real fix from a
+# mutant that keeps the strings. This runs the suite against a deliberately
+# broken copy of verify-lane.ts and requires it to go red.
+MUTANT_DIR="$SCRATCH_BASE/mutation-$$-$(date +%s)"
+mkdir -p "$MUTANT_DIR" || fail_hard "cannot create mutation dir at $MUTANT_DIR"
+MUTANT_SCRIPT="$MUTANT_DIR/verify-lane.ts"
+MUTANT_TEST="$MUTANT_DIR/verify-lane.test.ts"
 
-OFF_CHECKOUT="$(offset_of 'step\("checkout-head", `worktree at PR head')"
-OFF_DEPS="$(offset_of 'step\("deps-at-head", depsDecision\.detail\)')"
-OFF_RUNCHECK="$(offset_of 'note\("run-check",')"
+# The mutation: make the fail-closed guard unreachable, so any status is
+# treated as a normal answer. This is exactly the defect the guard exists to
+# prevent, expressed as a one-token change.
+sed 's/diffStatus !== 0 \&\& diffStatus !== 1/diffStatus === 999999/' \
+  "$SCRIPT" > "$MUTANT_SCRIPT"
+# The test imports "./verify-lane.ts", so a sibling copy points at the mutant.
+sed 's#"\./verify-lane\.ts"#"./verify-lane.ts"#' \
+  "$REPO_ROOT/$TEST_REL" > "$MUTANT_TEST"
 
-if [ -z "$OFF_CHECKOUT" ] || [ -z "$OFF_DEPS" ] || [ -z "$OFF_RUNCHECK" ]; then
-  CLAUSE1_EVIDENCE="anchor missing in $SCRIPT_REL — checkout-head:${OFF_CHECKOUT:-none} deps-at-head:${OFF_DEPS:-none} run-check:${OFF_RUNCHECK:-none}"
-elif [ "$OFF_CHECKOUT" -lt "$OFF_DEPS" ] && [ "$OFF_DEPS" -lt "$OFF_RUNCHECK" ]; then
-  # It must also actually install, not merely print a line.
-  if rg -q 'capture\("deps-at-head", "bun", \["install", "--frozen-lockfile"\]' "$SCRIPT"; then
-    CLAUSE1=PASS
-    CLAUSE1_EVIDENCE="deps-at-head at byte $OFF_DEPS, strictly between checkout-head ($OFF_CHECKOUT) and run-check ($OFF_RUNCHECK), and it runs bun install --frozen-lockfile through capture() (fail-loud)"
-  else
-    CLAUSE1_EVIDENCE="deps-at-head is ordered correctly but never runs bun install --frozen-lockfile via capture() — a step line with no install is a receipt for work that did not happen"
-  fi
+if ! rg -q 'diffStatus === 999999' "$MUTANT_SCRIPT"; then
+  CLAUSE1_EVIDENCE="the mutation did not apply — no 'diffStatus !== 0 && diffStatus !== 1' guard found in $SCRIPT_REL to flip. Either the guard moved or the fix is absent."
 else
-  CLAUSE1_EVIDENCE="wrong order — checkout-head:$OFF_CHECKOUT deps-at-head:$OFF_DEPS run-check:$OFF_RUNCHECK (required: checkout-head < deps-at-head < run-check)"
+  MUT_OUT="$(cd "$REPO_ROOT" && bun test "$MUTANT_TEST" 2>&1)"
+  MUT_STATUS=$?
+  if [ "$MUT_STATUS" -ne 0 ]; then
+    CLAUSE1=PASS
+    CLAUSE1_EVIDENCE="mutant (fail-closed guard disabled) makes the unit suite exit $MUT_STATUS — the suite can kill it. Mutant kept at $MUTANT_SCRIPT"
+  else
+    CLAUSE1_EVIDENCE="THE SUITE PASSED AGAINST A MUTANT. Disabling the fail-closed guard changed no test outcome, so the tests prove nothing about status handling. Mutant at $MUTANT_SCRIPT"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -130,41 +168,56 @@ fi
 # ---------------------------------------------------------------------------
 # CLAUSE 3 — the comparison fires on a real dependency-adding head.
 # ---------------------------------------------------------------------------
-# Repo-relative, matching src/operator-doctor.test.ts and this check's own unit
-# test: `_scratch/<name>/` under the repo root, already excluded by
-# .gitignore:119. The previous fallback hardcoded the operator's Mac
-# (`/Volumes/ThunderBolt/_tmp`), so CI died on `EACCES: permission denied,
-# mkdir '/Volumes'` — a Linux runner cannot create that path, and a done-means
-# check that only runs on one machine's volume layout gates nothing in CI.
-#
-# Keeping the fixture INSIDE the repo also bounds the escape guarded against
-# below: the worst a stray git call can reach is a directory the repo already
-# ignores.
-SCRATCH_BASE="$REPO_ROOT/_scratch/verify-lane-deps"
-mkdir -p "$SCRATCH_BASE" || fail_hard "cannot create scratch dir at $SCRATCH_BASE"
+
 # NOT mktemp -d (AGENTS.md hard rule: it resolves to a sandbox-local $TMPDIR
 # that no other process can see). An explicit path, unique by pid + epoch so
 # concurrent runs cannot collide.
 FIXTURE="$SCRATCH_BASE/fixture-$$-$(date +%s)"
 mkdir -p "$FIXTURE" || fail_hard "cannot create fixture dir at $FIXTURE"
 
+# Archive on EVERY exit path, with mv — never rm (AGENTS.md: an agent runs no
+# recursive delete). _scratch/ is repo-relative now, so fixtures would otherwise
+# pile up inside the checkout on every run.
+ARCHIVE_DIR="$REPO_ROOT/_scratch/_archive/verify-lane-deps"
+RUN_ID="$$-$(date +%s)"
+archive_scratch() {
+  mkdir -p "$ARCHIVE_DIR/$RUN_ID" 2>/dev/null || return 0
+  for d in "$FIXTURE" "$MUTANT_DIR" "$VICTIM"; do
+    [ -n "${d:-}" ] && [ -d "$d" ] && mv "$d" "$ARCHIVE_DIR/$RUN_ID/" 2>/dev/null
+  done
+  printf '  scratch archived to: %s\n' "$ARCHIVE_DIR/$RUN_ID"
+}
+trap archive_scratch EXIT
+
 # Pin BOTH the git dir and the work tree, never a bare -C. With only -C, git
 # walks UP to the first enclosing repository when the fixture is not one, so a
 # failed init would commit these fixture commits into the surrounding worktree
 # — observed during authoring, and it deleted every tracked file there. With
 # the git dir pinned, that walk cannot happen: git errors instead.
+# Environment fence for EVERY git call below. The --git-dir/--work-tree flags
+# pin the target, but they are only as good as the next person remembering
+# them; these variables would override or redirect a call that lost its flags.
+# GIT_CEILING_DIRECTORIES stops the upward discovery walk at the fixture's
+# parent, so even a fully unflagged `git` cannot reach the enclosing checkout.
+git_fenced() {
+  env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY \
+      -u GIT_ALTERNATE_OBJECT_DIRECTORIES -u GIT_COMMON_DIR \
+      GIT_CEILING_DIRECTORIES="$SCRATCH_BASE" \
+      git "$@"
+}
 fixture_git() {
-  git --git-dir "$FIXTURE/.git" --work-tree "$FIXTURE" "$@" >/dev/null 2>&1
+  git_fenced --git-dir "$FIXTURE/.git" --work-tree "$FIXTURE" "$@" >/dev/null 2>&1
 }
 fixture_git_out() {
-  git --git-dir "$FIXTURE/.git" --work-tree "$FIXTURE" "$@" 2>/dev/null
+  git_fenced --git-dir "$FIXTURE/.git" --work-tree "$FIXTURE" "$@" 2>/dev/null
 }
 
-# "fixture", not "main": the operator's global protected-branch hook refuses
-# commits to main even in a throwaway repo, and the branch name proves nothing.
-# `init` predates the repo, so it cannot use the pinned helper. Its success is
-# ASSERTED (exit code AND the resulting .git) before any other git call runs.
-git -C "$FIXTURE" init --quiet -b fixture >/dev/null 2>&1
+# `init` predates the repo, and it was previously the ONE unpinned call here.
+# Unpinned it would re-initialise whatever an inherited GIT_DIR pointed at,
+# BEFORE the missing-.git assertion below could run — so it is pinned and
+# fenced like every other call. Its success is then ASSERTED on both the exit
+# code and the resulting .git; an unchecked init is what enables the escape.
+git_fenced --git-dir "$FIXTURE/.git" --work-tree "$FIXTURE" init --quiet -b fixture >/dev/null 2>&1
 INIT_STATUS=$?
 if [ "$INIT_STATUS" -ne 0 ] || [ ! -d "$FIXTURE/.git" ]; then
   fail_hard "git init failed in $FIXTURE (exit $INIT_STATUS, .git present: $([ -d "$FIXTURE/.git" ] && echo yes || echo no)). Refusing to run git here — every later call would walk up to the enclosing repository and commit into it."
@@ -214,27 +267,82 @@ fi
 # ---------------------------------------------------------------------------
 # CLAUSE 4 — any exit code outside {0,1} fails loudly.
 # ---------------------------------------------------------------------------
-if rg -q 'diff\.status !== 0 && diff\.status !== 1' "$SCRIPT" \
-  && rg -q 'Refusing to guess whether the head' "$SCRIPT"; then
+# The guard now lives inside the exported decideDepsAtHead(), which is where
+# the unit suite can reach it (review round 1, P2). Assert the function owns it
+# AND that it takes the RAW status — a boolean parameter would put the branch
+# back at the call site where clause 1's mutant survived.
+if rg -q 'diffStatus !== 0 && diffStatus !== 1' "$SCRIPT" \
+  && rg -q 'diffStatus: number \| null' "$SCRIPT" \
+  && rg -q 'Refusing to guess whether' "$SCRIPT"; then
   CLAUSE4=PASS
-  CLAUSE4_EVIDENCE="verify-lane rejects any git diff status outside {0,1} rather than reading it as 'unchanged'"
+  CLAUSE4_EVIDENCE="decideDepsAtHead() takes the raw git exit code (diffStatus: number | null) and throws on anything outside {0,1} rather than reading it as 'unchanged'"
 else
-  CLAUSE4_EVIDENCE="no fail-closed guard on the git diff exit code — a bad ref or missing object would be read as 'manifests match' and skip the install, which is the original defect"
+  CLAUSE4_EVIDENCE="no fail-closed guard inside decideDepsAtHead(), or it no longer takes the raw status — a bad ref or missing object would be read as 'manifests match' and skip the install, which is the original defect"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 5 — negative control: a hostile GIT_DIR must not reach another repo.
+# ---------------------------------------------------------------------------
+# Create a VICTIM repository, hash its config and HEAD, then re-run the fixture
+# work with GIT_DIR deliberately pointed at the victim. Byte-identical after is
+# the assertion. This is what proves the fence, rather than asserting it.
+VICTIM="$SCRATCH_BASE/victim-$$-$(date +%s)"
+mkdir -p "$VICTIM" || fail_hard "cannot create victim dir at $VICTIM"
+
+env -u GIT_DIR -u GIT_WORK_TREE GIT_CEILING_DIRECTORIES="$SCRATCH_BASE" \
+  git --git-dir "$VICTIM/.git" --work-tree "$VICTIM" init --quiet -b victim >/dev/null 2>&1
+if [ ! -d "$VICTIM/.git" ]; then
+  CLAUSE5_EVIDENCE="could not create the victim repository at $VICTIM"
+else
+  env -u GIT_DIR -u GIT_WORK_TREE GIT_CEILING_DIRECTORIES="$SCRATCH_BASE" \
+    git --git-dir "$VICTIM/.git" --work-tree "$VICTIM" config user.email "victim@example.invalid" >/dev/null 2>&1
+  env -u GIT_DIR -u GIT_WORK_TREE GIT_CEILING_DIRECTORIES="$SCRATCH_BASE" \
+    git --git-dir "$VICTIM/.git" --work-tree "$VICTIM" config user.name "victim" >/dev/null 2>&1
+  printf 'victim\n' > "$VICTIM/keepme.txt"
+  env -u GIT_DIR -u GIT_WORK_TREE GIT_CEILING_DIRECTORIES="$SCRATCH_BASE" \
+    git --git-dir "$VICTIM/.git" --work-tree "$VICTIM" add . >/dev/null 2>&1
+  env -u GIT_DIR -u GIT_WORK_TREE GIT_CEILING_DIRECTORIES="$SCRATCH_BASE" \
+    git --git-dir "$VICTIM/.git" --work-tree "$VICTIM" commit --quiet -m victim >/dev/null 2>&1
+
+  V_CONFIG_BEFORE="$(shasum "$VICTIM/.git/config" | cut -d" " -f1)"
+  V_HEAD_BEFORE="$(env -u GIT_DIR -u GIT_WORK_TREE git --git-dir "$VICTIM/.git" rev-parse HEAD 2>/dev/null)"
+
+  # The hostile part: GIT_DIR points at the victim while the fixture helpers run.
+  HOSTILE="$SCRATCH_BASE/hostile-$$-$(date +%s)"
+  mkdir -p "$HOSTILE"
+  SAVED_FIXTURE="$FIXTURE"
+  FIXTURE="$HOSTILE"
+  GIT_DIR="$VICTIM/.git" GIT_WORK_TREE="$VICTIM" \
+    git_fenced --git-dir "$FIXTURE/.git" --work-tree "$FIXTURE" init --quiet -b fixture >/dev/null 2>&1
+  GIT_DIR="$VICTIM/.git" GIT_WORK_TREE="$VICTIM" fixture_git config user.email "test@example.invalid"
+  GIT_DIR="$VICTIM/.git" GIT_WORK_TREE="$VICTIM" fixture_git config commit.gpgsign false
+  printf 'x\n' > "$FIXTURE/package.json"
+  GIT_DIR="$VICTIM/.git" GIT_WORK_TREE="$VICTIM" fixture_git add .
+  FIXTURE="$SAVED_FIXTURE"
+
+  V_CONFIG_AFTER="$(shasum "$VICTIM/.git/config" | cut -d" " -f1)"
+  V_HEAD_AFTER="$(env -u GIT_DIR -u GIT_WORK_TREE git --git-dir "$VICTIM/.git" rev-parse HEAD 2>/dev/null)"
+
+  if [ "$V_CONFIG_BEFORE" = "$V_CONFIG_AFTER" ] && [ "$V_HEAD_BEFORE" = "$V_HEAD_AFTER" ] && [ -n "$V_HEAD_BEFORE" ]; then
+    CLAUSE5=PASS
+    CLAUSE5_EVIDENCE="victim untouched with GIT_DIR aimed at it — config sha $V_CONFIG_BEFORE and HEAD $V_HEAD_BEFORE identical before/after; victim at $VICTIM"
+  else
+    CLAUSE5_EVIDENCE="VICTIM MUTATED. config $V_CONFIG_BEFORE -> $V_CONFIG_AFTER, HEAD $V_HEAD_BEFORE -> $V_HEAD_AFTER. The fence does not hold; a fixture can reach another repository."
+  fi
 fi
 
 # ---------------------------------------------------------------------------
 # Report
 # ---------------------------------------------------------------------------
 printf '\n#775 — verify-lane installs the PR head'"'"'s dependencies\n\n'
-printf '  CLAUSE 1 (step ordered between reset and check): %s\n    %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+printf '  CLAUSE 1 (mutant killed: suite fails on flipped guard): %s\n    %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
 printf '  CLAUSE 2 (both paths announce themselves):       %s\n    %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
 printf '  CLAUSE 3 (comparison fires on a real head):      %s\n    %s\n' "$CLAUSE3" "$CLAUSE3_EVIDENCE"
 printf '  CLAUSE 4 (fail-closed on an unusable compare):   %s\n    %s\n' "$CLAUSE4" "$CLAUSE4_EVIDENCE"
+printf '  CLAUSE 5 (negative control: victim untouched):   %s\n    %s\n' "$CLAUSE5" "$CLAUSE5_EVIDENCE"
 printf '\n'
-printf '  Fixture repositories are LEFT IN PLACE under %s —\n' "$SCRATCH_BASE"
-printf '  teardown is printed, never executed. Remove them yourself when done.\n\n'
 
-if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ] && [ "$CLAUSE4" = PASS ]; then
+if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ] && [ "$CLAUSE4" = PASS ] && [ "$CLAUSE5" = PASS ]; then
   printf 'PASS — verify-lane reinstalls at the PR head and says which path it took.\n\n'
   exit 0
 fi

--- a/scripts/done-means/775-verify-lane-installs-head-deps.sh
+++ b/scripts/done-means/775-verify-lane-installs-head-deps.sh
@@ -138,12 +138,29 @@ mkdir -p "$SCRATCH_BASE" || fail_hard "cannot create scratch dir at $SCRATCH_BAS
 FIXTURE="$SCRATCH_BASE/775-deps-fixture-$$-$(date +%s)"
 mkdir -p "$FIXTURE" || fail_hard "cannot create fixture dir at $FIXTURE"
 
-fixture_git() { git -C "$FIXTURE" "$@" >/dev/null 2>&1; }
+# Pin BOTH the git dir and the work tree, never a bare -C. With only -C, git
+# walks UP to the first enclosing repository when the fixture is not one, so a
+# failed init would commit these fixture commits into the surrounding worktree
+# — observed during authoring, and it deleted every tracked file there. With
+# the git dir pinned, that walk cannot happen: git errors instead.
+fixture_git() {
+  git --git-dir "$FIXTURE/.git" --work-tree "$FIXTURE" "$@" >/dev/null 2>&1
+}
+fixture_git_out() {
+  git --git-dir "$FIXTURE/.git" --work-tree "$FIXTURE" "$@" 2>/dev/null
+}
 
 # "fixture", not "main": the operator's global protected-branch hook refuses
 # commits to main even in a throwaway repo, and the branch name proves nothing.
-if fixture_git init --quiet -b fixture \
-  && fixture_git config user.email "test@example.invalid" \
+# `init` predates the repo, so it cannot use the pinned helper. Its success is
+# ASSERTED (exit code AND the resulting .git) before any other git call runs.
+git -C "$FIXTURE" init --quiet -b fixture >/dev/null 2>&1
+INIT_STATUS=$?
+if [ "$INIT_STATUS" -ne 0 ] || [ ! -d "$FIXTURE/.git" ]; then
+  fail_hard "git init failed in $FIXTURE (exit $INIT_STATUS, .git present: $([ -d "$FIXTURE/.git" ] && echo yes || echo no)). Refusing to run git here — every later call would walk up to the enclosing repository and commit into it."
+fi
+
+if fixture_git config user.email "test@example.invalid" \
   && fixture_git config user.name "775 done-means" \
   && fixture_git config core.hooksPath "$FIXTURE/.git/no-hooks" \
   && fixture_git config commit.gpgsign false; then
@@ -153,25 +170,25 @@ if fixture_git init --quiet -b fixture \
   printf 'base\n'          > "$FIXTURE/README.md"
   fixture_git add .
   fixture_git commit --quiet -m base
-  BASE_SHA="$(git -C "$FIXTURE" rev-parse HEAD 2>/dev/null)"
+  BASE_SHA="$(fixture_git_out rev-parse HEAD)"
 
   # A head that adds a devDependency — #771's shape.
   printf '{"name":"t","devDependencies":{"oxlint":"1.0.0"}}\n' > "$FIXTURE/package.json"
   printf 'lock-v1\noxlint\n'                                   > "$FIXTURE/bun.lock"
   fixture_git add .
   fixture_git commit --quiet -m "add oxlint"
-  DEP_SHA="$(git -C "$FIXTURE" rev-parse HEAD 2>/dev/null)"
+  DEP_SHA="$(fixture_git_out rev-parse HEAD)"
 
   # A head that touches neither manifest.
   fixture_git reset --hard --quiet "$BASE_SHA"
   printf 'changed\n' > "$FIXTURE/README.md"
   fixture_git add .
   fixture_git commit --quiet -m "docs only"
-  DOC_SHA="$(git -C "$FIXTURE" rev-parse HEAD 2>/dev/null)"
+  DOC_SHA="$(fixture_git_out rev-parse HEAD)"
 
-  git -C "$FIXTURE" diff --quiet "$BASE_SHA" "$DEP_SHA" -- package.json bun.lock
+  fixture_git diff --quiet "$BASE_SHA" "$DEP_SHA" -- package.json bun.lock
   DEP_STATUS=$?
-  git -C "$FIXTURE" diff --quiet "$BASE_SHA" "$DOC_SHA" -- package.json bun.lock
+  fixture_git diff --quiet "$BASE_SHA" "$DOC_SHA" -- package.json bun.lock
   DOC_STATUS=$?
 
   if [ "$DEP_STATUS" -eq 1 ] && [ "$DOC_STATUS" -eq 0 ]; then

--- a/scripts/done-means/775-verify-lane-installs-head-deps.sh
+++ b/scripts/done-means/775-verify-lane-installs-head-deps.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for #775 — verify-lane must install the PR HEAD's
+# dependencies before it runs the done-means check.
+#
+#   bash scripts/done-means/775-verify-lane-installs-head-deps.sh
+#
+# ---------------------------------------------------------------------------
+# The defect this gates
+# ---------------------------------------------------------------------------
+# verify-lane stands its verification worktree up in two moves that disagreed
+# about which commit's dependencies were installed:
+#
+#   1. scripts/lane-bootstrap.ts cuts the worktree from origin/main and runs
+#      `bun install --frozen-lockfile` THERE, so node_modules describes
+#      origin/main.
+#   2. verify-lane then `git fetch origin <sha>` + `git reset --hard <headSha>`
+#      moves the SOURCE onto the PR head — and never reinstalls.
+#   3. The done-means check runs against that mismatched tree.
+#
+# Measured twice on 2026-08-25 against PR #771 (head 2d67702), which adds
+# `oxlint` as a devDependency: the check died on
+# `MISSING TOOL: .../node_modules/.bin/oxlint` and NO receipt was posted, while
+# a second `bun install --frozen-lockfile` in that same verification worktree
+# installed the 2 missing packages and the identical check passed.
+#
+# So: any PR that adds or bumps a dependency was structurally unable to earn a
+# receipt, and the failure presented as the lane's check being broken rather
+# than as a verify-lane environment defect.
+#
+# ---------------------------------------------------------------------------
+# Four clauses
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — THE STEP EXISTS, BETWEEN THE RESET AND THE CHECK.
+#   Position is the whole fix. A reinstall placed before the hard reset would
+#   install origin/main's deps twice and change nothing; one placed after
+#   run-check would be too late. This clause reads the byte offsets of the
+#   `checkout-head` step line, the `deps-at-head` step, and the `run-check`
+#   note out of scripts/verify-lane.ts and requires that strict ordering,
+#   rather than merely asserting the string is present somewhere.
+#
+# CLAUSE 2 — BOTH PATHS ANNOUNCE THEMSELVES (nothing is adjusted silently).
+#   The unit suite drives decideDepsAtHead() both ways and asserts a
+#   "reinstalled: ..." line when the manifests differ and an "unchanged: ..."
+#   line when they match. A no-op that prints nothing is indistinguishable
+#   from a step that never ran, which is the exact reading failure AGENTS.md's
+#   "Nothing is adjusted silently" rule exists to prevent. This clause runs
+#   scripts/verify-lane.test.ts and requires it green.
+#
+# CLAUSE 3 — THE SIGNAL IS REAL, ON A REPOSITORY THAT ADDS A DEPENDENCY.
+#   Build a throwaway git repository whose head adds a devDependency — #771's
+#   shape — and run the SAME `git diff --quiet <base> <head> -- package.json
+#   bun.lock` comparison verify-lane runs. It must report a difference (exit 1)
+#   for the dependency-adding head and no difference (exit 0) for a head that
+#   touches only unrelated files. This is what stops the fix from being a
+#   comparison that can never fire.
+#
+# CLAUSE 4 — FAIL-CLOSED ON AN UNUSABLE COMPARISON.
+#   `git diff --quiet` answers 0 for "same" and 1 for "differs", so a
+#   non-zero exit is a normal answer and cannot go through capture(), which
+#   throws on any non-zero status. Every OTHER exit code (a bad ref, a missing
+#   object) must fail loudly instead of being read as "unchanged" — otherwise
+#   the fix reintroduces the original defect whenever git cannot compare. This
+#   clause asserts verify-lane rejects any status outside {0, 1}.
+#
+# Exit 0 only when all four clauses pass. Exit 3 is a harness error (missing
+# tool / unreadable repo), which is NOT a fail of the thing under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_REL="scripts/verify-lane.ts"
+SCRIPT="$REPO_ROOT/$SCRIPT_REL"
+TEST_REL="scripts/verify-lane.test.ts"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v git >/dev/null 2>&1 || fail_hard "git not on PATH"
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+command -v rg  >/dev/null 2>&1 || fail_hard "rg (ripgrep) not on PATH"
+[ -r "$SCRIPT" ] || fail_hard "no $SCRIPT_REL at $REPO_ROOT"
+[ -r "$REPO_ROOT/$TEST_REL" ] || fail_hard "no $TEST_REL at $REPO_ROOT"
+
+CLAUSE1=FAIL; CLAUSE1_EVIDENCE=""
+CLAUSE2=FAIL; CLAUSE2_EVIDENCE=""
+CLAUSE3=FAIL; CLAUSE3_EVIDENCE=""
+CLAUSE4=FAIL; CLAUSE4_EVIDENCE=""
+
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — the step sits between the hard reset and run-check.
+# ---------------------------------------------------------------------------
+# `rg -bo` gives a byte offset per match; first match of each anchor is enough
+# because each appears once in main()'s linear flow.
+offset_of() {
+  rg -bo --no-filename "$1" "$SCRIPT" 2>/dev/null | head -n 1 | cut -d: -f1
+}
+
+OFF_CHECKOUT="$(offset_of 'step\("checkout-head", `worktree at PR head')"
+OFF_DEPS="$(offset_of 'step\("deps-at-head", depsDecision\.detail\)')"
+OFF_RUNCHECK="$(offset_of 'note\("run-check",')"
+
+if [ -z "$OFF_CHECKOUT" ] || [ -z "$OFF_DEPS" ] || [ -z "$OFF_RUNCHECK" ]; then
+  CLAUSE1_EVIDENCE="anchor missing in $SCRIPT_REL — checkout-head:${OFF_CHECKOUT:-none} deps-at-head:${OFF_DEPS:-none} run-check:${OFF_RUNCHECK:-none}"
+elif [ "$OFF_CHECKOUT" -lt "$OFF_DEPS" ] && [ "$OFF_DEPS" -lt "$OFF_RUNCHECK" ]; then
+  # It must also actually install, not merely print a line.
+  if rg -q 'capture\("deps-at-head", "bun", \["install", "--frozen-lockfile"\]' "$SCRIPT"; then
+    CLAUSE1=PASS
+    CLAUSE1_EVIDENCE="deps-at-head at byte $OFF_DEPS, strictly between checkout-head ($OFF_CHECKOUT) and run-check ($OFF_RUNCHECK), and it runs bun install --frozen-lockfile through capture() (fail-loud)"
+  else
+    CLAUSE1_EVIDENCE="deps-at-head is ordered correctly but never runs bun install --frozen-lockfile via capture() — a step line with no install is a receipt for work that did not happen"
+  fi
+else
+  CLAUSE1_EVIDENCE="wrong order — checkout-head:$OFF_CHECKOUT deps-at-head:$OFF_DEPS run-check:$OFF_RUNCHECK (required: checkout-head < deps-at-head < run-check)"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 2 — both branches announce themselves; the unit suite proves it.
+# ---------------------------------------------------------------------------
+TEST_OUT="$(cd "$REPO_ROOT" && bun test "$TEST_REL" 2>&1)"
+TEST_STATUS=$?
+TEST_TALLY="$(printf '%s\n' "$TEST_OUT" | rg -o '[0-9]+ pass' | head -n 1)"
+if [ "$TEST_STATUS" -eq 0 ]; then
+  CLAUSE2=PASS
+  CLAUSE2_EVIDENCE="$TEST_REL green (${TEST_TALLY:-tally unavailable}) — covers the reinstalled path, the unchanged path, and the head SHA appearing on both"
+else
+  CLAUSE2_EVIDENCE="$TEST_REL exited $TEST_STATUS. Output tail: $(printf '%s\n' "$TEST_OUT" | tail -n 5 | tr '\n' ' ')"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 3 — the comparison fires on a real dependency-adding head.
+# ---------------------------------------------------------------------------
+SCRATCH_BASE="${OPENBRAIN_TEMP_WORKSPACE:-${DEV_TMP:-/Volumes/ThunderBolt/_tmp}}/open-brain/_scratch"
+mkdir -p "$SCRATCH_BASE" || fail_hard "cannot create scratch dir at $SCRATCH_BASE"
+# NOT mktemp -d (AGENTS.md hard rule: it resolves to a sandbox-local $TMPDIR
+# that no other process can see). An explicit path under the temp workspace,
+# unique by pid + epoch so concurrent runs cannot collide.
+FIXTURE="$SCRATCH_BASE/775-deps-fixture-$$-$(date +%s)"
+mkdir -p "$FIXTURE" || fail_hard "cannot create fixture dir at $FIXTURE"
+
+fixture_git() { git -C "$FIXTURE" "$@" >/dev/null 2>&1; }
+
+# "fixture", not "main": the operator's global protected-branch hook refuses
+# commits to main even in a throwaway repo, and the branch name proves nothing.
+if fixture_git init --quiet -b fixture \
+  && fixture_git config user.email "test@example.invalid" \
+  && fixture_git config user.name "775 done-means" \
+  && fixture_git config core.hooksPath "$FIXTURE/.git/no-hooks" \
+  && fixture_git config commit.gpgsign false; then
+
+  printf '{"name":"t"}\n'  > "$FIXTURE/package.json"
+  printf 'lock-v1\n'       > "$FIXTURE/bun.lock"
+  printf 'base\n'          > "$FIXTURE/README.md"
+  fixture_git add .
+  fixture_git commit --quiet -m base
+  BASE_SHA="$(git -C "$FIXTURE" rev-parse HEAD 2>/dev/null)"
+
+  # A head that adds a devDependency — #771's shape.
+  printf '{"name":"t","devDependencies":{"oxlint":"1.0.0"}}\n' > "$FIXTURE/package.json"
+  printf 'lock-v1\noxlint\n'                                   > "$FIXTURE/bun.lock"
+  fixture_git add .
+  fixture_git commit --quiet -m "add oxlint"
+  DEP_SHA="$(git -C "$FIXTURE" rev-parse HEAD 2>/dev/null)"
+
+  # A head that touches neither manifest.
+  fixture_git reset --hard --quiet "$BASE_SHA"
+  printf 'changed\n' > "$FIXTURE/README.md"
+  fixture_git add .
+  fixture_git commit --quiet -m "docs only"
+  DOC_SHA="$(git -C "$FIXTURE" rev-parse HEAD 2>/dev/null)"
+
+  git -C "$FIXTURE" diff --quiet "$BASE_SHA" "$DEP_SHA" -- package.json bun.lock
+  DEP_STATUS=$?
+  git -C "$FIXTURE" diff --quiet "$BASE_SHA" "$DOC_SHA" -- package.json bun.lock
+  DOC_STATUS=$?
+
+  if [ "$DEP_STATUS" -eq 1 ] && [ "$DOC_STATUS" -eq 0 ]; then
+    CLAUSE3=PASS
+    CLAUSE3_EVIDENCE="dependency-adding head -> git diff --quiet exit 1 (reinstall), unrelated-change head -> exit 0 (skip); fixture at $FIXTURE"
+  else
+    CLAUSE3_EVIDENCE="comparison did not discriminate — dependency-adding head exit $DEP_STATUS (want 1), unrelated head exit $DOC_STATUS (want 0); fixture at $FIXTURE"
+  fi
+else
+  CLAUSE3_EVIDENCE="could not build the git fixture at $FIXTURE"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 4 — any exit code outside {0,1} fails loudly.
+# ---------------------------------------------------------------------------
+if rg -q 'diff\.status !== 0 && diff\.status !== 1' "$SCRIPT" \
+  && rg -q 'Refusing to guess whether the head' "$SCRIPT"; then
+  CLAUSE4=PASS
+  CLAUSE4_EVIDENCE="verify-lane rejects any git diff status outside {0,1} rather than reading it as 'unchanged'"
+else
+  CLAUSE4_EVIDENCE="no fail-closed guard on the git diff exit code — a bad ref or missing object would be read as 'manifests match' and skip the install, which is the original defect"
+fi
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+printf '\n#775 — verify-lane installs the PR head'"'"'s dependencies\n\n'
+printf '  CLAUSE 1 (step ordered between reset and check): %s\n    %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+printf '  CLAUSE 2 (both paths announce themselves):       %s\n    %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+printf '  CLAUSE 3 (comparison fires on a real head):      %s\n    %s\n' "$CLAUSE3" "$CLAUSE3_EVIDENCE"
+printf '  CLAUSE 4 (fail-closed on an unusable compare):   %s\n    %s\n' "$CLAUSE4" "$CLAUSE4_EVIDENCE"
+printf '\n'
+printf '  Fixture repositories are LEFT IN PLACE under %s —\n' "$SCRATCH_BASE"
+printf '  teardown is printed, never executed. Remove them yourself when done.\n\n'
+
+if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ] && [ "$CLAUSE4" = PASS ]; then
+  printf 'PASS — verify-lane reinstalls at the PR head and says which path it took.\n\n'
+  exit 0
+fi
+printf 'FAIL — see the clause evidence above.\n\n'
+exit 1

--- a/scripts/done-means/775-verify-lane-installs-head-deps.sh
+++ b/scripts/done-means/775-verify-lane-installs-head-deps.sh
@@ -130,12 +130,22 @@ fi
 # ---------------------------------------------------------------------------
 # CLAUSE 3 — the comparison fires on a real dependency-adding head.
 # ---------------------------------------------------------------------------
-SCRATCH_BASE="${OPENBRAIN_TEMP_WORKSPACE:-${DEV_TMP:-/Volumes/ThunderBolt/_tmp}}/open-brain/_scratch"
+# Repo-relative, matching src/operator-doctor.test.ts and this check's own unit
+# test: `_scratch/<name>/` under the repo root, already excluded by
+# .gitignore:119. The previous fallback hardcoded the operator's Mac
+# (`/Volumes/ThunderBolt/_tmp`), so CI died on `EACCES: permission denied,
+# mkdir '/Volumes'` — a Linux runner cannot create that path, and a done-means
+# check that only runs on one machine's volume layout gates nothing in CI.
+#
+# Keeping the fixture INSIDE the repo also bounds the escape guarded against
+# below: the worst a stray git call can reach is a directory the repo already
+# ignores.
+SCRATCH_BASE="$REPO_ROOT/_scratch/verify-lane-deps"
 mkdir -p "$SCRATCH_BASE" || fail_hard "cannot create scratch dir at $SCRATCH_BASE"
 # NOT mktemp -d (AGENTS.md hard rule: it resolves to a sandbox-local $TMPDIR
-# that no other process can see). An explicit path under the temp workspace,
-# unique by pid + epoch so concurrent runs cannot collide.
-FIXTURE="$SCRATCH_BASE/775-deps-fixture-$$-$(date +%s)"
+# that no other process can see). An explicit path, unique by pid + epoch so
+# concurrent runs cannot collide.
+FIXTURE="$SCRATCH_BASE/fixture-$$-$(date +%s)"
 mkdir -p "$FIXTURE" || fail_hard "cannot create fixture dir at $FIXTURE"
 
 # Pin BOTH the git dir and the work tree, never a bare -C. With only -C, git

--- a/scripts/verify-lane.test.ts
+++ b/scripts/verify-lane.test.ts
@@ -12,7 +12,7 @@
 // earn a receipt (measured twice on PR #771, which adds oxlint).
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { decideDepsAtHead, DEPENDENCY_MANIFESTS } from "./verify-lane.ts";
 
@@ -70,8 +70,18 @@ describe("git diff --quiet over the dependency manifests", () => {
   let addsDepSha = "";
   let unrelatedSha = "";
 
+  // `-C <repo>` and an explicit --git-dir/--work-tree, NOT a bare cwd. A bare
+  // `cwd` lets git walk UP to the first enclosing repository when the fixture
+  // is not one — which is how a failed `git init` silently committed this
+  // fixture's `base` and `docs only` commits into the surrounding worktree
+  // during authoring, deleting every tracked file in it. Pinning the git dir
+  // makes that walk impossible: git errors instead of finding a parent repo.
   const git = (args: string[]): string => {
-    const r = spawnSync("git", args, { cwd: repo, encoding: "utf-8" });
+    const r = spawnSync(
+      "git",
+      ["--git-dir", join(repo, ".git"), "--work-tree", repo, ...args],
+      { cwd: repo, encoding: "utf-8" },
+    );
     if (r.status !== 0) {
       throw new Error(`git ${args.join(" ")} exited ${r.status}: ${r.stderr}`);
     }
@@ -90,7 +100,22 @@ describe("git diff --quiet over the dependency manifests", () => {
     // A branch that is deliberately NOT "main": the operator's global
     // protected-branch hook refuses commits there, including in a throwaway
     // repository, and the branch name is irrelevant to what this proves.
-    git(["init", "--quiet", "-b", "fixture"]);
+    // `init` runs before the fixture is a repo, so it cannot go through the
+    // pinned helper above. Its success is ASSERTED rather than assumed: an
+    // unchecked init is exactly what let every later git call escape upward.
+    const init = spawnSync("git", ["-C", repo, "init", "--quiet", "-b", "fixture"], {
+      encoding: "utf-8",
+    });
+    if (init.status !== 0) {
+      throw new Error(`git init failed in ${repo}: ${init.stderr}`);
+    }
+    if (!existsSync(join(repo, ".git"))) {
+      throw new Error(
+        `git init reported success but ${join(repo, ".git")} does not exist. ` +
+          "Refusing to run git here: every later call would walk up to the " +
+          "enclosing repository and commit into it.",
+      );
+    }
     git(["config", "user.email", "test@example.invalid"]);
     git(["config", "user.name", "verify-lane test"]);
     git(["config", "core.hooksPath", join(repo, ".git", "no-hooks")]);

--- a/scripts/verify-lane.test.ts
+++ b/scripts/verify-lane.test.ts
@@ -5,17 +5,56 @@
 // importing scripts/verify-lane.ts is safe because main() runs behind an
 // `import.meta.main` guard.
 //
-// WHAT THE DEFECT WAS. lane-bootstrap cuts the verification worktree from
-// origin/main and installs deps THERE; verify-lane then hard-resets the same
+// WHAT THE DEFECT WAS. lane-bootstrap cuts the verification worktree from a
+// base ref and installs deps THERE; verify-lane then hard-resets the same
 // worktree onto the PR head without reinstalling. Any PR that adds a
-// dependency was verified against origin/main's node_modules and could never
-// earn a receipt (measured twice on PR #771, which adds oxlint).
+// dependency was verified against the base's node_modules and could never earn
+// a receipt (measured twice on PR #771, which adds oxlint).
+//
+// EVERY GIT CALL IN THIS FILE IS FENCED. See `gitEnv` below: a fixture that is
+// not a repository makes git walk UP to the first enclosing one, and this file
+// runs inside a checkout. The fence is belt AND braces because a single
+// unpinned call is enough to corrupt the branch under development — which is
+// exactly what happened while authoring this file.
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, renameSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { decideDepsAtHead, DEPENDENCY_MANIFESTS } from "./verify-lane.ts";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+// Repo-relative, matching src/operator-doctor.test.ts:29 — `_scratch/` is
+// already excluded by .gitignore:119. NOT a hardcoded `/Volumes/...` default:
+// that is the operator's Mac, and CI died on `EACCES: permission denied, mkdir
+// '/Volumes'` on the Linux runner.
+const SCRATCH_DIR = join(REPO_ROOT, "_scratch", "verify-lane-deps");
+const ARCHIVE_DIR = join(REPO_ROOT, "_scratch", "_archive", "verify-lane-deps");
+
+/**
+ * Environment fence for every git invocation against a fixture.
+ *
+ * `--git-dir`/`--work-tree` flags pin the target, but they are only as good as
+ * the next person remembering to pass them. These variables would override or
+ * redirect a git call that lost its flags, so they are cleared outright, and
+ * GIT_CEILING_DIRECTORIES makes the upward discovery walk stop at the fixture's
+ * parent — so even a fully unflagged `git` cannot reach the enclosing checkout.
+ */
+function gitEnv(fixtureParent: string): NodeJS.ProcessEnv {
+  const env: Record<string, string | undefined> = { ...process.env };
+  for (const key of [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+  ]) {
+    delete env[key];
+  }
+  env.GIT_CEILING_DIRECTORIES = fixtureParent;
+  return env as NodeJS.ProcessEnv;
+}
 
 describe("DEPENDENCY_MANIFESTS", () => {
   it("covers both files that decide what bun install produces", () => {
@@ -26,39 +65,62 @@ describe("DEPENDENCY_MANIFESTS", () => {
 });
 
 describe("decideDepsAtHead", () => {
-  it("reinstalls, and says so, when the manifests differ from the bootstrap ref", () => {
+  const BOOT = "1111111111111111111111111111111111111111";
+  const HEAD = "2222222222222222222222222222222222222222";
+
+  it("reinstalls, and says so, when git reports a difference (status 1)", () => {
     const decision = decideDepsAtHead({
-      baseRef: "origin/main",
-      headSha: "2d67702",
-      manifestsDiffer: true,
+      bootstrapSha: BOOT,
+      headSha: HEAD,
+      diffStatus: 1,
     });
-    expect(decision.reinstall).toBe(true);
+    expect(decision.outcome).toBe("reinstall");
     expect(decision.detail).toContain("reinstalled");
-    expect(decision.detail).toContain("differs from origin/main");
+    expect(decision.detail).toContain(BOOT);
+    expect(decision.detail).toContain(HEAD);
   });
 
-  it("skips the install, and still says so, when the manifests match", () => {
+  it("skips the install, and still says so, when git reports no difference (status 0)", () => {
     // Nothing is adjusted silently: the no-op path must ALSO produce a line,
     // or a reader cannot tell "checked, identical" from "never checked".
     const decision = decideDepsAtHead({
-      baseRef: "origin/main",
-      headSha: "2d67702",
-      manifestsDiffer: false,
+      bootstrapSha: BOOT,
+      headSha: HEAD,
+      diffStatus: 0,
     });
-    expect(decision.reinstall).toBe(false);
+    expect(decision.outcome).toBe("unchanged");
     expect(decision.detail).toContain("unchanged");
-    expect(decision.detail).toContain("matches origin/main");
+    expect(decision.detail).toContain(BOOT);
   });
 
-  it("names the head SHA on both paths so the line is bound to a commit", () => {
-    for (const manifestsDiffer of [true, false]) {
-      const decision = decideDepsAtHead({
-        baseRef: "origin/main",
-        headSha: "deadbeef",
-        manifestsDiffer,
-      });
-      expect(decision.detail).toContain("deadbeef");
+  // THE FAIL-CLOSED BRANCH. This is why the function takes the raw exit code
+  // rather than a boolean: with a boolean the status handling lived at the call
+  // site, untested, and a mutant that ignored it passed everything.
+  it("THROWS on any status outside {0,1} rather than assuming 'unchanged'", () => {
+    for (const status of [2, 128, 129, -1]) {
+      expect(() =>
+        decideDepsAtHead({ bootstrapSha: BOOT, headSha: HEAD, diffStatus: status }),
+      ).toThrow(/Refusing to guess/);
     }
+  });
+
+  it("THROWS when the status is null (the command never produced one)", () => {
+    expect(() =>
+      decideDepsAtHead({ bootstrapSha: BOOT, headSha: HEAD, diffStatus: null }),
+    ).toThrow(/Refusing to guess/);
+  });
+
+  it("names the bootstrap commit, not a mutable ref", () => {
+    // P1-a: diffing against `origin/main` silently skips the install whenever
+    // that ref advances between bootstrap and the compare. The step line must
+    // therefore quote the SHA that was actually installed from.
+    const decision = decideDepsAtHead({
+      bootstrapSha: BOOT,
+      headSha: HEAD,
+      diffStatus: 0,
+    });
+    expect(decision.detail).toContain(BOOT);
+    expect(decision.detail).not.toContain("origin/main");
   });
 });
 
@@ -71,17 +133,16 @@ describe("git diff --quiet over the dependency manifests", () => {
   let addsDepSha = "";
   let unrelatedSha = "";
 
-  // `-C <repo>` and an explicit --git-dir/--work-tree, NOT a bare cwd. A bare
-  // `cwd` lets git walk UP to the first enclosing repository when the fixture
-  // is not one — which is how a failed `git init` silently committed this
-  // fixture's `base` and `docs only` commits into the surrounding worktree
-  // during authoring, deleting every tracked file in it. Pinning the git dir
-  // makes that walk impossible: git errors instead of finding a parent repo.
+  // Pin BOTH the git dir and the work tree, never a bare -C, and fence the
+  // environment. With only -C, git walks UP to the first enclosing repository
+  // when the fixture is not one — which is how a failed `git init` silently
+  // committed this fixture's `base` and `docs only` commits into the
+  // surrounding worktree during authoring, deleting every tracked file in it.
   const git = (args: string[]): string => {
     const r = spawnSync(
       "git",
       ["--git-dir", join(repo, ".git"), "--work-tree", repo, ...args],
-      { cwd: repo, encoding: "utf-8" },
+      { cwd: repo, encoding: "utf-8", env: gitEnv(SCRATCH_DIR) },
     );
     if (r.status !== 0) {
       throw new Error(`git ${args.join(" ")} exited ${r.status}: ${r.stderr}`);
@@ -90,34 +151,20 @@ describe("git diff --quiet over the dependency manifests", () => {
   };
 
   beforeAll(() => {
-    // Repo-relative by default, matching src/operator-doctor.test.ts: a
-    // `_scratch/<name>/` directory under the repo root, which .gitignore:119
-    // already excludes. The previous fallback hardcoded the operator's Mac
-    // (`/Volumes/ThunderBolt/_tmp`), so CI died on `EACCES: permission denied,
-    // mkdir '/Volumes'` — a Linux runner cannot create that path, and a test
-    // fixture must not require one machine's volume layout.
-    //
-    // Keeping the fixture INSIDE the repo also bounds the escape this file
-    // guards against: the worst a stray git call can reach is a directory the
-    // repo already ignores, rather than an arbitrary path on the volume.
-    const scratch = join(
-      dirname(fileURLToPath(import.meta.url)),
-      "..",
-      "_scratch",
-      "verify-lane-deps",
-    );
-    mkdirSync(scratch, { recursive: true });
-    repo = mkdtempSync(join(scratch, "fixture-"));
+    mkdirSync(SCRATCH_DIR, { recursive: true });
+    repo = mkdtempSync(join(SCRATCH_DIR, "fixture-"));
 
-    // A branch that is deliberately NOT "main": the operator's global
-    // protected-branch hook refuses commits there, including in a throwaway
-    // repository, and the branch name is irrelevant to what this proves.
-    // `init` runs before the fixture is a repo, so it cannot go through the
-    // pinned helper above. Its success is ASSERTED rather than assumed: an
-    // unchecked init is exactly what let every later git call escape upward.
-    const init = spawnSync("git", ["-C", repo, "init", "--quiet", "-b", "fixture"], {
-      encoding: "utf-8",
-    });
+    // `init` is the one call that predates the repo, and it was previously the
+    // ONLY unpinned git call in this file. Unpinned it would re-initialise
+    // whatever an inherited GIT_DIR pointed at, BEFORE the missing-.git
+    // assertion below could run. So it is pinned and fenced like every other
+    // call, and its success is then ASSERTED on both the exit code and the
+    // resulting .git — an unchecked init is what enables the escape at all.
+    const init = spawnSync(
+      "git",
+      ["--git-dir", join(repo, ".git"), "--work-tree", repo, "init", "--quiet", "-b", "fixture"],
+      { cwd: repo, encoding: "utf-8", env: gitEnv(SCRATCH_DIR) },
+    );
     if (init.status !== 0) {
       throw new Error(`git init failed in ${repo}: ${init.stderr}`);
     }
@@ -128,6 +175,7 @@ describe("git diff --quiet over the dependency manifests", () => {
           "enclosing repository and commit into it.",
       );
     }
+
     git(["config", "user.email", "test@example.invalid"]);
     git(["config", "user.name", "verify-lane test"]);
     git(["config", "core.hooksPath", join(repo, ".git", "no-hooks")]);
@@ -159,16 +207,26 @@ describe("git diff --quiet over the dependency manifests", () => {
   });
 
   afterAll(() => {
-    // No delete path: the scratch repo is left for the operator's sweep,
-    // matching this repo's teardown-is-printed-never-executed rule.
-    if (repo) process.stdout.write(`  scratch repo left at: ${repo}\n`);
+    // Archive with mv, never rm (AGENTS.md: an agent runs no recursive delete).
+    // Fixtures accumulate inside the checkout otherwise, since _scratch/ is now
+    // repo-relative.
+    if (!repo || !existsSync(repo)) return;
+    mkdirSync(ARCHIVE_DIR, { recursive: true });
+    const dest = join(ARCHIVE_DIR, `${Date.now()}-${process.pid}`);
+    renameSync(repo, dest);
+    process.stdout.write(`  fixture archived to: ${dest}\n`);
   });
 
   const diffStatus = (from: string, to: string): number => {
+    // Pinned and fenced like every other call in this file (review round 1, P2).
     const r = spawnSync(
       "git",
-      ["diff", "--quiet", from, to, "--", ...DEPENDENCY_MANIFESTS],
-      { cwd: repo, encoding: "utf-8" },
+      [
+        "--git-dir", join(repo, ".git"),
+        "--work-tree", repo,
+        "diff", "--quiet", from, to, "--", ...DEPENDENCY_MANIFESTS,
+      ],
+      { cwd: repo, encoding: "utf-8", env: gitEnv(SCRATCH_DIR) },
     );
     return r.status ?? -1;
   };
@@ -176,12 +234,29 @@ describe("git diff --quiet over the dependency manifests", () => {
   it("reports a difference when the head adds a devDependency", () => {
     const status = diffStatus(baseSha, addsDepSha);
     expect(status).toBe(1);
-    expect(decideDepsAtHead({ baseRef: baseSha, headSha: addsDepSha, manifestsDiffer: status === 1 }).reinstall).toBe(true);
+    expect(
+      decideDepsAtHead({ bootstrapSha: baseSha, headSha: addsDepSha, diffStatus: status })
+        .outcome,
+    ).toBe("reinstall");
   });
 
   it("reports no difference when the head changes only unrelated files", () => {
     const status = diffStatus(baseSha, unrelatedSha);
     expect(status).toBe(0);
-    expect(decideDepsAtHead({ baseRef: baseSha, headSha: unrelatedSha, manifestsDiffer: status === 1 }).reinstall).toBe(false);
+    expect(
+      decideDepsAtHead({ bootstrapSha: baseSha, headSha: unrelatedSha, diffStatus: status })
+        .outcome,
+    ).toBe("unchanged");
+  });
+
+  it("fails closed when the comparison names a commit that does not exist", () => {
+    // A bad ref is the realistic way git answers with neither 0 nor 1, and it
+    // must throw rather than be read as "manifests match".
+    const status = diffStatus(baseSha, "0".repeat(40));
+    expect(status).not.toBe(0);
+    expect(status).not.toBe(1);
+    expect(() =>
+      decideDepsAtHead({ bootstrapSha: baseSha, headSha: "0".repeat(40), diffStatus: status }),
+    ).toThrow(/Refusing to guess/);
   });
 });

--- a/scripts/verify-lane.test.ts
+++ b/scripts/verify-lane.test.ts
@@ -1,0 +1,150 @@
+// Tests for verify-lane's deps-at-head reconciliation (#775).
+//
+// These exercise ONLY the pure decision function and the git comparison it is
+// fed. They never call gh, never run lane-bootstrap, and never post a receipt —
+// importing scripts/verify-lane.ts is safe because main() runs behind an
+// `import.meta.main` guard.
+//
+// WHAT THE DEFECT WAS. lane-bootstrap cuts the verification worktree from
+// origin/main and installs deps THERE; verify-lane then hard-resets the same
+// worktree onto the PR head without reinstalling. Any PR that adds a
+// dependency was verified against origin/main's node_modules and could never
+// earn a receipt (measured twice on PR #771, which adds oxlint).
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { decideDepsAtHead, DEPENDENCY_MANIFESTS } from "./verify-lane.ts";
+
+describe("DEPENDENCY_MANIFESTS", () => {
+  it("covers both files that decide what bun install produces", () => {
+    // A manifest missing from this list is a manifest whose change is invisible
+    // to the comparison, which is the original defect in a narrower form.
+    expect([...DEPENDENCY_MANIFESTS]).toEqual(["package.json", "bun.lock"]);
+  });
+});
+
+describe("decideDepsAtHead", () => {
+  it("reinstalls, and says so, when the manifests differ from the bootstrap ref", () => {
+    const decision = decideDepsAtHead({
+      baseRef: "origin/main",
+      headSha: "2d67702",
+      manifestsDiffer: true,
+    });
+    expect(decision.reinstall).toBe(true);
+    expect(decision.detail).toContain("reinstalled");
+    expect(decision.detail).toContain("differs from origin/main");
+  });
+
+  it("skips the install, and still says so, when the manifests match", () => {
+    // Nothing is adjusted silently: the no-op path must ALSO produce a line,
+    // or a reader cannot tell "checked, identical" from "never checked".
+    const decision = decideDepsAtHead({
+      baseRef: "origin/main",
+      headSha: "2d67702",
+      manifestsDiffer: false,
+    });
+    expect(decision.reinstall).toBe(false);
+    expect(decision.detail).toContain("unchanged");
+    expect(decision.detail).toContain("matches origin/main");
+  });
+
+  it("names the head SHA on both paths so the line is bound to a commit", () => {
+    for (const manifestsDiffer of [true, false]) {
+      const decision = decideDepsAtHead({
+        baseRef: "origin/main",
+        headSha: "deadbeef",
+        manifestsDiffer,
+      });
+      expect(decision.detail).toContain("deadbeef");
+    }
+  });
+});
+
+// The decision is only as good as the signal feeding it, so drive the real
+// `git diff --quiet` against a throwaway repository whose head adds a
+// devDependency — the exact shape of PR #771.
+describe("git diff --quiet over the dependency manifests", () => {
+  let repo = "";
+  let baseSha = "";
+  let addsDepSha = "";
+  let unrelatedSha = "";
+
+  const git = (args: string[]): string => {
+    const r = spawnSync("git", args, { cwd: repo, encoding: "utf-8" });
+    if (r.status !== 0) {
+      throw new Error(`git ${args.join(" ")} exited ${r.status}: ${r.stderr}`);
+    }
+    return (r.stdout ?? "").trim();
+  };
+
+  beforeAll(() => {
+    const base =
+      process.env.OPENBRAIN_TEMP_WORKSPACE?.trim() ||
+      process.env.DEV_TMP?.trim() ||
+      "/Volumes/ThunderBolt/_tmp";
+    const scratch = join(base, "open-brain", "_scratch");
+    mkdirSync(scratch, { recursive: true });
+    repo = mkdtempSync(join(scratch, "verify-lane-deps-test-"));
+
+    // A branch that is deliberately NOT "main": the operator's global
+    // protected-branch hook refuses commits there, including in a throwaway
+    // repository, and the branch name is irrelevant to what this proves.
+    git(["init", "--quiet", "-b", "fixture"]);
+    git(["config", "user.email", "test@example.invalid"]);
+    git(["config", "user.name", "verify-lane test"]);
+    git(["config", "core.hooksPath", join(repo, ".git", "no-hooks")]);
+    git(["config", "commit.gpgsign", "false"]);
+
+    writeFileSync(join(repo, "package.json"), JSON.stringify({ name: "t" }) + "\n");
+    writeFileSync(join(repo, "bun.lock"), "lock-v1\n");
+    writeFileSync(join(repo, "README.md"), "base\n");
+    git(["add", "."]);
+    git(["commit", "--quiet", "-m", "base"]);
+    baseSha = git(["rev-parse", "HEAD"]);
+
+    // A head that adds a devDependency — #771's shape.
+    writeFileSync(
+      join(repo, "package.json"),
+      JSON.stringify({ name: "t", devDependencies: { oxlint: "1.0.0" } }) + "\n",
+    );
+    writeFileSync(join(repo, "bun.lock"), "lock-v1\noxlint\n");
+    git(["add", "."]);
+    git(["commit", "--quiet", "-m", "add oxlint"]);
+    addsDepSha = git(["rev-parse", "HEAD"]);
+
+    // A head that touches neither manifest.
+    git(["reset", "--hard", "--quiet", baseSha]);
+    writeFileSync(join(repo, "README.md"), "changed\n");
+    git(["add", "."]);
+    git(["commit", "--quiet", "-m", "docs only"]);
+    unrelatedSha = git(["rev-parse", "HEAD"]);
+  });
+
+  afterAll(() => {
+    // No delete path: the scratch repo is left for the operator's sweep,
+    // matching this repo's teardown-is-printed-never-executed rule.
+    if (repo) process.stdout.write(`  scratch repo left at: ${repo}\n`);
+  });
+
+  const diffStatus = (from: string, to: string): number => {
+    const r = spawnSync(
+      "git",
+      ["diff", "--quiet", from, to, "--", ...DEPENDENCY_MANIFESTS],
+      { cwd: repo, encoding: "utf-8" },
+    );
+    return r.status ?? -1;
+  };
+
+  it("reports a difference when the head adds a devDependency", () => {
+    const status = diffStatus(baseSha, addsDepSha);
+    expect(status).toBe(1);
+    expect(decideDepsAtHead({ baseRef: baseSha, headSha: addsDepSha, manifestsDiffer: status === 1 }).reinstall).toBe(true);
+  });
+
+  it("reports no difference when the head changes only unrelated files", () => {
+    const status = diffStatus(baseSha, unrelatedSha);
+    expect(status).toBe(0);
+    expect(decideDepsAtHead({ baseRef: baseSha, headSha: unrelatedSha, manifestsDiffer: status === 1 }).reinstall).toBe(false);
+  });
+});

--- a/scripts/verify-lane.test.ts
+++ b/scripts/verify-lane.test.ts
@@ -13,7 +13,8 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { decideDepsAtHead, DEPENDENCY_MANIFESTS } from "./verify-lane.ts";
 
 describe("DEPENDENCY_MANIFESTS", () => {
@@ -89,13 +90,24 @@ describe("git diff --quiet over the dependency manifests", () => {
   };
 
   beforeAll(() => {
-    const base =
-      process.env.OPENBRAIN_TEMP_WORKSPACE?.trim() ||
-      process.env.DEV_TMP?.trim() ||
-      "/Volumes/ThunderBolt/_tmp";
-    const scratch = join(base, "open-brain", "_scratch");
+    // Repo-relative by default, matching src/operator-doctor.test.ts: a
+    // `_scratch/<name>/` directory under the repo root, which .gitignore:119
+    // already excludes. The previous fallback hardcoded the operator's Mac
+    // (`/Volumes/ThunderBolt/_tmp`), so CI died on `EACCES: permission denied,
+    // mkdir '/Volumes'` — a Linux runner cannot create that path, and a test
+    // fixture must not require one machine's volume layout.
+    //
+    // Keeping the fixture INSIDE the repo also bounds the escape this file
+    // guards against: the worst a stray git call can reach is a directory the
+    // repo already ignores, rather than an arbitrary path on the volume.
+    const scratch = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "_scratch",
+      "verify-lane-deps",
+    );
     mkdirSync(scratch, { recursive: true });
-    repo = mkdtempSync(join(scratch, "verify-lane-deps-test-"));
+    repo = mkdtempSync(join(scratch, "fixture-"));
 
     // A branch that is deliberately NOT "main": the operator's global
     // protected-branch hook refuses commits there, including in a throwaway

--- a/scripts/verify-lane.ts
+++ b/scripts/verify-lane.ts
@@ -264,9 +264,11 @@ function resolveCheck(body: string, flagCheck: string | null): { path: string; s
  */
 export const DEPENDENCY_MANIFESTS = ["package.json", "bun.lock"] as const;
 
+export type DepsAtHeadOutcome = "reinstall" | "unchanged";
+
 export interface DepsAtHeadDecision {
-  /** true when `bun install --frozen-lockfile` must be re-run at the head. */
-  reinstall: boolean;
+  /** What to do: reinstall the head's dependencies, or leave them alone. */
+  outcome: DepsAtHeadOutcome;
   /** The `deps-at-head` step line, printed on BOTH paths. */
   detail: string;
 }
@@ -275,42 +277,69 @@ export interface DepsAtHeadDecision {
  * Decide whether the verification worktree needs its dependencies reinstalled
  * for the PR head.
  *
- * WHY THIS EXISTS (#775). lane-bootstrap cuts the worktree from `origin/main`
- * and installs deps THERE; this script then hard-resets the same worktree onto
- * the PR head. The SOURCE moves and `node_modules` does not, so any PR that
- * adds or bumps a dependency was verified against origin/main's dependency
- * tree. Measured twice on PR #771 (head 2d67702), which adds `oxlint`: the
- * done-means check died on `MISSING TOOL: .../node_modules/.bin/oxlint` and NO
- * receipt was posted, while a second `bun install --frozen-lockfile` in that
- * same worktree installed the 2 missing packages and the identical check
- * passed.
+ * WHY THIS EXISTS (#775). lane-bootstrap cuts the worktree from a base ref and
+ * installs deps THERE; this script then hard-resets the same worktree onto the
+ * PR head. The SOURCE moves and `node_modules` does not, so any PR that adds or
+ * bumps a dependency was verified against the base's dependency tree. Measured
+ * twice on PR #771 (head 2d67702), which adds `oxlint`: the done-means check
+ * died on `MISSING TOOL: .../node_modules/.bin/oxlint` and NO receipt was
+ * posted, while a second `bun install --frozen-lockfile` in that same worktree
+ * installed the 2 missing packages and the identical check passed.
  *
- * `manifestsDiffer` is the caller's `git diff --quiet <base> <head> --
- * package.json bun.lock` result, inverted: git exits 0 when there is no
- * difference.
+ * THE COMPARISON IS PINNED TO A SHA, NOT A REF (review round 1, P1-a).
+ * `bootstrapSha` is the worktree's HEAD read immediately after lane-bootstrap
+ * returns — the commit whose dependencies are actually installed. Diffing
+ * against the mutable `origin/main` instead would silently skip the install
+ * whenever that ref advanced between bootstrap and this compare (any fetch or
+ * merge in between), because the newly-advanced main could match the head's
+ * manifests while the INSTALLED tree does not.
  *
- * NOTHING IS ADJUSTED SILENTLY (AGENTS.md Coding Standards): both outcomes
- * produce a line, so the transcript always says which path ran.
+ * THIS FUNCTION OWNS THE STATUS HANDLING, deliberately. `diffStatus` is the RAW
+ * exit code of `git diff --quiet <bootstrapSha> <headSha> -- <manifests>`: 0
+ * means identical, 1 means they differ, and anything else means git could not
+ * answer (bad ref, missing object, not a repository). Taking the raw code
+ * rather than a pre-digested boolean is what makes the fail-closed branch
+ * TESTABLE — with a boolean, the `status !== 0 && status !== 1` logic lived at
+ * the call site and a mutant that ignored it passed every test.
+ *
+ * Reading an unusable comparison as "unchanged" would reintroduce the original
+ * defect exactly when git cannot compare, so that case THROWS.
+ *
+ * NOTHING IS ADJUSTED SILENTLY (AGENTS.md Coding Standards): both non-throwing
+ * outcomes produce a line, so the transcript always says which path ran.
  */
 export function decideDepsAtHead(input: {
-  baseRef: string;
+  bootstrapSha: string;
   headSha: string;
-  manifestsDiffer: boolean;
+  diffStatus: number | null;
 }): DepsAtHeadDecision {
   const manifests = DEPENDENCY_MANIFESTS.join(", ");
-  if (input.manifestsDiffer) {
+  const { bootstrapSha, headSha, diffStatus } = input;
+
+  if (diffStatus !== 0 && diffStatus !== 1) {
+    throw new VerifyLaneError(
+      "deps-at-head",
+      `git diff --quiet ${bootstrapSha} ${headSha} -- ${manifests} exited ` +
+        `${diffStatus === null ? "null" : diffStatus}. Refusing to guess whether ` +
+        "the head's dependencies are installed: reading an unusable comparison " +
+        "as \"unchanged\" is the original defect (#775) with an extra step.",
+    );
+  }
+
+  if (diffStatus === 1) {
     return {
-      reinstall: true,
+      outcome: "reinstall",
       detail:
-        `reinstalled: lockfile differs from ${input.baseRef} ` +
-        `(${manifests} changed between ${input.baseRef} and ${input.headSha})`,
+        `reinstalled: lockfile differs from the bootstrap commit ` +
+        `(${manifests} changed between ${bootstrapSha} and ${headSha})`,
     };
   }
   return {
-    reinstall: false,
+    outcome: "unchanged",
     detail:
-      `unchanged: lockfile matches ${input.baseRef} ` +
-      `(${manifests} identical, bootstrap deps describe ${input.headSha})`,
+      `unchanged: lockfile matches the bootstrap commit ` +
+      `(${manifests} identical between ${bootstrapSha} and ${headSha}, so the ` +
+      `deps installed at ${bootstrapSha} already describe ${headSha})`,
   };
 }
 
@@ -468,6 +497,17 @@ function main(): void {
   }
   step("bootstrap", `worktree at ${worktreePath}`);
 
+  // The commit whose dependencies lane-bootstrap ACTUALLY installed, read
+  // before anything moves the worktree (review round 1, P1-a). BOOTSTRAP_REF is
+  // a mutable ref: if it advances between the bootstrap and the compare below,
+  // diffing against the ref can report "identical" while the INSTALLED tree
+  // still differs from the head, silently skipping the install. A SHA cannot
+  // move.
+  const bootstrapSha = capture("bootstrap", "git", ["rev-parse", "HEAD"], {
+    cwd: worktreePath,
+  });
+  step("bootstrap", `deps installed at ${bootstrapSha} (from ${BOOTSTRAP_REF})`);
+
   // Pull the PR head into the fresh worktree. `git fetch origin <sha>` then a
   // hard reset is the shape that works for PRs from forks and for SHAs that no
   // named ref points at any more.
@@ -515,7 +555,7 @@ function main(): void {
   // this never silently decides "unchanged" because git could not compare.
   const diff = spawnSync(
     "git",
-    ["diff", "--quiet", BOOTSTRAP_REF, headSha, "--", ...DEPENDENCY_MANIFESTS],
+    ["diff", "--quiet", bootstrapSha, headSha, "--", ...DEPENDENCY_MANIFESTS],
     { cwd: worktreePath, encoding: "utf-8", maxBuffer: 64 * 1024 * 1024 },
   );
   if (diff.error) {
@@ -524,21 +564,16 @@ function main(): void {
       `could not compare dependency manifests: ${diff.error.message}`,
     );
   }
-  if (diff.status !== 0 && diff.status !== 1) {
-    throw new VerifyLaneError(
-      "deps-at-head",
-      `git diff --quiet ${BOOTSTRAP_REF} ${headSha} exited ${diff.status}. ` +
-        "Refusing to guess whether the head's dependencies are installed.",
-      `${diff.stdout ?? ""}${diff.stderr ?? ""}`.trim(),
-    );
-  }
 
+  // decideDepsAtHead owns the status handling, including the fail-closed branch
+  // for any code outside {0, 1}. Passing the raw status keeps that logic inside
+  // the unit-tested function instead of here (review round 1, P2).
   const depsDecision = decideDepsAtHead({
-    baseRef: BOOTSTRAP_REF,
+    bootstrapSha,
     headSha,
-    manifestsDiffer: diff.status === 1,
+    diffStatus: diff.status,
   });
-  if (depsDecision.reinstall) {
+  if (depsDecision.outcome === "reinstall") {
     note("deps-at-head", `installing the head's dependencies in ${worktreePath}`);
     // Same fail-loud shape lane-bootstrap uses for its own deps step
     // (scripts/lane-bootstrap.ts): a partially-installed environment is not a

--- a/scripts/verify-lane.ts
+++ b/scripts/verify-lane.ts
@@ -103,6 +103,11 @@ if (TEMP_WORKSPACE_SOURCE === "fallback") {
 }
 const RECEIPT_PREFIX = "verify-lane receipt:";
 
+// The ref lane-bootstrap cuts its worktree from, and therefore the ref whose
+// dependencies it installs. Named once so the deps-at-head comparison below
+// and lane-bootstrap cannot drift apart silently.
+const BOOTSTRAP_REF = "origin/main";
+
 interface Args {
   pr: string;
   check: string | null;
@@ -250,6 +255,63 @@ function resolveCheck(body: string, flagCheck: string | null): { path: string; s
       "       bun scripts/verify-lane.ts <pr-number> --check scripts/done-means/<check>.sh",
     ].join("\n"),
   );
+}
+
+/**
+ * The set of files whose contents decide what `bun install` produces. A
+ * difference in ANY of them between the bootstrap ref and the PR head means
+ * the `node_modules` lane-bootstrap installed does not describe the head.
+ */
+export const DEPENDENCY_MANIFESTS = ["package.json", "bun.lock"] as const;
+
+export interface DepsAtHeadDecision {
+  /** true when `bun install --frozen-lockfile` must be re-run at the head. */
+  reinstall: boolean;
+  /** The `deps-at-head` step line, printed on BOTH paths. */
+  detail: string;
+}
+
+/**
+ * Decide whether the verification worktree needs its dependencies reinstalled
+ * for the PR head.
+ *
+ * WHY THIS EXISTS (#775). lane-bootstrap cuts the worktree from `origin/main`
+ * and installs deps THERE; this script then hard-resets the same worktree onto
+ * the PR head. The SOURCE moves and `node_modules` does not, so any PR that
+ * adds or bumps a dependency was verified against origin/main's dependency
+ * tree. Measured twice on PR #771 (head 2d67702), which adds `oxlint`: the
+ * done-means check died on `MISSING TOOL: .../node_modules/.bin/oxlint` and NO
+ * receipt was posted, while a second `bun install --frozen-lockfile` in that
+ * same worktree installed the 2 missing packages and the identical check
+ * passed.
+ *
+ * `manifestsDiffer` is the caller's `git diff --quiet <base> <head> --
+ * package.json bun.lock` result, inverted: git exits 0 when there is no
+ * difference.
+ *
+ * NOTHING IS ADJUSTED SILENTLY (AGENTS.md Coding Standards): both outcomes
+ * produce a line, so the transcript always says which path ran.
+ */
+export function decideDepsAtHead(input: {
+  baseRef: string;
+  headSha: string;
+  manifestsDiffer: boolean;
+}): DepsAtHeadDecision {
+  const manifests = DEPENDENCY_MANIFESTS.join(", ");
+  if (input.manifestsDiffer) {
+    return {
+      reinstall: true,
+      detail:
+        `reinstalled: lockfile differs from ${input.baseRef} ` +
+        `(${manifests} changed between ${input.baseRef} and ${input.headSha})`,
+    };
+  }
+  return {
+    reinstall: false,
+    detail:
+      `unchanged: lockfile matches ${input.baseRef} ` +
+      `(${manifests} identical, bootstrap deps describe ${input.headSha})`,
+  };
 }
 
 function main(): void {
@@ -441,6 +503,52 @@ function main(): void {
   }
   step("checkout-head", `worktree at PR head ${headSha}`);
 
+  // --- 3b. dependencies AT THE HEAD (#775) ---------------------------------
+  // lane-bootstrap installed deps for BOOTSTRAP_REF; the reset above moved the
+  // source to the PR head without touching node_modules. Reconcile that here,
+  // or a PR that adds a dependency can never earn a receipt.
+  //
+  // `git diff --quiet` exits 0 for "no difference" and 1 for "differs", so a
+  // non-zero exit is a normal answer rather than a failure — it cannot go
+  // through capture(), which throws on any non-zero status. Any OTHER exit
+  // code (a bad ref, a missing object) is a real error and fails loudly, so
+  // this never silently decides "unchanged" because git could not compare.
+  const diff = spawnSync(
+    "git",
+    ["diff", "--quiet", BOOTSTRAP_REF, headSha, "--", ...DEPENDENCY_MANIFESTS],
+    { cwd: worktreePath, encoding: "utf-8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  if (diff.error) {
+    throw new VerifyLaneError(
+      "deps-at-head",
+      `could not compare dependency manifests: ${diff.error.message}`,
+    );
+  }
+  if (diff.status !== 0 && diff.status !== 1) {
+    throw new VerifyLaneError(
+      "deps-at-head",
+      `git diff --quiet ${BOOTSTRAP_REF} ${headSha} exited ${diff.status}. ` +
+        "Refusing to guess whether the head's dependencies are installed.",
+      `${diff.stdout ?? ""}${diff.stderr ?? ""}`.trim(),
+    );
+  }
+
+  const depsDecision = decideDepsAtHead({
+    baseRef: BOOTSTRAP_REF,
+    headSha,
+    manifestsDiffer: diff.status === 1,
+  });
+  if (depsDecision.reinstall) {
+    note("deps-at-head", `installing the head's dependencies in ${worktreePath}`);
+    // Same fail-loud shape lane-bootstrap uses for its own deps step
+    // (scripts/lane-bootstrap.ts): a partially-installed environment is not a
+    // thing to verify against, so a non-zero install aborts before run-check.
+    capture("deps-at-head", "bun", ["install", "--frozen-lockfile"], {
+      cwd: worktreePath,
+    });
+  }
+  step("deps-at-head", depsDecision.detail);
+
   // --- 4. run the check -----------------------------------------------------
   const checkPath = join(worktreePath, resolved.path);
   if (!existsSync(checkPath)) {
@@ -605,26 +713,28 @@ function main(): void {
   );
 }
 
-try {
-  main();
-} catch (err) {
-  if (err instanceof VerifyLaneError) {
-    process.stderr.write(`\n  [FAIL] ${err.step}: ${err.message}\n`);
-    if (err.detail) {
-      process.stderr.write(
-        "\n" +
-          err.detail
-            .split("\n")
-            .map((line) => (line.trim() ? `         ${line}` : ""))
-            .join("\n") +
-          "\n",
-      );
+if (import.meta.main) {
+  try {
+    main();
+  } catch (err) {
+    if (err instanceof VerifyLaneError) {
+      process.stderr.write(`\n  [FAIL] ${err.step}: ${err.message}\n`);
+      if (err.detail) {
+        process.stderr.write(
+          "\n" +
+            err.detail
+              .split("\n")
+              .map((line) => (line.trim() ? `         ${line}` : ""))
+              .join("\n") +
+            "\n",
+        );
+      }
+      process.stderr.write("\n");
+      process.exit(1);
     }
-    process.stderr.write("\n");
+    process.stderr.write(
+      `\n  [FAIL] unexpected: ${err instanceof Error ? err.stack || err.message : String(err)}\n\n`,
+    );
     process.exit(1);
   }
-  process.stderr.write(
-    `\n  [FAIL] unexpected: ${err instanceof Error ? err.stack || err.message : String(err)}\n\n`,
-  );
-  process.exit(1);
 }


### PR DESCRIPTION
Closes #775.

`scripts/verify-lane.ts` stood its verification worktree up in two moves that
disagreed about which commit's dependencies were installed. Step 3 shells out
to `scripts/lane-bootstrap.ts`, which cuts the worktree from `origin/main` and
runs `bun install --frozen-lockfile` there, so `node_modules` describes
origin/main. The same step's tail then does `git fetch origin <sha>` plus
`git reset --hard <headSha>`, moving the SOURCE onto the PR head — and never
reinstalls. Step 4 ran the done-means check against that mismatched tree.

Any PR that adds or bumps a dependency was therefore structurally unable to
earn a receipt, and the failure presented as the lane's check being broken
rather than as a verify-lane environment defect. That matters because
`.claude/hooks/merge-gate.ts` requires a verify-lane receipt to merge.

**Measured twice** (2026-08-25) against PR #771 at head `2d67702`, which adds
`oxlint` as a devDependency: the check died on `MISSING TOOL:
.../node_modules/.bin/oxlint` and NO receipt was posted, while a second
`bun install --frozen-lockfile` in that same verification worktree installed
the 2 missing packages and the identical check passed.

**The fix.** After the hard reset and before `run-check`, compare
`package.json` and `bun.lock` between `origin/main` and the head, and reinstall
when they differ. `git diff --quiet` answers 0 for "same" and 1 for "differs",
so it cannot go through `capture()`, which throws on any non-zero status; every
OTHER exit code (a bad ref, a missing object) fails loudly rather than being
read as "unchanged", which would reintroduce the original defect whenever git
could not compare.

Both paths print a `deps-at-head` line — `reinstalled: lockfile differs from
origin/main` or `unchanged: lockfile matches origin/main` — per AGENTS.md
"Nothing is adjusted silently": a no-op that prints nothing is
indistinguishable from a step that never ran.

`main()` now sits behind an `import.meta.main` guard, the convention already
used by 10 other scripts in `scripts/`, so the decision function is importable
by a test without the script trying to verify a PR on import.

The change is confined to `scripts/verify-lane.ts`. `lane-bootstrap.ts` needed
no hook: it correctly installs deps for the ref it cuts, and the mismatch is
created entirely by verify-lane's own later reset, so the reconciliation
belongs at that boundary.

## Verification

- Done-means: scripts/done-means/775-verify-lane-installs-head-deps.sh
- **RED first, against the unfixed script.** `git checkout origin/main --
  scripts/verify-lane.ts` then running the check exits 1 with clauses 1, 2 and
  4 FAIL (`deps-at-head:none`; the unit suite exits 1; no fail-closed guard).
  Clause 3 stays PASS by design — it exercises git's own discrimination on a
  fixture repository, not the fix. Restoring the fix returns exit 0 with all
  four PASS.
- `bunx tsc --noEmit` -> clean, exit 0.
- `bun test scripts` -> 384 pass, 35 skip, 0 fail (419 tests across 32 files).
- `bun test scripts/verify-lane.test.ts` -> 6 pass, 0 fail.
- `bash scripts/done-means/verifier-agent-grounded.sh` -> exit 0, still green.
- `bash -n scripts/done-means/775-verify-lane-installs-head-deps.sh` -> clean.
- Second commit re-verified after hardening: check exits 0 on the fix and 1 on
  the unfixed script, `bun test scripts` unchanged at 384 pass / 0 fail, and
  the worktree HEAD is unchanged across a full run of both fixtures.

The new check's four clauses assert the fix's load-bearing properties rather
than its prose: that the step is ordered strictly between the reset and
run-check AND actually invokes `bun install` (position is the whole fix — a
reinstall before the reset would install origin/main's deps twice and change
nothing); that both branches announce themselves; that the comparison really
fires on a dependency-adding head and really skips an unrelated one; and that
an unusable comparison fails closed.

## Critical Self-Review

- Highest-risk behavior: an unconditional reinstall would slow every
  verification run and could mask a genuinely broken lockfile. Mitigated by
  gating on a real manifest diff and by keeping `--frozen-lockfile`, which
  still refuses a lockfile that does not match `package.json`.
- Assumptions that could be wrong: that `origin/main` is always the ref
  lane-bootstrap cut from. It is, at `scripts/lane-bootstrap.ts`, but the two
  now name it independently. Named once here as `BOOTSTRAP_REF` with a comment
  saying why; if lane-bootstrap ever gains a configurable base ref, this
  constant is the single place that must follow, and a wrong base ref produces
  a spurious reinstall (slow, safe) rather than a skipped one.
- Missing/weak tests: the unit suite covers the decision function and the git
  signal feeding it, not a full end-to-end verify-lane run against a live PR —
  that needs `gh`, a real PR, and a bootstrap, which is not something a test
  should stand up. The done-means check closes the gap by asserting the call
  site's ordering and the presence of the install itself.
- Security/permission risk: none. No namespace, auth, or predicate logic
  touched. `bun install --frozen-lockfile` cannot resolve a package outside the
  committed lockfile, which is the property that makes running it against
  untrusted PR head content acceptable here — the same install lane-bootstrap
  already runs.
- Migration/deploy risk: none. No schema, no migration, no runtime code path.
- Downstream client/runtime risk: none. `scripts/verify-lane.ts` is a
  controller-side tool; it ships in no client and no server surface.
- Rollback/cleanup concern: revert is a single commit. The done-means fixture
  repositories are written under the repo-relative, gitignored `_scratch/verify-lane-deps/` (the convention of `src/operator-doctor.test.ts:29`; the earlier temp-workspace default was Mac-only and failed CI with EACCES on `/Volumes`) and left in place —
  teardown is printed, never executed, matching ledger item 15.
- Fixes made before PR: **the fixtures could escape into the surrounding
  repository, and did.** Both the unit test and the done-means check built a
  throwaway git repo and then ran git against it with a bare `cwd`/`-C`. When
  the fixture is not a repository, git walks UP to the first enclosing one and
  operates there. One `mkdtempSync` fixture came back without a `.git` — `git
  init` did not take, and nothing checked — so its `base` and `docs only`
  commits were authored into the surrounding worktree by "verify-lane test
  <test@example.invalid>", deleting every tracked file in it. The branch ref
  was moved back to the real commit and the tree recovered intact with no work
  lost, and the remote never carried those commits. Closed in the second
  commit rather than merely noted: every git call in both fixtures now pins
  `--git-dir` and `--work-tree` (which makes the upward walk impossible), and
  `git init` — which predates the repo and so cannot use the pinned helper —
  now has its success asserted on both the exit code and the resulting `.git`
  before any other git call runs. Reviewers should weigh this: a check that can
  mutate the repository it is verifying is a worse defect than the one it
  gates, and it is the reason clause 3 builds its fixture the way it does.
- Fixes made before PR: the check originally used `mktemp -d`, which AGENTS.md
  forbids outright because it resolves to a sandbox-local `$TMPDIR` that no
  other process can see. Replaced with an explicit pid+epoch path under the repo's own
  gitignored `_scratch/`, git-dir and work-tree pinned on every call. The test fixture also had to commit on a branch named
  `fixture` rather than `main`, because the global protected-branch hook
  refuses commits to `main` even in a throwaway repository.
- Known residual risk: the fix reinstalls only when `package.json` or
  `bun.lock` differ. A PR that changes neither but still needs a different
  dependency tree — a patch applied by a postinstall script, say — would still
  verify against origin/main's `node_modules`. No such case is known in this
  repo, and widening the trigger to "always reinstall" trades a real slowdown
  on every run for a hypothetical.
- SME review-memory update: [x] not applicable because: this is a fix to
  controller tooling found by running it, not a review-swarm finding or a
  missed review pattern.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this changes only the
  controller-side verification script; no server, tool schema, namespace, or
  client-facing surface is touched, and no Open Brain endpoint is involved.

