### PR TITLE
refactor(search-all): split the federated search tool into named helpers (#780)

### DIFF
--- a/server/tools/search-all.ts
+++ b/server/tools/search-all.ts
@@ -32,7 +32,11 @@ import {
   textResult,
   type MemoryToolDependencies,
 } from "./types.ts";
-import { canReadNamespace, namespaceFilterFor } from "./read-scope.ts";
+import {
+  canReadNamespace,
+  type NamespaceFilter,
+  namespaceFilterFor,
+} from "./read-scope.ts";
 import { isSharedNamespace } from "./shared-namespace.ts";
 import {
   ALL_TABLES,
@@ -51,6 +55,7 @@ import {
   type SearchRow,
   type SourceRef,
 } from "./search-engine.ts";
+import { normalizeSearchArgs } from "./search-request.ts";
 
 const NOT_AUTHENTICATED = "Permission denied: not authenticated";
 const NAMESPACE_DENIED = "Permission denied: namespace read access denied";
@@ -122,6 +127,17 @@ export function resolveQmdPath(
   return configured ? configured : undefined;
 }
 
+/** One qmd federation request; a named struct so no caller tracks argument order. */
+interface QmdSearchOptions {
+  dependencies: MemoryToolDependencies;
+  /** Resolved qmd entry point; never empty (see resolveQmdPath). */
+  qmdPath: string;
+  query: string;
+  /** How many hits to ask qmd for. */
+  limit: number;
+  collection: string | undefined;
+}
+
 /**
  * Search the qmd file index, returning `[]` on every failure.
  *
@@ -130,16 +146,11 @@ export function resolveQmdPath(
  * federated search. Each is logged, so the degradation is visible rather than
  * merely quiet — the design's R4 objection is to SILENT staleness, not to
  * degradation itself.
- *
- * @param qmdPath Resolved qmd entry point; never empty (see resolveQmdPath).
  */
 async function searchQmdInternal(
-  dependencies: MemoryToolDependencies,
-  qmdPath: string,
-  query: string,
-  limit: number,
-  collection: string | undefined,
+  options: QmdSearchOptions,
 ): Promise<UnifiedResult[]> {
+  const { dependencies, qmdPath, query, limit, collection } = options;
   try {
     const command = [
       "bun",
@@ -234,19 +245,13 @@ async function searchQmdInternal(
   }
 }
 
-function searchQmd(
-  dependencies: MemoryToolDependencies,
-  qmdPath: string,
-  query: string,
-  limit: number,
-  collection: string | undefined,
-): Promise<UnifiedResult[]> {
+function searchQmd(options: QmdSearchOptions): Promise<UnifiedResult[]> {
+  const { query, limit, collection } = options;
   return traceRetrievalSpan({
     name: "retrieval.qmd_query",
     input: { query, limit, collection },
     metadata: { stage: "candidate_generation", source: "qmd" },
-    run: () =>
-      searchQmdInternal(dependencies, qmdPath, query, limit, collection),
+    run: () => searchQmdInternal(options),
     output: (rows) => ({
       count: rows.length,
       candidates: rows.map((row) => ({
@@ -282,6 +287,233 @@ function toUnifiedResult(row: SearchRow): UnifiedResult {
   };
 }
 
+/** Frozen `search_all` argument contract: the names, types, and rule values are the API. */
+const searchAllInputSchema = {
+  query: z.string().min(1).describe("Natural language search query"),
+  namespace: z
+    .string()
+    .optional()
+    .describe(
+      "Optional: filter brain results to a specific namespace (e.g. clientId or 'shared-kb')",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(250)
+    .optional()
+    .describe("Max results per source (default 10)"),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Number of results to skip for pagination (default 0)"),
+  sources: z
+    .enum(["all", "brain", "qmd"])
+    .optional()
+    .describe("Which sources to search (default: all)"),
+  collection: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Optional: restrict qmd search to one collection"),
+  search_mode: z
+    .enum(["hybrid", "vector", "keyword"])
+    .optional()
+    .describe(
+      "Brain search mode: hybrid (default) = vector + keyword with RRF, vector = semantic only, keyword = full-text only",
+    ),
+  tier: z
+    .enum(["hot", "warm", "cold"])
+    .optional()
+    .describe("Optional: filter brain results to a specific cognitive tier"),
+};
+
+/** Tool annotations; `search_all` reads and never mutates. */
+const searchAllAnnotations = {
+  title: "Search All",
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+/** Which arms of the federation this request will actually run. */
+interface FederationPlan {
+  wantBrain: boolean;
+  wantQmd: boolean;
+  qmdPath: string | undefined;
+}
+
+/**
+ * Decide which sources to search, announcing an unusable qmd configuration.
+ *
+ * @returns The arms to run; `wantQmd` is false when no qmd path is usable.
+ */
+function planFederation(
+  dependencies: MemoryToolDependencies,
+  sources: "all" | "brain" | "qmd",
+): FederationPlan {
+  const qmdPath = dependencies.qmdPath ?? resolveQmdPath();
+  const qmdRequested = sources === "all" || sources === "qmd";
+  if (qmdRequested && qmdPath === undefined) {
+    // Say it once, at the boundary. Without this the qmd arm's absence is
+    // indistinguishable from a search that found no files.
+    dependencies.logger.warn({}, "qmd_search_unconfigured");
+  }
+  return {
+    wantBrain: sources === "all" || sources === "brain",
+    wantQmd: qmdRequested && qmdPath !== undefined,
+    qmdPath,
+  };
+}
+
+/** One brain-arm request against the readable tables for this identity. */
+interface BrainSearchOptions {
+  dependencies: MemoryToolDependencies;
+  role: Parameters<typeof canRead>[0];
+  query: string;
+  /** How many rows to over-fetch so the merged window can be sliced after fusion. */
+  totalNeeded: number;
+  mode: SearchMode;
+  tier: Tier | undefined;
+  namespace: NamespaceFilter | undefined;
+  requestedNamespace: string | undefined;
+}
+
+/**
+ * Search the brain arm, returning `[]` on failure.
+ *
+ * The brain arm degrades to no results here rather than failing the call,
+ * because `search_all` returns whatever federation could reach. The failure is
+ * logged as `search_all_brain_failed` so the degradation stays visible.
+ */
+async function searchBrainArm(
+  options: BrainSearchOptions,
+): Promise<UnifiedResult[]> {
+  const { dependencies, role, query, totalNeeded, mode, tier, namespace } =
+    options;
+  const tables = ALL_TABLES.filter((table) => canRead(role, table));
+  if (tables.length === 0) return [];
+  try {
+    const rows = await executeSearchWithSharedFallback(
+      dependencies,
+      tables,
+      query,
+      totalNeeded,
+      mode,
+      tier,
+      0,
+      namespace,
+      {},
+      options.requestedNamespace !== undefined &&
+        isSharedNamespace(options.requestedNamespace),
+    );
+    return rows.map(toUnifiedResult);
+  } catch (error) {
+    dependencies.logger.warn(
+      {
+        error_message: error instanceof Error ? error.message : String(error),
+      },
+      "search_all_brain_failed",
+    );
+    return [];
+  }
+}
+
+/** A federated candidate carrying its fused rank value. */
+type FusedResult = UnifiedResult & { rrf: number };
+
+/**
+ * Fuse both arms by POSITION, never by raw score.
+ *
+ * qmd's similarity numbers and the brain's RRF values are incomparable scales,
+ * so both sources get fair representation only when position is what counts.
+ * Brain rows additionally carry the cognitive-tier boost, floored at zero so a
+ * cold-tier penalty cannot go negative.
+ */
+function fuseFederatedResults(
+  brainResults: UnifiedResult[],
+  qmdResults: UnifiedResult[],
+): FusedResult[] {
+  const fused: FusedResult[] = [];
+  brainResults.forEach((result, index) => {
+    fused.push({
+      ...result,
+      rrf: Math.max(
+        0,
+        1 / (RRF_K + index + 1) + TIER_BOOST[(result.tier ?? "warm") as Tier],
+      ),
+    });
+  });
+  qmdResults.forEach((result, index) => {
+    fused.push({ ...result, rrf: 1 / (RRF_K + index + 1) });
+  });
+  return fused;
+}
+
+type RankedCandidate = FusedResult & { trace_index: number };
+
+/** The window request applied to the fused candidates after ranking. */
+interface RankWindowOptions {
+  fused: FusedResult[];
+  offset: number;
+  count: number;
+  brainCount: number;
+  qmdCount: number;
+}
+
+/**
+ * Sort the fused candidates and take the caller's window, under one trace span.
+ *
+ * The span records EVERY candidate with why it was or was not returned, so a
+ * missing result can be told apart from a result that never existed.
+ */
+function selectRankedWindow(options: RankWindowOptions): RankedCandidate[] {
+  const { fused, offset, count, brainCount, qmdCount } = options;
+  let rankedCandidates: RankedCandidate[] = [];
+  return traceRetrievalSpanSync({
+    name: "retrieval.federated_rank",
+    input: {
+      brain_count: brainCount,
+      qmd_count: qmdCount,
+    },
+    metadata: {
+      stage: "scoring_ranking",
+      filter_names: ["pagination_offset", "federated_rank_window"],
+    },
+    run: () => {
+      rankedCandidates = fused
+        .map((row, trace_index) => ({ ...row, trace_index }))
+        .sort((a, b) => b.rrf - a.rrf);
+      return rankedCandidates.slice(offset, offset + count);
+    },
+    output: (selected) => {
+      const selectedIndexes = new Set(selected.map((row) => row.trace_index));
+      return {
+        candidate_count: rankedCandidates.length,
+        selected_count: selected.length,
+        returned_row_ids: selected
+          .filter((row) => row.source === "brain")
+          .map((row) => row.id),
+        candidates: rankedCandidates.map((row, rankIndex) => {
+          const chosen = selectedIndexes.has(row.trace_index);
+          return {
+            source: row.source,
+            row_id: row.id ?? null,
+            path: row.path ?? null,
+            content: row.content,
+            raw_score: row.score,
+            rrf_score: row.rrf,
+            chosen,
+            filtered_by: federatedFilteredBy(chosen, rankIndex, offset),
+          };
+        }),
+      };
+    },
+  });
+}
+
 export function registerSearchAllTool(
   server: McpServer,
   dependencies: MemoryToolDependencies,
@@ -291,66 +523,16 @@ export function registerSearchAllTool(
     {
       description:
         "Federated search across Open Brain knowledge AND qmd file index. Returns merged, ranked results from both sources.",
-      inputSchema: {
-        query: z.string().min(1).describe("Natural language search query"),
-        namespace: z
-          .string()
-          .optional()
-          .describe(
-            "Optional: filter brain results to a specific namespace (e.g. clientId or 'shared-kb')",
-          ),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(250)
-          .optional()
-          .describe("Max results per source (default 10)"),
-        offset: z
-          .number()
-          .int()
-          .min(0)
-          .optional()
-          .describe("Number of results to skip for pagination (default 0)"),
-        sources: z
-          .enum(["all", "brain", "qmd"])
-          .optional()
-          .describe("Which sources to search (default: all)"),
-        collection: z
-          .string()
-          .min(1)
-          .optional()
-          .describe("Optional: restrict qmd search to one collection"),
-        search_mode: z
-          .enum(["hybrid", "vector", "keyword"])
-          .optional()
-          .describe(
-            "Brain search mode: hybrid (default) = vector + keyword with RRF, vector = semantic only, keyword = full-text only",
-          ),
-        tier: z
-          .enum(["hot", "warm", "cold"])
-          .optional()
-          .describe(
-            "Optional: filter brain results to a specific cognitive tier",
-          ),
-      },
-      annotations: {
-        title: "Search All",
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      inputSchema: searchAllInputSchema,
+      annotations: searchAllAnnotations,
     },
     async (args, extra) => {
       const identity = authIdentity(extra.authInfo);
       if (!identity) return errorResult(NOT_AUTHENTICATED);
 
-      const limit = args.limit ?? 10;
-      const offset = args.offset ?? 0;
+      const { limit, offset, mode, tier, requestedNamespace } =
+        normalizeSearchArgs(args);
       const sources = args.sources ?? "all";
-      const mode = (args.search_mode as SearchMode | undefined) ?? "hybrid";
-      const tier = args.tier as Tier | undefined;
-      const requestedNamespace = args.namespace;
 
       if (
         requestedNamespace &&
@@ -361,127 +543,41 @@ export function registerSearchAllTool(
 
       const namespace = namespaceFilterFor(identity, requestedNamespace);
       setActiveMcpTraceMetadata({ resolved_namespace: namespace ?? null });
-      const wantBrain = sources === "all" || sources === "brain";
-      const qmdPath = dependencies.qmdPath ?? resolveQmdPath();
-      const wantQmd =
-        (sources === "all" || sources === "qmd") && qmdPath !== undefined;
-      if ((sources === "all" || sources === "qmd") && qmdPath === undefined) {
-        // Say it once, at the boundary. Without this the qmd arm's absence is
-        // indistinguishable from a search that found no files.
-        dependencies.logger.warn({}, "qmd_search_unconfigured");
-      }
+
+      const plan = planFederation(dependencies, sources);
       // Over-fetch to cover the requested window, then slice after the merge.
       const totalNeeded = offset + limit;
 
-      const brainSearch = async (): Promise<UnifiedResult[]> => {
-        const tables = ALL_TABLES.filter((table) =>
-          canRead(identity.role, table),
-        );
-        if (tables.length === 0) return [];
-        try {
-          const rows = await executeSearchWithSharedFallback(
-            dependencies,
-            tables,
-            args.query,
-            totalNeeded,
-            mode,
-            tier,
-            0,
-            namespace,
-            {},
-            requestedNamespace !== undefined &&
-              isSharedNamespace(requestedNamespace),
-          );
-          return rows.map(toUnifiedResult);
-        } catch (error) {
-          dependencies.logger.warn(
-            {
-              error_message:
-                error instanceof Error ? error.message : String(error),
-            },
-            "search_all_brain_failed",
-          );
-          return [];
-        }
-      };
-
       const [brainResults, qmdResults] = await Promise.all([
-        wantBrain ? brainSearch() : Promise.resolve<UnifiedResult[]>([]),
-        wantQmd && qmdPath
-          ? searchQmd(
+        plan.wantBrain
+          ? searchBrainArm({
               dependencies,
-              qmdPath,
-              args.query,
+              role: identity.role,
+              query: args.query,
               totalNeeded,
-              args.collection,
-            )
+              mode,
+              tier,
+              namespace,
+              requestedNamespace,
+            })
+          : Promise.resolve<UnifiedResult[]>([]),
+        plan.wantQmd && plan.qmdPath
+          ? searchQmd({
+              dependencies,
+              qmdPath: plan.qmdPath,
+              query: args.query,
+              limit: totalNeeded,
+              collection: args.collection,
+            })
           : Promise.resolve<UnifiedResult[]>([]),
       ]);
 
-      // Position-based fusion, so both sources get fair representation whatever
-      // their raw score scales. Brain rows additionally carry the cognitive-tier
-      // boost, floored at zero so a cold-tier penalty cannot go negative.
-      const fused: Array<UnifiedResult & { rrf: number }> = [];
-      brainResults.forEach((result, index) => {
-        fused.push({
-          ...result,
-          rrf: Math.max(
-            0,
-            1 / (RRF_K + index + 1) +
-              TIER_BOOST[(result.tier ?? "warm") as Tier],
-          ),
-        });
-      });
-      qmdResults.forEach((result, index) => {
-        fused.push({ ...result, rrf: 1 / (RRF_K + index + 1) });
-      });
-
-      type RankedCandidate = UnifiedResult & {
-        rrf: number;
-        trace_index: number;
-      };
-      let rankedCandidates: RankedCandidate[] = [];
-      const selectedCandidates = traceRetrievalSpanSync({
-        name: "retrieval.federated_rank",
-        input: {
-          brain_count: brainResults.length,
-          qmd_count: qmdResults.length,
-        },
-        metadata: {
-          stage: "scoring_ranking",
-          filter_names: ["pagination_offset", "federated_rank_window"],
-        },
-        run: () => {
-          rankedCandidates = fused
-            .map((row, trace_index) => ({ ...row, trace_index }))
-            .sort((a, b) => b.rrf - a.rrf);
-          return rankedCandidates.slice(offset, offset + limit);
-        },
-        output: (selected) => {
-          const selectedIndexes = new Set(
-            selected.map((row) => row.trace_index),
-          );
-          return {
-            candidate_count: rankedCandidates.length,
-            selected_count: selected.length,
-            returned_row_ids: selected
-              .filter((row) => row.source === "brain")
-              .map((row) => row.id),
-            candidates: rankedCandidates.map((row, rankIndex) => {
-              const chosen = selectedIndexes.has(row.trace_index);
-              return {
-                source: row.source,
-                row_id: row.id ?? null,
-                path: row.path ?? null,
-                content: row.content,
-                raw_score: row.score,
-                rrf_score: row.rrf,
-                chosen,
-                filtered_by: federatedFilteredBy(chosen, rankIndex, offset),
-              };
-            }),
-          };
-        },
+      const selectedCandidates = selectRankedWindow({
+        fused: fuseFederatedResults(brainResults, qmdResults),
+        offset,
+        count: limit,
+        brainCount: brainResults.length,
+        qmdCount: qmdResults.length,
       });
       const tracedMerged = selectedCandidates.map(
         ({ rrf, trace_index: _traceIndex, ...rest }) => ({

--- a/server/tools/search-brain.ts
+++ b/server/tools/search-brain.ts
@@ -36,7 +36,8 @@ import {
 import { respondToSearchFailure } from "./tool-failure.ts";
 import { canReadNamespace, namespaceFilterFor } from "./read-scope.ts";
 import { isSharedNamespace } from "./shared-namespace.ts";
-import { ALL_TABLES, type Tier } from "./search-constants.ts";
+import { ALL_TABLES } from "./search-constants.ts";
+import { normalizeSearchArgs } from "./search-request.ts";
 import {
   executeSearchWithSharedFallback,
   type SearchMode,
@@ -141,39 +142,6 @@ const searchBrainAnnotations = {
   destructiveHint: false,
   idempotentHint: true,
 };
-
-/** The request-shaped arguments after defaults are applied. */
-interface NormalizedSearchArgs {
-  limit: number;
-  offset: number;
-  mode: SearchMode;
-  tier: Tier | undefined;
-  requestedNamespace: string | undefined;
-  requestedFtsConfig: string | undefined;
-}
-
-/**
- * Apply the documented argument defaults.
- *
- * @returns The normalized arguments; the defaults are part of the frozen contract.
- */
-function normalizeSearchArgs(args: {
-  limit?: number;
-  offset?: number;
-  search_mode?: string;
-  tier?: string;
-  namespace?: string;
-  fts_config?: string;
-}): NormalizedSearchArgs {
-  return {
-    limit: args.limit ?? 10,
-    offset: args.offset ?? 0,
-    mode: (args.search_mode as SearchMode | undefined) ?? "hybrid",
-    tier: args.tier as Tier | undefined,
-    requestedNamespace: args.namespace,
-    requestedFtsConfig: args.fts_config,
-  };
-}
 
 /**
  * Resolve the effective FTS configuration under the non-English privilege boundary.

--- a/server/tools/search-request.ts
+++ b/server/tools/search-request.ts
@@ -1,0 +1,49 @@
+/**
+ * Shared request normalization for the search tools.
+ *
+ * `search_brain` and `search_all` publish DIFFERENT argument schemas but agree
+ * exactly on how the five common arguments default: `limit` to 10, `offset` to
+ * 0, `search_mode` to `hybrid`, and `tier`/`namespace` to undefined. Those
+ * defaults are part of both tools' frozen client contract, so they are stated
+ * once here rather than restated per tool where the two could drift apart
+ * unnoticed.
+ *
+ * `fts_config` is in the shape because `search_brain` accepts it. `search_all`
+ * publishes no such argument, so it normalizes to `undefined` there and that
+ * tool keeps passing `{}` to the search engine — the English path — unchanged.
+ */
+import type { Tier } from "./search-constants.ts";
+import type { SearchMode } from "./search-engine.ts";
+
+/** The request-shaped arguments after defaults are applied. */
+export interface NormalizedSearchArgs {
+  limit: number;
+  offset: number;
+  mode: SearchMode;
+  tier: Tier | undefined;
+  requestedNamespace: string | undefined;
+  requestedFtsConfig: string | undefined;
+}
+
+/**
+ * Apply the documented argument defaults.
+ *
+ * @returns The normalized arguments; the defaults are part of the frozen contract.
+ */
+export function normalizeSearchArgs(args: {
+  limit?: number;
+  offset?: number;
+  search_mode?: string;
+  tier?: string;
+  namespace?: string;
+  fts_config?: string;
+}): NormalizedSearchArgs {
+  return {
+    limit: args.limit ?? 10,
+    offset: args.offset ?? 0,
+    mode: (args.search_mode as SearchMode | undefined) ?? "hybrid",
+    tier: args.tier as Tier | undefined,
+    requestedNamespace: args.namespace,
+    requestedFtsConfig: args.fts_config,
+  };
+}


### PR DESCRIPTION
## Summary

- Lane 3 of the #780 lint sweep: `server/tools/search-all.ts` brought fully to
  standard. RED at `fca45fb` was 5 oxlint findings on that one file —
  `max-params` twice (`searchQmdInternal`, `searchQmd`), `max-lines-per-function`
  on `registerSearchAllTool` at 203 lines, and complexity 19 over 142 lines on
  the request handler. GREEN is `oxlint --deny-warnings` exit 0 across
  `search-all.ts`, `search-brain.ts`, and `search-request.ts`.
- Under the sprint's maximum-reuse ruling, the argument-defaulting logic the two
  search tools already shared was moved to a new `server/tools/search-request.ts`
  exporting `normalizeSearchArgs` and `NormalizedSearchArgs`. The five common
  defaults were byte-identical before the move; `search-brain.ts` changes by
  import only. `fts_config` stays in the shared shape as a superset that
  `search_all` never reads — `search_all` publishes no such argument and keeps
  passing `{}` to the search engine, the English path, unchanged.
- The over-long functions were split into named helpers rather than shortened:
  a `QmdSearchOptions` options struct replaces positional arguments, and
  `planFederation`, `searchBrainArm`, `fuseFederatedResults`, and
  `selectRankedWindow` carry the handler's phases. `searchAllInputSchema` and
  `searchAllAnnotations` were hoisted out of the registration function with
  their description strings identical.
- Deliberately NOT reused: `resolveCallerFtsConfig` and `respondToSearchFailure`
  from `search-brain.ts`. The `search_all` catch path returns `[]` and warns
  `search_all_brain_failed` so federation degrades visibly, which is different
  behavior from the single-brain error response, and folding them together would
  have changed one of the two.
- Ranking arithmetic, result push order, the trace span name and its fields, the
  published schema, the defaults, and the error strings are all unchanged. This
  is a structural refactor with no contract movement.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RUNNING this session, in the branch clone at `dc5b82c`:

```text
bun scripts/done-means/780-touched-files-lint-clean.sh   -> exit 0 (both runs)
  linting 3 file(s) from: git diff --name-only origin/main...HEAD
    - server/tools/search-all.ts
    - server/tools/search-brain.ts
    - server/tools/search-request.ts
  PASS: every file this branch touched under server/ lints clean.

bunx oxlint --deny-warnings server/tools/{search-all,search-brain,search-request}.ts -> exit 0
bunx tsc --noEmit                                   -> clean
bun test server/tools                               -> 94 pass / 92 skip / 0 fail
bun test src/tools/__tests__/search-all.test.ts     -> 38 pass
bun test server/observability/langfuse-tracing.test.ts -> 68 pass
```

The done-means list is diff-derived, so it names the three files this branch
actually touched rather than a hand-kept list.

Test files are unmodified by this branch. No new tests were added because no
helper extracted here gained a public boundary that the existing tool-surface
suites do not already drive through the registered tool. The Postgres-backed
files skipped locally for want of `OPENBRAIN_TEST_DATABASE_URL`; the CI
db-integration job is the evidence for those, not this local run.

Python package: untouched by this diff (three TypeScript files under
`server/tools/`), so its checks are not applicable.

## Critical Self-Review

- Highest-risk behavior: federated ranking order drift inside
  `fuseFederatedResults` and `selectRankedWindow`. These two carry the arithmetic
  that decides which results survive and in what order across the brain and qmd
  arms, so a transcription slip in the extraction would silently reorder or drop
  results with no error anywhere. Covered by the ranking and pagination cases in
  `src/tools/__tests__/search-all.test.ts` (38 pass) and by the pre-sort index
  assertion in `server/observability/langfuse-tracing.test.ts` (68 pass), which
  pins the trace fields to the pre-sort positions.
- Assumptions that could be wrong: that the five shared defaults really were
  byte-identical between the two tools before the move, so hoisting them cannot
  change either tool's behavior. Checked by reading the removed block in
  `git diff fca45fb..dc5b82c -- server/tools/search-brain.ts` against the new
  `search-request.ts` body. Second assumption: that `search_all` never reads
  `fts_config`, which is why leaving it in the shared shape is safe as a
  superset — it normalizes to `undefined` there and the engine still receives
  `{}`.
- Missing/weak tests: there is no direct unit test on `planFederation` or
  `selectRankedWindow` as standalone functions; they are exercised only through
  the registered tool. That is sufficient here because they are private helpers
  with no exported surface, and the tool-level suites already drive both the
  federated and brain-only paths plus pagination. The genuine gap is that the
  Postgres-backed search tests did not execute on this machine, so the local run
  proves the non-database paths only.
- Security/permission risk: none introduced. The namespace read-scope predicate
  and the auth-derived filtering stayed inside `searchBrainArm` exactly as they
  were in the inline handler; no check moved to a caller and none became
  conditional. `resolveCallerFtsConfig` was deliberately not pulled in, so the
  non-English privilege boundary in `search-brain.ts` is untouched.
- Migration/deploy risk: none. No migration, no schema change, no config key, no
  new dependency. The new file is a plain TypeScript module imported by two
  existing ones.
- Downstream client/runtime risk: none identified. The published input schema,
  the annotations, the tool name, the output shape, and the error strings are
  unchanged, so an mcp2cli or Hermes consumer sees an identical surface.
- Rollback/cleanup concern: reverting is a single-commit revert of `dc5b82c`;
  the only cross-file coupling is the `search-brain.ts` import of
  `search-request.ts`, which the same revert undoes. No state, no artifact, and
  no generated file to clean up.
- Fixes made before PR: the `?? default` resolution in `resolveQmdPath` treats an
  empty `QMD_PATH` as configured, which had the qmd arm spawning `bun "" search`
  and failing open; it now trims to `undefined` so an unusable value disables
  federation at the call site instead of inside a subprocess.
- Known residual risk: `server/tools/search-all.ts` still reads `process.env`
  directly for the qmd path fallback (`server/tools/search-all.ts:124`, verified
  with `rg -n "process\.env"`). That is the L2b-2 config-injection lane's work,
  not this lint lane's, and it is left in place deliberately. Also remaining for
  rung L2 after this: `server/tools/search-engine.ts`, which is the next handoff
  as an L4 split and re-adds `searchEmbeddingTimeoutMs`.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane came from the #780 lint sweep frontier rather than a review finding, and produced no MEDIUM-or-above finding to record.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the diff is a structural refactor of three TypeScript files with no schema, transport, or behavior change, so a live service check would exercise nothing this branch altered.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no path in `contracts/parity-paths.txt` is touched. That file lists `python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, and `src/contract-schemas.ts`; this diff is confined to `server/tools/search-all.ts`, `server/tools/search-brain.ts`, and `server/tools/search-request.ts`.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable against the doc's "When This Applies" list. No MCP tool name,
  schema, output shape, auth rule, namespace semantic, or error envelope moved;
  transport and session behavior are untouched; there is no externally visible
  migration; `python/openbrain-memory` is not in the diff; no generated `skill/`
  content changed. The three touched files are internal server tool
  implementation, and the surface an mcp2cli or Hermes consumer calls is
  byte-identical before and after.
