### PR TITLE
feat(config): type every server/ env read in the validated schema (L2a)

### DIFF
--- a/_plans/l2-composition-root-inventory.md
+++ b/_plans/l2-composition-root-inventory.md
@@ -1,0 +1,58 @@
+# L2 composition-root inventory
+
+Status: WRITTEN 2026-08-26, measured by a read-only Codex lane against origin/main 96978a8 (`server/` identical on chore/oxlint-enforcement). Feeds `_plans/server-hardening-ladder.md` L2.
+
+```text
+RESULTS
+
+A.
+server/observability/langfuse-tracing.ts:599 OPENBRAIN_TRACING_ENDPOINT/PUBLIC_KEY/SECRET_KEY/ENABLED/MASKING_ENABLED -- whole-env default; trim, enabled only with flag `1` and all coordinates, masking defaults on -- NO -- `readMcpTracingConfig`
+server/tools/shared-namespace.ts:37 SHARED_NAMESPACE_CANONICAL/OPENBRAIN_SHARED_NAMESPACE/SHARED_NAMESPACE_PHYSICAL/SHARED_NAMESPACE_LEGACY/OPENBRAIN_LEGACY_SHARED_NAMESPACE -- trim; first non-empty else caller default -- SHARED_NAMESPACE_CANONICAL; others NO -- `envString` via `sharedNamespaceConfig`
+server/tools/shared-namespace.ts:45 OPENBRAIN_LEGACY_SHARED_FALLBACK -- trim; true for `1/true/yes/on`, default false -- NO -- `envBoolean` via `sharedNamespaceConfig`
+server/tools/shared-namespace.ts:52 OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS -- base-10 positive integer, fallback 5 -- NO -- `envPositiveInteger` via `sharedNamespaceConfig`
+server/tools/realtime-stores.ts:46 OPENBRAIN_RECOVERY_WAL_PATH -- `?? null`, no trim/parse -- NO -- `recoveryWalStoreFor`
+server/tools/search-all.ts:119 QMD_PATH -- whole-env default; trim blank to undefined -- NO -- `resolveQmdPath`, called by `registerSearchAllTool`
+server/tools/search-engine.ts:148 OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS -- preferred value; base-10 integer >=1 else 3000 -- NO -- `searchEmbeddingTimeoutMs`
+server/tools/search-engine.ts:149 SEARCH_EMBEDDING_TIMEOUT_MS -- legacy fallback; same parse/default -- NO -- `searchEmbeddingTimeoutMs`
+server/tools/fts-config.ts:111 OPENBRAIN_FTS_CONFIG -- whole-env default; trim, allowlisted language, fallback english -- NO -- `corpusFtsConfig`
+server/tools/fts-config.ts:128 OPENBRAIN_FTS_CONFIG -- whole-env default; request override else corpus default -- NO -- `requestFtsConfig`
+server/tools/operator-doctor.ts:62 OPENBRAIN_TRANSPORT and OPENBRAIN_NATS_* -- whole-env default; trim/lowercase, HTTP/auth/fallback defaults and local-URL guard -- NO -- `readNatsRuntimeBoundary`
+Scan-only non-read hits: `server/application/nats.ts:19` and `server/config/nats.ts:6` are comments.
+
+B.
+main.ts:210 -- config: `loadServerConfig()` calls `parseServerConfig` at `server/config.ts:350`; skipped when `options.config` is supplied.
+main.ts:211 -- logger: `createLogger(config.logging)`.
+main.ts:218-222 -- nonempty-token guard, then pool: `createDatabase(config.database, logger)`.
+main.ts:228 -- tracing: `createTracingRuntime()`; no config passed, so it rereads tracing env before migrations/NATS.
+main.ts:232-241 -- migrations from `config.database.migrationsDirectory`, unless skipped by option.
+main.ts:243-268 -- NATS boundary, health, token map, and bridge from `config.nats`.
+main.ts:74-77,170,247,287,348 -- embedder is not constructed; imported `generateEmbedding*` functions are passed through, with module-level env state already loaded.
+main.ts:278-282 -- capture-health runtime receives raw `process.env`.
+main.ts:284-360 -- auth, REST surface, application, MCP factory, and routes are composed.
+main.ts:362-371 -- port/bind host are resolved, then the HTTP listener opens.
+Direct env departures: `:153` WAL path, `:279` capture env, `:313` `ALLOWED_ORIGINS`, `:362` `PORT`, `:364` `OPEN_BRAIN_BIND_HOST`; audit at `:159` also defaults to `src/audit-log.ts` env parsing.
+src/embedding.ts:6-10,35-36 -- import-time embedding configuration -- imported by `server/main.ts:74-77`, `src/maintenance-bootstrap.ts:41`, `server/tools/ingest-conversation-facts.ts:37`, and `src/operator-doctor.ts:7-13`.
+src/logger.ts:26,115-125,175-189,201-205,583 -- module logger/config/file-sink singleton -- imported directly by `server/observability/langfuse-tracing.ts:100` and indirectly by source modules.
+server/tools/realtime-stores.ts:26-27,34-46 -- lazy module-scoped fallback stores, not import-time; main injects stores at `main.ts:150-155`.
+
+C.
+server/config.ts:115-123 -- database fields.
+server/config.ts:124-127 -- logging/service fields.
+server/config.ts:128-135 -- transport/session fields.
+server/config.ts:136-137 -- embedding fields.
+server/config.ts:138 -- shared-namespace field.
+server/config.ts:139-144 -- auth-token fields.
+server/config.ts:145-146 -- catchall optional strings, including NATS/maintenance keys not explicitly schema fields.
+Yes, beyond main: production call is `server/config.ts:350`; direct test calls are in `server/config.test.ts`, `server/application/{shadow-application.test.ts,sdk-protocol.pg.test.ts}`, and `server/main.pg.test.ts`. `main.ts` calls `loadServerConfig`, not `parseServerConfig` directly.
+
+D.
+Import-time blockers: `src/embedding.ts` and `src/logger.ts` above.
+Runtime source blockers: `src/audit-log.ts:134-156`, `src/operator-doctor.ts:331,433-435,637,649-686`, `src/qmd-path.ts:14-22`, `src/nats-runtime.ts:493-529`, `src/shared-namespace.ts:14,21,27,44+`, `src/promotion-service.ts:235`, `src/drop-folder-collector.ts:97,145`, and `src/maintenance-bootstrap.ts:232-246`.
+Env-mutating tests needing exemption or rewiring include `server/application/sdk-protocol.pg.test.ts:395-396`, `server/config.test.ts:234-247`, `src/embedding.test.ts`, `src/operator-doctor.test.ts`, namespace-policy tests, search timeout tests, FTS tests, and promotion tests.
+
+verified: `rg -n 'process\.env' server --type ts | rg -v '\.test\.ts'` -> 22 textual hits across 11 files; 11 executable reads outside config.ts/main.ts.
+verified: `rg -n 'parseServerConfig' server src` -> 27 textual references; production definition/call only at config.ts:314/350; remaining direct calls are tests.
+verified: `rg -n 'process\.env' src --type ts | rg -v '\.test\.ts'` -> 81 legacy-source textual hits.
+verified: inventory was read-only; no edit, commit, or test command issued.
+
+```

--- a/docs/lane-contract.md
+++ b/docs/lane-contract.md
@@ -87,6 +87,45 @@ Every lane, no exceptions:
 
 Newest first. Every entry: what changed, and the observation that forced it.
 
