### PR TITLE
feat(config): inject four tool-layer env values from validated config (L2b-1a)

### DIFF
--- a/scripts/done-means/750-l2b1-tool-readers-take-config.sh
+++ b/scripts/done-means/750-l2b1-tool-readers-take-config.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for lane L2b-1 of the server/ hardening ladder
+# (`_plans/server-hardening-ladder.md`, rung L2 "Composition root").
+#
+#   bash scripts/done-means/750-l2b1-tool-readers-take-config.sh
+#
+# ---------------------------------------------------------------------------
+# The defect this gates
+# ---------------------------------------------------------------------------
+# The rewrite charter (`_plans/463-server-rewrite-charter.md:108,119`) puts ALL
+# env parsing behind `server/config/` and forbids domain code from importing
+# `process.env`. L2a (#778) delivered the SCHEMA half: every one of these reads
+# is now typed and parsed into a `ServerConfig` group. That left the repo in a
+# deliberately doubled state — the validated group AND the original scattered
+# reader both existed, and only the reader was actually consulted.
+#
+# A doubled state is worse than either half alone, because it looks finished
+# from the config side. `config.search.embeddingTimeoutMs` can be correct,
+# tested, and reported in `/health` while the search path continues to read
+# `process.env` directly and answer something else entirely. Nothing fails; the
+# two simply drift, and the config becomes documentation of an intention rather
+# than the value in force.
+#
+# This lane closes the five readers in `server/tools/` that L2a typed. The
+# assertion is therefore about ABSENCE at a named boundary: those five files
+# must contain no `process.env` at all, because every value they need now
+# arrives through a parameter or through `MemoryToolDependencies`.
+#
+# ---------------------------------------------------------------------------
+# WHY CLAUSE 3 EXISTS — the vacuous-pass problem
+# ---------------------------------------------------------------------------
+# The natural check is "rg finds no `process.env` in these five files", and that
+# assertion passes for two very different reasons: because the reads are gone,
+# or because the scan examined nothing. A renamed file, a typo in a path, an
+# `rg` that is not on PATH, a bad `--glob` — every one of them produces a silent
+# clean sweep and an exit 0 that means nothing. This repo has been burned by the
+# "0 items examined, exit 0" shape before, which is why the toolbox convention
+# is to prove the tool can still see a hit somewhere it MUST see one.
+#
+# So the check is three clauses, and all three must pass:
+#
+# CLAUSE 1 — ALL FIVE TARGET FILES EXIST.
+#   Each path is `test -f`'d individually and named in the output. A file that
+#   was renamed or deleted makes the scan vacuous, so it is a hard fail here
+#   rather than an invisible pass in clause 2.
+#
+# CLAUSE 2 — NONE OF THEM READS `process.env`.
+#   `rg -n 'process\.env' <five files>` must produce no output. Any match is
+#   printed, so a failure names the file and line instead of just refusing.
+#
+# CLAUSE 3 — THE SCANNER IS PROVEN TO MATCH.
+#   `rg -c 'process\.env' server/config.ts` must be > 0. `server/config.ts` is
+#   the composition root's own env reader: it is the one file in `server/` that
+#   MUST read the environment, because it is the boundary the charter puts the
+#   parsing behind. If the same pattern, the same tool, and the same invocation
+#   find nothing THERE, the clean result in clause 2 is a broken scan and not a
+#   clean tree. This is a positive control, deliberately pointed at a file this
+#   lane does not touch and no future lane should empty.
+#
+# Exit 0 only when all three clauses pass. Exit 3 is a harness error (missing
+# tool / wrong repo root), which is NOT a fail of the thing under test.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v rg >/dev/null 2>&1 || fail_hard "rg (ripgrep) not on PATH"
+[ -d "$REPO_ROOT/.git" ] || [ -f "$REPO_ROOT/.git" ] || fail_hard "not a git repo at $REPO_ROOT"
+
+# The five readers L2a typed and this lane rewires. Listed literally rather
+# than globbed: a glob that stops matching is exactly the vacuous pass clause 3
+# guards against, and naming them makes a rename fail loudly in clause 1.
+TARGETS="server/tools/search-engine.ts
+server/tools/fts-config.ts
+server/tools/search-all.ts
+server/tools/realtime-stores.ts
+server/tools/operator-doctor.ts"
+
+# The positive control: the composition root's OWN env reader, which must keep
+# reading `process.env` for the boundary to exist at all.
+CONTROL="server/config.ts"
+
+CLAUSE1=FAIL; CLAUSE1_EVIDENCE=""
+CLAUSE2=FAIL; CLAUSE2_EVIDENCE=""
+CLAUSE3=FAIL; CLAUSE3_EVIDENCE=""
+
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — every target file is present.
+# ---------------------------------------------------------------------------
+MISSING=""
+N_TARGETS=0
+while IFS= read -r t; do
+  [ -n "$t" ] || continue
+  N_TARGETS=$((N_TARGETS + 1))
+  [ -f "$REPO_ROOT/$t" ] || MISSING="${MISSING}${t} "
+done <<EOF
+$TARGETS
+EOF
+
+if [ "$N_TARGETS" -ne 5 ]; then
+  CLAUSE1_EVIDENCE="expected 5 target paths, the list yielded $N_TARGETS — the check itself is miswritten"
+elif [ -n "$MISSING" ]; then
+  CLAUSE1_EVIDENCE="target file(s) NOT found: ${MISSING}— a scan over missing files passes vacuously"
+else
+  CLAUSE1=PASS
+  CLAUSE1_EVIDENCE="all 5 target files present under $REPO_ROOT"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 2 — none of the five reads process.env.
+# ---------------------------------------------------------------------------
+if [ "$CLAUSE1" != PASS ]; then
+  CLAUSE2_EVIDENCE="skipped — target files are not all present, so any result is vacuous"
+else
+  # Build the argument list from the same literal set clause 1 verified.
+  set --
+  while IFS= read -r t; do
+    [ -n "$t" ] || continue
+    set -- "$@" "$REPO_ROOT/$t"
+  done <<EOF
+$TARGETS
+EOF
+
+  HITS="$(cd "$REPO_ROOT" && rg -n 'process\.env' "$@" 2>/dev/null)"
+  RG_STATUS=$?
+  # rg exits 1 for "no matches" (the pass) and 2 for a real error. A 2 is a
+  # harness problem, not a clean tree, and must not be read as success.
+  if [ "$RG_STATUS" -ge 2 ]; then
+    fail_hard "rg failed with status $RG_STATUS scanning the five target files"
+  fi
+
+  if [ -n "$HITS" ]; then
+    CLAUSE2_EVIDENCE="$(printf '%s\n' "$HITS" | wc -l | tr -d ' ') process.env read(s) remain:"
+    CLAUSE2_HITS="$HITS"
+  else
+    CLAUSE2=PASS
+    CLAUSE2_EVIDENCE="no process.env read in any of the 5 files — each value now arrives from validated config"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 3 — positive control: the scanner still finds a known hit.
+# ---------------------------------------------------------------------------
+if [ ! -f "$REPO_ROOT/$CONTROL" ]; then
+  CLAUSE3_EVIDENCE="positive control $CONTROL does not exist — cannot prove the scan matches anything"
+else
+  CONTROL_COUNT="$(cd "$REPO_ROOT" && rg -c 'process\.env' "$CONTROL" 2>/dev/null)"
+  CONTROL_COUNT="${CONTROL_COUNT:-0}"
+  if [ "$CONTROL_COUNT" -gt 0 ]; then
+    CLAUSE3=PASS
+    CLAUSE3_EVIDENCE="$CONTROL still contains $CONTROL_COUNT process.env line(s) — the pattern, tool, and invocation are proven to match"
+  else
+    CLAUSE3_EVIDENCE="$CONTROL contains ZERO process.env lines — either the composition root stopped reading the environment, or this scan is broken and clause 2's clean result is meaningless"
+  fi
+fi
+
+printf 'CLAUSE 1 (all 5 target files exist):                    %s — %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+printf 'CLAUSE 2 (no process.env in any of the 5):              %s — %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+if [ "$CLAUSE2" != PASS ] && [ -n "${CLAUSE2_HITS:-}" ]; then
+  printf '%s\n' "$CLAUSE2_HITS" | sed 's/^/    /'
+fi
+printf 'CLAUSE 3 (scanner proven to match in %s):   %s — %s\n' "$CONTROL" "$CLAUSE3" "$CLAUSE3_EVIDENCE"
+
+if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ]; then
+  exit 0
+fi
+exit 1

