### PR TITLE
refactor(server): bring server/main.ts to lint standard (#780 lane 1)

### DIFF
--- a/scripts/done-means/780-touched-files-lint-clean.sh
+++ b/scripts/done-means/780-touched-files-lint-clean.sh
@@ -69,10 +69,20 @@ if [ -n "${DONE_MEANS_780_FILES:-}" ]; then
   targets=(${DONE_MEANS_780_FILES})
 else
   source_label="git diff --name-only origin/main...HEAD"
+  # FILTERED WITH rg, NOT WITH A GIT PATHSPEC. `-- 'server/**/*.ts'` looks
+  # correct and silently matches NOTHING for a file sitting directly in
+  # server/: git's default pathspec globbing requires `**` to consume at least
+  # one directory, so server/main.ts -- the exact file this lane changed -- was
+  # excluded while server/db/pool.ts would have matched. Measured on this
+  # branch: the pathspec form returned empty, `:(glob)server/**/*.ts` returned
+  # server/main.ts. That is the plausible-looking wrong answer the lane
+  # contract keeps recording (round 30's `rg -r`/`-E`/`--` family): the command
+  # exits 0 and the list is just quietly short. An anchored regex over the full
+  # diff has no such edge, and the empty-list guard below is what surfaced it.
   while IFS= read -r f; do
     [ -n "$f" ] && targets+=("$f")
-  done < <(git diff --name-only origin/main...HEAD -- 'server/**/*.ts' \
-    | rg -v '\.test\.ts$' || true)
+  done < <(git diff --name-only origin/main...HEAD \
+    | rg '^server/.*\.ts$' | rg -v '\.test\.ts$' || true)
 fi
 
 # Deleted or renamed-away paths are in the diff but not on disk. Lint what

--- a/scripts/done-means/780-touched-files-lint-clean.sh
+++ b/scripts/done-means/780-touched-files-lint-clean.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Done-means for the #780 lint-debt sweep (Rico ruling 2026-08-26, option O1:
+# one file at a time, each brought fully to standard before the next).
+#
+# WHAT THIS CHECKS, in plain words: every non-test TypeScript file under
+# server/ that THIS BRANCH CHANGED must lint clean under the repo's own
+# .oxlintrc.json with warnings treated as errors. That is the whole claim.
+#
+# WHAT A GREEN RUN DOES NOT MEAN. It does NOT mean server/ is clean. The
+# sweep's own config comment records 142 production findings across 99 files in
+# server/ at the lint gate's landing, and this sweep retires them ONE FILE PER
+# LANE. So "PASS" here reads exactly as: "the files this PR touched are clean",
+# never "the directory is clean". Anyone quoting this check as directory-level
+# evidence is quoting it wrong.
+#
+# WHY THE FILE LIST COMES FROM THE DIFF. A per-lane check hardcoding its own
+# file name would have to be edited every lane, and an edited check is a check
+# nobody re-reads. Deriving the list from `git diff --name-only
+# origin/main...HEAD` makes ONE script serve every rung of the sweep, and it
+# also means a lane cannot pass by forgetting to list the file it changed.
+#
+# WHY AN EMPTY LIST IS A FAILURE, NOT A PASS. A linter handed zero paths exits
+# 0. That is the classic vacuous green: the check would report success on a
+# branch that changed nothing, on a detached HEAD where the three-dot diff comes
+# back empty, and on a merge-base resolution that quietly broke. So an empty
+# list exits 1 and SAYS SO by name, rather than being read as "all clean".
+#
+# THE OVERRIDE IS THE RED CONTROL. DONE_MEANS_780_FILES="<space-separated
+# paths>" replaces the diff-derived list. That exists so the check can be proven
+# to FAIL on content that is known dirty -- a check that has never failed proves
+# nothing (docs/lane-contract.md, standing contract item 1). For lane 1:
+#
+#   # RED, on origin/main content -- must exit 1 naming the three findings
+#   git stash / checkout origin/main -- server/main.ts   (or run from a main tree)
+#   DONE_MEANS_780_FILES=server/main.ts bash scripts/done-means/780-touched-files-lint-clean.sh
+#
+#   # GREEN, on the lane head -- must exit 0 both with and without the override
+#   bash scripts/done-means/780-touched-files-lint-clean.sh
+#   DONE_MEANS_780_FILES=server/main.ts bash scripts/done-means/780-touched-files-lint-clean.sh
+#
+# MISSING BINARY FAILS CLOSED. If ./node_modules/.bin/oxlint is absent the check
+# exits 1 naming it, never 0. Round 34 measured this exact hole from the other
+# side: verify-lane installed dependencies at origin/main, hit `MISSING TOOL:
+# oxlint`, and posted NO receipt. A lint check whose linter is missing has
+# measured nothing, and must not be readable as clean.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+OXLINT=./node_modules/.bin/oxlint
+if [ ! -x "$OXLINT" ]; then
+  echo "FAIL: missing lint binary $OXLINT -- run 'bun install --frozen-lockfile'."
+  echo "      A lint check without a linter has measured nothing; failing closed."
+  exit 1
+fi
+if [ ! -f .oxlintrc.json ]; then
+  echo "FAIL: missing .oxlintrc.json at the repo root; there is no config to lint against."
+  exit 1
+fi
+
+# The file list. Override wins; otherwise the branch's own diff against the
+# upstream default branch, filtered to non-test TypeScript under server/.
+declare -a targets=()
+source_label=""
+if [ -n "${DONE_MEANS_780_FILES:-}" ]; then
+  source_label="DONE_MEANS_780_FILES override"
+  # Word-split deliberately: the contract is a space-separated path list.
+  # shellcheck disable=SC2206
+  targets=(${DONE_MEANS_780_FILES})
+else
+  source_label="git diff --name-only origin/main...HEAD"
+  while IFS= read -r f; do
+    [ -n "$f" ] && targets+=("$f")
+  done < <(git diff --name-only origin/main...HEAD -- 'server/**/*.ts' \
+    | rg -v '\.test\.ts$' || true)
+fi
+
+# Deleted or renamed-away paths are in the diff but not on disk. Lint what
+# exists; announce anything dropped, because nothing is adjusted silently
+# (AGENTS.md Coding Standards, 2026-08-08).
+declare -a present=()
+for f in "${targets[@]}"; do
+  if [ -f "$f" ]; then
+    present+=("$f")
+  else
+    echo "note: $f is in the file list but not on disk (deleted or renamed); not linted."
+  fi
+done
+
+if [ "${#present[@]}" -eq 0 ]; then
+  echo "FAIL: EMPTY FILE LIST -- nothing was linted, so this run proves nothing."
+  echo "      source: $source_label"
+  echo "      A lint run over zero paths exits 0; that is a vacuous green and is"
+  echo "      refused here. Expected at least one non-test server/**/*.ts file."
+  exit 1
+fi
+
+echo "linting ${#present[@]} file(s) from: $source_label"
+for f in "${present[@]}"; do echo "  - $f"; done
+
+if "$OXLINT" --config .oxlintrc.json --deny-warnings "${present[@]}"; then
+  echo "PASS: every file this branch touched under server/ lints clean."
+  echo "      This says nothing about the rest of server/ -- see the header."
+  exit 0
+fi
+
+echo "FAIL: oxlint reported findings in the file(s) listed above."
+exit 1

--- a/server/main.ts
+++ b/server/main.ts
@@ -42,6 +42,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   createShadowApplication,
   type ShadowApplication,
+  type ShadowApplicationInput,
 } from "./application/index.ts";
 import {
   createNatsBridgeHealth,
@@ -198,11 +199,275 @@ function handlerLogger(logger: Logger): {
 }
 
 /**
+ * The live pieces a started process owns, in the order startup produced them.
+ *
+ * Named as one type because shutdown needs exactly this set and nothing else,
+ * and because a five-argument `shutdown(application, database, server, logger,
+ * tracing)` is a struct that has not been named yet — every caller has to
+ * remember the order, and the compiler cannot help when two of the five are
+ * transposed.
+ */
+interface RunningProcess {
+  readonly application: ShadowApplication;
+  readonly database: Database<pg.Pool>;
+  readonly server: Server;
+  readonly logger: Logger;
+  readonly tracing: ReturnType<typeof createTracingRuntime>;
+}
+
+/**
+ * Apply migrations, or record that they were deliberately skipped.
+ *
+ * The skip is `OPEN_BRAIN_RUN_MIGRATIONS=0`'s shape for extra workers: exactly
+ * one process in a multi-worker deployment applies schema, and the others say
+ * so in the log rather than staying silent, because a worker that ran no
+ * migrations and never mentioned it is indistinguishable from one whose
+ * migration step failed to be reached.
+ */
+async function applyMigrations(input: {
+  database: Database<pg.Pool>;
+  config: ServerConfig;
+  logger: Logger;
+  enabled: boolean;
+}): Promise<void> {
+  const { database, config, logger } = input;
+  if (!input.enabled) {
+    logger.info({}, "migrations_skipped");
+    return;
+  }
+  const applied = await runMigrations(
+    database.pool,
+    config.database.migrationsDirectory,
+    logger,
+  );
+  logger.info({ applied: applied.length }, "migrations_complete");
+}
+
+/** The NATS phase's outputs, all of which the composition step consumes. */
+interface NatsPhase {
+  readonly boundary: ReturnType<typeof natsRuntimeBoundaryFromConfig>;
+  readonly health: ReturnType<typeof createNatsBridgeHealth>;
+  readonly bridge: Awaited<ReturnType<typeof startNatsBridgeRuntime>>;
+}
+
+/**
+ * Bring up the NATS ingress: boundary, health counters, and the bridge runtime.
+ *
+ * The token map the bridge needs is the `src/` shape. It is derived from the
+ * SAME parsed config the HTTP middleware uses, not from a second env read, so
+ * the two ingresses cannot end up honoring different tokens.
+ */
+async function startNatsPhase(input: {
+  database: Database<pg.Pool>;
+  config: ServerConfig;
+  logger: Logger;
+  tracing: ReturnType<typeof createTracingRuntime>;
+}): Promise<NatsPhase> {
+  const { database, config, logger, tracing } = input;
+  const boundary = natsRuntimeBoundaryFromConfig(config.nats);
+  const health = createNatsBridgeHealth(config.nats.availability);
+  const deps: ToolDeps = {
+    pool: database.pool,
+    embedFn: generateEmbedding,
+    natsRuntimeBoundary: boundary,
+    natsBridgeHealth: health,
+  };
+
+  const tokenMap = new Map<string, AuthInfo>(
+    config.authTokens.map((entry) => [
+      entry.token,
+      { role: entry.role, clientId: entry.clientId },
+    ]),
+  );
+
+  const bridge = await startNatsBridgeRuntime({
+    config: config.nats,
+    logger: logger.child({ component: "nats" }),
+    tokenMap,
+    deps,
+    health,
+    ...(tracing.background ? { tracing: tracing.background } : {}),
+  });
+
+  return { boundary, health, bridge };
+}
+
+/**
+ * The background runtimes the application shuts down in order.
+ *
+ * The capture observer owns a refresh interval, which makes it a background
+ * runtime and not a value: `server/application/index.ts` already owns ordered
+ * shutdown through this port, so the timer stops on the same path as the NATS
+ * bridge and the maintenance runner rather than through a second hand-rolled
+ * teardown. A runtime that is running but absent from `backgroundRuntimes` is
+ * the abandoned-lease bug (index.ts:127-131).
+ */
+function backgroundRuntimesFor(input: {
+  bridge: NatsPhase["bridge"];
+  captureHealth: ReturnType<typeof createCaptureHealthRuntime>;
+}): ShadowApplicationInput["backgroundRuntimes"] {
+  const { bridge, captureHealth } = input;
+  return [
+    ...(bridge.runtime ? [bridge.runtime] : []),
+    ...(captureHealth.captureObserver
+      ? [
+          {
+            name: "capture-health-observer",
+            stop: async (): Promise<void> => captureHealth.stop(),
+          },
+        ]
+      : []),
+  ];
+}
+
+/**
+ * Compose the application: auth, REST, MCP sessions, health, and the shutdown
+ * order. Binds no socket — the listener is the caller's next step.
+ */
+function composeApplication(input: {
+  options: StartServerOptions;
+  config: ServerConfig;
+  logger: Logger;
+  database: Database<pg.Pool>;
+  tracing: ReturnType<typeof createTracingRuntime>;
+  nats: NatsPhase;
+  captureHealth: ReturnType<typeof createCaptureHealthRuntime>;
+}): ShadowApplication {
+  const { options, config, logger, database, tracing, nats, captureHealth } =
+    input;
+  const authenticate = createAuthMiddleware(config.authTokens);
+  const restSurface = createRestSurface({
+    pool: database.pool,
+    embedFn: generateEmbedding,
+    authenticate,
+    logger: logger.child({ component: "rest" }),
+    operatorDoctor: () =>
+      getOperatorDoctorStatus(database.pool, nats.boundary, nats.health),
+  });
+
+  return createShadowApplication({
+    config,
+    logger,
+    database,
+    authenticate,
+    parseRequestBody: express.json({ limit: "1mb" }),
+    serverFactory: createServerFactory({
+      pool: database.pool,
+      logger,
+      config,
+      tracing,
+    }),
+    // CORS and request logging run ahead of EVERY route, `/health` included:
+    // an unauthenticated probe is still traffic, and a deployment that cannot
+    // see its own health requests cannot tell a dead monitor from a healthy
+    // service.
+    beforeRoutes: installHttpMiddleware({
+      allowedOrigins:
+        options.allowedOrigins ??
+        parseAllowedOrigins(process.env.ALLOWED_ORIGINS),
+      logger: logger.child({ component: "http" }),
+    }),
+    routers: [{ path: "/api/v1", handler: restSurface }],
+    // Absent when no namespace is configured, and absence is the composition
+    // publishing NOTHING rather than a neutral value: a deployment that runs
+    // no capture lane must not report itself broken for a job it was never
+    // given (`docs/lane-contract.md` Tightenings rounds 8 and 13).
+    ...(captureHealth.captureObserver
+      ? { captureObserver: captureHealth.captureObserver }
+      : {}),
+    backgroundRuntimes: backgroundRuntimesFor({
+      bridge: nats.bridge,
+      captureHealth,
+    }),
+    // The maintenance handler map is what makes the runner exist at all; the
+    // application composes it from `config.maintenance` and puts it last in
+    // the shutdown order, so "maintenance runs" and "maintenance drains"
+    // remain one decision rather than two that can disagree.
+    maintenanceHandlers: composeMaintenanceHandlers({
+      pool: database.pool,
+      logger: handlerLogger(logger.child({ component: "maintenance" })),
+      embedFn: generateEmbeddingWithMetadata,
+      graphAuth: MAINTENANCE_GRAPH_AUTH,
+      ...(tracing.background ? { tracing: tracing.background } : {}),
+    }),
+    // A LIVE bridge knows its own failure counters; config cannot. Health
+    // therefore reads the running health object, falling back to the parsed
+    // config for the static half of the block.
+    natsHealth: () =>
+      natsHealthFromConfig(config.nats, {
+        consecutiveFailures: nats.health.consecutiveFailures,
+        lastError: Boolean(nats.health.lastError),
+      }),
+  });
+}
+
+/**
+ * Open the socket and report the port that was actually bound.
+ *
+ * `address()` rather than the requested port, because `0` asks the kernel for
+ * an ephemeral one and the requested value is then a lie in the log and in the
+ * returned handle.
+ */
+async function openListener(input: {
+  application: ShadowApplication;
+  options: StartServerOptions;
+  logger: Logger;
+}): Promise<{ server: Server; boundPort: number }> {
+  const { application, options, logger } = input;
+  const port = options.port ?? Number(process.env.PORT ?? DEFAULT_PORT);
+  const bindHost = options.bindHost ?? process.env.OPEN_BRAIN_BIND_HOST?.trim();
+  const server = await new Promise<Server>((resolve, reject) => {
+    const listener = bindHost
+      ? application.app.listen(port, bindHost, () => resolve(listener))
+      : application.app.listen(port, () => resolve(listener));
+    listener.once("error", reject);
+  });
+  const address = server.address();
+  const boundPort =
+    typeof address === "object" && address !== null ? address.port : port;
+  logger.info(
+    { port: boundPort, bind_host: bindHost ?? "all" },
+    "server_started",
+  );
+  return { server, boundPort };
+}
+
+/**
+ * Release everything a partial startup allocated, so the CAUSE can be rethrown.
+ *
+ * The application may or may not have been composed; both it and the pool are
+ * released here. The tracing client owns a background flush timer, so leaving
+ * it running after a failed start keeps the process alive with nothing to
+ * serve. Every failure in here is swallowed deliberately: the startup error is
+ * the one the operator needs, and a cleanup error that replaced it would hide
+ * the reason the process could not start.
+ */
+async function releaseAfterFailedStart(input: {
+  application: ShadowApplication | undefined;
+  database: Database<pg.Pool>;
+  tracing: ReturnType<typeof createTracingRuntime>;
+}): Promise<void> {
+  try {
+    await input.application?.close();
+  } catch {
+    // Already reported by closeInOrder's own logging; the startup failure is
+    // the one the operator needs, so it wins.
+  }
+  await input.tracing.shutdown().catch(() => undefined);
+  await input.database.close().catch(() => undefined);
+}
+
+/**
  * Compose and start the whole process. Throws on any fatal startup failure.
  *
  * Returns the handle rather than installing signal handlers, so a test can
  * start and stop it without touching process-global state; `main()` below is
  * the part that owns signals and exit codes.
+ *
+ * THE PHASES ARE THE HELPERS ABOVE, CALLED IN STARTUP ORDER. This function is
+ * deliberately a sequence rather than a place where work happens: the file's
+ * header says order is its content, so the order has to be readable on one
+ * screen instead of inferred from interleaved composition.
  */
 export async function startServer(
   options: StartServerOptions = {},
@@ -229,44 +494,14 @@ export async function startServer(
   logger.info({ enabled: tracing.sink !== undefined }, "mcp_tracing_configured");
   let application: ShadowApplication | undefined;
   try {
-    if (options.runMigrations !== false) {
-      const applied = await runMigrations(
-        database.pool,
-        config.database.migrationsDirectory,
-        logger,
-      );
-      logger.info({ applied: applied.length }, "migrations_complete");
-    } else {
-      logger.info({}, "migrations_skipped");
-    }
-
-    const natsBoundary = natsRuntimeBoundaryFromConfig(config.nats);
-    const natsHealth = createNatsBridgeHealth(config.nats.availability);
-    const toolDeps: ToolDeps = {
-      pool: database.pool,
-      embedFn: generateEmbedding,
-      natsRuntimeBoundary: natsBoundary,
-      natsBridgeHealth: natsHealth,
-    };
-
-    // The token map the NATS bridge needs is the `src/` shape. It is derived
-    // from the SAME parsed config the HTTP middleware uses, not from a second
-    // env read, so the two ingresses cannot end up honoring different tokens.
-    const tokenMap = new Map<string, AuthInfo>(
-      config.authTokens.map((entry) => [
-        entry.token,
-        { role: entry.role, clientId: entry.clientId },
-      ]),
-    );
-
-    const bridge = await startNatsBridgeRuntime({
-      config: config.nats,
-      logger: logger.child({ component: "nats" }),
-      tokenMap,
-      deps: toolDeps,
-      health: natsHealth,
-      ...(tracing.background ? { tracing: tracing.background } : {}),
+    await applyMigrations({
+      database,
+      config,
+      logger,
+      enabled: options.runMigrations !== false,
     });
+
+    const nats = await startNatsPhase({ database, config, logger, tracing });
 
     // The capture-health observer this process runs, from REQUIRED config
     // (operator ruling 2026-08-08, ledger item 28 in `docs/issue-graph.md`).
@@ -281,101 +516,22 @@ export async function startServer(
       logger: logger.child({ component: "capture-health" }),
     });
 
-    const authenticate = createAuthMiddleware(config.authTokens);
-    const restSurface = createRestSurface({
-      pool: database.pool,
-      embedFn: generateEmbedding,
-      authenticate,
-      logger: logger.child({ component: "rest" }),
-      operatorDoctor: () =>
-        getOperatorDoctorStatus(database.pool, natsBoundary, natsHealth),
-    });
-
-    application = createShadowApplication({
+    application = composeApplication({
+      options,
       config,
       logger,
       database,
-      authenticate,
-      parseRequestBody: express.json({ limit: "1mb" }),
-      serverFactory: createServerFactory({
-        pool: database.pool,
-        logger,
-        config,
-        tracing,
-      }),
-      // CORS and request logging run ahead of EVERY route, `/health` included:
-      // an unauthenticated probe is still traffic, and a deployment that cannot
-      // see its own health requests cannot tell a dead monitor from a healthy
-      // service.
-      beforeRoutes: installHttpMiddleware({
-        allowedOrigins:
-          options.allowedOrigins ??
-          parseAllowedOrigins(process.env.ALLOWED_ORIGINS),
-        logger: logger.child({ component: "http" }),
-      }),
-      routers: [{ path: "/api/v1", handler: restSurface }],
-      // Absent when no namespace is configured, and absence is the composition
-      // publishing NOTHING rather than a neutral value: a deployment that runs
-      // no capture lane must not report itself broken for a job it was never
-      // given (`docs/lane-contract.md` Tightenings rounds 8 and 13).
-      ...(captureHealth.captureObserver
-        ? { captureObserver: captureHealth.captureObserver }
-        : {}),
-      // The observer owns a refresh interval, which makes it a background
-      // runtime and not a value: `server/application/index.ts` already owns
-      // ordered shutdown through this port, so the timer stops on the same
-      // path as the NATS bridge and the maintenance runner rather than through
-      // a second hand-rolled teardown. A runtime that is running but absent
-      // from `backgroundRuntimes` is the abandoned-lease bug (index.ts:127-131).
-      backgroundRuntimes: [
-        ...(bridge.runtime ? [bridge.runtime] : []),
-        ...(captureHealth.captureObserver
-          ? [
-              {
-                name: "capture-health-observer",
-                stop: async () => captureHealth.stop(),
-              },
-            ]
-          : []),
-      ],
-      // The maintenance handler map is what makes the runner exist at all; the
-      // application composes it from `config.maintenance` and puts it last in
-      // the shutdown order, so "maintenance runs" and "maintenance drains"
-      // remain one decision rather than two that can disagree.
-      maintenanceHandlers: composeMaintenanceHandlers({
-        pool: database.pool,
-        logger: handlerLogger(logger.child({ component: "maintenance" })),
-        embedFn: generateEmbeddingWithMetadata,
-        graphAuth: MAINTENANCE_GRAPH_AUTH,
-        ...(tracing.background ? { tracing: tracing.background } : {}),
-      }),
-      // A LIVE bridge knows its own failure counters; config cannot. Health
-      // therefore reads the running health object, falling back to the parsed
-      // config for the static half of the block.
-      natsHealth: () =>
-        natsHealthFromConfig(config.nats, {
-          consecutiveFailures: natsHealth.consecutiveFailures,
-          lastError: Boolean(natsHealth.lastError),
-        }),
+      tracing,
+      nats,
+      captureHealth,
     });
 
-    const port = options.port ?? Number(process.env.PORT ?? DEFAULT_PORT);
-    const bindHost =
-      options.bindHost ?? process.env.OPEN_BRAIN_BIND_HOST?.trim();
     const composed = application;
-    const server = await new Promise<Server>((resolve, reject) => {
-      const listener = bindHost
-        ? composed.app.listen(port, bindHost, () => resolve(listener))
-        : composed.app.listen(port, () => resolve(listener));
-      listener.once("error", reject);
+    const { server, boundPort } = await openListener({
+      application: composed,
+      options,
+      logger,
     });
-    const address = server.address();
-    const boundPort =
-      typeof address === "object" && address !== null ? address.port : port;
-    logger.info(
-      { port: boundPort, bind_host: bindHost ?? "all" },
-      "server_started",
-    );
 
     return {
       application: composed,
@@ -383,23 +539,14 @@ export async function startServer(
       server,
       port: boundPort,
       logger,
-      shutdown: () => shutdown(composed, database, server, logger, tracing),
+      shutdown: () =>
+        shutdown({ application: composed, database, server, logger, tracing }),
     };
   } catch (error: unknown) {
-    // A failure anywhere after the pool exists must not leak it. The
-    // application may or may not have been composed; both are released here,
-    // and the original failure is rethrown so the caller sees the CAUSE rather
-    // than a cleanup error.
-    try {
-      await application?.close();
-    } catch {
-      // Already reported by closeInOrder's own logging; the startup failure is
-      // the one the operator needs, so it wins.
-    }
-    // The tracing client owns a background flush timer; leaving it running
-    // after a failed start keeps the process alive with nothing to serve.
-    await tracing.shutdown().catch(() => undefined);
-    await database.close().catch(() => undefined);
+    // A failure anywhere after the pool exists must not leak it. Everything
+    // allocated so far is released, and the original failure is rethrown so the
+    // caller sees the CAUSE rather than a cleanup error.
+    await releaseAfterFailedStart({ application, database, tracing });
     throw error;
   }
 }
@@ -418,13 +565,8 @@ export async function startServer(
  * rethrown: a partial shutdown must not be readable as a clean one, or a
  * supervisor restarts on top of leases that are still live.
  */
-async function shutdown(
-  application: ShadowApplication,
-  database: Database<pg.Pool>,
-  server: Server,
-  logger: Logger,
-  tracing: ReturnType<typeof createTracingRuntime>,
-): Promise<void> {
+async function shutdown(running: RunningProcess): Promise<void> {
+  const { application, database, server, logger, tracing } = running;
   logger.info({}, "server_shutdown_started");
   await new Promise<void>((resolve) => server.close(() => resolve()));
   let firstFailure: unknown;
@@ -470,6 +612,7 @@ async function shutdown(
   logger.info({}, "server_shutdown_complete");
   if (firstFailure !== undefined) throw firstFailure;
 }
+
 
 /**
  * The launchd-facing process wrapper: signals, exit codes, nothing else.


### PR DESCRIPTION
## Summary

- Lane 1 of the #780 lint-debt sweep (Rico ruling 2026-08-26, option O1: one file at a time, each brought fully to standard before the next). Scope is ONE file, `server/main.ts`, and nothing else: no other file's findings, no `process.env` moves (the L2 rungs own those), no `src/`, no #779 wiring.
- Retires the three findings `server/main.ts` carried on `origin/main` at `49ecfbe`: `startServer` at complexity 22 against a max of 10, at 140 code lines against a max of 100, and `shutdown` at 5 parameters against a max of 4.
- `startServer` is split along the phases the file's own header already documents — config, logger, database, migrations, NATS, tools/HTTP, listen. The new helpers are `applyMigrations`, `startNatsPhase`, `backgroundRuntimesFor`, `composeApplication`, `openListener`, and `releaseAfterFailedStart`; `startServer` becomes the sequence that calls them. No phase was invented and none was reordered. `shutdown` takes a named `RunningProcess` instead of five positional arguments; it is module-private, so no caller outside this file changes.
- NO BEHAVIOR CHANGE, and the parts that could carry one were diffed rather than asserted: all six `process.env` reads are byte-identical and stay exactly where they were, log event names diff clean, and `logger.info`/`warn`/`error` call counts diff clean against `origin/main`. Startup order, every error path, and the non-zero exit on a failed start are unchanged.
- Existing tests are UNMODIFIED. No test file is touched by this PR.
- Adds `scripts/done-means/780-touched-files-lint-clean.sh`, written generic for the whole sweep rather than for this one file, so every later rung reuses it instead of copying it.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh

That check lints every non-test `server/**/*.ts` file changed between `origin/main` and HEAD with `./node_modules/.bin/oxlint --deny-warnings` and the repo's `.oxlintrc.json`. It exits 1 by name on an empty file list so it cannot pass vacuously, fails closed when the oxlint binary is missing, and honors `DONE_MEANS_780_FILES` as a file-list override. A green run means "the files this PR touched", never "server/ is clean".

RED, proven before the fix existed. The check was committed at `d5fdab3`, ahead of any change to `server/main.ts`:

```
$ DONE_MEANS_780_FILES=server/main.ts bash scripts/done-means/780-touched-files-lint-clean.sh
linting 1 file(s) from: DONE_MEANS_780_FILES override
  - server/main.ts
server/main.ts:207:8: error eslint(max-lines-per-function): The async function `startServer` has too many lines (140). Maximum allowed is 100.
server/main.ts:207:8: error eslint(complexity): async function `startServer` has a complexity of 22. Maximum allowed is 10.
server/main.ts:421:24: error eslint(max-params): Function 'shutdown' has too many parameters (5). Maximum allowed is 4.
FAIL: oxlint reported findings in the file(s) listed above.
exit=1
```

RED on the diff-derived path, which is the one the merge gate runs. Stronger than the override RED above, because it drives the real file-list resolution rather than a supplied list — `server/main.ts` reverted to `origin/main` content at this head:

```
$ bash scripts/done-means/780-touched-files-lint-clean.sh
linting 1 file(s) from: git diff --name-only origin/main...HEAD
  - server/main.ts
server/main.ts:207:8: error eslint(max-lines-per-function): ... too many lines (140) ...
server/main.ts:207:8: error eslint(complexity): ... complexity of 22 ...
server/main.ts:421:24: error eslint(max-params): ... too many parameters (5) ...
FAIL: oxlint reported findings in the file(s) listed above.
exit=1
```

Two further RED controls, so the check's refusals are exercised and not assumed:

```
$ bash scripts/done-means/780-touched-files-lint-clean.sh     # empty list
FAIL: EMPTY FILE LIST -- nothing was linted, so this run proves nothing.
exit=1

$ (oxlint binary moved aside) DONE_MEANS_780_FILES=server/main.ts bash scripts/done-means/780-touched-files-lint-clean.sh
FAIL: missing lint binary ./node_modules/.bin/oxlint -- run 'bun install --frozen-lockfile'.
exit=1
```

GREEN at head `e4e4cb5`, both with and without the override:

```
$ bash scripts/done-means/780-touched-files-lint-clean.sh
linting 1 file(s) from: git diff --name-only origin/main...HEAD
  - server/main.ts
PASS: every file this branch touched under server/ lints clean.
exit=0

$ DONE_MEANS_780_FILES=server/main.ts bash scripts/done-means/780-touched-files-lint-clean.sh
PASS: every file this branch touched under server/ lints clean.
exit=0

$ ./node_modules/.bin/oxlint --deny-warnings server/main.ts
exit=0
```

Typecheck, tests, and the commit gate:

```
$ bunx tsc --noEmit                      -> exit 0, no output
$ bun run test:isolated server/main.pg.test.ts server/application/
  -> 35 pass / 0 fail, 129 expect() calls, 3 files
$ bun run test:isolated server/main.pg.test.ts
  -> 8 pass / 0 fail; server/main.ts coverage 73.33% funcs / 82.07% lines
$ bun run test:isolated server/config.test.ts server/observability/langfuse-tracing.test.ts \
    server/transport/session-manager.test.ts scripts/local-clone.test.ts \
    contracts/server-contract-providers.test.ts
  -> 185 pass / 0 fail, 186 tests across 5 files
```

The same suite on `origin/main` content (this file stashed) returns the identical 35 pass / 0 fail, so the count is a comparison rather than a claim. The 82.07% line coverage on `server/main.ts` is the evidence the Postgres suite actually EXECUTED against the refactor — a silent skip on a missing `OPENBRAIN_TEST_DATABASE_URL` would have reported green having tested nothing.

Pre-commit and pre-push ran on every commit with no `--no-verify` and no bypass. The pre-commit gate's staged-content oxlint and `tsc --noEmit` both passed on the `server/main.ts` commit.

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable — not applicable: no file under `python/` is touched.
- [x] Live Open Brain smoke passed or is not applicable — not applicable: this is an intra-file refactor of a private composition path with no contract, schema, or wire change.

## Critical Self-Review

- Highest-risk behavior: process startup order. This file is the one place an environment becomes a running process, and a reordering that still typechecks and still lints could bind the socket before a fatal check runs. Mitigated by extracting along the phases already present rather than restructuring them, and by diffing the observable startup surface — log event names, logger call counts, and every `process.env` expression — against `origin/main` rather than eyeballing it.
- Assumptions that could be wrong: that `server/main.pg.test.ts` plus `server/application/` genuinely cover the startup path rather than merely importing it. Checked rather than assumed — `server/main.ts` reports 82.07% line coverage in the run, and the uncovered ranges are the failure branches. The startup-failure cleanup path (`releaseAfterFailedStart`) is among the less-covered lines and is the weakest spot in this PR.
- Missing/weak tests: no new test was added, deliberately. The change is a pure intra-file extraction whose contract is "identical behavior", and the existing entrypoint test already drives the real composition; a test asserting that helpers exist would assert the shape of this refactor rather than any behavior. The brief allowed a new test file if a helper needed one; none does, since every helper is private and reached only through `startServer`.
- Security/permission risk: none introduced. The token guard still runs FIRST, before the pool, the bridge, or the listener — that ordering is the point of the check and it did not move. The capture-health namespace still has no fallback, so an unset variable still means no observer rather than a guessed tenant.
- Migration/deploy risk: low. `applyMigrations` preserves both branches exactly, including the `migrations_skipped` log that `OPEN_BRAIN_RUN_MIGRATIONS=0` relies on for extra workers. No migration file is touched.
- Downstream client/runtime risk: none. No exported signature changes — `startServer`, `StartedServer`, `StartServerOptions`, and `main` are byte-compatible. `shutdown` changed shape but is module-private. Per `docs/downstream-rollout.md` this is not an MCP tool, schema, protocol, or client-facing change.
- Rollback/cleanup concern: rollback is reverting two commits; the file has no persistent state and the entrypoint's own rollback story (`src/index.ts`, byte-untouched) is unaffected. No scratch, worktree, or database was left behind — the isolated test databases were dropped by the runner.
- Fixes made before PR: one real defect in my own check, caught by the check's own empty-list guard. `git diff --name-only origin/main...HEAD -- 'server/**/*.ts'` silently matched NOTHING for `server/main.ts`: git's default pathspec globbing requires `**` to consume at least one directory, so a file sitting directly in `server/` was excluded while `server/db/pool.ts` would have matched. The command exits 0 and the list is just quietly short — the plausible-looking wrong answer, not an error. Replaced with an anchored `rg '^server/.*\.ts$'` over the full diff, and the RED was re-proven afterward per the rule that editing an assertion obliges a fresh RED. Had the empty list been treated as "nothing to lint, pass", this lane would have shipped a green receipt for a file the check never opened, and every later rung would have inherited it.
- Known residual risk: the refactor is proven by the existing suite plus a byte-level diff of the observable surface, not by starting the real launchd process. A behavior change that is invisible to both — one depending on the exact timing between two phases that now sit behind function calls — would not be caught here. I judge this low: no `await` was added or removed, and the sequence of awaited calls is unchanged.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the one lesson worth keeping (a git pathspec `**` silently dropping files at the root of its directory) is operating knowledge for lanes writing checks, not review knowledge for a reviewer reading a diff. It is returned to the controller for the lane-contract Tightenings instead, which is where the file-list-derivation family already lives.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no wire, schema, or tool surface changes, so a live smoke would exercise nothing this PR touched.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, schema, or tool declaration is touched. The change is private composition structure inside one entrypoint file; `contracts/server-contract-providers.test.ts` passes unchanged in the run above.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board. `docs/downstream-rollout.md` scopes the gate to MCP tool, schema, protocol, and client-facing changes. This PR exports the same symbols with the same signatures, registers the same tools through the same factory, and changes no wire format — the only external artifact that moves is the shape of `server/main.ts` itself.
- REPORTED, NOT ABSORBED: `scripts/done-means/750-server-baseline-holds.sh` is RED on this branch, and it is RED identically on untouched `origin/main` content — proven by stashing `server/main.ts` and re-running. It measures 100 non-test files under `server/` against a pinned 99, and 12 files reading `process.env` against a pinned 11. Both numbers moved in #778 (L2a), which added `server/config/env-groups.ts` without re-measuring the baseline; that check's own header says it is EXPECTED to go red when a ladder rung moves the numbers and that the rung updates both. This lane changed neither number — `server/main.ts` still holds exactly six `process.env` reads and no file was added or removed — so re-pinning it from inside a lint PR would be absorbing another rung's unfinished step. Left for the controller.