+### 2026-08-26 (round 35) — harvest of the L2a config-schema lane (PR #778)
+
+- **A schema field that "mirrors" a reader is differenced against the reader
+  input by input, and the test calls the reader.** L2a declared 23 env names
+  with parsers that reproduced the readers' fallbacks, and every test picked
+  inputs where reader and schema agreed, so 65 green tests could not falsify
+  the PR's own start-equivalence claim. The Light-tier reviewer ran a 15-input
+  differencing set (`"3000ms"`, `"1e3"`, `"0x10"`, `"10.5"`, `""`, `"   "`,
+  `"-1"`, `"Infinity"`, ...) and found three P1 divergences: `PORT` is read
+  with `Number()` (`server/main.ts:362`) and the schema used `parseInt`, so a
+  value that crashes `listen` today silently became 3100; the capture-health
+  integers are read with `Number(raw.trim())` + `isInteger`
+  (`server/capture/liveness-observer.ts:535-550`), not `parseInt`; and the
+  shared-namespace canonical precedence was inverted against `envString`
+  (`server/tools/shared-namespace.ts:79-82`). Where the reader is exported,
+  the equivalence test calls it and compares; where the reader would crash the
+  process, the schema rejects with a named issue, never a substitute value.
+- **Cite the parse, not the constant.** The PR body cited
+  `liveness-observer.ts:404-408`, which is where the env NAMES are declared;
+  the parse is at `:535`. A citation to the name constant reads as "checked"
+  while the semantics were never opened.
+- **`??` is not "blank falls through".** `process.env.A ?? process.env.B`
+  keeps `A=""`; a blank-as-absent preprocessor makes it fall through to `B`.
+  Two readers with different blank handling cannot share one preprocessor.
+- **`GROUPS` is a bash builtin** holding the user's numeric group IDs;
+  assigning it in a done-means script silently yields that list and fails as
+  `but 20 is missing`, which reads like a broken check rather than a name
+  collision.
+- **Tooling:** the Codex git guard refuses `git checkout main` in the clone
+  for the head as well as for workers ("do not switch to main/master for
+  work"); verify-lane runs fine from a feature-branch checkout because it cuts
+  its own worktree from `origin/main`. Two CI runs on one SHA inverted their
+  flakes (`db-integration` vs `python-capture`, #614/#764); every job has a
+  green run on the SHA, which is the evidence, not a re-run to all-green.
+- **`max-lines` at 500 on a test file changes how a table-driven block is
+  added.** The fixer retired five hand-constant assertions the reader-driven
+  table subsumes so `server/config.test.ts` still passed the rule; the next
+  rung adds a sibling `*.test.ts` per group instead of removing assertions.
+
 ### 2026-08-26 (round 34) — harvest of the verify-lane deps-at-head lane (PR #776, #775)
 
 - **verify-lane installed dependencies at `origin/main` and then verified the

--- a/scripts/done-means/750-l2a-config-covers-every-env-read.sh
+++ b/scripts/done-means/750-l2a-config-covers-every-env-read.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for #750 lane L2a (_plans/server-hardening-ladder.md, rung
+# L2 "Composition root").
+#
+#   bash scripts/done-means/750-l2a-config-covers-every-env-read.sh
+#
+# ---------------------------------------------------------------------------
+# What this asserts
+# ---------------------------------------------------------------------------
+# `_plans/463-server-rewrite-charter.md:108` gives `server/config/` ownership of
+# ALL env parsing and startup validation, and `:119` states that domain code
+# must not import `process.env`. The charter is a claim about the SCHEMA's
+# coverage, not about who happens to read the variable today: a consumer cannot
+# be rewired onto injected config (L2b/L2c) until the field it needs exists in
+# the validated schema.
+#
+# So the invariant this file gates is one-directional and checkable now:
+#
+#   every env var name read anywhere in non-test `server/` code is declared as
+#   a key of `environmentSchema` in `server/config.ts`.
+#
+# It deliberately does NOT assert the converse (that nothing reads
+# `process.env`) — that is the `no-process-env` lint rule L2c installs. Until
+# then a name can be both schema-declared and still read directly, which is
+# exactly the intermediate state L2a produces on purpose.
+#
+# ---------------------------------------------------------------------------
+# Why main.ts's names are listed literally
+# ---------------------------------------------------------------------------
+# `server/config.ts` is excluded because it IS the schema — every name in it
+# would match itself and the check would pass vacuously. `server/main.ts` is
+# excluded from the SCAN because it is the composition root and is allowed to
+# read the environment, but its five departures (inventory section B) are the
+# ones L2b removes, so they are named here explicitly rather than skipped. A
+# name added to main.ts later is caught by the inventory refresh, not by this
+# file; that is a known and accepted limit of listing them.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+
+CONFIG=server/config.ts
+[[ -f $CONFIG ]] || { echo "FAIL: $CONFIG not found"; exit 1; }
+
+# The schema literal only: from `const environmentSchema` to its `.catchall(`
+# terminator. Scanning the whole file would let a name mentioned in a comment,
+# in `OPTIONAL_SECRET_KEYS`, or in `buildConfig` satisfy the check without the
+# field existing — the exact false green this is here to avoid.
+schema_block="$(awk '/^const environmentSchema = z$/{on=1} on{print} on&&/^  \.catchall\(/{exit}' "$CONFIG")"
+if [[ -z $schema_block ]]; then
+  echo "FAIL: could not locate the environmentSchema literal in $CONFIG"
+  exit 1
+fi
+
+# Explicit `KEY:` declarations inside that literal. A key must be DECLARED, not
+# merely mentioned, so the colon is part of the pattern.
+declared="$(printf '%s\n' "$schema_block" | rg -o '^\s{4}([A-Z][A-Z0-9_]+):' -r '$1' | sort -u)"
+
+# The literal may compose a group module with `...extendedEnvironmentFields`,
+# which keeps `server/config.ts` inside the 100-code-line-per-function lint
+# limit. A spread is a real declaration, so it is FOLLOWED — but only into the
+# named sibling module, and only into that module's own object literal. Trusting
+# an arbitrary spread would let a name be "declared" by anything the file
+# happens to mention, which is the vacuous pass this check exists to prevent.
+# NOT named `GROUPS`: that is a bash builtin holding the user's group IDs,
+# and assigning it silently yields the numeric group list instead.
+GROUPS_FILE=server/config/env-groups.ts
+if printf '%s\n' "$schema_block" | rg -q '^\s*\.\.\.extendedEnvironmentFields,$'; then
+  [[ -f $GROUPS_FILE ]] || { echo "FAIL: schema spreads extendedEnvironmentFields but $GROUPS_FILE is missing"; exit 1; }
+  group_block="$(awk '/^export const extendedEnvironmentFields = \{$/{on=1} on{print} on&&/^\} as const;$/{exit}' "$GROUPS_FILE")"
+  [[ -n $group_block ]] || { echo "FAIL: could not locate extendedEnvironmentFields in $GROUPS_FILE"; exit 1; }
+  group_declared="$(printf '%s\n' "$group_block" | rg -o '^\s{2}([A-Z][A-Z0-9_]+):' -r '$1' | sort -u)"
+  declared="$(printf '%s\n%s\n' "$declared" "$group_declared" | rg -v '^$' | sort -u)"
+fi
+
+# Section A: every name read in non-test `server/` code, config.ts and main.ts
+# excluded per the header.
+scanned="$(rg -oN 'process\.env\.([A-Z0-9_]+)' -r '$1' server --type ts \
+  | rg -v '^server/config\.ts:' \
+  | rg -v '^server/main\.ts:' \
+  | rg -v 'test\.ts:' \
+  | sed 's/^.*://' \
+  | sort -u)"
+
+# The same scan misses names reached through an exported constant rather than a
+# literal member expression (`env[CAPTURE_HEALTH_NAMESPACE_ENV]`), and misses
+# names read via an injected `env` parameter whose only production argument is
+# `process.env`, and misses `server/tools/shared-namespace.ts`'s `envString`
+# family, which indexes `process.env[name]` with a name passed in as data. All
+# three are real reads and all are in inventory section A/B, so they are
+# enumerated. NATS is absent from this list on purpose: `server/config/nats.ts`
+# already parses `OPENBRAIN_TRANSPORT` and every `OPENBRAIN_NATS_*` from the
+# environment object the schema's `.catchall` passes it, so those names reach
+# `parseNatsConfig` through validated config and are not direct reads.
+indirect="SHARED_NAMESPACE_CANONICAL
+OPENBRAIN_SHARED_NAMESPACE
+SHARED_NAMESPACE_PHYSICAL
+SHARED_NAMESPACE_LEGACY
+OPENBRAIN_LEGACY_SHARED_NAMESPACE
+OPENBRAIN_LEGACY_SHARED_FALLBACK
+OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS
+OPENBRAIN_CAPTURE_HEALTH_NAMESPACE
+OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES
+OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS
+OPENBRAIN_TRACING_ENDPOINT
+OPENBRAIN_TRACING_PUBLIC_KEY
+OPENBRAIN_TRACING_SECRET_KEY
+OPENBRAIN_TRACING_ENABLED
+OPENBRAIN_TRACING_MASKING_ENABLED
+QMD_PATH
+OPENBRAIN_FTS_CONFIG"
+
+# Section B: main.ts's own direct reads, per the inventory.
+main_names="OPENBRAIN_RECOVERY_WAL_PATH
+ALLOWED_ORIGINS
+PORT
+OPEN_BRAIN_BIND_HOST"
+
+required="$(printf '%s\n%s\n%s\n' "$scanned" "$indirect" "$main_names" | rg -v '^$' | sort -u)"
+
+count=0
+missing=()
+while IFS= read -r name; do
+  [[ -n $name ]] || continue
+  count=$((count + 1))
+  if ! printf '%s\n' "$declared" | rg -q "^${name}$"; then
+    missing+=("$name")
+  fi
+done <<< "$required"
+
+# A scan that found nothing is a broken scan, not a clean repo. `rg` returning
+# no matches would otherwise make this exit 0 while examining zero names.
+if (( count < 15 )); then
+  echo "FAIL: only $count env names collected — the scan is broken, not the repo"
+  exit 1
+fi
+
+if (( ${#missing[@]} > 0 )); then
+  echo "FAIL: $count env names read in server/; ${#missing[@]} are not declared in environmentSchema:"
+  printf '  %s\n' "${missing[@]}"
+  exit 1
+fi
+
+echo "PASS: all $count env names read in server/ are declared in environmentSchema ($CONFIG)"

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -6,6 +6,10 @@
 import { describe, expect, it, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { loadServerConfig, OPTIONAL_SECRET_KEYS, parseServerConfig } from "./config.ts";
+import { resolveFtsConfig } from "./tools/fts-config.ts";
+import { resolveQmdPath } from "./tools/search-all.ts";
+import { parseAllowedOrigins } from "./transport/rest.ts";
+import { readMcpTracingConfig } from "./observability/langfuse-tracing.ts";
 
 const REQUIRED = {
   DB_HOST: "db.internal",
@@ -299,7 +303,7 @@ describe("loadServerConfig against a real process.env", () => {
  * A valid configuration with `overrides` applied, or a failure naming the
  * issues. Shared by every group block below.
  */
-function extendedConfig(overrides: Record<string, string> = {}) {
+function extendedConfig(overrides: Record<string, string | undefined> = {}) {
   const result = parseServerConfig({ ...REQUIRED, ...overrides });
   if (!result.ok) {
     throw new Error(`expected valid configuration: ${JSON.stringify(result.issues)}`);
@@ -333,15 +337,11 @@ describe("extended env — search", () => {
     ).toBe(100);
   });
 
-  it("ignores a non-integer timeout rather than failing startup", () => {
-    expect(
-      extendedConfig({ OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: "abc" }).search.embeddingTimeoutMs,
-    ).toBe(3_000);
-  });
-
   it("ignores a below-minimum timeout, and does NOT fall through to the legacy name", () => {
     // The name is chosen before the value is parsed, so an unusable preferred
-    // value lands on the DEFAULT, not on whatever the legacy name holds.
+    // value lands on the DEFAULT, not on whatever the legacy name holds. The
+    // unparseable case (`abc`) is covered against the reader itself in the
+    // start-equivalence table below.
     expect(
       extendedConfig({
         OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: "0",
@@ -364,9 +364,8 @@ describe("extended env — fts", () => {
     expect(extendedConfig({ OPENBRAIN_FTS_CONFIG: " Spanish " }).fts.corpusConfig).toBe("spanish");
   });
 
-  it("falls back to english on an unrecognized token rather than failing startup", () => {
-    expect(extendedConfig({ OPENBRAIN_FTS_CONFIG: "klingon" }).fts.corpusConfig).toBe("english");
-  });
+  // The unrecognized-token fallback is asserted against `resolveFtsConfig`
+  // itself in the start-equivalence table below, over the whole input set.
 });
 
 describe("extended env — qmd", () => {
@@ -492,12 +491,8 @@ describe("extended env — tracing", () => {
     ).toBe(false);
   });
 
-  it("stays off when the flag is set but a coordinate is missing", () => {
-    const partial = { ...COORDINATES, OPENBRAIN_TRACING_SECRET_KEY: "" };
-    expect(extendedConfig({ ...partial, OPENBRAIN_TRACING_ENABLED: "1" }).tracing.enabled).toBe(
-      false,
-    );
-  });
+  // The incomplete-coordinate and masking shapes are asserted against
+  // `readMcpTracingConfig` itself in the start-equivalence block below.
 
   it("disables masking only on an exact 0", () => {
     expect(extendedConfig({ OPENBRAIN_TRACING_MASKING_ENABLED: "0" }).tracing.maskingEnabled).toBe(
@@ -534,14 +529,8 @@ describe("extended env — captureHealth", () => {
     );
   });
 
-  it("ignores an unparseable window or refresh rather than failing startup", () => {
-    const capture = extendedConfig({
-      OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES: "soon",
-      OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS: "-5",
-    }).captureHealth;
-    expect(capture.windowMinutes).toBe(360);
-    expect(capture.refreshMs).toBe(60_000);
-  });
+  // The unparseable and non-positive cases are asserted against
+  // `readPositiveInteger` itself in the start-equivalence table below.
 });
 
 describe("extended env — http", () => {
@@ -555,8 +544,17 @@ describe("extended env — http", () => {
     expect(extendedConfig({ PORT: "7150" }).http.port).toBe(7_150);
   });
 
-  it("ignores an unusable port rather than failing startup", () => {
-    expect(extendedConfig({ PORT: "not-a-port" }).http.port).toBe(3_100);
+  it("rejects an unbindable port by name instead of substituting a default", () => {
+    // The reader is `Number(process.env.PORT ?? DEFAULT_PORT)`
+    // (`server/main.ts:362`) and `Number("not-a-port")` is `NaN`, which
+    // `listen` throws on — so this deployment does NOT start today. A silent
+    // 3100 here would boot it on a port nobody configured; a named config
+    // issue is the same crash, reached earlier. Full equivalence table is in
+    // the start-equivalence block below.
+    const result = parseServerConfig({ ...REQUIRED, PORT: "not-a-port" });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected an unbindable port to be rejected");
+    expect(result.issues.map((issue) => issue.path)).toEqual(["PORT"]);
   });
 
   it("splits, trims, and drops blanks from the origin list", () => {
@@ -566,7 +564,170 @@ describe("extended env — http", () => {
     ).toEqual(["https://a.example", "https://b.example"]);
   });
 
-  it("yields no origins for a blank list", () => {
-    expect(extendedConfig({ ALLOWED_ORIGINS: "  " }).http.allowedOrigins).toEqual([]);
+  // The blank list is asserted against `parseAllowedOrigins` itself in the
+  // start-equivalence table below, over the whole input set.
+});
+
+
+/**
+ * START-EQUIVALENCE: the schema must answer what the READER answers.
+ *
+ * The blocks above assert the schema against a hand-written expected value,
+ * which is what let three divergences pass their own suite (PR #778 review):
+ * every input they chose is one on which reader and schema happen to agree.
+ * These drive the assertion from the reader instead, over the reviewer's
+ * divergence-finding input set, so the equivalence claim is falsifiable.
+ *
+ * An exported reader is IMPORTED and called. A module-private one has its exact
+ * expression written out beside its file and line, so an edit to either side
+ * fails a test rather than drifting apart quietly.
+ */
+const DIVERGENCE_INPUTS = [
+  "3000ms", "10.5", "1e3", " 42 ", "0x10", "abc", "-1", "0", "", "   ",
+  undefined, "007", "3,000", "+5", "Infinity",
+] as const;
+
+/** `server/capture/liveness-observer.ts:535-550`, reproduced: `Number`, not `parseInt`. */
+function readPositiveInteger(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const parsed = Number(raw.trim());
+  const ok = Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0;
+  return ok ? parsed : fallback;
+}
+
+/** `server/tools/search-engine.ts:147-152`, reproduced: `??` does NOT skip `""`. */
+function searchEmbeddingTimeoutMs(
+  preferred: string | undefined,
+  legacy: string | undefined,
+): number {
+  const raw = preferred ?? legacy;
+  if (!raw) return 3_000;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isNaN(parsed) || parsed < 1 ? 3_000 : parsed;
+}
+
+/**
+ * `server/main.ts:362` is `Number(process.env.PORT ?? DEFAULT_PORT)` handed to
+ * `server.listen(port)`, which THROWS on a non-integer or an out-of-range one —
+ * so those environments crash today and a named rejection is that same crash,
+ * earlier. A silent 3100 would instead boot a deployment that does not boot.
+ */
+function expectPortMatchesReader(input: string | undefined): void {
+  const expected = Number(input ?? 3_100);
+  const bindable = Number.isInteger(expected) && expected >= 0 && expected <= 65_535;
+  const result = parseServerConfig({ ...REQUIRED, PORT: input });
+  if (bindable) {
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("expected valid configuration");
+    expect(result.config.http.port).toBe(expected);
+    return;
+  }
+  expect(result.ok).toBe(false);
+  if (result.ok) throw new Error(`expected PORT=${String(input)} rejected`);
+  expect(result.issues.map((issue) => issue.path)).toEqual(["PORT"]);
+}
+
+function expectCaptureHealthMatchesReader(input: string | undefined): void {
+  const capture = extendedConfig({
+    OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES: input,
+    OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS: input,
+  }).captureHealth;
+  expect(capture.windowMinutes).toBe(readPositiveInteger(input, 360));
+  expect(capture.refreshMs).toBe(readPositiveInteger(input, 60_000));
+}
+
+function expectSearchTimeoutMatchesReader(input: string | undefined): void {
+  expect(
+    extendedConfig({ OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: input }).search.embeddingTimeoutMs,
+  ).toBe(searchEmbeddingTimeoutMs(input, undefined));
+  expect(
+    extendedConfig({ SEARCH_EMBEDDING_TIMEOUT_MS: input }).search.embeddingTimeoutMs,
+  ).toBe(searchEmbeddingTimeoutMs(undefined, input));
+}
+
+/** The readers that ARE exported are imported and called, not reproduced. */
+function expectExportedReadersAgree(input: string | undefined): void {
+  const config = extendedConfig({
+    OPENBRAIN_FTS_CONFIG: input,
+    ALLOWED_ORIGINS: input,
+    QMD_PATH: input,
+  });
+  expect(config.fts.corpusConfig).toEqual(resolveFtsConfig(input?.trim()));
+  expect(config.http.allowedOrigins).toEqual(parseAllowedOrigins(input));
+  expect(config.qmd.path).toBe(resolveQmdPath({ QMD_PATH: input }));
+}
+
+describe("start-equivalence — every field answers what its reader answers", () => {
+  test.each([...DIVERGENCE_INPUTS])("every reader agrees for %o", (input) => {
+    expectPortMatchesReader(input);
+    expectCaptureHealthMatchesReader(input);
+    expectSearchTimeoutMatchesReader(input);
+    expectExportedReadersAgree(input);
+  });
+
+  it("binds the ephemeral port for PORT= rather than substituting 3100", () => {
+    // `Number("")` is 0, and 0 asks the OS for an ephemeral port. That is a real
+    // deployment shape — the same one `QMD_PATH=` produced a live defect with.
+    expect(extendedConfig({ PORT: "" }).http.port).toBe(0);
+    expect(extendedConfig({ PORT: "   " }).http.port).toBe(0);
+  });
+
+  it("takes Number's reading of exponent, hex, and padded port forms", () => {
+    expect(extendedConfig({ PORT: "1e3" }).http.port).toBe(1_000);
+    expect(extendedConfig({ PORT: "0x10" }).http.port).toBe(16);
+    expect(extendedConfig({ PORT: " 42 " }).http.port).toBe(42);
+  });
+
+  it("does not fall through to the legacy timeout name when the preferred is blank", () => {
+    // `??` is not `||`: a present-but-empty preferred name is still PRESENT, so
+    // the reader answers 3000 and never looks at the legacy value.
+    const answer = extendedConfig({
+      OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: "",
+      SEARCH_EMBEDDING_TIMEOUT_MS: "900",
+    }).search.embeddingTimeoutMs;
+    expect(answer).toBe(searchEmbeddingTimeoutMs("", "900"));
+    expect(answer).toBe(3_000);
+  });
+});
+
+/**
+ * Canonical shared-namespace precedence.
+ *
+ * `server/tools/shared-namespace.ts:79-82` is
+ * `envString(["SHARED_NAMESPACE_CANONICAL", "OPENBRAIN_SHARED_NAMESPACE"], …)`
+ * — the first NON-EMPTY trimmed value in THAT order, so the canonical name
+ * wins. The schema declares it as a literal with a default
+ * (`server/config.ts:167`), so `parsed` cannot express "unset" and the RAW
+ * environment value has to decide. Namespace resolution is a security boundary
+ * (`docs/sme/security.md`); the same value propagates into `physical`.
+ */
+describe("start-equivalence — shared-namespace canonical precedence", () => {
+  test.each([
+    // canonical unset -> the override is what `envString` reaches next
+    [{ OPENBRAIN_SHARED_NAMESPACE: "other" }, "other"],
+    // both set -> the CANONICAL name wins; the group had this inverted
+    [{ SHARED_NAMESPACE_CANONICAL: "shared-kb", OPENBRAIN_SHARED_NAMESPACE: "other" }, "shared-kb"],
+    // an explicit physical name outranks either canonical coordinate
+    [{ OPENBRAIN_SHARED_NAMESPACE: "other", SHARED_NAMESPACE_PHYSICAL: "shared-kb-v2" }, "shared-kb-v2"],
+  ])("resolves the physical name from %o", (env, expected) => {
+    expect(extendedConfig(env).sharedNamespaceNames.physical).toBe(expected);
+  });
+
+  it("matches readMcpTracingConfig on the complete and incomplete shapes", () => {
+    const complete = {
+      OPENBRAIN_TRACING_ENABLED: "1",
+      OPENBRAIN_TRACING_ENDPOINT: "https://langfuse.internal",
+      OPENBRAIN_TRACING_PUBLIC_KEY: "pk",
+      OPENBRAIN_TRACING_SECRET_KEY: "sk",
+    };
+    const incomplete = { ...complete, OPENBRAIN_TRACING_ENDPOINT: "  " };
+    for (const shape of [{}, { OPENBRAIN_TRACING_ENABLED: "1" }, complete, incomplete]) {
+      const reader = readMcpTracingConfig(shape);
+      const schema = extendedConfig(shape).tracing;
+      expect(schema.enabled).toBe(reader.enabled);
+      expect(schema.maskingEnabled).toBe(reader.maskingEnabled);
+      expect(schema.endpoint).toBe(reader.endpoint);
+      expect(schema.publicKey).toBe(reader.publicKey);
+    }
   });
 });

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -268,8 +268,305 @@ describe("loadServerConfig against a real process.env", () => {
     // The empty-as-absent rule must not have turned the boundary into one that
     // accepts anything: a missing REQUIRED field still has to stop startup, and
     // the message still has to say which field.
-    expect(() => withEnv({ DB_HOST: "" }, () => loadServerConfig())).toThrow(
+    // `load` is named rather than inlined so this stays inside the
+    // max-nested-callbacks limit: describe > it > expect-thunk > withEnv-thunk
+    // is four deep, and the last two say the same thing.
+    const load = () => loadServerConfig();
+    expect(() => withEnv({ DB_HOST: "" }, load)).toThrow(
       /server_configuration_invalid.*DB_HOST/,
     );
+  });
+});
+
+/**
+ * The env groups added by #750 lane L2a.
+ *
+ * Design authority: `_plans/463-server-rewrite-charter.md:108` — `server/config/`
+ * owns ALL env parsing and startup validation. Field-by-field scope and the
+ * reader each one mirrors are in `_plans/l2-composition-root-inventory.md`.
+ *
+ * The bar every case below holds to is START-EQUIVALENCE, not tidiness: the
+ * assertion is that the schema answers what the CURRENT reader answers for the
+ * same input, including the inputs the current reader shrugs off. That is why
+ * the "rejection" cases assert a FALLBACK rather than `ok: false` — several of
+ * these readers deliberately ignore an unusable value (`abc` → 3000 at
+ * `server/tools/search-engine.ts:148`; `-1` → 5 at
+ * `server/tools/shared-namespace.ts:52`), and turning that into a startup
+ * rejection here would stop a deployment that boots today. A test asserting
+ * `ok: false` would be asserting a behavior change nobody asked for.
+ */
+/**
+ * A valid configuration with `overrides` applied, or a failure naming the
+ * issues. Shared by every group block below.
+ */
+function extendedConfig(overrides: Record<string, string> = {}) {
+  const result = parseServerConfig({ ...REQUIRED, ...overrides });
+  if (!result.ok) {
+    throw new Error(`expected valid configuration: ${JSON.stringify(result.issues)}`);
+  }
+  return result.config;
+}
+
+describe("extended env — search", () => {
+  it("defaults the embedding timeout to 3000ms", () => {
+    expect(extendedConfig().search.embeddingTimeoutMs).toBe(3_000);
+  });
+
+  it("takes an explicit timeout", () => {
+    expect(
+      extendedConfig({ OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: "750" }).search.embeddingTimeoutMs,
+    ).toBe(750);
+  });
+
+  it("falls back to the legacy name when the preferred one is absent", () => {
+    expect(
+      extendedConfig({ SEARCH_EMBEDDING_TIMEOUT_MS: "900" }).search.embeddingTimeoutMs,
+    ).toBe(900);
+  });
+
+  it("prefers the current name over the legacy one when both are set", () => {
+    expect(
+      extendedConfig({
+        OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: "100",
+        SEARCH_EMBEDDING_TIMEOUT_MS: "900",
+      }).search.embeddingTimeoutMs,
+    ).toBe(100);
+  });
+
+  it("ignores a non-integer timeout rather than failing startup", () => {
+    expect(
+      extendedConfig({ OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: "abc" }).search.embeddingTimeoutMs,
+    ).toBe(3_000);
+  });
+
+  it("ignores a below-minimum timeout, and does NOT fall through to the legacy name", () => {
+    // The name is chosen before the value is parsed, so an unusable preferred
+    // value lands on the DEFAULT, not on whatever the legacy name holds.
+    expect(
+      extendedConfig({
+        OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: "0",
+        SEARCH_EMBEDDING_TIMEOUT_MS: "900",
+      }).search.embeddingTimeoutMs,
+    ).toBe(3_000);
+  });
+});
+
+describe("extended env — fts", () => {
+  it("defaults the corpus configuration to english", () => {
+    expect(extendedConfig().fts.corpusConfig).toBe("english");
+  });
+
+  it("takes an explicit supported configuration", () => {
+    expect(extendedConfig({ OPENBRAIN_FTS_CONFIG: "simple" }).fts.corpusConfig).toBe("simple");
+  });
+
+  it("maps a language token to its configuration", () => {
+    expect(extendedConfig({ OPENBRAIN_FTS_CONFIG: " Spanish " }).fts.corpusConfig).toBe("spanish");
+  });
+
+  it("falls back to english on an unrecognized token rather than failing startup", () => {
+    expect(extendedConfig({ OPENBRAIN_FTS_CONFIG: "klingon" }).fts.corpusConfig).toBe("english");
+  });
+});
+
+describe("extended env — qmd", () => {
+  it("omits the path when unset, so federation is off rather than mis-spawned", () => {
+    expect("path" in extendedConfig().qmd).toBe(false);
+  });
+
+  it("takes an explicit path", () => {
+    expect(extendedConfig({ QMD_PATH: "/usr/local/bin/qmd" }).qmd.path).toBe("/usr/local/bin/qmd");
+  });
+
+  it("treats a blank path as unset, which is the dogfood shape QMD_PATH=", () => {
+    // `docs/qmd-ob-layered-recall.md`: `QMD_PATH=` (empty, not absent) made a
+    // `?? default` resolution spawn `bun "" search …` and fail open forever.
+    expect("path" in extendedConfig({ QMD_PATH: "   " }).qmd).toBe(false);
+  });
+});
+
+describe("extended env — recovery", () => {
+  it("defaults the WAL path to null", () => {
+    expect(extendedConfig().recovery.walPath).toBeNull();
+  });
+
+  it("takes an explicit WAL path", () => {
+    expect(extendedConfig({ OPENBRAIN_RECOVERY_WAL_PATH: "var/wal.log" }).recovery.walPath).toBe(
+      "var/wal.log",
+    );
+  });
+
+  it("treats a blank WAL path as null", () => {
+    expect(extendedConfig({ OPENBRAIN_RECOVERY_WAL_PATH: "" }).recovery.walPath).toBeNull();
+  });
+});
+
+describe("extended env — sharedNamespaceNames", () => {
+  it("defaults physical to the canonical name and legacy to empty", () => {
+    const names = extendedConfig().sharedNamespaceNames;
+    expect(names.physical).toBe("shared-kb");
+    // #167 retired `collab`; an empty legacy name must never match input.
+    expect(names.legacy).toBe("");
+    expect(names.legacyFallbackEnabled).toBe(false);
+    expect(names.fallbackMinResults).toBe(5);
+  });
+
+  it("takes an explicit physical name pointed away from the canonical one", () => {
+    expect(
+      extendedConfig({ SHARED_NAMESPACE_PHYSICAL: "shared-kb-v2" }).sharedNamespaceNames.physical,
+    ).toBe("shared-kb-v2");
+  });
+
+  it("takes an explicit legacy name, preferring SHARED_NAMESPACE_LEGACY", () => {
+    const names = extendedConfig({
+      SHARED_NAMESPACE_LEGACY: "collab",
+      OPENBRAIN_LEGACY_SHARED_NAMESPACE: "older",
+    }).sharedNamespaceNames;
+    expect(names.legacy).toBe("collab");
+  });
+
+  it("falls back to OPENBRAIN_LEGACY_SHARED_NAMESPACE", () => {
+    expect(
+      extendedConfig({ OPENBRAIN_LEGACY_SHARED_NAMESPACE: "collab" }).sharedNamespaceNames.legacy,
+    ).toBe("collab");
+  });
+
+  it("enables the legacy fallback on each permissive true token", () => {
+    for (const token of ["1", "true", "YES", " on "]) {
+      expect(
+        extendedConfig({ OPENBRAIN_LEGACY_SHARED_FALLBACK: token }).sharedNamespaceNames
+          .legacyFallbackEnabled,
+      ).toBe(true);
+    }
+  });
+
+  it("treats an unrecognized flag token as false rather than failing startup", () => {
+    expect(
+      extendedConfig({ OPENBRAIN_LEGACY_SHARED_FALLBACK: "maybe" }).sharedNamespaceNames
+        .legacyFallbackEnabled,
+    ).toBe(false);
+  });
+
+  it("takes an explicit fallback minimum", () => {
+    expect(
+      extendedConfig({ OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS: "12" }).sharedNamespaceNames
+        .fallbackMinResults,
+    ).toBe(12);
+  });
+
+  it("ignores a non-positive fallback minimum rather than failing startup", () => {
+    for (const bad of ["0", "-1", "abc"]) {
+      expect(
+        extendedConfig({ OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS: bad }).sharedNamespaceNames
+          .fallbackMinResults,
+      ).toBe(5);
+    }
+  });
+});
+
+describe("extended env — tracing", () => {
+  const COORDINATES = {
+    OPENBRAIN_TRACING_ENDPOINT: "https://langfuse.internal",
+    OPENBRAIN_TRACING_PUBLIC_KEY: "pk-test",
+    OPENBRAIN_TRACING_SECRET_KEY: "sk-test",
+  };
+
+  it("is off by default, with empty coordinates and masking on", () => {
+    const tracing = extendedConfig().tracing;
+    expect(tracing.enabled).toBe(false);
+    expect(tracing.maskingEnabled).toBe(true);
+    expect(tracing.endpoint).toBe("");
+  });
+
+  it("is on only when the flag is set AND all three coordinates are present", () => {
+    const tracing = extendedConfig({ ...COORDINATES, OPENBRAIN_TRACING_ENABLED: "1" }).tracing;
+    expect(tracing.enabled).toBe(true);
+    expect(tracing.endpoint).toBe("https://langfuse.internal");
+    expect(tracing.publicKey).toBe("pk-test");
+  });
+
+  it("stays off when the coordinates are complete but the flag is not exactly 1", () => {
+    // An external payload-carrying export is opt-in; `true` is not the flag.
+    expect(
+      extendedConfig({ ...COORDINATES, OPENBRAIN_TRACING_ENABLED: "true" }).tracing.enabled,
+    ).toBe(false);
+  });
+
+  it("stays off when the flag is set but a coordinate is missing", () => {
+    const partial = { ...COORDINATES, OPENBRAIN_TRACING_SECRET_KEY: "" };
+    expect(extendedConfig({ ...partial, OPENBRAIN_TRACING_ENABLED: "1" }).tracing.enabled).toBe(
+      false,
+    );
+  });
+
+  it("disables masking only on an exact 0", () => {
+    expect(extendedConfig({ OPENBRAIN_TRACING_MASKING_ENABLED: "0" }).tracing.maskingEnabled).toBe(
+      false,
+    );
+    expect(
+      extendedConfig({ OPENBRAIN_TRACING_MASKING_ENABLED: "false" }).tracing.maskingEnabled,
+    ).toBe(true);
+  });
+});
+
+describe("extended env — captureHealth", () => {
+  it("omits the namespace when unset — no observer, never a guessed tenant", () => {
+    const capture = extendedConfig().captureHealth;
+    expect("namespace" in capture).toBe(false);
+    expect(capture.windowMinutes).toBe(360);
+    expect(capture.refreshMs).toBe(60_000);
+  });
+
+  it("takes an explicit namespace, window, and refresh", () => {
+    const capture = extendedConfig({
+      OPENBRAIN_CAPTURE_HEALTH_NAMESPACE: "rico",
+      OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES: "60",
+      OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS: "5000",
+    }).captureHealth;
+    expect(capture.namespace).toBe("rico");
+    expect(capture.windowMinutes).toBe(60);
+    expect(capture.refreshMs).toBe(5_000);
+  });
+
+  it("treats a blank namespace as unset, which is what disables the observer", () => {
+    expect("namespace" in extendedConfig({ OPENBRAIN_CAPTURE_HEALTH_NAMESPACE: "  " }).captureHealth).toBe(
+      false,
+    );
+  });
+
+  it("ignores an unparseable window or refresh rather than failing startup", () => {
+    const capture = extendedConfig({
+      OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES: "soon",
+      OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS: "-5",
+    }).captureHealth;
+    expect(capture.windowMinutes).toBe(360);
+    expect(capture.refreshMs).toBe(60_000);
+  });
+});
+
+describe("extended env — http", () => {
+  it("defaults to port 3100 and an EMPTY origin allowlist, never a wildcard", () => {
+    const http = extendedConfig().http;
+    expect(http.port).toBe(3_100);
+    expect(http.allowedOrigins).toEqual([]);
+  });
+
+  it("takes an explicit port", () => {
+    expect(extendedConfig({ PORT: "7150" }).http.port).toBe(7_150);
+  });
+
+  it("ignores an unusable port rather than failing startup", () => {
+    expect(extendedConfig({ PORT: "not-a-port" }).http.port).toBe(3_100);
+  });
+
+  it("splits, trims, and drops blanks from the origin list", () => {
+    expect(
+      extendedConfig({ ALLOWED_ORIGINS: "https://a.example, ,https://b.example " }).http
+        .allowedOrigins,
+    ).toEqual(["https://a.example", "https://b.example"]);
+  });
+
+  it("yields no origins for a blank list", () => {
+    expect(extendedConfig({ ALLOWED_ORIGINS: "  " }).http.allowedOrigins).toEqual([]);
   });
 });

--- a/server/config.ts
+++ b/server/config.ts
@@ -292,8 +292,16 @@ function parseUserTokens(environment: Environment): ConfigResult | AuthTokenConf
   return issues.length > 0 ? { ok: false, issues } : configured;
 }
 
+/**
+ * `environment` is the RAW input alongside the parsed one, not a duplicate of
+ * it: `SHARED_NAMESPACE_CANONICAL` is declared as a literal with a default
+ * (`:167`), so `parsed` can never say "the operator did not set this" — and the
+ * reader `sharedNamespaceConfig` (`server/tools/shared-namespace.ts:79-82`)
+ * decides precedence on exactly that distinction.
+ */
 function buildConfig(
   parsed: ParsedEnvironment,
+  environment: Environment,
   userTokens: AuthTokenConfig[],
   deployedRevision?: string,
 ): ServerConfig {
@@ -354,7 +362,7 @@ function buildConfig(
     recovery: recoveryGroup(parsed),
     sharedNamespaceNames: sharedNamespaceGroup(
       parsed,
-      parsed.SHARED_NAMESPACE_CANONICAL,
+      environment.SHARED_NAMESPACE_CANONICAL,
     ),
     tracing: tracingGroup(parsed),
     captureHealth: captureHealthGroup(parsed),
@@ -387,7 +395,7 @@ export function parseServerConfig(
   if (!Array.isArray(userTokens)) return userTokens;
   return {
     ok: true,
-    config: buildConfig(parsed.data, userTokens, deployedRevision),
+    config: buildConfig(parsed.data, environment, userTokens, deployedRevision),
   };
 }
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -14,6 +14,25 @@ import {
 } from "./config/maintenance.ts";
 import { parseNatsConfig, type NatsConfig } from "./config/nats.ts";
 import {
+  captureHealthGroup,
+  extendedEnvironmentFields,
+  ftsGroup,
+  httpGroup,
+  qmdGroup,
+  recoveryGroup,
+  searchGroup,
+  sharedNamespaceGroup,
+  tracingGroup,
+  type CaptureHealthGroup,
+  type FtsConfigGroup,
+  type HttpConfigGroup,
+  type QmdConfigGroup,
+  type RecoveryConfigGroup,
+  type SearchConfigGroup,
+  type SharedNamespaceGroup,
+  type TracingConfigGroup,
+} from "./config/env-groups.ts";
+import {
   readDeployedRevision,
   resolveServerIdentity,
 } from "./transport/server-identity.ts";
@@ -22,6 +41,16 @@ export type { MaintenanceConfig } from "./config/maintenance.ts";
 export { parseMaintenanceConfig } from "./config/maintenance.ts";
 export type { NatsConfig } from "./config/nats.ts";
 export { natsHealthFromConfig, parseNatsConfig } from "./config/nats.ts";
+export type {
+  CaptureHealthGroup,
+  FtsConfigGroup,
+  HttpConfigGroup,
+  QmdConfigGroup,
+  RecoveryConfigGroup,
+  SearchConfigGroup,
+  SharedNamespaceGroup,
+  TracingConfigGroup,
+} from "./config/env-groups.ts";
 
 const LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
 const ROLE_NAMES = [
@@ -142,6 +171,11 @@ const environmentSchema = z
     AUTH_TOKEN_OB_ADMIN: optionalSecret,
     AUTH_TOKEN_PROMOTER: optionalSecret,
     AUTH_TOKEN_READONLY: optionalSecret,
+    // Every remaining variable any non-test `server/` module reads, typed here
+    // so a consumer can be handed a value instead of reaching for
+    // `process.env`. Declarations and the reasoning behind each parser live in
+    // `./config/env-groups.ts`; the readers themselves are rewired by L2b/L2c.
+    ...extendedEnvironmentFields,
   })
   .catchall(z.string().optional());
 
@@ -199,6 +233,19 @@ export interface ServerConfig {
   readonly nats: NatsConfig;
   readonly maintenance: MaintenanceConfig;
   readonly sharedNamespace: "shared-kb";
+  readonly search: SearchConfigGroup;
+  readonly fts: FtsConfigGroup;
+  readonly qmd: QmdConfigGroup;
+  readonly recovery: RecoveryConfigGroup;
+  /**
+   * Physical and legacy shared-namespace names. The CANONICAL name is
+   * `sharedNamespace` above and stays there — these are the migration
+   * coordinates that may point away from it.
+   */
+  readonly sharedNamespaceNames: SharedNamespaceGroup;
+  readonly tracing: TracingConfigGroup;
+  readonly captureHealth: CaptureHealthGroup;
+  readonly http: HttpConfigGroup;
 }
 
 export interface ConfigIssue {
@@ -301,6 +348,17 @@ function buildConfig(
       parsed as Record<string, string | undefined>,
     ),
     sharedNamespace: parsed.SHARED_NAMESPACE_CANONICAL,
+    search: searchGroup(parsed),
+    fts: ftsGroup(parsed),
+    qmd: qmdGroup(parsed),
+    recovery: recoveryGroup(parsed),
+    sharedNamespaceNames: sharedNamespaceGroup(
+      parsed,
+      parsed.SHARED_NAMESPACE_CANONICAL,
+    ),
+    tracing: tracingGroup(parsed),
+    captureHealth: captureHealthGroup(parsed),
+    http: httpGroup(parsed),
   };
 }
 

--- a/server/config/env-groups.ts
+++ b/server/config/env-groups.ts
@@ -14,18 +14,34 @@
  * rewiring is the next rung's work (L2b/L2c). Until then both this and the
  * original reader exist, deliberately.
  *
- * WHY THE PARSERS ARE PERMISSIVE AND THE EXISTING ONES ARE NOT REWRITTEN. The
- * bar for this rung is start-equivalence: a deployment whose environment starts
- * the server today must still start it, with the same values. Several of these
+ * WHY THE PARSERS MIRROR THEIR READER RATHER THAN BEING TIDIED. The bar for
+ * this rung is start-equivalence: a deployment whose environment starts the
+ * server today must still start it, with the same values. Several of these
  * readers deliberately IGNORE an unusable value and fall back rather than
- * failing — `searchEmbeddingTimeoutMs` (`server/tools/search-engine.ts:148`)
+ * failing — `searchEmbeddingTimeoutMs` (`server/tools/search-engine.ts:147`)
  * answers 3000 for `abc`, and `envPositiveInteger`
  * (`server/tools/shared-namespace.ts:52`) answers 5 for `-1`. Tightening any of
  * those into a hard rejection here would turn a currently-booting deployment
  * into `server_configuration_invalid` at startup, which is a behavior change
  * smuggled in under a typing change. So the fallback semantics are reproduced
- * exactly, and only the fields whose current reader ALREADY rejects — none of
- * them, at present — would reject here.
+ * exactly.
+ *
+ * WHICH PARSE FUNCTION, THOUGH — `Number` AND `parseInt` ARE NOT THE SAME. They
+ * disagree in both directions (`Number("1e3")` is 1000, `parseInt("1e3")` is 1;
+ * `Number("3000ms")` is `NaN`, `parseInt("3000ms")` is 3000), so a mirror is
+ * only a mirror if it uses the reader's own function. Three helpers below, one
+ * per reader shape, and each field's comment names the reader line it copies:
+ * `fallbackInteger` for the `parseInt` readers, `numberPositiveInteger` for
+ * `readPositiveInteger` (`server/capture/liveness-observer.ts:535`), and
+ * `portNumber` for `server/main.ts:362`.
+ *
+ * ONE FIELD REJECTS, AND REJECTING IS THE EQUIVALENT ANSWER THERE. `PORT` is
+ * the reader that does not fall back: `Number(...)` goes straight to
+ * `server.listen(port)`, which THROWS on a non-integer or an out-of-range port,
+ * so those environments crash the process today. Naming the bad variable in a
+ * config issue is that same crash reached earlier and legibly. Substituting a
+ * silent default would be the behavior change — it boots a deployment that does
+ * not boot now, on a port nobody chose.
  *
  * The one place that is stricter is the shape, not the value: a field that is
  * documented as a positive integer is typed `number`, so a consumer reading it
@@ -47,11 +63,16 @@ const blankAsAbsent = z.preprocess(
 /**
  * A base-10 integer at or above `minimum`, falling back on anything else.
  *
- * Reproduces `Number.parseInt(raw, 10)` plus a range guard, which is what every
- * integer reader in section A does. `parseInt` is NOT `Number`: it accepts a
- * trailing suffix, so `3000ms` is 3000 to the current readers and must stay
- * 3000 here. Using `z.coerce.number()` would reject it and stop a deployment
- * that boots today.
+ * Reproduces `Number.parseInt(raw, 10)` plus a range guard, which is what the
+ * `parseInt`-shaped integer readers in section A do — `envPositiveInteger`
+ * (`server/tools/shared-namespace.ts:52`) is the one this still serves.
+ * `parseInt` is NOT `Number`: it accepts a trailing suffix, so `3000ms` is 3000
+ * to that reader and must stay 3000 here. Using `z.coerce.number()` would
+ * reject it and stop a deployment that boots today.
+ *
+ * The readers that use `Number` instead — `PORT` and the capture-health pair —
+ * do NOT use this helper; mirroring `parseInt` onto them was the start-
+ * equivalence defect this rung's review caught.
  */
 function fallbackInteger(minimum: number, fallback: number) {
   return z.preprocess((value) => {
@@ -60,6 +81,54 @@ function fallbackInteger(minimum: number, fallback: number) {
     return Number.isInteger(parsed) && parsed >= minimum ? parsed : fallback;
   }, z.number().int());
 }
+
+/**
+ * A positive integer parsed the way `readPositiveInteger` parses one.
+ *
+ * Mirrors `server/capture/liveness-observer.ts:535-550` line for line:
+ * `Number(raw.trim())`, then `Number.isFinite` + `Number.isInteger` + `> 0`,
+ * else the fallback. NOT `parseInt`: that reader deliberately REJECTS anything
+ * which is not a clean integer, so `10.5` is a rejected override there and must
+ * not become a silent 10 here. `readPositiveInteger` is module-private, so it
+ * is reproduced rather than called; the WARN it emits
+ * (`capture_health_override_invalid`) stays with the reader, which owns a
+ * logger, and this is the pure derivation.
+ */
+function numberPositiveInteger(fallback: number) {
+  return z.preprocess((value) => {
+    if (typeof value !== "string" || value.trim() === "") return fallback;
+    const parsed = Number(value.trim());
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+      return fallback;
+    }
+    return parsed;
+  }, z.number().int());
+}
+
+/**
+ * A port parsed the way `server/main.ts:362` parses one, rejecting unbindable.
+ *
+ * The reader is `Number(process.env.PORT ?? DEFAULT_PORT)` followed by
+ * `server.listen(port)`, so `Number` semantics are exact here and `parseInt`
+ * would be wrong in both directions: `""` is 0 (an ephemeral port, a real
+ * deployment shape), `"1e3"` is 1000, `"0x10"` is 16, `" 42 "` is 42, and
+ * `"3000ms"` is `NaN`.
+ *
+ * Where the reader produces a value `listen` THROWS on — a non-integer, or one
+ * outside `0..65535` — this rejects with a config issue naming `PORT` instead.
+ * That is start-equivalent: the process crashes today on exactly those inputs,
+ * and an earlier named crash is the same outcome reached sooner. Substituting a
+ * silent 3100 would not be: it would boot a deployment that does not boot now,
+ * on a port nobody configured.
+ */
+const portNumber = z.preprocess(
+  (value) => (typeof value === "string" ? Number(value) : 3_100),
+  z
+    .number()
+    .int("PORT must be an integer port number that `listen` can bind")
+    .min(0, "PORT must be between 0 and 65535")
+    .max(65_535, "PORT must be between 0 and 65535"),
+);
 
 /** `1`/`true`/`yes`/`on` are true; anything else, including blank, is `false`. */
 const permissiveBoolean = z.preprocess((value) => {
@@ -104,11 +173,15 @@ const originList = z.preprocess((value) => {
 
 /** Fields added by this rung, merged into `environmentSchema`. */
 export const extendedEnvironmentFields = {
-  // search — `server/tools/search-engine.ts:148-149`. The legacy name is a
+  // search — `server/tools/search-engine.ts:147-152`. The legacy name is a
   // FALLBACK, not an alias: the preferred name wins even when both are set, so
   // an operator migrating can set the new one without unsetting the old.
-  OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: blankAsAbsent,
-  SEARCH_EMBEDDING_TIMEOUT_MS: blankAsAbsent,
+  // RAW strings, deliberately not `blankAsAbsent`: the reader joins the two
+  // names with `??`, which does NOT fall through on `""`, so
+  // `OPENBRAIN_…=""` with the legacy name set answers 3000 today. Normalizing
+  // blank to absent here would let the legacy value through instead.
+  OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: z.string().optional(),
+  SEARCH_EMBEDDING_TIMEOUT_MS: z.string().optional(),
   // fts — `server/tools/fts-config.ts:111`.
   OPENBRAIN_FTS_CONFIG: ftsConfigEnv,
   // qmd — `server/tools/search-all.ts:119`.
@@ -130,14 +203,16 @@ export const extendedEnvironmentFields = {
   OPENBRAIN_TRACING_SECRET_KEY: blankAsAbsent,
   OPENBRAIN_TRACING_ENABLED: strictOneFlag,
   OPENBRAIN_TRACING_MASKING_ENABLED: strictZeroDisablesFlag,
-  // capture health — `server/capture/liveness-observer.ts:404-408`, read via
-  // the exported name constants rather than a literal member expression.
+  // capture health — names at `server/capture/liveness-observer.ts:404-408`,
+  // read via the exported name constants rather than a literal member
+  // expression; the PARSE is `readPositiveInteger` at `:535-550`, which is
+  // `Number`-based, not `parseInt`-based.
   OPENBRAIN_CAPTURE_HEALTH_NAMESPACE: blankAsAbsent,
-  OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES: fallbackInteger(1, 360),
-  OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS: fallbackInteger(1, 60_000),
-  // http — `server/main.ts:313` and `:362`.
+  OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES: numberPositiveInteger(360),
+  OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS: numberPositiveInteger(60_000),
+  // http — `server/main.ts:313` (origins) and `:362` (port).
   ALLOWED_ORIGINS: originList,
-  PORT: fallbackInteger(1, 3100),
+  PORT: portNumber,
 } as const;
 
 type ExtendedEnvironment = z.infer<z.ZodObject<typeof extendedEnvironmentFields>>;
@@ -200,18 +275,22 @@ export interface HttpConfigGroup {
 /**
  * The search timeout, preferring the current name over the legacy one.
  *
- * Both names are typed as optional strings rather than parsed integers because
- * the FALLBACK is between the names, not between a value and a default:
- * `OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS=abc` must not fall through to
- * `SEARCH_EMBEDDING_TIMEOUT_MS`, it must fall through to 3000 — which is what
- * `server/tools/search-engine.ts:148` does, since it picks the name first and
- * parses second.
+ * Reproduces `searchEmbeddingTimeoutMs` (`server/tools/search-engine.ts:147-152`)
+ * line for line, and both of the reader's quirks are load-bearing:
+ *
+ *   - the FALLBACK is between the NAMES, not between a value and a default, so
+ *     `OPENBRAIN_…=abc` falls to 3000 rather than through to the legacy name —
+ *     the reader picks the name first and parses second;
+ *   - the join is `??`, which does NOT fall through on `""`. So
+ *     `OPENBRAIN_…=""` with `SEARCH_EMBEDDING_TIMEOUT_MS=900` answers 3000,
+ *     not 900. Both fields are therefore raw strings; blank-as-absent here
+ *     would answer 900 and diverge from a live deployment.
  */
 export function searchGroup(parsed: ExtendedEnvironment): SearchConfigGroup {
   const raw =
     parsed.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS ??
     parsed.SEARCH_EMBEDDING_TIMEOUT_MS;
-  if (raw === undefined) return { embeddingTimeoutMs: 3_000 };
+  if (!raw) return { embeddingTimeoutMs: 3_000 };
   const value = Number.parseInt(raw, 10);
   return {
     embeddingTimeoutMs: Number.isNaN(value) || value < 1 ? 3_000 : value,
@@ -239,12 +318,24 @@ export function recoveryGroup(parsed: ExtendedEnvironment): RecoveryConfigGroup 
  * the two are equal in every normal deployment and diverge only when an
  * operator points them apart during a migration —
  * `server/tools/shared-namespace.ts` header.
+ *
+ * PRECEDENCE IS THE READER'S, AND IT IS NOT THE SCHEMA'S DEFAULT. The reader is
+ * `envString(["SHARED_NAMESPACE_CANONICAL", "OPENBRAIN_SHARED_NAMESPACE"], "shared-kb")`
+ * (`server/tools/shared-namespace.ts:79-82`): the first NON-EMPTY trimmed value
+ * in that order, so `SHARED_NAMESPACE_CANONICAL` wins. `parsed` cannot express
+ * that, because the schema declares that name as a literal WITH a default
+ * (`server/config.ts:167`) and so it is never absent there. The RAW value is
+ * therefore threaded in: blank or absent means unset, exactly as `envString`
+ * reads it. Namespace resolution is a security boundary
+ * (`docs/sme/security.md`), so a precedence inversion here is not cosmetic even
+ * while the consumer is un-rewired.
  */
 export function sharedNamespaceGroup(
   parsed: ExtendedEnvironment,
-  canonical: string,
+  rawCanonical: string | undefined,
 ): SharedNamespaceGroup {
-  const resolvedCanonical = parsed.OPENBRAIN_SHARED_NAMESPACE ?? canonical;
+  const resolvedCanonical =
+    rawCanonical?.trim() || parsed.OPENBRAIN_SHARED_NAMESPACE || "shared-kb";
   return {
     physical: parsed.SHARED_NAMESPACE_PHYSICAL ?? resolvedCanonical,
     legacy:

--- a/server/config/env-groups.ts
+++ b/server/config/env-groups.ts
@@ -1,0 +1,301 @@
+/**
+ * The env fields the composition root does not yet inject.
+ *
+ * Design authority: `_plans/463-server-rewrite-charter.md:108` — `server/config/`
+ * owns ALL env parsing and startup validation, "replaces 18 scattered
+ * process.env readers with injected config" — and `:119`, domain code must not
+ * import `process.env`. `_DOCS/STANDARDS-typescript.md:183-191` requires one
+ * validated config module.
+ *
+ * Every field here mirrors a reader that still exists today, listed with its
+ * file and line in `_plans/l2-composition-root-inventory.md` section A/B. This
+ * module is the SCHEMA half only: declaring the field is what makes rewiring
+ * the consumer a mechanical change rather than a behavior change, and the
+ * rewiring is the next rung's work (L2b/L2c). Until then both this and the
+ * original reader exist, deliberately.
+ *
+ * WHY THE PARSERS ARE PERMISSIVE AND THE EXISTING ONES ARE NOT REWRITTEN. The
+ * bar for this rung is start-equivalence: a deployment whose environment starts
+ * the server today must still start it, with the same values. Several of these
+ * readers deliberately IGNORE an unusable value and fall back rather than
+ * failing — `searchEmbeddingTimeoutMs` (`server/tools/search-engine.ts:148`)
+ * answers 3000 for `abc`, and `envPositiveInteger`
+ * (`server/tools/shared-namespace.ts:52`) answers 5 for `-1`. Tightening any of
+ * those into a hard rejection here would turn a currently-booting deployment
+ * into `server_configuration_invalid` at startup, which is a behavior change
+ * smuggled in under a typing change. So the fallback semantics are reproduced
+ * exactly, and only the fields whose current reader ALREADY rejects — none of
+ * them, at present — would reject here.
+ *
+ * The one place that is stricter is the shape, not the value: a field that is
+ * documented as a positive integer is typed `number`, so a consumer reading it
+ * cannot receive the string it would get from `process.env`.
+ */
+import { z } from "zod";
+import { ftsConfigSchema, resolveFtsConfig, type FtsConfig } from "../tools/fts-config.ts";
+
+/** Trim, and treat a blank value as absent. Present-but-empty is unset. */
+const blankAsAbsent = z.preprocess(
+  (value) => {
+    if (typeof value !== "string") return value;
+    const trimmed = value.trim();
+    return trimmed === "" ? undefined : trimmed;
+  },
+  z.string().optional(),
+);
+
+/**
+ * A base-10 integer at or above `minimum`, falling back on anything else.
+ *
+ * Reproduces `Number.parseInt(raw, 10)` plus a range guard, which is what every
+ * integer reader in section A does. `parseInt` is NOT `Number`: it accepts a
+ * trailing suffix, so `3000ms` is 3000 to the current readers and must stay
+ * 3000 here. Using `z.coerce.number()` would reject it and stop a deployment
+ * that boots today.
+ */
+function fallbackInteger(minimum: number, fallback: number) {
+  return z.preprocess((value) => {
+    if (typeof value !== "string" || value.trim() === "") return fallback;
+    const parsed = Number.parseInt(value, 10);
+    return Number.isInteger(parsed) && parsed >= minimum ? parsed : fallback;
+  }, z.number().int());
+}
+
+/** `1`/`true`/`yes`/`on` are true; anything else, including blank, is `false`. */
+const permissiveBoolean = z.preprocess((value) => {
+  if (typeof value !== "string" || value.trim() === "") return false;
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}, z.boolean());
+
+/** Exactly `1` enables; every other value, absent included, disables. */
+const strictOneFlag = z.preprocess((value) => value === "1", z.boolean());
+
+/** Exactly `0` disables; every other value, absent included, enables. */
+const strictZeroDisablesFlag = z.preprocess(
+  (value) => value !== "0",
+  z.boolean(),
+);
+
+/**
+ * Any free-text language token, mapped to a supported FTS configuration.
+ *
+ * `resolveFtsConfig` (`server/tools/fts-config.ts:97`) is reused rather than
+ * reimplemented: it owns the alias table and the english fallback, and a second
+ * allowlist here would be a second opinion on the same question.
+ */
+const ftsConfigEnv = z.preprocess(
+  (value) => resolveFtsConfig(typeof value === "string" ? value.trim() : undefined),
+  ftsConfigSchema,
+);
+
+/**
+ * A comma-separated origin list, normalized to an array.
+ *
+ * Unset or empty yields an EMPTY allowlist, never a wildcard —
+ * `server/transport/rest.ts:115` and the note above it.
+ */
+const originList = z.preprocess((value) => {
+  if (typeof value !== "string") return [];
+  return value
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0);
+}, z.array(z.string()));
+
+/** Fields added by this rung, merged into `environmentSchema`. */
+export const extendedEnvironmentFields = {
+  // search — `server/tools/search-engine.ts:148-149`. The legacy name is a
+  // FALLBACK, not an alias: the preferred name wins even when both are set, so
+  // an operator migrating can set the new one without unsetting the old.
+  OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: blankAsAbsent,
+  SEARCH_EMBEDDING_TIMEOUT_MS: blankAsAbsent,
+  // fts — `server/tools/fts-config.ts:111`.
+  OPENBRAIN_FTS_CONFIG: ftsConfigEnv,
+  // qmd — `server/tools/search-all.ts:119`.
+  QMD_PATH: blankAsAbsent,
+  // recovery — `server/tools/realtime-stores.ts:46` and `server/main.ts:153`.
+  OPENBRAIN_RECOVERY_WAL_PATH: blankAsAbsent,
+  // shared namespace — `server/tools/shared-namespace.ts:37-52`. The canonical
+  // name is already declared in `environmentSchema`; these are the override and
+  // legacy-migration coordinates around it.
+  OPENBRAIN_SHARED_NAMESPACE: blankAsAbsent,
+  SHARED_NAMESPACE_PHYSICAL: blankAsAbsent,
+  SHARED_NAMESPACE_LEGACY: blankAsAbsent,
+  OPENBRAIN_LEGACY_SHARED_NAMESPACE: blankAsAbsent,
+  OPENBRAIN_LEGACY_SHARED_FALLBACK: permissiveBoolean,
+  OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS: fallbackInteger(1, 5),
+  // tracing — `server/observability/langfuse-tracing.ts:599-604`.
+  OPENBRAIN_TRACING_ENDPOINT: blankAsAbsent,
+  OPENBRAIN_TRACING_PUBLIC_KEY: blankAsAbsent,
+  OPENBRAIN_TRACING_SECRET_KEY: blankAsAbsent,
+  OPENBRAIN_TRACING_ENABLED: strictOneFlag,
+  OPENBRAIN_TRACING_MASKING_ENABLED: strictZeroDisablesFlag,
+  // capture health — `server/capture/liveness-observer.ts:404-408`, read via
+  // the exported name constants rather than a literal member expression.
+  OPENBRAIN_CAPTURE_HEALTH_NAMESPACE: blankAsAbsent,
+  OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES: fallbackInteger(1, 360),
+  OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS: fallbackInteger(1, 60_000),
+  // http — `server/main.ts:313` and `:362`.
+  ALLOWED_ORIGINS: originList,
+  PORT: fallbackInteger(1, 3100),
+} as const;
+
+type ExtendedEnvironment = z.infer<z.ZodObject<typeof extendedEnvironmentFields>>;
+
+/** No namespace is legacy by default; #167 retired `collab`. */
+const DEFAULT_LEGACY_SHARED_NAMESPACE = "";
+/** Ruled default observation window: 6 hours (ledger item 28). */
+const DEFAULT_CAPTURE_WINDOW_MINUTES = 360;
+
+export interface SearchConfigGroup {
+  /** Milliseconds the query-embedding call may take before degrading. */
+  readonly embeddingTimeoutMs: number;
+}
+
+export interface FtsConfigGroup {
+  /** Deployment-wide corpus default for full-text search. */
+  readonly corpusConfig: FtsConfig;
+}
+
+export interface QmdConfigGroup {
+  /** Path to the qmd binary, absent when federation is not configured. */
+  readonly path?: string;
+}
+
+export interface RecoveryConfigGroup {
+  /** WAL file path, `null` when the store runs without durable backing. */
+  readonly walPath: string | null;
+}
+
+export interface SharedNamespaceGroup {
+  readonly physical: string;
+  readonly legacy: string;
+  readonly legacyFallbackEnabled: boolean;
+  readonly fallbackMinResults: number;
+}
+
+export interface TracingConfigGroup {
+  /** True only when the flag is set AND all three coordinates are present. */
+  readonly enabled: boolean;
+  readonly maskingEnabled: boolean;
+  readonly endpoint: string;
+  readonly publicKey: string;
+  /** Never logged and never emitted in `/health`. */
+  readonly secretKey: string;
+}
+
+export interface CaptureHealthGroup {
+  /** Absent means NO observer — never a guessed tenant (ledger item 28). */
+  readonly namespace?: string;
+  readonly windowMinutes: number;
+  readonly refreshMs: number;
+}
+
+export interface HttpConfigGroup {
+  readonly port: number;
+  /** Empty means no origin is permitted, never every origin. */
+  readonly allowedOrigins: readonly string[];
+}
+
+/**
+ * The search timeout, preferring the current name over the legacy one.
+ *
+ * Both names are typed as optional strings rather than parsed integers because
+ * the FALLBACK is between the names, not between a value and a default:
+ * `OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS=abc` must not fall through to
+ * `SEARCH_EMBEDDING_TIMEOUT_MS`, it must fall through to 3000 — which is what
+ * `server/tools/search-engine.ts:148` does, since it picks the name first and
+ * parses second.
+ */
+export function searchGroup(parsed: ExtendedEnvironment): SearchConfigGroup {
+  const raw =
+    parsed.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS ??
+    parsed.SEARCH_EMBEDDING_TIMEOUT_MS;
+  if (raw === undefined) return { embeddingTimeoutMs: 3_000 };
+  const value = Number.parseInt(raw, 10);
+  return {
+    embeddingTimeoutMs: Number.isNaN(value) || value < 1 ? 3_000 : value,
+  };
+}
+
+export function ftsGroup(parsed: ExtendedEnvironment): FtsConfigGroup {
+  return { corpusConfig: parsed.OPENBRAIN_FTS_CONFIG };
+}
+
+export function qmdGroup(parsed: ExtendedEnvironment): QmdConfigGroup {
+  return parsed.QMD_PATH ? { path: parsed.QMD_PATH } : {};
+}
+
+export function recoveryGroup(parsed: ExtendedEnvironment): RecoveryConfigGroup {
+  return { walPath: parsed.OPENBRAIN_RECOVERY_WAL_PATH ?? null };
+}
+
+/**
+ * Physical and legacy shared-namespace names.
+ *
+ * The canonical name stays on `ServerConfig.sharedNamespace`, which is a
+ * `"shared-kb"` literal by decision (`docs/decisions/shared-kb-canonical-namespace.md`).
+ * The PHYSICAL name defaults to whatever the canonical override resolved to, so
+ * the two are equal in every normal deployment and diverge only when an
+ * operator points them apart during a migration —
+ * `server/tools/shared-namespace.ts` header.
+ */
+export function sharedNamespaceGroup(
+  parsed: ExtendedEnvironment,
+  canonical: string,
+): SharedNamespaceGroup {
+  const resolvedCanonical = parsed.OPENBRAIN_SHARED_NAMESPACE ?? canonical;
+  return {
+    physical: parsed.SHARED_NAMESPACE_PHYSICAL ?? resolvedCanonical,
+    legacy:
+      parsed.SHARED_NAMESPACE_LEGACY ??
+      parsed.OPENBRAIN_LEGACY_SHARED_NAMESPACE ??
+      DEFAULT_LEGACY_SHARED_NAMESPACE,
+    legacyFallbackEnabled: parsed.OPENBRAIN_LEGACY_SHARED_FALLBACK,
+    fallbackMinResults: parsed.OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS,
+  };
+}
+
+/**
+ * Tracing coordinates, off unless the flag is set and all three are present.
+ *
+ * The opposite default to audit, deliberately: a payload-carrying export to an
+ * external server is opt-in per deployment, never something a missing variable
+ * turns on by accident (`server/observability/langfuse-tracing.ts:589-595`).
+ * The incomplete-flag WARN stays with the reader, which owns a logger; this is
+ * the pure derivation.
+ */
+export function tracingGroup(parsed: ExtendedEnvironment): TracingConfigGroup {
+  const endpoint = parsed.OPENBRAIN_TRACING_ENDPOINT ?? "";
+  const publicKey = parsed.OPENBRAIN_TRACING_PUBLIC_KEY ?? "";
+  const secretKey = parsed.OPENBRAIN_TRACING_SECRET_KEY ?? "";
+  const complete =
+    endpoint.length > 0 && publicKey.length > 0 && secretKey.length > 0;
+  return {
+    enabled: parsed.OPENBRAIN_TRACING_ENABLED && complete,
+    maskingEnabled: parsed.OPENBRAIN_TRACING_MASKING_ENABLED,
+    endpoint,
+    publicKey,
+    secretKey,
+  };
+}
+
+export function captureHealthGroup(
+  parsed: ExtendedEnvironment,
+): CaptureHealthGroup {
+  const namespace = parsed.OPENBRAIN_CAPTURE_HEALTH_NAMESPACE;
+  return {
+    ...(namespace ? { namespace } : {}),
+    windowMinutes:
+      parsed.OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES ??
+      DEFAULT_CAPTURE_WINDOW_MINUTES,
+    refreshMs: parsed.OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS,
+  };
+}
+
+export function httpGroup(parsed: ExtendedEnvironment): HttpConfigGroup {
+  return {
+    port: parsed.PORT,
+    allowedOrigins: parsed.ALLOWED_ORIGINS,
+  };
+}


### PR DESCRIPTION
Lane L2a of the `server/` hardening ladder
(`_plans/server-hardening-ladder.md`, rung L2 "Composition root"). Schema half
only -- no consumer is rewired here.

`_plans/463-server-rewrite-charter.md:108` gives `server/config/` ownership of
ALL env parsing and startup validation, "replaces 18 scattered process.env
readers with injected config", and `:119` states that domain code must not
import `process.env`. Twenty-one of the twenty-three variables non-test
`server/` code reads had no field in `environmentSchema` at all, so no consumer
could be handed a value even in principle. The rewiring L2b/L2c does was
blocked on the type not existing, which is what this fixes.

Every reader named below still reads `process.env` today, deliberately. Both
paths exist until the injection and the `no-process-env` lint rule land; that
intermediate state is the point of splitting the rung.

New groups on `ServerConfig`, each mirroring one existing reader:

| group | reader |
|---|---|
| `search` | `server/tools/search-engine.ts:148-149` |
| `fts` | `server/tools/fts-config.ts:111` |
| `qmd` | `server/tools/search-all.ts:119` |
| `recovery` | `server/tools/realtime-stores.ts:46`, `server/main.ts:153` |
| `sharedNamespaceNames` | `server/tools/shared-namespace.ts:37-52` |
| `tracing` | `server/observability/langfuse-tracing.ts:599-604` |
| `captureHealth` | `server/capture/liveness-observer.ts:404-408` |
| `http` | `server/main.ts:313,362` |

The NATS group is deliberately NOT duplicated. `server/config/nats.ts` already
parses `OPENBRAIN_TRANSPORT` and every `OPENBRAIN_NATS_*` key from the
environment object the schema's `.catchall` hands `parseNatsConfig`, so those
names already reach a consumer through validated config. Adding fields for them
would be a second opinion on a question already answered.

**The bar is start-equivalence, not tidiness.** Several of these readers
deliberately ignore an unusable value and fall back rather than failing:
`searchEmbeddingTimeoutMs` answers 3000 for `abc`, `envPositiveInteger` answers
5 for `-1`, `resolveQmdPath` treats `QMD_PATH=` as unset. Tightening any of
those into a hard rejection here would turn a deployment that boots today into
`server_configuration_invalid` at startup -- a behavior change smuggled in
under a typing change, and the same class of failure as the 2026-08-02
`EMBEDDING_API_KEY=` launchd throttle-loop this schema already carries a
preprocessor for. The fallbacks are reproduced exactly, including
`Number.parseInt`'s tolerance of a trailing suffix (`3000ms` stays 3000), which
`z.coerce.number()` would have rejected.

Fields live in `server/config/env-groups.ts` rather than inline because
`buildConfig` is already near the 100-code-lines-per-function lint limit;
`environmentSchema` composes them with one named spread.

`_plans/l2-composition-root-inventory.md` is the read-only scan the scope came
from, landed in the first commit so L2b/L2c read it from the repo rather than a
scratch directory.

## Verification

- Done-means: scripts/done-means/750-l2a-config-covers-every-env-read.sh
- RED, final script against `origin/main`'s `server/config.ts` with
  `env-groups.ts` moved away -> `FAIL: 23 env names read in server/; 21 are not
  declared in environmentSchema`, exit 1, all 21 listed by name.
- GREEN on this branch -> `PASS: all 23 env names read in server/ are declared
  in environmentSchema (server/config.ts)`, exit 0.
- RED for the tests: deleting the `OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES`
  field and its group read -> `(fail) extended env - captureHealth > takes an
  explicit namespace, window, and refresh`, 64 pass / 1 fail. Restored -> 65
  pass / 0 fail.
- `bun run test:isolated server/config.test.ts` -> 65 pass, 0 fail, 102
  expect() calls.
- `bun run test:isolated server/main.pg.test.ts server/application/` -> 35
  pass, 0 fail, confirming the widened `ServerConfig` broke no existing
  composer.
- `bunx tsc --noEmit` -> clean, exit 0.
- `bunx oxlint --deny-warnings server/config.ts server/config/env-groups.ts
  server/config.test.ts` -> exit 0.
- The `_githooks` pre-commit gate (gitleaks + oxlint on staged content + whole
  project tsc) passed on both commits. It caught a pre-existing
  `max-nested-callbacks` violation at `server/config.test.ts:271` that the
  whole-file lint surfaces once the file is staged; fixed in place by naming
  the inner thunk.

## Critical Self-Review

- Highest-risk behavior: a parser here disagreeing with the reader it mirrors,
  so a value silently changes when L2b swaps the consumer over. Mitigated by
  reproducing each reader's exact semantics rather than a tidier version, and
  by asserting the shrug-off cases (`abc`, `0`, `-1`, blank) as fallbacks
  rather than rejections.
- Assumptions that could be wrong: that the inventory's section A/B is
  complete. Three read shapes the literal `process.env.X` scan cannot see --
  `env[CONST]` in the capture observer, injected-`env` parameters in
  fts/tracing/qmd, and `process.env[name]` in `shared-namespace.ts` -- are
  enumerated explicitly in the done-means script, so a name reached that way is
  covered but a NEW one of that shape would not be caught automatically. The
  script's header says so.
- Missing/weak tests: the group builders are covered through
  `parseServerConfig`, not called directly, so a builder reachable only from an
  unexercised branch would show as covered. Coverage reports 100% funcs/lines
  on `env-groups.ts`, which is a floor and not the argument; the RED run is.
- Security/permission risk: `tracing.secretKey` and the shared-namespace names
  are now on the config object. The secret is typed as a string like the
  existing `EMBEDDING_API_KEY`, and no logging or health emitter reads it in
  this change; nothing is added to any response payload. No namespace
  predicate, auth check, or role mapping is touched.
- Migration/deploy risk: none. No schema migration, and no variable's meaning,
  name, or default changes -- an environment that starts the server today
  produces the same values.
- Downstream client/runtime risk: none. No MCP tool, transport schema, REST
  route, or Python client shape changes; `ServerConfig` is internal to
  `server/` and gains fields rather than changing any.
- Rollback/cleanup concern: revert is two commits, one of which is a doc copy.
  No consumer depends on the new fields yet, which is what makes it cheap.
- Fixes made before PR: the done-means script initially named a variable
  `GROUPS`, which is a bash builtin holding the user's group IDs, so the
  filename expanded to a numeric group list and the check failed for the wrong
  reason. Renamed with a comment. The `max-nested-callbacks` fix above.
- Known residual risk: `environmentSchema` now spreads a second module, so the
  done-means check follows that spread. If a later change adds a SECOND spread,
  the check only follows the one named `extendedEnvironmentFields` -- it would
  fail loudly rather than pass, since those names would appear undeclared.
- SME review-memory update: [x] not applicable because: no review finding or
  missed pattern surfaced here; the lane's only new lesson is the bash-builtin
  name collision, recorded below.

## Review Gate

- [x] Critical self-review fields above are filled
- [x] MEDIUM+ review findings were captured
- Live Open Brain checks: [x] not applicable because: this change adds typed
  fields to an internal config object and rewires no consumer, so no running
  behavior differs and there is nothing for a live check to observe.

## Harvest

Tightenings candidate -- a done-means script assigning `GROUPS=` gets the
user's numeric group IDs instead, because `GROUPS` is a bash builtin. The
failure surfaces as a nonsense path in an error message ("but 20 is missing"),
which reads like a broken check rather than a name collision. Any
`scripts/done-means/*.sh` naming a variable after a common word should avoid
bash's builtin set (`GROUPS`, `SECONDS`, `LINES`, `COLUMNS`, `PWD`, `RANDOM`,
`UID`, `PIPESTATUS`).