--- a/scripts/done-means/750-l2b1-tool-readers-take-config.sh
+++ b/scripts/done-means/750-l2b1-tool-readers-take-config.sh
@@ -26,6 +26,14 @@
 # at all, because every value they need now arrives through a parameter or
 # through `MemoryToolDependencies`.
 #
+# ABSENCE ALONE IS NOT THE BAR. A reader that stopped reading `process.env` and
+# whose caller never started passing the value is not wired -- it is silently
+# running on its `?? default` forever, and clauses 1-3 go green on exactly that
+# state (observed on this branch: three of the four readers took parameters and
+# `server/main.ts` passed none of them). So CLAUSE 4 asserts ARRIVAL at the
+# composition root: each value must be handed down from the ONE validated parse
+# at the call site that reaches the tool layer.
+#
 # ---------------------------------------------------------------------------
 # WHAT THIS CHECK DELIBERATELY DOES NOT COVER, AND WHY
 # ---------------------------------------------------------------------------
@@ -86,7 +94,24 @@
 #   clean tree. This is a positive control, deliberately pointed at a file this
 #   lane does not touch and no future lane should empty.
 #
-# Exit 0 only when all three clauses pass. Exit 3 is a harness error (missing
+# CLAUSE 4 -- THE VALUES ARRIVE AT THE COMPOSITION ROOT.
+#   Absence proves the reader stopped guessing; arrival proves someone started
+#   telling it. Four anchored `rg` patterns, each of which must match EXACTLY
+#   once -- zero means unwired, more than once means two composition paths that
+#   can disagree, which is the doubled state this rung exists to end:
+#     server/main.ts       `ftsCorpusConfig: config.fts.corpusConfig`
+#     server/main.ts       `recoveryWalPath: config.recovery.walPath`
+#     server/main.ts       `natsRuntimeBoundary: nats.boundary`  -- the boundary
+#         the NATS phase ALREADY computed (`natsRuntimeBoundaryFromConfig` at
+#         server/main.ts:267, returned as `NatsPhase.boundary`). Calling that
+#         function a second time here would rebuild a second boundary from the
+#         same config, which is a second source of truth by construction.
+#     server/tools/search-brain.ts  `ftsCorpusConfig: dependencies.ftsCorpusConfig`
+#         -- the corpus default threaded into `resolveCallerFtsConfig`, which is
+#         what passes it as `requestFtsConfig`'s second argument. Without this
+#         the branch's new second parameter is never supplied by any caller.
+#
+# Exit 0 only when all four clauses pass. Exit 3 is a harness error (missing
 # tool / wrong repo root), which is NOT a fail of the thing under test.
 set -uo pipefail
 
@@ -119,6 +144,7 @@ CONTROL="server/config.ts"
 CLAUSE1=FAIL; CLAUSE1_EVIDENCE=""
 CLAUSE2=FAIL; CLAUSE2_EVIDENCE=""
 CLAUSE3=FAIL; CLAUSE3_EVIDENCE=""
+CLAUSE4=FAIL; CLAUSE4_EVIDENCE=""
 
 # ---------------------------------------------------------------------------
 # CLAUSE 1 — every target file is present.
@@ -190,6 +216,51 @@ else
   fi
 fi
 
+# ---------------------------------------------------------------------------
+# CLAUSE 4 — the values ARRIVE at the composition root.
+# ---------------------------------------------------------------------------
+# Each entry is `<file>|<fixed-string pattern>`. `rg -F` so the pattern is read
+# literally, and the count must be exactly 1: 0 is unwired, >1 is two
+# composition paths.
+ARRIVALS="server/main.ts|ftsCorpusConfig: config.fts.corpusConfig
+server/main.ts|recoveryWalPath: config.recovery.walPath
+server/main.ts|natsRuntimeBoundary: nats.boundary
+server/tools/search-brain.ts|ftsCorpusConfig: dependencies.ftsCorpusConfig"
+
+ARRIVAL_BAD=""
+ARRIVAL_OK=0
+N_ARRIVALS=0
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  N_ARRIVALS=$((N_ARRIVALS + 1))
+  a_file="${entry%%|*}"
+  a_pat="${entry#*|}"
+  if [ ! -f "$REPO_ROOT/$a_file" ]; then
+    ARRIVAL_BAD="${ARRIVAL_BAD}
+    MISSING FILE $a_file (for: $a_pat)"
+    continue
+  fi
+  a_count="$(cd "$REPO_ROOT" && rg -cF -- "$a_pat" "$a_file" 2>/dev/null)"
+  a_count="${a_count:-0}"
+  if [ "$a_count" -eq 1 ]; then
+    ARRIVAL_OK=$((ARRIVAL_OK + 1))
+  else
+    ARRIVAL_BAD="${ARRIVAL_BAD}
+    $a_file: found $a_count, expected 1 — \"$a_pat\""
+  fi
+done <<EOF
+$ARRIVALS
+EOF
+
+if [ "$N_ARRIVALS" -ne 4 ]; then
+  CLAUSE4_EVIDENCE="expected 4 arrival assertions, the list yielded $N_ARRIVALS — the check itself is miswritten"
+elif [ -n "$ARRIVAL_BAD" ]; then
+  CLAUSE4_EVIDENCE="$ARRIVAL_OK/4 values arrive; the rest are not wired:${ARRIVAL_BAD}"
+else
+  CLAUSE4=PASS
+  CLAUSE4_EVIDENCE="all 4 values are passed exactly once from the composition root"
+fi
+
 printf 'CLAUSE 1 (all 4 target files exist):                    %s — %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
 printf 'CLAUSE 2 (no process.env in any of the 4):              %s — %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
 if [ "$CLAUSE2" != PASS ] && [ -n "${CLAUSE2_HITS:-}" ]; then
@@ -197,7 +268,9 @@ if [ "$CLAUSE2" != PASS ] && [ -n "${CLAUSE2_HITS:-}" ]; then
 fi
 printf 'CLAUSE 3 (scanner proven to match in %s):   %s — %s\n' "$CONTROL" "$CLAUSE3" "$CLAUSE3_EVIDENCE"
 
-if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ]; then
+printf 'CLAUSE 4 (values arrive at the composition root):        %s — %s\n' "$CLAUSE4" "$CLAUSE4_EVIDENCE"
+
+if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ] && [ "$CLAUSE4" = PASS ]; then
   exit 0
 fi
 exit 1

--- a/scripts/done-means/750-l2b1-tool-readers-take-config.sh
+++ b/scripts/done-means/750-l2b1-tool-readers-take-config.sh
@@ -111,7 +111,31 @@
 #         what passes it as `requestFtsConfig`'s second argument. Without this
 #         the branch's new second parameter is never supplied by any caller.
 #
-# Exit 0 only when all four clauses pass. Exit 3 is a harness error (missing
+# CLAUSE 5 -- THE INJECTED VALUES ARRIVE AT THEIR CONSUMERS.
+#   Clause 4 reads the composition root's SOURCE and proves the three values are
+#   written at the call site. That is a textual assertion: it proves someone
+#   typed the wiring, never that the value survives the trip. A field can be
+#   spelled correctly at the root and still be dropped by the registrar, shadowed
+#   by a fallback, or read from the wrong place by the handler, and every one of
+#   those states keeps clause 4 green.
+#
+#   So clause 5 EXERCISES the wiring. `server/tools/dependency-arrival.test.ts`
+#   registers the real tools through a fake McpServer, injects each value, and
+#   asserts on observable behavior at the far end:
+#     ftsCorpusConfig      -> the SQL search_brain emits names the injected
+#                             configuration, with no per-request argument.
+#     recoveryWalPath      -> recovery_wal_append writes a real JSONL file at
+#                             the injected path, through the fallback store.
+#     natsRuntimeBoundary  -> operator_doctor reports the injected transport,
+#                             not the one an empty environment produces.
+#
+#   The clause runs `bun test` on that one file and requires exit 0 AND at least
+#   3 passing tests parsed from the output. The parsed count is the vacuity
+#   guard, the same shape as clause 3: a runner that loads no tests also exits 0,
+#   and "0 pass" must never read as success. A missing file is a hard FAIL here
+#   rather than a skip, for the same reason clause 1 is a hard fail.
+#
+# Exit 0 only when all five clauses pass. Exit 3 is a harness error (missing
 # tool / wrong repo root), which is NOT a fail of the thing under test.
 set -uo pipefail
 
@@ -145,6 +169,12 @@ CLAUSE1=FAIL; CLAUSE1_EVIDENCE=""
 CLAUSE2=FAIL; CLAUSE2_EVIDENCE=""
 CLAUSE3=FAIL; CLAUSE3_EVIDENCE=""
 CLAUSE4=FAIL; CLAUSE4_EVIDENCE=""
