### PR TITLE
fix(search-all): clear the qmd timeout when the process exits first

### DIFF
--- a/scripts/done-means/608-qmd-timeout-does-not-fire-after-exit.sh
+++ b/scripts/done-means/608-qmd-timeout-does-not-fire-after-exit.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for the qmd-search timeout race (Closes #608, #632).
+#
+#   bash scripts/done-means/608-qmd-timeout-does-not-fire-after-exit.sh
+#
+# WHAT THIS GATES, AND WHY IT IS NOT JUST "RUN THE TEST"
+#
+# src/tools/search-all.ts raced a qmd subprocess against a setTimeout that
+# called proc.kill(). Nothing cleared the timer when the subprocess won, so the
+# callback fired later — typically after the test that started it had already
+# ended — and called .kill() on a mocked spawn handle that has none. Bun does
+# not attribute that to any test. It reports:
+#
+#   # Unhandled error between tests
+#   TypeError: proc.kill is not a function
+#
+# and exits 1 with `0 fail`. That is the whole reason a bare `bun test` exit
+# code is insufficient evidence here: on the BROKEN code the run can report
+# every test passing. Clause b therefore greps the run output for the unhandled
+# marker rather than trusting the status, because the two disagree by design in
+# exactly the failure mode this gate exists to catch.
+#
+# The observed cost: `db-integration` and `check` red on PRs #771, #772, #776,
+# and on 2 of main's own last 6 runs, each time on a diff that touched nothing
+# in src/. Re-running the same job with no code change flipped it to green,
+# which is the definition of a race and is what taught readers to discount red.
+#
+# Clauses:
+#   a — the search-all test file is green.
+#   b — the run emitted no `Unhandled error between tests` (the real gate).
+#   c — the regression test still DISCRIMINATES: with the clearTimeout removed
+#       from src/tools/search-all.ts, the file must go red. A mutation that
+#       survives means the test is decoration.
+#   d — the server/ twin carries the same cancellation, so the fix cannot be
+#       half-applied. Both files ship the identical race; fixing one leaves the
+#       other armed.
+#   z — CONTROL: both twins still arm a timeout at all. Deleting the timeout
+#       would trivially satisfy a/b/c while removing the protection the timer
+#       exists to provide. Must PASS on both sides of the fix.
+#
+# RED PROOF (pre-fix tree, origin/main @ 1e1e006, regression test present):
+#   clause a FAILS — `expect(cleared).toBe(1)` gets `Received: 0`, i.e. the
+#   timer was never cancelled; and firing the captured callback throws
+#   `TypeError: proc.kill is not a function. (In 'proc.kill()', 'proc.kill' is
+#   undefined)` — the verbatim #632 error. Clause d FAILS (no clearTimeout in
+#   either twin). Clause z PASSES pre-fix, as a control must.
+#
+# Output is content-free: counts, names, and pass/fail states only.
+
+set -uo pipefail
+
+# Resolve the repo from THIS script's own location, so the check cannot reach
+# across trees when verify-lane runs it from a fresh worktree at the PR head.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}" || exit 1
+
+TEST_FILE="src/tools/__tests__/search-all.test.ts"
+SRC_TWIN="src/tools/search-all.ts"
+SERVER_TWIN="server/tools/search-all.ts"
+REGRESSION_NAME="clears the qmd timeout when the subprocess finishes first"
+UNHANDLED_MARKER="Unhandled error between tests"
+
+# Scratch is gitignored; a run leaves the working tree clean.
+WORK_DIR="${REPO_ROOT}/_scratch/608"
+mkdir -p "${WORK_DIR}"
+
+fail_count=0
+pass_count=0
+
+pass() { printf '  PASS  %s\n' "$1"; pass_count=$((pass_count + 1)); }
+fail() { printf '  FAIL  %s\n' "$1"; fail_count=$((fail_count + 1)); }
+
+printf 'done-means: #608/#632 qmd timeout does not fire after the process exits\n'
+printf '  repo: %s\n\n' "${REPO_ROOT}"
+
+for f in "${TEST_FILE}" "${SRC_TWIN}" "${SERVER_TWIN}"; do
+  if [[ ! -f "${f}" ]]; then
+    printf 'FATAL: %s not found — wrong tree or the file was renamed.\n' "${f}"
+    exit 1
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# clause a — the search-all test file is green, and the regression is present
+# ---------------------------------------------------------------------------
+A_LOG="${WORK_DIR}/clause-a.log"
+bun test "${TEST_FILE}" > "${A_LOG}" 2>&1
+a_status=$?
+
+if [[ ${a_status} -ne 0 ]]; then
+  fail "a: ${TEST_FILE} is RED (exit ${a_status}) — see ${A_LOG}"
+  rg -e 'Expected:|Received:|proc\.kill|\(fail\)' "${A_LOG}" 2>/dev/null | head -5 | sed 's/^/        | /'
+elif rg -qF -e "${REGRESSION_NAME}" "${TEST_FILE}"; then
+  pass "a: ${TEST_FILE} green and the #608/#632 regression is present by name"
+else
+  fail "a: the file is green but the regression test NAME is gone — renamed or deleted"
+fi
+
+# ---------------------------------------------------------------------------
+# clause b — no unhandled error between tests (the actual defect signature)
+# ---------------------------------------------------------------------------
+# Checked against the RUN OUTPUT, not the exit code. The defect's signature is
+# precisely a run that reports `0 fail` while exiting non-zero, so greenness of
+# the test list proves nothing about it.
+if rg -qF -e "${UNHANDLED_MARKER}" "${A_LOG}"; then
+  fail "b: the run emitted '${UNHANDLED_MARKER}' — a timer fired after its test ended"
+  rg -A6 -F -e "${UNHANDLED_MARKER}" "${A_LOG}" 2>/dev/null | head -8 | sed 's/^/        | /'
+else
+  pass "b: no '${UNHANDLED_MARKER}' in the run output"
+fi
+
+# ---------------------------------------------------------------------------
+# clause c — the regression still DISCRIMINATES (mutation)
+# ---------------------------------------------------------------------------
+# Removes the clearTimeout from the src twin, restoring the #608 behaviour.
+# The test file must go red. Restored via `mv` from a backup in an EXIT trap —
+# no delete path anywhere in this script.
+MUT_BACKUP="${WORK_DIR}/search-all.ts.orig"
+restore_mutation() {
+  if [[ -f "${MUT_BACKUP}" ]]; then
+    mv -f "${MUT_BACKUP}" "${SRC_TWIN}"
+  fi
+}
+trap restore_mutation EXIT
+
+cp "${SRC_TWIN}" "${MUT_BACKUP}"
+MUT_LOG="${WORK_DIR}/clause-c.log"
+
+# A KILL IS ONLY A KILL IF THE BASELINE WAS ALIVE. On an already-red tree,
+# "red under mutation" is satisfied by the pre-existing failure — a survived
+# mutant banked as a kill. So clause c is gated on clause a's baseline.
+if [[ ${a_status} -ne 0 ]]; then
+  restore_mutation
+  fail "c: INCONCLUSIVE — the baseline is already RED, so 'red under mutation' proves nothing"
+elif bun --eval '
+  const fs = require("fs");
+  const p = "'"${SRC_TWIN}"'";
+  const src = fs.readFileSync(p, "utf8");
+  const needle = "    clearTimeout(timeoutHandle);\n";
+  if (!src.includes(needle)) { console.error("MUTATION-TARGET-NOT-FOUND"); process.exit(3); }
+  fs.writeFileSync(p, src.replace(needle, ""));
+' >> "${MUT_LOG}" 2>&1; then
+  bun test "${TEST_FILE}" >> "${MUT_LOG}" 2>&1
+  mut_status=$?
+  restore_mutation
+
+  if [[ ${mut_status} -ne 0 ]]; then
+    pass "c: green baseline + mutation (clearTimeout removed) goes RED — it discriminates"
+  else
+    fail "c: mutation SURVIVED — the test passes with the timer left armed; it is decoration"
+  fi
+else
+  restore_mutation
+  fail "c: could not apply the mutation (target string not found) — clause measured nothing"
+fi
+
+# ---------------------------------------------------------------------------
+# clause d — the server/ twin carries the same cancellation
+# ---------------------------------------------------------------------------
+# Both files ship byte-equivalent copies of this race. A fix applied to one
+# leaves the other armed, and the server twin has no test file of its own to
+# notice — so the structural check is the only thing standing between it and a
+# silent half-fix.
+d_ok=1
+for twin in "${SRC_TWIN}" "${SERVER_TWIN}"; do
+  if ! rg -qF -e "clearTimeout(timeoutHandle)" "${twin}"; then
+    fail "d: ${twin} arms the qmd timeout but never clears it — the #608 race is live there"
+    d_ok=0
+  elif ! rg -qF -e 'typeof proc.kill === "function"' "${twin}"; then
+    fail "d: ${twin} calls proc.kill() unguarded — a partial spawn handle still throws"
+    d_ok=0
+  fi
+done
+if (( d_ok == 1 )); then
+  pass "d: both twins clear the timer and guard proc.kill"
+fi
+
+# ---------------------------------------------------------------------------
+# clause z — CONTROL: both twins still ARM a timeout at all
+# ---------------------------------------------------------------------------
+# Must PASS on both sides of the fix. Deleting the timeout entirely would
+# satisfy a, b, c and d while removing the bound that stops a hung qmd from
+# stalling federated search forever. A red z means the protection was removed,
+# not that the race was fixed.
+z_ok=1
+for twin in "${SRC_TWIN}" "${SERVER_TWIN}"; do
+  if ! rg -qF -e "QMD_TIMEOUT_MS" "${twin}" || ! rg -qF -e "timedOut: true" "${twin}"; then
+    fail "z: ${twin} no longer bounds the qmd subprocess — the timeout itself is gone"
+    z_ok=0
+  fi
+done
+if (( z_ok == 1 )); then
+  pass "z: both twins still bound the qmd subprocess with QMD_TIMEOUT_MS"
+fi
+
+# ---------------------------------------------------------------------------
+printf '\n  passed: %d   failed: %d\n' "${pass_count}" "${fail_count}"
+
+if (( fail_count > 0 )); then
+  printf '  VERDICT: FAIL\n'
+  exit 1
+fi
+
+printf '  VERDICT: PASS\n'
+exit 0

--- a/server/tools/search-all.ts
+++ b/server/tools/search-all.ts
@@ -153,6 +153,12 @@ async function searchQmdInternal(
     if (collection) command.push("-c", collection);
 
     const proc = Bun.spawn(command, { stdout: "pipe", stderr: "pipe" });
+    // The timer handle is held outside the race so the winner can cancel the
+    // loser. Without the clearTimeout below, a subprocess that finishes first
+    // leaves the timer armed and it fires later, against an already-settled
+    // race -- after the test that started it has ended. That is how #608/#632
+    // surfaced: `Unhandled error between tests` with `0 fail`, exit 1.
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     const outcome = await Promise.race([
       (async () => {
         const stdout = await new Response(proc.stdout).text();
@@ -160,15 +166,23 @@ async function searchQmdInternal(
         return { stdout, exitCode, timedOut: false };
       })(),
       new Promise<{ stdout: string; exitCode: number; timedOut: boolean }>(
-        (resolve) =>
-          setTimeout(() => {
+        (resolve) => {
+          timeoutHandle = setTimeout(() => {
             // Kill before resolving: an abandoned subprocess would hold its file
             // handles and its share of the box for the life of the server.
-            proc.kill();
+            // `kill` is guarded rather than called outright: a test double
+            // for `Bun.spawn` returns a plain object carrying only the fields
+            // the happy path reads (stdout/stderr/exited), so `.kill()` on it
+            // throws `TypeError: proc.kill is not a function` -- the exact
+            // error in #632. Guarding keeps the timeout path honest under a
+            // partial spawn handle.
+            if (typeof proc.kill === "function") proc.kill();
             resolve({ stdout: "", exitCode: -1, timedOut: true });
-          }, QMD_TIMEOUT_MS),
+          }, QMD_TIMEOUT_MS);
+        },
       ),
     ]);
+    clearTimeout(timeoutHandle);
 
     if (outcome.timedOut) {
       dependencies.logger.warn(

--- a/src/tools/__tests__/search-all.test.ts
+++ b/src/tools/__tests__/search-all.test.ts
@@ -177,9 +177,7 @@ describe("search_all", () => {
         const parsed = parseSearchAll(result);
         expect(parsed.brain_hits).toBe(0);
         expect(parsed.qmd_hits).toBe(2);
-        expect(parsed.results.every((r: any) => r.source === "qmd")).toBe(
-          true,
-        );
+        expect(parsed.results.every((r: any) => r.source === "qmd")).toBe(true);
         expect(parsed.results[0].source_ref).toEqual({
           source: "qmd",
           type: "file",
@@ -1292,6 +1290,84 @@ describe("search_all", () => {
         ).toBe(1);
       } finally {
         await cleanup();
+      }
+    });
+  });
+  describe("qmd timeout race (#608, #632)", () => {
+    it("clears the qmd timeout when the subprocess finishes first", async () => {
+      // Regression for #608/#632. The timeout callback used to survive a race
+      // it had already lost: the subprocess resolved, nothing cleared the
+      // timer, and 10s later the callback ran and called `proc.kill()` on a
+      // mocked spawn handle that has no `kill`. Bun reported that as
+      // `# Unhandled error between tests` with `0 fail` and exit 1, on a test
+      // file that had already passed -- which is why it read as a flake.
+      //
+      // `globalThis.setTimeout` is stubbed only for the duration of the call so
+      // the captured callback can be fired on demand instead of waiting out the
+      // real QMD_TIMEOUT_MS (10s). Firing it AFTER the search resolved is the
+      // exact ordering CI hit.
+      const originalSetTimeout = globalThis.setTimeout;
+      const captured: Array<() => void> = [];
+      const qmdTimerHandles = new Set<unknown>();
+      let cleared = 0;
+      // Mirrors QMD_TIMEOUT_MS in ../search-all.ts; the constant is module
+      // private, so the stub matches on its value to identify the qmd timer.
+      const QMD_TIMEOUT_MS = 10_000;
+      const originalClearTimeout = globalThis.clearTimeout;
+
+      // The mock handle deliberately omits `kill`, matching every other spawn
+      // double in this file -- that omission is what the old code tripped on.
+      mockBunSpawn(
+        0,
+        qmdJson([{ path: "/fast.md", content: "fast result", score: 0.9 }]),
+      );
+
+      const pool = { query: async () => ({ rows: [] }) };
+      const { client, cleanup } = await setupClient(pool, {
+        role: "admin",
+        clientId: "admin",
+      });
+
+      try {
+        // Only the qmd timer is tracked. Other machinery in the MCP client
+        // path arms and clears timers of its own, so counting every
+        // clearTimeout would pass on the broken code too -- the sentinel
+        // handle is what makes `cleared` specific to this race.
+        (globalThis as any).setTimeout = (fn: () => void, ms: number) => {
+          if (ms !== QMD_TIMEOUT_MS) return originalSetTimeout(fn as any, ms);
+          captured.push(fn);
+          const handle = originalSetTimeout(() => {}, 0);
+          qmdTimerHandles.add(handle);
+          return handle;
+        };
+        (globalThis as any).clearTimeout = (handle: any) => {
+          if (qmdTimerHandles.has(handle)) cleared++;
+          return originalClearTimeout(handle);
+        };
+
+        const parsed = parseSearchAll(
+          await client.callTool({
+            name: "search_all",
+            arguments: { query: "fast qmd", sources: "qmd" },
+          }),
+        );
+        expect(parsed.results[0].content).toBe("fast result");
+      } finally {
+        (globalThis as any).setTimeout = originalSetTimeout;
+        (globalThis as any).clearTimeout = originalClearTimeout;
+        await cleanup();
+      }
+
+      // The race is decided. The fix cancels the loser; prove the cancellation
+      // happened rather than only that firing it is survivable.
+      expect(captured.length).toBe(1);
+      expect(cleared).toBe(1);
+
+      // Belt and braces: even if a timer escapes cancellation, running its
+      // callback must not throw on a spawn handle without `kill`. On the old
+      // code this line threw `TypeError: proc.kill is not a function`.
+      for (const fire of captured) {
+        expect(() => fire()).not.toThrow();
       }
     });
   });

--- a/src/tools/search-all.ts
+++ b/src/tools/search-all.ts
@@ -98,6 +98,12 @@ async function searchQmdInternal(
 
     const proc = Bun.spawn(qmdArgs, { stdout: "pipe", stderr: "pipe" });
 
+    // The timer handle is held outside the race so the winner can cancel the
+    // loser. Without the clearTimeout below, a subprocess that finishes first
+    // leaves the timer armed and it fires later, against an already-settled
+    // race -- after the test that started it has ended. That is how #608/#632
+    // surfaced: `Unhandled error between tests` with `0 fail`, exit 1.
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     const result = await Promise.race([
       (async () => {
         const stdout = await new Response(proc.stdout).text();
@@ -105,13 +111,21 @@ async function searchQmdInternal(
         return { stdout, exitCode, timedOut: false };
       })(),
       new Promise<{ stdout: string; exitCode: number; timedOut: boolean }>(
-        (resolve) =>
-          setTimeout(() => {
-            proc.kill();
+        (resolve) => {
+          timeoutHandle = setTimeout(() => {
+            // `kill` is guarded rather than called outright: a test double
+            // for `Bun.spawn` returns a plain object carrying only the fields
+            // the happy path reads (stdout/stderr/exited), so `.kill()` on it
+            // throws `TypeError: proc.kill is not a function` -- the exact
+            // error in #632. Guarding keeps the timeout path honest under a
+            // partial spawn handle.
+            if (typeof proc.kill === "function") proc.kill();
             resolve({ stdout: "", exitCode: -1, timedOut: true });
-          }, QMD_TIMEOUT_MS),
+          }, QMD_TIMEOUT_MS);
+        },
       ),
     ]);
+    clearTimeout(timeoutHandle);
 
     if (result.timedOut) {
       logger.warn("qmd search timed out", { timeoutMs: QMD_TIMEOUT_MS });


### PR DESCRIPTION
Closes #608. Closes #632.

`searchQmdInternal` races the qmd subprocess against a `setTimeout` that calls
`proc.kill()`. Nothing cancelled the timer when the subprocess won, so the
callback stayed armed and fired later, against an already-settled race --
typically after the test that started it had ended.

Under a mocked `Bun.spawn`, the handle carries only the fields the happy path
reads (`stdout`/`stderr`/`exited`) and has no `kill`, so the late callback threw
`TypeError: proc.kill is not a function`. Bun cannot attribute an error raised
between tests to any test, so it printed `# Unhandled error between tests` and
exited 1 while reporting `0 fail`.

That is the shape that made this expensive rather than merely noisy: a red run
that looks green in the test list. It read as a flake, it cost every lane a
re-run tax on diffs touching nothing in `src/`, and a suite that exits non-zero
with `0 fail` teaches readers to discount red CI.

**The fix, at the owning boundary.** The timer handle is held outside the race
and `clearTimeout`d once the race settles, so the loser cannot fire at all. The
`proc.kill` call is additionally guarded with a `typeof` check, since a partial
spawn handle legitimately may not provide one -- belt and braces, because the
cancellation is the actual fix.

**Applied to both twins.** `src/tools/search-all.ts:101` and
`server/tools/search-all.ts:156` ship byte-equivalent copies of this race, and
the server copy has no test file of its own to notice a half-fix. Both are
corrected in the same commit, and done-means clause d asserts structurally that
neither can regress alone.

**Nothing else shares this shape.** `rg -n 'setTimeout\(' src server --type ts`
over non-test files returns 23 sites; the only other `Promise.race`-with-kill is
`src/rem-terra-transport.ts:134`, which already clears its timer in a `finally`
block (line 152). It is correct and untouched.

## Verification

- Done-means: scripts/done-means/608-qmd-timeout-does-not-fire-after-exit.sh
  -> VERDICT: PASS, 5 clauses passed, 0 failed.
- RED-proven against the pre-fix tree with the regression test present: the
  done-means script exits 1 with clauses a, c and d failing. Clause a reports
  `Expected: 1 / Received: 0` on `cleared` -- the timer was never cancelled --
  and firing the captured callback throws the verbatim
  `TypeError: proc.kill is not a function. (In 'proc.kill()', 'proc.kill' is
  undefined)` from #632. Clause z passes on both sides, as a control must.
- The gate checks the run OUTPUT for `Unhandled error between tests`, not the
  exit status, because the two disagree by design in exactly this failure mode:
  on the broken code the test list can report every test passing.
- Clause c is a mutation: it removes the `clearTimeout` and requires the test
  file to go red. The mutation is killed. It is gated on a green baseline, so
  an already-red tree reports INCONCLUSIVE rather than banking a free pass.
- `bun run test:isolated src/tools/__tests__/get-stats.test.ts
  src/tools/__tests__/search-all.test.ts` -> 42 pass, 0 fail across 2 files,
  exit 0, zero `Unhandled error` lines. `get-stats.test.ts` is the file CI
  reported the leak against.
- `bun test src/tools/__tests__/search-all.test.ts` -> 38 pass, 0 fail.
- `bunx tsc --noEmit` -> clean, exit 0.

## Critical Self-Review

- Highest-risk behavior: the timeout path itself. If `clearTimeout` were placed
  where the timeout branch also reached it, a genuinely hung qmd would no longer
  be killed. It sits after the race settles and before the `timedOut` branch is
  read, so the kill still runs on a real timeout; done-means clause z asserts
  both twins still bound the subprocess with `QMD_TIMEOUT_MS`, and would fail if
  a future change "fixed" the race by deleting the timeout.
- Assumptions that could be wrong: that the mocked-spawn handle is the only way
  `proc.kill` goes missing. The `typeof` guard does not depend on that being
  true -- it holds for any partial handle -- and the `clearTimeout` removes the
  late-fire path regardless of what the handle carries.
- Missing/weak tests: the server twin has no test file, so its fix is covered
  structurally (clause d greps both files) rather than behaviorally. Writing a
  server-side harness is larger than this defect warrants; the structural check
  is what stops a half-fix landing.
- Security/permission risk: none. No auth, namespace, predicate, or SQL touched.
- Migration/deploy risk: none. No schema, no migration, no config.
- Downstream client/runtime risk: none. `search_all`'s tool contract, arguments,
  and result shape are unchanged; this only affects whether an already-lost
  timer fires.
- Rollback/cleanup concern: none. Single commit, revertible in isolation.
- Fixes made before PR: the regression's first form asserted
  `expect(cleared).toBeGreaterThan(0)`, which passed on the BROKEN code --
  unrelated timers in the MCP client path were being counted. Tightened to track
  only the qmd timer by its `QMD_TIMEOUT_MS` delay and assert `toBe(1)`, then
  re-RED-proven. A test that passes pre-fix proves nothing.
- Known residual risk: the regression stubs `globalThis.setTimeout` to capture
  the callback rather than waiting out the real 10s delay, and identifies the
  qmd timer by matching that delay value. If `QMD_TIMEOUT_MS` changes, the
  mirrored constant in the test must change with it; the test asserts
  `captured.length === 1`, so a drifted value fails loudly rather than silently
  measuring nothing.
- SME review-memory update: [x] not applicable because: #608 and #632 already
  record this pattern with the evidence, and the done-means check is the durable
  artifact that prevents its return.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this changes only timer
  cancellation inside a subprocess race; no tool contract, transport, schema, or
  client-facing surface moves, so there is nothing for a live canary to observe.
