### PR TITLE
refactor(server): bring server/tools/search-brain.ts to lint standard (#780 lane 2)

### DIFF
--- a/server/tools/search-brain.ts
+++ b/server/tools/search-brain.ts
@@ -33,6 +33,7 @@ import {
   textResult,
   type MemoryToolDependencies,
 } from "./types.ts";
+import { respondToSearchFailure } from "./tool-failure.ts";
 import { canReadNamespace, namespaceFilterFor } from "./read-scope.ts";
 import { isSharedNamespace } from "./shared-namespace.ts";
 import { ALL_TABLES, type Tier } from "./search-constants.ts";
@@ -43,6 +44,7 @@ import {
 import { setActiveMcpTraceMetadata } from "../observability/langfuse-tracing.ts";
 import {
   DEFAULT_FTS_CONFIG,
+  type FtsConfig,
   requestFtsConfig,
   SUPPORTED_FTS_CONFIGS,
 } from "./fts-config.ts";
@@ -74,6 +76,136 @@ function resolveTables(
   return { tables: [...tables] };
 }
 
+/** Frozen `search_brain` argument contract: the names, types, and rule values are the API. */
+const searchBrainInputSchema = {
+  query: z.string().min(1).describe("Natural language search query"),
+  table: z
+    .enum(["thoughts", "decisions", "relationships", "projects", "sessions"])
+    .optional()
+    .describe("Optional: limit search to a specific table"),
+  namespace: z
+    .string()
+    .trim()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe(
+      "Optional: filter results to a specific namespace (e.g. clientId or 'shared-kb')",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(250)
+    .optional()
+    .describe("Maximum results to return (default 10)"),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Number of results to skip for pagination (default 0)"),
+  search_mode: z
+    .enum(["hybrid", "vector", "keyword"])
+    .optional()
+    .describe(
+      "Search mode: hybrid (default) = vector + keyword with RRF fusion, vector = semantic only, keyword = full-text only",
+    ),
+  tier: z
+    .enum(["hot", "warm", "cold"])
+    .optional()
+    .describe("Optional: filter results to a specific cognitive tier"),
+  fts_config: z
+    .string()
+    .trim()
+    .min(1)
+    .max(64)
+    .optional()
+    .describe(
+      `Optional: keyword full-text-search language configuration for this request. ` +
+        `Accepts a supported Postgres regconfig (${SUPPORTED_FTS_CONFIGS.join(", ")}) ` +
+        `or a language token (e.g. 'de', 'de-DE', 'spanish'). Unrecognized values ` +
+        `fall back to the deployment corpus default (OPENBRAIN_FTS_CONFIG, else english). ` +
+        `An explicitly requested effective non-English config requires admin or ob-admin ` +
+        `for keyword/hybrid searches; vector mode performs no FTS, so fts_config is ` +
+        `ignored there. For ordinary roles, a non-English deployment env default ` +
+        `degrades to english rather than denying. ` +
+        `Affects keyword/hybrid stemming only; english is byte-identical to prior behavior.`,
+    ),
+};
+
+/** Tool annotations; `search_brain` reads and never mutates. */
+const searchBrainAnnotations = {
+  title: "Search Brain",
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+/** The request-shaped arguments after defaults are applied. */
+interface NormalizedSearchArgs {
+  limit: number;
+  offset: number;
+  mode: SearchMode;
+  tier: Tier | undefined;
+  requestedNamespace: string | undefined;
+  requestedFtsConfig: string | undefined;
+}
+
+/**
+ * Apply the documented argument defaults.
+ *
+ * @returns The normalized arguments; the defaults are part of the frozen contract.
+ */
+function normalizeSearchArgs(args: {
+  limit?: number;
+  offset?: number;
+  search_mode?: string;
+  tier?: string;
+  namespace?: string;
+  fts_config?: string;
+}): NormalizedSearchArgs {
+  return {
+    limit: args.limit ?? 10,
+    offset: args.offset ?? 0,
+    mode: (args.search_mode as SearchMode | undefined) ?? "hybrid",
+    tier: args.tier as Tier | undefined,
+    requestedNamespace: args.namespace,
+    requestedFtsConfig: args.fts_config,
+  };
+}
+
+/**
+ * Resolve the effective FTS configuration under the non-English privilege boundary.
+ *
+ * The boundary applies to the EFFECTIVE configuration for arms that actually run
+ * FTS, regardless of where it came from: both an explicit argument and the
+ * deployment env default select the same unindexed on-the-fly `to_tsvector` path
+ * (#368 finding 1).
+ *
+ * @returns The resolved config, or a denial when an ordinary role explicitly
+ *   requested a non-English config for an arm that runs FTS.
+ */
+function resolveCallerFtsConfig(options: {
+  role: string;
+  mode: SearchMode;
+  requestedFtsConfig: string | undefined;
+}): { ftsConfig: FtsConfig } | { denial: string } {
+  const { role, mode, requestedFtsConfig } = options;
+  const ftsPrivileged = role === "admin" || role === "ob-admin";
+  const ftsConfig = requestFtsConfig(requestedFtsConfig);
+  if (ftsConfig === DEFAULT_FTS_CONFIG || ftsPrivileged) return { ftsConfig };
+  if (mode !== "vector" && requestedFtsConfig !== undefined) {
+    return { denial: NON_ENGLISH_FTS_DENIED };
+  }
+  // Reached only when the non-English config came from the operator env
+  // default, or the mode is vector and performs no FTS at all (#368
+  // finding 2). Degrade to the GIN-indexed english path instead of
+  // denying: an ordinary role keeps exactly the pre-#341 availability and
+  // cost, and an argument that cannot influence execution must not deny.
+  return { ftsConfig: DEFAULT_FTS_CONFIG };
+}
+
 export function registerSearchBrainTool(
   server: McpServer,
   dependencies: MemoryToolDependencies,
@@ -83,74 +215,8 @@ export function registerSearchBrainTool(
     {
       description:
         "Search across all brain tables. Supports hybrid (vector + keyword), pure vector, or keyword-only modes.",
-      inputSchema: {
-        query: z.string().min(1).describe("Natural language search query"),
-        table: z
-          .enum([
-            "thoughts",
-            "decisions",
-            "relationships",
-            "projects",
-            "sessions",
-          ])
-          .optional()
-          .describe("Optional: limit search to a specific table"),
-        namespace: z
-          .string()
-          .trim()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe(
-            "Optional: filter results to a specific namespace (e.g. clientId or 'shared-kb')",
-          ),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(250)
-          .optional()
-          .describe("Maximum results to return (default 10)"),
-        offset: z
-          .number()
-          .int()
-          .min(0)
-          .optional()
-          .describe("Number of results to skip for pagination (default 0)"),
-        search_mode: z
-          .enum(["hybrid", "vector", "keyword"])
-          .optional()
-          .describe(
-            "Search mode: hybrid (default) = vector + keyword with RRF fusion, vector = semantic only, keyword = full-text only",
-          ),
-        tier: z
-          .enum(["hot", "warm", "cold"])
-          .optional()
-          .describe("Optional: filter results to a specific cognitive tier"),
-        fts_config: z
-          .string()
-          .trim()
-          .min(1)
-          .max(64)
-          .optional()
-          .describe(
-            `Optional: keyword full-text-search language configuration for this request. ` +
-              `Accepts a supported Postgres regconfig (${SUPPORTED_FTS_CONFIGS.join(", ")}) ` +
-              `or a language token (e.g. 'de', 'de-DE', 'spanish'). Unrecognized values ` +
-              `fall back to the deployment corpus default (OPENBRAIN_FTS_CONFIG, else english). ` +
-              `An explicitly requested effective non-English config requires admin or ob-admin ` +
-              `for keyword/hybrid searches; vector mode performs no FTS, so fts_config is ` +
-              `ignored there. For ordinary roles, a non-English deployment env default ` +
-              `degrades to english rather than denying. ` +
-              `Affects keyword/hybrid stemming only; english is byte-identical to prior behavior.`,
-          ),
-      },
-      annotations: {
-        title: "Search Brain",
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      inputSchema: searchBrainInputSchema,
+      annotations: searchBrainAnnotations,
     },
     async (args, extra) => {
       const identity = authIdentity(extra.authInfo);
@@ -162,31 +228,16 @@ export function registerSearchBrainTool(
       );
       if ("denial" in resolved) return errorResult(resolved.denial);
 
-      const limit = args.limit ?? 10;
-      const offset = args.offset ?? 0;
-      const mode = (args.search_mode as SearchMode | undefined) ?? "hybrid";
-      const tier = args.tier as Tier | undefined;
-      const requestedNamespace = args.namespace;
-      const requestedFtsConfig = args.fts_config;
+      const { limit, offset, mode, tier, requestedNamespace, requestedFtsConfig } =
+        normalizeSearchArgs(args);
 
-      // The non-English privilege boundary applies to the EFFECTIVE configuration
-      // for arms that actually run FTS, regardless of where it came from: both an
-      // explicit argument and the deployment env default select the same
-      // unindexed on-the-fly to_tsvector path (#368 finding 1).
-      const ftsPrivileged =
-        identity.role === "admin" || identity.role === "ob-admin";
-      let ftsConfig = requestFtsConfig(requestedFtsConfig);
-      if (ftsConfig !== DEFAULT_FTS_CONFIG && !ftsPrivileged) {
-        if (mode !== "vector" && requestedFtsConfig !== undefined) {
-          return errorResult(NON_ENGLISH_FTS_DENIED);
-        }
-        // Reached only when the non-English config came from the operator env
-        // default, or the mode is vector and performs no FTS at all (#368
-        // finding 2). Degrade to the GIN-indexed english path instead of
-        // denying: an ordinary role keeps exactly the pre-#341 availability and
-        // cost, and an argument that cannot influence execution must not deny.
-        ftsConfig = DEFAULT_FTS_CONFIG;
-      }
+      const fts = resolveCallerFtsConfig({
+        role: identity.role,
+        mode,
+        requestedFtsConfig,
+      });
+      if ("denial" in fts) return errorResult(fts.denial);
+      const ftsConfig = fts.ftsConfig;
 
       if (
         requestedNamespace &&
@@ -216,19 +267,14 @@ export function registerSearchBrainTool(
         // The one place the driver's diagnostic fields still exist. By the time
         // this is a text response they are gone, and an empty array would be
         // indistinguishable from a genuine no-match.
-        dependencies.logger.error(
-          {
-            namespace,
-            mode,
-            tier,
-            error_message:
-              error instanceof Error ? error.message : String(error),
-          },
-          "search_brain_failed",
-        );
-        return errorResult(
-          error instanceof Error ? error.message : String(error),
-        );
+        return respondToSearchFailure({
+          logger: dependencies.logger,
+          event: "search_brain_failed",
+          error,
+          namespace,
+          mode,
+          tier,
+        });
       }
     },
   );

--- a/server/tools/tool-failure.ts
+++ b/server/tools/tool-failure.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared retrieval-failure response for search-shaped tools.
+ *
+ * Extracted from `search-brain.ts` (#780 lane 2). The identical inline block in
+ * `brain-answer.ts:268-283` is the second caller and is expected to adopt this
+ * helper in its own lane; that file is intentionally NOT edited here.
+ *
+ * The contract this preserves is `docs/GOTCHAS.md`'s named anti-pattern: a
+ * retrieval failure must log the driver's diagnostic fields — the one place
+ * they still exist — and return `isError: true`, never an empty result set that
+ * would be indistinguishable from a genuine no-match.
+ */
+import { errorResult } from "./types.ts";
+import type { NamespaceFilter } from "./read-scope.ts";
+
+/** The subset of the tool dependencies this helper needs. */
+interface FailureLogger {
+  error: (fields: Record<string, unknown>, message: string) => void;
+}
+
+/**
+ * Log a retrieval failure with its diagnostic fields and map it to an error result.
+ *
+ * @returns The tool error response carrying the failure message.
+ */
+export function respondToSearchFailure(options: {
+  logger: FailureLogger;
+  event: string;
+  error: unknown;
+  namespace: NamespaceFilter | undefined;
+  mode: string;
+  tier: string | undefined;
+}): ReturnType<typeof errorResult> {
+  const { logger, event, error, namespace, mode, tier } = options;
+  const message = error instanceof Error ? error.message : String(error);
+  logger.error({ namespace, mode, tier, error_message: message }, event);
+  return errorResult(message);
+}


### PR DESCRIPTION
## Summary

Lane 2 of #780 (Rico ruling 2026-08-26: one file per lane). Scope is
`server/tools/search-brain.ts` plus one new shared module,
`server/tools/tool-failure.ts`. No behavior change is intended and none is
observed; this is a structural refactor to bring the file to lint standard.

- **Hoisted to module consts.** The inline zod input schema and the annotations
  object became `searchBrainInputSchema` and `searchBrainAnnotations`. The
  schema object content is byte-identical — every `describe()` string in the
  diff appears once removed and once added, so the wire-visible tool
  description is unchanged. The inline schema is what carried
  `registerSearchBrainTool` to 142 lines.
- **Three named helpers**, taking handler complexity from 18 to under 10:
  `normalizeSearchArgs` applies the documented argument defaults;
  `resolveCallerFtsConfig` owns the #341/#368 non-English FTS privilege
  boundary and returns either the resolved config or the denial;
  `respondToSearchFailure` logs the driver diagnostics and maps them to an
  error result.
- **`respondToSearchFailure` is EXPORTED from the new
  `server/tools/tool-failure.ts`** rather than kept private, because
  `brain-answer.ts:268-283` carries an identical inline block. That file is
  **not** edited here — its own #780 lane adopts the helper. The new module
  preserves the `docs/GOTCHAS.md` contract by name: a retrieval failure logs
  the driver's diagnostic fields and returns `isError: true`, never an empty
  result set that would read as a genuine no-match.
- **Reuse over rewrite.** The helpers call existing repo code rather than
  reimplementing it: `types.ts` (auth parse, result envelopes),
  `fts-config.ts`, `read-scope.ts`, `shared-namespace.ts`, `search-engine.ts`,
  and this file's own `resolveTables`.

Behavior evidence beyond the tests: the string-literal diff shows every
user-facing literal moved in matched pairs — the `describe()` texts, the denial
constants (`NO_READABLE_TABLES`, `NON_ENGLISH_FTS_DENIED`, `NAMESPACE_DENIED`),
and the `search_brain_failed` log event. The only unpaired literals are the new
`"denial"` discriminant and the new `"./tool-failure.ts"` import path. The
handler's early-return order is unchanged: identity, table resolution, argument
normalization, FTS resolution, namespace check, then search. Test files are
byte-unmodified (`git diff --name-only origin/main...HEAD -- '*.test.ts'` is
empty).

Harvest: No new lessons: the lane hit nothing that changes the lane contract —
the only refusal was the fast-tools gate on `grep`, already recorded as a
Tightening, and the `brain-answer.ts` duplicate block is a finding recorded on
 #780 for that file's own lane, not a lane-contract lesson.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED, re-proven live this session against the `origin/main` copy of the file
(extracted with `git show` to a scratch path; the working tree was not
modified):

```text
$ ./node_modules/.bin/oxlint --deny-warnings .../search-brain-main.ts
search-brain-main.ts:77:8: error eslint(max-lines-per-function): The function
  `registerSearchBrainTool` has too many lines (142). Maximum allowed is 100.
search-brain-main.ts:155:5: error eslint(complexity): async function has a
  complexity of 18. Maximum allowed is 10.
exit=1
```

GREEN, this session on `e8e3b51`:

```text
$ bash scripts/done-means/780-touched-files-lint-clean.sh
linting 2 file(s) from: git diff --name-only origin/main...HEAD
  - server/tools/search-brain.ts
  - server/tools/tool-failure.ts
PASS: every file this branch touched under server/ lints clean.
exit=0

$ DONE_MEANS_780_FILES=server/tools/search-brain.ts bash scripts/done-means/780-touched-files-lint-clean.sh
linting 1 file(s) from: DONE_MEANS_780_FILES override
  - server/tools/search-brain.ts
PASS: every file this branch touched under server/ lints clean.
exit=0

$ bunx tsc --noEmit
exit=0

$ bun run test:isolated server/tools/search-read-scope.test.ts server/tools/namespace-denial.test.ts
 22 pass
 0 fail
 76 expect() calls
Ran 22 tests across 2 files. [318.00ms]
  tests exited 0
```

The done-means check derives its file list from the diff against `origin/main`,
so it takes no arguments; the override run is shown only to prove the list is
not hardcoded.

## Critical Self-Review

- Highest-risk behavior: `resolveCallerFtsConfig` now owns the #341/#368 FTS privilege boundary that used to be inline in the handler — if it returned a config where it should return a denial, an ordinary role could reach the on-the-fly `to_tsvector` path with an arbitrary config string. Four tests in `server/tools/search-read-scope.test.ts` pin it and passed this session: "an ordinary role asking for german on a keyword search is denied", "vector mode ignores fts_config entirely rather than denying", "an admin gets the on-the-fly to_tsvector path with the requested config", and "english reads the stored GIN-indexed column, never a recomputed vector".
- Assumptions that could be wrong: that hoisting the zod schema to a module const preserves the wire-visible tool description exactly. Checked rather than assumed — every `describe()` literal appears exactly twice in the diff (once removed, once added), so the text is moved, not rewritten. The second assumption is that `brain-answer.ts:268-283` is genuinely identical in shape to the extracted helper; it is left untouched here, so a mismatch costs that lane rework but cannot regress this one.
- Missing/weak tests: no test asserts that `searchBrainInputSchema` serializes to the same JSON Schema as before, so a subtle zod-shape change would be caught only by the string-literal diff I did by hand. `server/tools/tool-failure.ts` has no direct unit test of its own — it is covered transitively through the search-brain failure path. Both are acceptable here because the schema content is provably byte-identical and the helper is a pure move of an already-covered block; a dedicated `tool-failure` test belongs with the brain-answer lane that adds the second caller.
- Security/permission risk: the FTS privilege boundary and the namespace-denial predicate both moved code. Neither predicate changed — `NON_ENGLISH_FTS_DENIED` and `NAMESPACE_DENIED` appear as matched add/remove pairs in the diff — and `namespace-denial.test.ts` passed unmodified as part of the 22.
- Migration/deploy risk: none. No migration, no schema change, no config change, no new dependency. `server/tools/tool-failure.ts` is a new source file with no runtime registration of its own.
- Downstream client/runtime risk: none. No tool name, input schema, output shape, error envelope, or annotation changed — the schema object content is byte-identical, so an mcp2cli or Hermes consumer sees exactly the previous surface.
- Rollback/cleanup concern: reverting is a single-commit revert of `e8e3b51`, which also removes the new `server/tools/tool-failure.ts`. The one ordering constraint is that the `brain-answer.ts` lane must land AFTER this one, since it imports that module; if the lanes were reverted out of order, `brain-answer.ts` would fail to resolve the import and `tsc --noEmit` would catch it before merge.
- Fixes made before PR: the failure helper was initially private to `search-brain.ts`; it was moved to an exported `server/tools/tool-failure.ts` after finding the identical inline block at `brain-answer.ts:268-283`, so the second lane adopts a shared helper instead of duplicating a third copy.
- Known residual risk: the JSON Schema equivalence of the hoisted zod object rests on a hand-checked literal diff rather than an automated snapshot, so a zod-level change that preserved every string but altered a modifier would not be caught by this branch's checks. `tsc --noEmit` at exit 0 and the 22 passing tests constrain but do not fully exclude it.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no review finding at MEDIUM or above — it is a lint-driven structural refactor with no behavior change, and the one cross-file observation (the duplicate failure block in `brain-answer.ts`) is recorded on #780 for that file's lane rather than being a reusable review pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no tool schema, name, wire shape, or runtime behavior changed, so a live service check could not distinguish this branch from `origin/main`; the lint, typecheck, and 22 isolated-database tests are the evidence that applies.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: neither touched file is under a path in `contracts/parity-paths.txt` (which lists `python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, `src/contract-schemas.ts`); this branch changes only `server/tools/search-brain.ts` and the new `server/tools/tool-failure.ts`, which are TypeScript-server-internal with no cross-runtime contract surface.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable, classified against `docs/downstream-rollout.md` "When This Applies". No MCP tool name, input schema, output shape, auth path, namespace semantic, or error envelope changed — the hoisted schema object is byte-identical to the inline one it replaces. No transport or session behavior, no externally visible migration, no `python/openbrain-memory` change, and no generated `skill/` content is touched. Nothing an mcp2cli or Hermes consumer calls has a different surface after this commit.