+CLAUSE5=FAIL; CLAUSE5_EVIDENCE=""
+
+# The behavioral test clause 5 runs, and the least number of passing tests that
+# can honestly satisfy it -- one per injected value.
+ARRIVAL_TEST="server/tools/dependency-arrival.test.ts"
+ARRIVAL_TEST_MIN_PASS=3
 
 # ---------------------------------------------------------------------------
 # CLAUSE 1 — every target file is present.
@@ -268,9 +298,40 @@ if [ "$CLAUSE2" != PASS ] && [ -n "${CLAUSE2_HITS:-}" ]; then
 fi
 printf 'CLAUSE 3 (scanner proven to match in %s):   %s — %s\n' "$CONTROL" "$CLAUSE3" "$CLAUSE3_EVIDENCE"
 
-printf 'CLAUSE 4 (values arrive at the composition root):        %s — %s\n' "$CLAUSE4" "$CLAUSE4_EVIDENCE"
+# ---------------------------------------------------------------------------
+# CLAUSE 5 — the injected values arrive at their consumers, proven by running.
+# ---------------------------------------------------------------------------
+if [ ! -f "$REPO_ROOT/$ARRIVAL_TEST" ]; then
+  CLAUSE5_EVIDENCE="$ARRIVAL_TEST does not exist — clause 4 asserts the wiring was TYPED; nothing here asserts it WORKS"
+else
+  command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH; cannot run $ARRIVAL_TEST"
+  ARRIVAL_TEST_OUT="$(cd "$REPO_ROOT" && bun test "$ARRIVAL_TEST" 2>&1)"
+  ARRIVAL_TEST_STATUS=$?
+  # bun prints a summary line of the form "N pass". Read the last one, so an
+  # earlier per-file line cannot be mistaken for the total.
+  ARRIVAL_PASS="$(printf '%s\n' "$ARRIVAL_TEST_OUT" | rg -o '^\s*([0-9]+) pass' -r '$1' | tail -n 1)"
+  ARRIVAL_PASS="${ARRIVAL_PASS:-0}"
+  if [ "$ARRIVAL_TEST_STATUS" -ne 0 ]; then
+    CLAUSE5_EVIDENCE="bun test $ARRIVAL_TEST exited $ARRIVAL_TEST_STATUS ($ARRIVAL_PASS passing) — an injected value does not reach its consumer:"
+    CLAUSE5_OUT="$ARRIVAL_TEST_OUT"
+  elif [ "$ARRIVAL_PASS" -lt "$ARRIVAL_TEST_MIN_PASS" ]; then
+    # exit 0 with too few tests is the vacuous pass: the runner found the file
+    # and ran nothing meaningful in it.
+    CLAUSE5_EVIDENCE="bun test $ARRIVAL_TEST exited 0 but only $ARRIVAL_PASS test(s) passed, expected at least $ARRIVAL_TEST_MIN_PASS — one per injected value, so a green run here examined nothing"
+    CLAUSE5_OUT="$ARRIVAL_TEST_OUT"
+  else
+    CLAUSE5=PASS
+    CLAUSE5_EVIDENCE="$ARRIVAL_PASS test(s) passed in $ARRIVAL_TEST — each injected value observed at its consumer, not just at the call site"
+  fi
+fi
 
-if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ] && [ "$CLAUSE4" = PASS ]; then
+printf 'CLAUSE 4 (values arrive at the composition root):        %s — %s\n' "$CLAUSE4" "$CLAUSE4_EVIDENCE"
+printf 'CLAUSE 5 (injected values observed at their consumers):  %s — %s\n' "$CLAUSE5" "$CLAUSE5_EVIDENCE"
+if [ "$CLAUSE5" != PASS ] && [ -n "${CLAUSE5_OUT:-}" ]; then
+  printf '%s\n' "$CLAUSE5_OUT" | sed 's/^/    /'
+fi
+
+if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ] && [ "$CLAUSE4" = PASS ] && [ "$CLAUSE5" = PASS ]; then
   exit 0
 fi
 exit 1

--- a/scripts/done-means/750-l2b1-tool-readers-take-config.sh
+++ b/scripts/done-means/750-l2b1-tool-readers-take-config.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# DONE-MEANS check for lane L2b-1 of the server/ hardening ladder
+# DONE-MEANS check for lane L2b-1a of the server/ hardening ladder
 # (`_plans/server-hardening-ladder.md`, rung L2 "Composition root").
 #
 #   bash scripts/done-means/750-l2b1-tool-readers-take-config.sh
@@ -21,15 +21,44 @@
 # two simply drift, and the config becomes documentation of an intention rather
 # than the value in force.
 #
-# This lane closes the five readers in `server/tools/` that L2a typed. The
-# assertion is therefore about ABSENCE at a named boundary: those five files
-# must contain no `process.env` at all, because every value they need now
-# arrives through a parameter or through `MemoryToolDependencies`.
+# This lane closes FOUR of the readers L2a typed. The assertion is about
+# ABSENCE at a named boundary: those four files must contain no `process.env`
+# at all, because every value they need now arrives through a parameter or
+# through `MemoryToolDependencies`.
+#
+# ---------------------------------------------------------------------------
+# WHAT THIS CHECK DELIBERATELY DOES NOT COVER, AND WHY
+# ---------------------------------------------------------------------------
+# `server/tools/search-all.ts` and `server/tools/search-engine.ts` are the other
+# two readers L2a typed. They are OUT of this check, and their `process.env`
+# reads are still present in the tree. This is a deferral recorded in the open,
+# not an oversight and not a silent narrowing of the bar.
+#
+# The reason is a collision with a different gate. `_githooks/pre-commit` lints
+# whole STAGED files with no main-vs-branch baseline, and both files already
+# violate `.oxlintrc.json` on unmodified `origin/main` — 5 violations in
+# `search-all.ts` and 9 in `search-engine.ts`. So ANY commit touching either
+# file is refused by the hook, whether or not the commit's own change is clean.
+# `--no-verify` is not an approved workaround in this repo.
+#
+# `.oxlintrc.json` states the intended policy — the backlog is "paid per-file as
+# work naturally touches them" — so the sanctioned path is to clear each file on
+# touch. Measured, that does not fit inside a start-equivalence rewiring: the
+# violations are 5-to-10-parameter signatures across the whole search stack
+# (`executeSearch` alone has 55 references repo-wide), a 203-line handler, and an
+# 837-code-line file. Converting those to options objects and splitting them is a
+# behavior-risky refactor of the core search path, and burying a start-equivalence
+# rewiring inside it is exactly what the lane contract forbids.
+#
+# Those two files therefore move to a follow-up lane that dispatches after the
+# lint-debt ruling (head ruling, 2026-08-26). When that lane lands, this check
+# grows its target list back to six and this section goes away. Until then, a
+# GREEN here means FOUR files are clean — never that the rung is finished.
 #
 # ---------------------------------------------------------------------------
 # WHY CLAUSE 3 EXISTS — the vacuous-pass problem
 # ---------------------------------------------------------------------------
-# The natural check is "rg finds no `process.env` in these five files", and that
+# The natural check is "rg finds no `process.env` in these files", and that
 # assertion passes for two very different reasons: because the reads are gone,
 # or because the scan examined nothing. A renamed file, a typo in a path, an
 # `rg` that is not on PATH, a bad `--glob` — every one of them produces a silent
@@ -39,13 +68,13 @@
 #
 # So the check is three clauses, and all three must pass:
 #
-# CLAUSE 1 — ALL FIVE TARGET FILES EXIST.
+# CLAUSE 1 — ALL FOUR TARGET FILES EXIST.
 #   Each path is `test -f`'d individually and named in the output. A file that
 #   was renamed or deleted makes the scan vacuous, so it is a hard fail here
 #   rather than an invisible pass in clause 2.
 #
 # CLAUSE 2 — NONE OF THEM READS `process.env`.
-#   `rg -n 'process\.env' <five files>` must produce no output. Any match is
+#   `rg -n 'process\.env' <four files>` must produce no output. Any match is
 #   printed, so a failure names the file and line instead of just refusing.
 #
 # CLAUSE 3 — THE SCANNER IS PROVEN TO MATCH.
@@ -71,12 +100,15 @@ fail_hard() {
 command -v rg >/dev/null 2>&1 || fail_hard "rg (ripgrep) not on PATH"
 [ -d "$REPO_ROOT/.git" ] || [ -f "$REPO_ROOT/.git" ] || fail_hard "not a git repo at $REPO_ROOT"
 
-# The five readers L2a typed and this lane rewires. Listed literally rather
-# than globbed: a glob that stops matching is exactly the vacuous pass clause 3
-# guards against, and naming them makes a rename fail loudly in clause 1.
-TARGETS="server/tools/search-engine.ts
+# The four readers this lane rewires. `search-all.ts` and `search-engine.ts`
+# are the other two L2a typed and are deferred to a follow-up lane -- see "WHAT
+# THIS CHECK DELIBERATELY DOES NOT COVER" above for the reason and the counts.
+#
+# Listed literally rather than globbed: a glob that stops matching is exactly
+# the vacuous pass clause 3 guards against, and naming them makes a rename fail
+# loudly in clause 1.
+TARGETS="server/tools/types.ts
 server/tools/fts-config.ts
-server/tools/search-all.ts
 server/tools/realtime-stores.ts
 server/tools/operator-doctor.ts"
 
@@ -101,13 +133,13 @@ done <<EOF
 $TARGETS
 EOF
 
-if [ "$N_TARGETS" -ne 5 ]; then
-  CLAUSE1_EVIDENCE="expected 5 target paths, the list yielded $N_TARGETS — the check itself is miswritten"
+if [ "$N_TARGETS" -ne 4 ]; then
+  CLAUSE1_EVIDENCE="expected 4 target paths, the list yielded $N_TARGETS — the check itself is miswritten"
 elif [ -n "$MISSING" ]; then
   CLAUSE1_EVIDENCE="target file(s) NOT found: ${MISSING}— a scan over missing files passes vacuously"
 else
   CLAUSE1=PASS
-  CLAUSE1_EVIDENCE="all 5 target files present under $REPO_ROOT"
+  CLAUSE1_EVIDENCE="all 4 target files present under $REPO_ROOT"
 fi
 
 # ---------------------------------------------------------------------------
@@ -130,7 +162,7 @@ EOF
   # rg exits 1 for "no matches" (the pass) and 2 for a real error. A 2 is a
   # harness problem, not a clean tree, and must not be read as success.
   if [ "$RG_STATUS" -ge 2 ]; then
-    fail_hard "rg failed with status $RG_STATUS scanning the five target files"
+    fail_hard "rg failed with status $RG_STATUS scanning the four target files"
   fi
 
   if [ -n "$HITS" ]; then
@@ -138,7 +170,7 @@ EOF
     CLAUSE2_HITS="$HITS"
   else
     CLAUSE2=PASS
-    CLAUSE2_EVIDENCE="no process.env read in any of the 5 files — each value now arrives from validated config"
+    CLAUSE2_EVIDENCE="no process.env read in any of the 4 files — each value now arrives from validated config"
   fi
 fi
 
@@ -158,8 +190,8 @@ else
   fi
 fi
 
-printf 'CLAUSE 1 (all 5 target files exist):                    %s — %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
-printf 'CLAUSE 2 (no process.env in any of the 5):              %s — %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+printf 'CLAUSE 1 (all 4 target files exist):                    %s — %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+printf 'CLAUSE 2 (no process.env in any of the 4):              %s — %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
 if [ "$CLAUSE2" != PASS ] && [ -n "${CLAUSE2_HITS:-}" ]; then
   printf '%s\n' "$CLAUSE2_HITS" | sed 's/^/    /'
 fi

--- a/server/main.ts
+++ b/server/main.ts
@@ -146,12 +146,13 @@ function createServerFactory(input: {
   logger: Logger;
   config: ServerConfig;
   tracing: ReturnType<typeof createTracingRuntime>;
+  nats: NatsPhase;
 }): () => McpServer {
-  const { pool, logger, config } = input;
+  const { pool, logger, config, nats } = input;
   const realtime = {
     workingSetStore: new WorkingSetStore(),
     recoveryWalStore: new RecoveryWalStore({
-      walPath: process.env.OPENBRAIN_RECOVERY_WAL_PATH ?? null,
+      walPath: config.recovery.walPath,
     }),
   };
   const toolLogger = logger.child({ component: "tools" });
@@ -173,6 +174,16 @@ function createServerFactory(input: {
       ...(config.transport.embeddingBaseUrl
         ? { embeddingModel: config.transport.embeddingBaseUrl }
         : {}),
+      // The values the tool layer used to read from `process.env` itself, now
+      // handed down from the ONE validated parse (#778 typed them;
+      // `_plans/463-server-rewrite-charter.md:108,119` puts the parsing here).
+      // The NATS boundary is the one the NATS phase already built, not a second
+      // `natsRuntimeBoundaryFromConfig(config.nats)` call: rebuilding it here
+      // would give the doctor a boundary object that can drift from the one the
+      // bridge and `/health` actually run on.
+      ftsCorpusConfig: config.fts.corpusConfig,
+      recoveryWalPath: config.recovery.walPath,
+      natsRuntimeBoundary: nats.boundary,
       ...realtime,
     });
     return server;
@@ -356,6 +367,7 @@ function composeApplication(input: {
       logger,
       config,
       tracing,
+      nats,
     }),
     // CORS and request logging run ahead of EVERY route, `/health` included:
     // an unauthenticated probe is still traffic, and a deployment that cannot

--- a/server/tools/dependency-arrival.test.ts
+++ b/server/tools/dependency-arrival.test.ts
@@ -22,7 +22,8 @@
  * already use.
  */
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -158,13 +159,19 @@ describe("ftsCorpusConfig arrives at search_brain's SQL", () => {
   });
 });
 
-/** Unique per process and per case, so two runs never share a file. */
+/**
+ * Unique per case, in a directory that exists on every runner.
+ *
+ * A repo-relative scratch path is a developer-machine assumption: CI has no
+ * such directory, so the file could never be written there. Same shape as
+ * `src/rotating-file.test.ts`.
+ */
 let walCounter = 0;
 function scratchWalPath(): string {
   walCounter += 1;
   return join(
-    "/Volumes/ThunderBolt/_tmp/open-brain/_scratch",
-    `arrival-recovery-wal-${process.pid}-${walCounter}.jsonl`,
+    mkdtempSync(join(tmpdir(), "ob-arrival-")),
+    `arrival-recovery-wal-${walCounter}.jsonl`,
   );
 }
 
@@ -195,6 +202,45 @@ describe("recoveryWalPath arrives at the fallback recovery WAL store", () => {
     expect(result.isError).toBeFalsy();
     expect(existsSync(walPath)).toBe(true);
     expect(readFileSync(walPath, "utf8")).toContain('"content":"arrival"');
+  });
+
+  test("a second registration with a different path writes to that path, not the first", async () => {
+    // The fallback is process-lifetime and SHARED, so in a run that registers
+    // more than once the first path must not decide where every later caller
+    // writes. This is the CI shape: the whole directory runs in one process,
+    // and whichever file registered first would otherwise own the fallback.
+    const firstPath = scratchWalPath();
+    const secondPath = scratchWalPath();
+
+    for (const [walPath, content] of [
+      [firstPath, "first-arrival"],
+      [secondPath, "second-arrival"],
+    ] as const) {
+      const client = await clientFor(
+        { pool: capturingPool([]), recoveryWalPath: walPath },
+        "admin",
+        "operator",
+      );
+      const result = await client.callTool({
+        name: "recovery_wal_append",
+        arguments: {
+          agent: "claude",
+          platform: "claude-code",
+          server_id: "arrival-host",
+          channel_id: "open-brain",
+          session_key: "arrival-lane",
+          content,
+        },
+      });
+      expect(result.isError).toBeFalsy();
+    }
+
+    expect(existsSync(firstPath)).toBe(true);
+    expect(existsSync(secondPath)).toBe(true);
+    expect(readFileSync(firstPath, "utf8")).toContain('"content":"first-arrival"');
+    expect(readFileSync(secondPath, "utf8")).toContain(
+      '"content":"second-arrival"',
+    );
   });
 });
 

--- a/server/tools/dependency-arrival.test.ts
+++ b/server/tools/dependency-arrival.test.ts
@@ -1,0 +1,253 @@
+/**
+ * ARRIVAL regressions for the three values the composition root injects.
+ *
+ * `scripts/done-means/750-l2b1-tool-readers-take-config.sh` clause 4 reads
+ * `server/main.ts` and proves each value is WRITTEN at the call site. That is a
+ * textual assertion, and it stays green for a value that is typed correctly at
+ * the root and then dropped on the way down: a registrar that forgets to thread
+ * the dependency through, a handler that reads a different field, a fallback
+ * that shadows the injected one. Each of those is a silent revert to a default,
+ * which is precisely the doubled state the rung exists to end.
+ *
+ * So these tests assert on the FAR END. Every case registers the real tools
+ * through a real `McpServer` over an in-memory transport, injects one value,
+ * and observes something the default could not produce:
+ *
+ *   - `ftsCorpusConfig` -> the SQL text `search_brain` actually sends.
+ *   - `recoveryWalPath` -> a JSONL file that exists on disk afterwards.
+ *   - `natsRuntimeBoundary` -> the transport `operator_doctor` reports.
+ *
+ * No database is involved: the pool is a fake that records or answers queries,
+ * the same shape `search-read-scope.test.ts` and `src/operator-doctor.test.ts`
+ * already use.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import pino from "pino";
+import type { Pool } from "pg";
+import type { Role } from "../config.ts";
+import { readNatsRuntimeBoundary } from "../../src/nats-runtime.ts";
+import { resetOperatorDoctorCache } from "../../src/operator-doctor.ts";
+import { registerMemoryTools } from "./index.ts";
+import type { MemoryToolDependencies } from "./types.ts";
+
+interface CapturedQuery {
+  readonly sql: string;
+  readonly values: readonly unknown[];
+}
+
+const closers: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(closers.splice(0).map((close) => close()));
+  resetOperatorDoctorCache();
+});
+
+/**
+ * Connect a client to a server carrying the real tools and the given
+ * dependencies, authenticated as `role`.
+ *
+ * The auth info rides on the transport rather than a header, which is how
+ * `search-read-scope.test.ts` reaches the handlers' `extra.authInfo`.
+ */
+async function clientFor(
+  dependencies: Omit<MemoryToolDependencies, "pool" | "embedFn" | "logger"> & {
+    pool: Pool;
+  },
+  role: Role,
+  clientId: string,
+): Promise<Client> {
+  const server = new McpServer({ name: "arrival-test", version: "1.0.0" });
+  registerMemoryTools(server, {
+    embedFn: async () => Array(768).fill(0.01),
+    logger: pino({ level: "silent" }),
+    ...dependencies,
+  });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const send = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message, options_) =>
+    send(message, {
+      ...options_,
+      authInfo: { role, clientId, namespaceSource: "token" },
+    } as unknown as Parameters<typeof send>[1]);
+  const client = new Client({ name: "arrival-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  closers.push(async () => {
+    await client.close();
+    await server.close();
+  });
+  return client;
+}
+
+/** A pool that records every query and returns no rows. */
+function capturingPool(queries: CapturedQuery[]): Pool {
+  return {
+    query: async (sql: string, values: unknown[] = []) => {
+      queries.push({ sql, values });
+      return { rows: [] };
+    },
+  } as unknown as Pool;
+}
+
+/** @returns The single captured query, failing when the count is not one. */
+function onlyQuery(queries: readonly CapturedQuery[]): CapturedQuery {
+  expect(queries).toHaveLength(1);
+  const query = queries[0];
+  if (!query) throw new Error("handler ran no query");
+  return query;
+}
+
+/** @returns The tool's text content parsed as JSON. */
+function payloadOf(result: unknown): Record<string, unknown> {
+  const content = (result as { content?: Array<{ text?: string }> }).content;
+  const text = content?.[0]?.text;
+  if (typeof text !== "string") throw new Error("tool returned no text content");
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+describe("ftsCorpusConfig arrives at search_brain's SQL", () => {
+  test("an injected corpus default names itself in the emitted tsvector and tsquery", async () => {
+    const queries: CapturedQuery[] = [];
+    // Admin, because the non-English privilege boundary applies to the
+    // EFFECTIVE config regardless of origin; an ordinary role would be denied
+    // and never reach the SQL this case is about.
+    const client = await clientFor(
+      { pool: capturingPool(queries), ftsCorpusConfig: "german" },
+      "admin",
+      "operator",
+    );
+
+    // No fts_config argument: the ONLY way german can reach the SQL is the
+    // injected deployment default.
+    await client.callTool({
+      name: "search_brain",
+      arguments: { query: "nadel", search_mode: "keyword" },
+    });
+
+    const query = onlyQuery(queries);
+    expect(query.sql).toContain("to_tsvector('german'");
+    expect(query.sql).toContain("plainto_tsquery('german'");
+    // The query text stays a parameterized placeholder; only the allowlisted
+    // configuration literal is ever interpolated into the SQL.
+    expect(query.values[0]).toBe("nadel");
+  });
+
+  test("no injected corpus default leaves the indexed english column in force", async () => {
+    const queries: CapturedQuery[] = [];
+    const client = await clientFor(
+      { pool: capturingPool(queries) },
+      "admin",
+      "operator",
+    );
+
+    await client.callTool({
+      name: "search_brain",
+      arguments: { query: "nadel", search_mode: "keyword" },
+    });
+
+    const query = onlyQuery(queries);
+    // english is byte-identical to the pre-#341 path: it reads the stored,
+    // GIN-indexed column rather than recomputing a tsvector per row.
+    expect(query.sql).toContain(".search_vector");
+    expect(query.sql).not.toContain("'german'");
+  });
+});
+
+/** Unique per process and per case, so two runs never share a file. */
+let walCounter = 0;
+function scratchWalPath(): string {
+  walCounter += 1;
+  return join(
+    "/Volumes/ThunderBolt/_tmp/open-brain/_scratch",
+    `arrival-recovery-wal-${process.pid}-${walCounter}.jsonl`,
+  );
+}
+
+describe("recoveryWalPath arrives at the fallback recovery WAL store", () => {
+  test("recovery_wal_append writes JSONL at the injected path with no injected store", async () => {
+    const walPath = scratchWalPath();
+    // No recoveryWalStore: the path is consulted ONLY on the fallback branch of
+    // `recoveryWalStoreFor`, which is the branch a composition root that injects
+    // a path but not a store takes.
+    const client = await clientFor(
+      { pool: capturingPool([]), recoveryWalPath: walPath },
+      "admin",
+      "operator",
+    );
+
+    const result = await client.callTool({
+      name: "recovery_wal_append",
+      arguments: {
+        agent: "claude",
+        platform: "claude-code",
+        server_id: "arrival-host",
+        channel_id: "open-brain",
+        session_key: "arrival-lane",
+        content: "arrival",
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(existsSync(walPath)).toBe(true);
+    expect(readFileSync(walPath, "utf8")).toContain('"content":"arrival"');
+  });
+});
+
+/**
+ * A pool answering the probes `buildOperatorDoctorStatus` runs.
+ *
+ * `SELECT 1` proves connectivity and `_migrations` returns the applied set;
+ * every other probe degrades on an empty result, which is fine here because
+ * only the `transport` section is under test.
+ */
+function doctorPool(): Pool {
+  return {
+    totalCount: 1,
+    idleCount: 1,
+    waitingCount: 0,
+    query: async (query: string | { text: string }) => {
+      const sql = typeof query === "string" ? query : query.text;
+      if (sql.trim() === "SELECT 1") return { rows: [{ ok: 1 }] };
+      if (sql.includes("FROM _migrations")) return { rows: [] };
+      return { rows: [] };
+    },
+  } as unknown as Pool;
+}
+
+describe("natsRuntimeBoundary arrives at operator_doctor", () => {
+  test("the doctor reports the injected transport, not the one an empty environment produces", async () => {
+    // The boundary a nats deployment with the bridge OFF produces: the doctor
+    // must report the transport that was REQUESTED alongside the availability
+    // actually in force, rather than re-deriving `http` from the ambient
+    // environment the test process happens to carry.
+    const boundary = readNatsRuntimeBoundary({
+      OPENBRAIN_TRANSPORT: "nats",
+      OPENBRAIN_NATS_ENABLE_BRIDGE: "false",
+      OPENBRAIN_NATS_FALLBACK_HTTP: "true",
+      OPENBRAIN_NATS_CONTEXT_PACK_SUBJECT: "arrival.test",
+    });
+    // The doctor memoizes one probe cycle across callers, so a status built by
+    // an earlier test would otherwise be served here.
+    resetOperatorDoctorCache();
+    const client = await clientFor(
+      { pool: doctorPool(), natsRuntimeBoundary: boundary },
+      "admin",
+      "operator",
+    );
+
+    const result = await client.callTool({
+      name: "operator_doctor",
+      arguments: {},
+    });
+
+    expect(result.isError).toBeFalsy();
+    const transport = payloadOf(result).transport as Record<string, unknown>;
+    expect(transport.mode).toBe("nats");
+    expect(transport.availability).toBe("not_runtime_available");
+  });
+});

--- a/server/tools/fts-config.ts
+++ b/server/tools/fts-config.ts
@@ -106,13 +106,6 @@ export function resolveFtsConfig(raw: string | undefined): FtsConfig {
   );
 }
 
-/** Resolve the deployment-wide corpus default from the environment. */
-export function corpusFtsConfig(
-  env: NodeJS.ProcessEnv = process.env,
-): FtsConfig {
-  return resolveFtsConfig(env.OPENBRAIN_FTS_CONFIG?.trim());
-}
-
 /**
  * Resolve the configuration for one request.
  *
@@ -120,15 +113,24 @@ export function corpusFtsConfig(
  * than to english, so an operator who pinned a corpus keeps that pinning; an
  * explicitly recognized english token stays english.
  *
+ * THE DEPLOYMENT DEFAULT IS NOW A PARAMETER, NOT AN ENV READ. It arrives from
+ * `config.fts.corpusConfig`, which `server/config/env-groups.ts` derives by
+ * calling `resolveFtsConfig` on `OPENBRAIN_FTS_CONFIG` — the same function this
+ * module exports, so there is one allowlist and one alias table rather than two
+ * opinions on the same question. `server/config/` owns env parsing
+ * (`_plans/463-server-rewrite-charter.md:108,119`); the former
+ * `corpusFtsConfig(env)` reader was the duplicate half and is gone.
+ *
  * @param requested The request's `fts_config` argument, if any.
- * @param env Environment carrying the deployment default.
+ * @param corpusDefault The deployment-wide default; english when unset, which
+ *   is what an unset `OPENBRAIN_FTS_CONFIG` resolved to.
  */
 export function requestFtsConfig(
   requested: string | undefined,
-  env: NodeJS.ProcessEnv = process.env,
+  corpusDefault: FtsConfig = DEFAULT_FTS_CONFIG,
 ): FtsConfig {
   const raw = requested?.trim();
-  if (!raw) return corpusFtsConfig(env);
+  if (!raw) return corpusDefault;
   const normalized = raw.toLowerCase();
   const resolved = resolveFtsConfig(normalized);
   if (resolved !== DEFAULT_FTS_CONFIG) return resolved;
@@ -138,7 +140,7 @@ export function requestFtsConfig(
     ftsConfigSchema.safeParse(normalized).success ||
     LANGUAGE_TOKEN_TO_CONFIG[normalized] !== undefined ||
     LANGUAGE_TOKEN_TO_CONFIG[primarySubtag(normalized)] !== undefined;
-  return knownEnglishToken ? "english" : corpusFtsConfig(env);
+  return knownEnglishToken ? "english" : corpusDefault;
 }
 
 /**

--- a/server/tools/operator-doctor.ts
+++ b/server/tools/operator-doctor.ts
@@ -11,10 +11,19 @@
  * this server doing" and keeps that answer under the existing lock.
  *
  * The builder is a pure function of `(pool, natsRuntimeBoundary,
- * natsBridgeHealth)`. The rewrite has not ported `nats-runtime.ts`, so the
- * boundary is read from the environment exactly as current-src's tool does when
- * no boundary was injected -- that path opens no NATS connection, it only reads
- * `OPENBRAIN_TRANSPORT`/`OPENBRAIN_NATS_URL` and reports what they declare.
+ * natsBridgeHealth)`. The boundary is INJECTED, from
+ * `natsRuntimeBoundaryFromConfig(config.nats)` at the composition root: the
+ * same parsed `NatsConfig` the bridge and `/health` already answer from. It
+ * used to be read here from the ambient environment, which made the doctor a
+ * second opinion on the transport -- it could report `nats` while the process
+ * was serving http, because nothing tied the two reads together. `server/config/`
+ * owns env parsing (`_plans/463-server-rewrite-charter.md:108,119`), so the
+ * doctor now reports the boundary in force rather than re-deriving one.
+ *
+ * The fallback when nothing is injected is the boundary an EMPTY environment
+ * produces, not a re-read: a caller that registers tools without a composition
+ * root has no transport configured, and that is exactly what the empty-env
+ * boundary declares.
  *
  * Two properties are deliberate and load-bearing:
  *
@@ -32,6 +41,17 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getOperatorDoctorStatus } from "../../src/operator-doctor.ts";
 import { readNatsRuntimeBoundary } from "../../src/nats-runtime.ts";
 import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
+
+/**
+ * The boundary an unconfigured deployment declares.
+ *
+ * Derived ONCE from the reader itself against an empty environment, rather than
+ * hand-written, so it cannot drift from the shape `readNatsRuntimeBoundary`
+ * produces if that shape gains a field. The input is the EMPTY object:
+ * no environment is consulted, and the answer is the constant "http transport,
+ * no bridge requested" that an unwired caller is entitled to.
+ */
+const UNCONFIGURED_NATS_BOUNDARY = readNatsRuntimeBoundary({});
 
 export function registerOperatorDoctorTool(
   server: McpServer,
@@ -59,7 +79,7 @@ export function registerOperatorDoctorTool(
       try {
         const status = await getOperatorDoctorStatus(
           dependencies.pool,
-          readNatsRuntimeBoundary(process.env),
+          dependencies.natsRuntimeBoundary ?? UNCONFIGURED_NATS_BOUNDARY,
         );
         dependencies.logger.info(
           { tool: "operator_doctor", status: status.status },

--- a/server/tools/realtime-stores.ts
+++ b/server/tools/realtime-stores.ts
@@ -43,7 +43,7 @@ export function recoveryWalStoreFor(
 ): RecoveryWalStore {
   if (dependencies.recoveryWalStore) return dependencies.recoveryWalStore;
   fallbackRecoveryWalStore ??= new RecoveryWalStore({
-    walPath: process.env.OPENBRAIN_RECOVERY_WAL_PATH ?? null,
+    walPath: dependencies.recoveryWalPath ?? null,
     logger: dependencies.logger,
   });
   return fallbackRecoveryWalStore;

--- a/server/tools/realtime-stores.ts
+++ b/server/tools/realtime-stores.ts
@@ -25,6 +25,8 @@ import type { MemoryToolDependencies } from "./types.ts";
 
 let fallbackWorkingSetStore: WorkingSetStore | undefined;
 let fallbackRecoveryWalStore: RecoveryWalStore | undefined;
+/** The `recoveryWalPath` the current fallback was built for. */
+let fallbackRecoveryWalPath: string | null | undefined;
 
 /** The injected working-set store, or the shared process-lifetime fallback. */
 export function workingSetStoreFor(
@@ -37,14 +39,28 @@ export function workingSetStoreFor(
   return fallbackWorkingSetStore;
 }
 
-/** The injected recovery WAL store, or the shared process-lifetime fallback. */
+/**
+ * The injected recovery WAL store, or the shared process-lifetime fallback.
+ *
+ * The fallback is keyed on the `recoveryWalPath` it was built for, so an
+ * injected path is honored no matter WHEN it arrives: callers asking for the
+ * same path keep sharing one store — which is the point of a process-lifetime
+ * fallback — and a caller asking for a different path (or for none) gets a
+ * store built for that path instead of silently writing to the first one seen.
+ * Memoizing on first touch alone made the answer depend on registration order,
+ * which is invisible in a single-file run and wrong in a whole-suite one.
+ */
 export function recoveryWalStoreFor(
   dependencies: MemoryToolDependencies,
 ): RecoveryWalStore {
   if (dependencies.recoveryWalStore) return dependencies.recoveryWalStore;
-  fallbackRecoveryWalStore ??= new RecoveryWalStore({
-    walPath: dependencies.recoveryWalPath ?? null,
-    logger: dependencies.logger,
-  });
+  const walPath = dependencies.recoveryWalPath ?? null;
+  if (!fallbackRecoveryWalStore || fallbackRecoveryWalPath !== walPath) {
+    fallbackRecoveryWalStore = new RecoveryWalStore({
+      walPath,
+      logger: dependencies.logger,
+    });
+    fallbackRecoveryWalPath = walPath;
+  }
   return fallbackRecoveryWalStore;
 }

--- a/server/tools/search-brain.ts
+++ b/server/tools/search-brain.ts
@@ -190,10 +190,11 @@ function resolveCallerFtsConfig(options: {
   role: string;
   mode: SearchMode;
   requestedFtsConfig: string | undefined;
+  ftsCorpusConfig: FtsConfig | undefined;
 }): { ftsConfig: FtsConfig } | { denial: string } {
-  const { role, mode, requestedFtsConfig } = options;
+  const { role, mode, requestedFtsConfig, ftsCorpusConfig } = options;
   const ftsPrivileged = role === "admin" || role === "ob-admin";
-  const ftsConfig = requestFtsConfig(requestedFtsConfig);
+  const ftsConfig = requestFtsConfig(requestedFtsConfig, ftsCorpusConfig);
   if (ftsConfig === DEFAULT_FTS_CONFIG || ftsPrivileged) return { ftsConfig };
   if (mode !== "vector" && requestedFtsConfig !== undefined) {
     return { denial: NON_ENGLISH_FTS_DENIED };
@@ -235,6 +236,7 @@ export function registerSearchBrainTool(
         role: identity.role,
         mode,
         requestedFtsConfig,
+        ftsCorpusConfig: dependencies.ftsCorpusConfig,
       });
       if ("denial" in fts) return errorResult(fts.denial);
       const ftsConfig = fts.ftsConfig;

--- a/server/tools/types.ts
+++ b/server/tools/types.ts
@@ -40,15 +40,6 @@ export interface MemoryToolDependencies {
   readonly workingSetStore?: WorkingSetStore;
   readonly recoveryWalStore?: RecoveryWalStore;
   /**
-   * Milliseconds the query-embedding call may take before the search degrades.
-   *
-   * From `config.search.embeddingTimeoutMs`. Optional with the same default the
-   * reader it replaces used, because a caller that registers tools without a
-   * full composition root — the NATS bridge's `ToolDeps`, a focused test — must
-   * keep working rather than start timing out at zero.
-   */
-  readonly searchEmbeddingTimeoutMs?: number;
-  /**
    * Deployment-wide corpus default for full-text search.
    *
    * From `config.fts.corpusConfig`. Absent means english, which is what

--- a/server/tools/types.ts
+++ b/server/tools/types.ts
@@ -2,6 +2,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Logger } from "pino";
 import type { Pool } from "pg";
 import type { AuthIdentity } from "../auth/types.ts";
+import type { NatsRuntimeBoundary } from "../../src/nats-runtime.ts";
+import type { FtsConfig } from "./fts-config.ts";
 import type { WorkingSetStore } from "../realtime/working-set.ts";
 import type { RecoveryWalStore } from "../realtime/recovery-wal.ts";
 
@@ -37,6 +39,38 @@ export interface MemoryToolDependencies {
    */
   readonly workingSetStore?: WorkingSetStore;
   readonly recoveryWalStore?: RecoveryWalStore;
+  /**
+   * Milliseconds the query-embedding call may take before the search degrades.
+   *
+   * From `config.search.embeddingTimeoutMs`. Optional with the same default the
+   * reader it replaces used, because a caller that registers tools without a
+   * full composition root — the NATS bridge's `ToolDeps`, a focused test — must
+   * keep working rather than start timing out at zero.
+   */
+  readonly searchEmbeddingTimeoutMs?: number;
+  /**
+   * Deployment-wide corpus default for full-text search.
+   *
+   * From `config.fts.corpusConfig`. Absent means english, which is what
+   * `corpusFtsConfig` answered for an unset environment.
+   */
+  readonly ftsCorpusConfig?: FtsConfig;
+  /**
+   * Recovery WAL path for the fallback store, `null` for RAM-only.
+   *
+   * From `config.recovery.walPath`. Only consulted when no `recoveryWalStore`
+   * was injected; a composition root that builds the store itself has already
+   * applied this value and never reaches the fallback.
+   */
+  readonly recoveryWalPath?: string | null;
+  /**
+   * The NATS runtime boundary `operator_doctor` reports.
+   *
+   * From `natsRuntimeBoundaryFromConfig(config.nats)`. Absent means the doctor
+   * reports the boundary an unset environment produces — an http transport that
+   * requested no bridge — rather than reading the environment a second time.
+   */
+  readonly natsRuntimeBoundary?: NatsRuntimeBoundary;
 }
 
 export interface McpAuthInfo {


### PR DESCRIPTION
## Summary

- Lane **L2b-1a** of the `server/` hardening ladder (`_plans/server-hardening-ladder.md`, rung L2 "Composition root"). #778 typed every `server/` env read into a validated `ServerConfig` group but left the original readers in place, so both halves existed and only the reader was consulted. That doubled state is worse than either half alone: a group value can be correct, tested, and reported in `/health` while the tool path answers something else, and nothing fails — the config quietly becomes documentation of an intention rather than the value in force.
- **Both halves of the lane are now in this PR.** Six commits over `origin/main`:

| Commit | What it lands |
|---|---|
| `22802df` | RED: assert the typed tool readers stop reading `process.env` |
| `b7c6966` | Readers take the env values as injected parameters (1/2) |
| `407f83f` | Rescope the done-means to the four files this lane lands |
| `7b257c0` | Composition root supplies those values (2/2) |
| `fd6e294` | `server/tools/dependency-arrival.test.ts` + done-means CLAUSE 5 |
| `d0bbbd3` | The fallback recovery WAL store honors an injected path whenever it arrives |

- **Reader half (`b7c6966`).** `server/tools/fts-config.ts` takes the deployment default as a `corpusDefault` parameter, and `corpusFtsConfig` is deleted rather than kept as a wrapper — `server/config/env-groups.ts` already derives the group by calling `resolveFtsConfig`, this module's own export, so the allowlist and alias table keep exactly one owner. `server/tools/realtime-stores.ts` takes `recoveryWalPath` from dependencies. `server/tools/operator-doctor.ts` takes the NATS boundary object injected. `server/tools/types.ts` declares the new optional fields on `MemoryToolDependencies`.
- **Composition-root half (`7b257c0`).** `createServerFactory` gained a `nats: NatsPhase` input and now passes `ftsCorpusConfig: config.fts.corpusConfig`, `recoveryWalPath: config.recovery.walPath`, and `natsRuntimeBoundary: nats.boundary` into `registerMemoryTools`; the recovery WAL store in `server/main.ts` reads `config.recovery.walPath` instead of `process.env.OPENBRAIN_RECOVERY_WAL_PATH`. The boundary passed is the one the NATS phase **already built** (`natsRuntimeBoundaryFromConfig` at `server/main.ts:267`, returned as `NatsPhase.boundary`), not a second call — rebuilding it at the factory would be a second source of truth by construction, able to drift from the one the bridge and `/health` run on. `server/tools/search-brain.ts` threads `dependencies.ftsCorpusConfig` through `resolveCallerFtsConfig` into `requestFtsConfig`'s new second argument. The dead `searchEmbeddingTimeoutMs` field was removed from `server/tools/types.ts`: nothing supplied it and nothing consumed it, so leaving it declared would have advertised a wire that does not exist.
- **Arrival fix (`d0bbbd3`).** `server/tools/realtime-stores.ts` keys the fallback recovery WAL store on the `recoveryWalPath` it was built for. Callers asking for the same path keep sharing one store, which is the point of a process-lifetime fallback; a caller asking for a different path gets a store rebuilt for that path, so an injected path is honored no matter WHEN it arrives rather than whichever registration touched the fallback first. `workingSetStoreFor` is untouched. `server/tools/dependency-arrival.test.ts` gained an order-independence case that registers twice in one process with two different paths and requires both files written, and its scratch path moved to `mkdtempSync(join(tmpdir(), "ob-arrival-"))` so it does not depend on a developer-machine directory.
- `operator_doctor` gains a real property it did not have: it previously read `OPENBRAIN_TRANSPORT`/`OPENBRAIN_NATS_*` in a SECOND env read, so it could report `nats` while the process served http, because nothing tied the two reads together. It now answers from the same parsed `NatsConfig` the bridge and `/health` use.
- Start-equivalence is the bar. Every field keeps its reader's own default for a caller that injects nothing — english, a RAM-only WAL, and the boundary an empty environment declares — so this changes no behavior on a deployment that boots today.

### Scope: what is deferred, and to where

`server/tools/search-all.ts` and `server/tools/search-engine.ts` are the other two readers L2a typed. They are **not** in this PR and their `process.env` reads are still in the tree (`search-all.ts:119`, `search-engine.ts:148-149`).

The reason is a collision with a different gate. `_githooks/pre-commit` lints whole **staged** files with no main-vs-branch baseline, and both files already violate `.oxlintrc.json` on unmodified `origin/main` — 5 violations in `search-all.ts`, 9 in `search-engine.ts`. So any commit touching them is refused whether or not its own change is clean, and `--no-verify` is not an approved workaround in this repo. `.oxlintrc.json` states the intended policy — the backlog is "paid per-file as work naturally touches them" — and measured, clearing those files is a behavior-risky refactor of the core search path (`executeSearch` alone has 55 references repo-wide, a 203-line handler, an 837-code-line file). Burying a start-equivalence rewiring inside that is what the lane contract forbids.

Where each deferred piece now goes:

- `server/tools/search-all.ts` — **lane 3, next**, on the #780 checklist.
- `server/tools/search-engine.ts` — **next handoff**, the L4 split.
- `searchEmbeddingTimeoutMs` wiring belongs to the search-engine lane. That lane must **re-add** the field to `MemoryToolDependencies` and wire `config.search.embeddingTimeoutMs` to it; this PR removed it precisely so nobody reads its presence as evidence the value is flowing.
- `server/tools/search-brain.ts` lint debt was cleared separately by **#786**, which is why this PR could touch it.

## Verification

- Done-means: scripts/done-means/750-l2b1-tool-readers-take-config.sh

Five clauses, all of which must pass:

1. All four target files exist (a rename would make the scan vacuous).
2. None of the four reads `process.env`.
3. Positive control — the same pattern, tool, and invocation must still find hits in `server/config.ts`, the one file in `server/` that MUST read the environment. Guards the "0 items examined, exit 0" shape.
4. Each of the four values arrives **exactly once** at the composition root. Zero means unwired; more than one means two composition paths that can disagree.
5. The injected values are observed **at their consumers**, by running `server/tools/dependency-arrival.test.ts` and requiring exit 0 with at least 3 passing tests. It now reports 5.

**RED evidence that clauses 4 and 5 are not decoration.** The absence-only version of this check (clauses 1-3) passed at `1d0b9b2` while **nothing was wired** — three of the four readers took parameters and `server/main.ts` supplied none of them, so every one was silently running on its `?? default` forever. That is exactly the pair of P1s the #779 review raised, and clause 4 was written to make that state fail. Clause 5 in turn FAILS with the test file absent (`"...does not exist — clause 4 asserts the wiring was TYPED; nothing here asserts it WORKS"`), because clause 4 is a textual assertion: a field can be spelled correctly at the root and still be dropped by the registrar, shadowed by a fallback, or read from the wrong place by the handler. The arrival test is proven able to fail — the french-variant assertion in the `ftsCorpusConfig` case fails when the injected corpus default does not reach the emitted tsvector/tsquery.

**CI RED that `d0bbbd3` answered.** The `db-integration` job on `fd6e294` (runs 32994328337 and 32994354301) FAILED the new arrival case: `expect(existsSync(walPath)).toBe(true)` received `false`. Two real causes, both fixed in `d0bbbd3` — the test wrote its WAL under a developer-machine scratch directory absent on the runner, and the fallback recovery WAL store memoized on first touch, so in the single bun process CI uses for the whole suite whichever registration touched it first decided the path for every later caller. The order-independence case was written RED-first: `server/tools/dependency-arrival.test.ts:238` `expect(existsSync(firstPath)).toBe(true)` received `false` before the fix.

GREEN on this PR head, run in the lane clone:

```
CLAUSE 1 (all 4 target files exist):                    PASS — all 4 target files present
CLAUSE 2 (no process.env in any of the 4):              PASS — no process.env read in any of the 4 files
CLAUSE 3 (scanner proven to match in server/config.ts):   PASS — server/config.ts still contains 4 process.env line(s)
CLAUSE 4 (values arrive at the composition root):        PASS — all 4 values are passed exactly once from the composition root
CLAUSE 5 (injected values observed at their consumers):  PASS — 5 test(s) passed in server/tools/dependency-arrival.test.ts
EXIT=0
```

- [x] Relevant Open Brain tests/typecheck/migrations passed — `bunx tsc --noEmit` clean; oxlint 0 over the touched and adjacent tool files; `bun run test:isolated server/` → 488 pass / 0 fail across 36 files; 112 pass / 0 fail across `main.pg`, `search-read-scope`, `namespace-denial`, and `config` on the wired head; the 5 arrival tests pass through the done-means clause 5 run shown above. Isolated databases dropped on exit.
- [x] Python package checks passed or are not applicable — not applicable; no change under `python/`.
- [x] Live Open Brain smoke passed or is not applicable — not applicable; no contract, schema, transport, or client-facing surface changes. `operator_doctor`'s payload shape is unchanged and still under the `DOCTOR_CONTRACT_VERSION` lock in `src/operator-doctor.test.ts`.

## Critical Self-Review

- Highest-risk behavior: `operator_doctor`'s NATS boundary object. It changes SOURCE (a second env read → the parsed `NatsConfig` the NATS phase already built), and the two could disagree in a deployment where they already did — which is the defect being fixed, so a difference in output there is the correction, not a regression. The frozen payload SHAPE is untouched and still under the `DOCTOR_CONTRACT_VERSION` lock.
- Assumptions that could be wrong: that `registerMemoryTools` at `createServerFactory` is the ONLY path these tools are registered through. Checked — the NATS bridge takes a separate `ToolDeps` and registers none of these tools (`rg` over `server/application/nats.ts` and the bridge found no `registerMemoryTools`/`registerOperatorDoctorTool`). If a future caller registers them elsewhere without injecting, it silently gets the documented defaults rather than the deployment's config, and nothing in this PR would catch that.
- Missing/weak tests: `server/tools/dependency-arrival.test.ts` covers the three values this lane wires through a fake McpServer, but it exercises no real transport and no real process start, so it cannot catch a value that is correct in `createServerFactory` and wrong in the launch path that builds `ServerConfig`. The two deferred readers have no arrival coverage at all — by construction, since they are not wired yet. The order-independence of the fallback recovery WAL store is now covered by the second registration case added in `d0bbbd3`.
- Security/permission risk: low. No namespace predicate, auth check, or role gate is touched. `operator_doctor`'s admin/ob-admin gate and its fixed-string error path are unchanged, and the NATS URL stays out of the doctor payload. `search-brain.ts`'s non-english corpus denial for unprivileged roles is preserved — the injected corpus default flows through `resolveCallerFtsConfig`, which still applies the privileged-role rule before returning.
- Migration/deploy risk: none. No schema, no migration. Start-equivalence is the explicit bar and each field keeps its reader's default, so an environment that boots today boots identically. `createServerFactory` gained a required `nats` input; every call site is inside `server/main.ts` and tsc is clean.
- Downstream client/runtime risk: none identified. No MCP tool schema, transport protocol, or Python client surface changes; the four readers are internal to `server/`. `docs/downstream-rollout.md` classifies this as not applicable.
- Rollback/cleanup concern: revert is clean — six commits, no state, no schema. The isolated test databases were dropped by the harness. Nothing is left stashed or dirty: the composition-root half that the previous body described as parked in `stash@{0}` is now committed as `7b257c0`, so that stash is no longer the home of any unlanded work.
- Fixes made before PR: the #779 review's two P1s, both of which were that the wiring did not exist. `7b257c0` supplies all three values from the composition root and `fd6e294` proves they arrive at their consumers; the done-means grew clause 4 (arrival at the root) and clause 5 (arrival at the consumer) so the unwired state that passed at `1d0b9b2` fails loudly. Also caught that `qmdPath` must be spread conditionally rather than assigned `undefined`, because `exactOptionalPropertyTypes` distinguishes the two, and that removing `searchEmbeddingTimeoutMs` is correct only because `search-engine.ts` still parses its own — recorded in the deferral so the search-engine lane re-adds it.
- Known residual risk: rung L2 is not finished. `search-all.ts` and `search-engine.ts` still read `process.env` in the tree, so the composition root is the single source for three of the five typed values and not yet for all of them; the done-means header says so rather than letting a green read as completion. `server/tools/dependency-arrival.test.ts` exercises no real transport and no real process start, so a value that is correct in `createServerFactory` and wrong in the launch path that builds `ServerConfig` would not be caught here.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the #779 review findings were P1s against this branch's own unfinished wiring, fixed here rather than being a reusable reviewer pattern; the transferable lesson — an absence-only check passes on an unwired reader, so pair it with an arrival assertion — is captured executably in the done-means header and harvested to the lane contract's Tightenings.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no contract, transport, schema, or client-facing change; the affected surfaces are internal composition wiring with start-equivalent values.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the diff touches no path in `contracts/parity-paths.txt` and no contract fixture covers these values. `operator_doctor`'s payload shape is unchanged and remains locked by `src/operator-doctor.test.ts` against `DOCTOR_CONTRACT_VERSION`.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable against every trigger in the doc's "When This Applies": no MCP tool name, schema, or output shape changes; no auth or namespace semantics change; no error envelope change; no transport or session behavior change; no externally visible migration; no `python/openbrain-memory` behavior or export change; no generated `skill/` content change. The four readers are internal to `server/`, and every injected value is start-equivalent to what the reader it replaced produced, so no mcp2cli or Hermes consumer observes a difference.
