### PR TITLE
refactor(brain-answer): bring server/tools/brain-answer.ts to the lint standard (#780)

### DIFF
--- a/server/tools/answer-evidence.ts
+++ b/server/tools/answer-evidence.ts
@@ -1,0 +1,225 @@
+/**
+ * Pure evidence and citation shaping for `brain_answer`.
+ *
+ * Extracted from `brain-answer.ts` (#780) so the tool handler is left with
+ * request handling and the retrieval call, and the reasoning about WHICH rows
+ * are citable — and what the tool does not know about them — lives in one
+ * testable place with no server or transport dependency.
+ *
+ * Nothing here paraphrases. Every function either selects a stored excerpt,
+ * scores it, or states a caveat about it; the extractive constraint that makes
+ * `brain_answer` traceable is preserved by construction.
+ */
+import type { SearchRow, SourceRef } from "./search-engine.ts";
+
+/** Longest excerpt quoted per citation. */
+const MAX_EXCERPT_CHARS = 500;
+
+export interface Citation {
+  index: number;
+  source_ref: SourceRef;
+  excerpt: string;
+  score: number;
+  stale: boolean;
+}
+
+export interface Evidence {
+  row: SearchRow;
+  excerpt: string;
+  source_ref: SourceRef;
+}
+
+/** Retrieved rows split into citable evidence and the gaps that explain the rest. */
+export interface EvidenceSelection {
+  evidence: Evidence[];
+  knownGaps: string[];
+}
+
+/**
+ * Clamp a relevance score into a finite `[0,1]`.
+ *
+ * Neither raw input is bounded: `ts_rank_cd` is only *typically* below 1, and
+ * cosine distance can exceed 1, which makes `1 - distance` negative. Clamping at
+ * this consumer boundary keeps the emitted score a comparable relevance value
+ * rather than an artifact of whichever arm produced it.
+ */
+function clampScore(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+/** Relevance score for one row, from whichever arm ranked it. */
+export function scoreFor(row: SearchRow): number {
+  return clampScore(
+    row.distance != null ? 1 - row.distance : (row.fts_rank ?? 0.5),
+  );
+}
+
+/** Collapse whitespace and shorten one row's quotable excerpt. */
+export function excerptFor(row: SearchRow): string | null {
+  const excerpt = (row.content_preview ?? "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, MAX_EXCERPT_CHARS);
+  return excerpt.length > 0 ? excerpt : null;
+}
+
+/**
+ * Whether a row is older than the staleness window.
+ *
+ * A row with no usable timestamp counts as STALE. Age cannot be proven, and the
+ * failure modes are asymmetric: flagging fresh evidence costs a caveat, while
+ * silently presenting undateable evidence as current is the error this exists to
+ * prevent.
+ */
+export function isStale(row: SearchRow, maxAgeDays: number): boolean {
+  const raw = row.source_ref?.last_updated_at ?? row.source_ref?.created_at;
+  if (!raw) return true;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) return true;
+  return Date.now() - parsed.getTime() > maxAgeDays * 86_400_000;
+}
+
+/** Normalize a "use X" target so the two polarities compare on equal footing. */
+function normalizeUseTarget(target: string): string {
+  return target
+    .toLowerCase()
+    .replace(/[`~"'()]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Collect every normalized target matched by a polarity pattern. */
+function useTargets(text: string, pattern: RegExp): Set<string> {
+  const targets = new Set<string>();
+  for (const match of text.matchAll(pattern)) {
+    const target = normalizeUseTarget(match[1] ?? "");
+    if (target) targets.add(target);
+  }
+  return targets;
+}
+
+/**
+ * Detect evidence that both endorses and forbids the same target.
+ *
+ * A deliberately shallow lexical check, and it is reported as UNCERTAINTY rather
+ * than resolved: two records saying "use X" and "never use X" are usually a
+ * superseded decision, and picking a winner by recency would silently discard a
+ * still-current constraint. The tool surfaces the conflict and lets the caller
+ * decide.
+ */
+export function hasConflictingUseTargets(
+  evidence: readonly Evidence[],
+): boolean {
+  const negative = new Set<string>();
+  const affirmative = new Set<string>();
+  for (const item of evidence) {
+    const lower = item.excerpt.toLowerCase();
+    for (const target of useTargets(
+      lower,
+      /\b(?:should not|must not|do not|don't|never)\s+use\s+([^.;,]+)/g,
+    )) {
+      negative.add(target);
+    }
+    for (const target of useTargets(
+      lower,
+      /\b(?<!not\s)(?:should\s+use|must\s+use|use)\s+([^.;,]+)/g,
+    )) {
+      affirmative.add(target);
+    }
+  }
+  for (const target of negative) {
+    if (affirmative.has(target)) return true;
+  }
+  return false;
+}
+
+/** The exact no-evidence gap sentence; frozen by the parity contract. */
+export function gapMessage(query: string): string {
+  return `No readable Open Brain evidence was found for: ${query}`;
+}
+
+/**
+ * Split retrieved rows into citable evidence, recording why each rejection happened.
+ *
+ * A row without a `source_ref` or without usable preview text cannot be traced
+ * back to a stored record, so it is dropped and NAMED in `knownGaps` rather than
+ * silently omitted.
+ */
+export function selectEvidence(rows: readonly SearchRow[]): EvidenceSelection {
+  const evidence: Evidence[] = [];
+  const knownGaps: string[] = [];
+  for (const row of rows) {
+    const excerpt = excerptFor(row);
+    if (!row.source_ref || !excerpt) {
+      knownGaps.push(
+        `Skipped ${row.source_type}:${row.id} because it lacked citation metadata or usable preview text.`,
+      );
+      continue;
+    }
+    evidence.push({ row, excerpt, source_ref: row.source_ref });
+  }
+  return { evidence, knownGaps };
+}
+
+/** Number every piece of selected evidence and attach its score and staleness. */
+export function buildCitations(
+  evidence: readonly Evidence[],
+  maxAgeDays: number,
+): Citation[] {
+  return evidence.map((item, index) => ({
+    index: index + 1,
+    source_ref: item.source_ref,
+    excerpt: item.excerpt,
+    score: scoreFor(item.row),
+    stale: isStale(item.row, maxAgeDays),
+  }));
+}
+
+/**
+ * State what the answer does NOT establish about its own evidence.
+ *
+ * Stale citations, self-contradicting wording, and rows dropped as uncitable are
+ * each reported rather than resolved; removing any of them would leave a
+ * confident-looking answer with its caveats stripped.
+ */
+export function uncertaintyFor(options: {
+  citations: readonly Citation[];
+  evidence: readonly Evidence[];
+  retrievedCount: number;
+  maxAgeDays: number;
+}): string[] {
+  const { citations, evidence, retrievedCount, maxAgeDays } = options;
+  const uncertainty: string[] = [];
+  const staleCount = citations.filter((citation) => citation.stale).length;
+  if (staleCount > 0) {
+    uncertainty.push(
+      `${staleCount} cited entr${staleCount === 1 ? "y is" : "ies are"} older than ${maxAgeDays} days or missing a usable timestamp.`,
+    );
+  }
+  if (hasConflictingUseTargets(evidence)) {
+    uncertainty.push(
+      "Retrieved evidence contains both affirmative and negative wording; verify whether these are truly contradictory before treating this as settled.",
+    );
+  }
+  if (evidence.length < retrievedCount) {
+    uncertainty.push(
+      "Some retrieved rows were omitted because they were not safe to cite.",
+    );
+  }
+  return uncertainty;
+}
+
+/**
+ * The extractive answer body.
+ *
+ * Every bullet is a stored excerpt followed by the index of the citation it came
+ * from. No sentence originates in this tool.
+ */
+export function renderAnswer(citations: readonly Citation[]): string {
+  return [
+    "Cited Open Brain evidence:",
+    "",
+    ...citations.map((citation) => `- ${citation.excerpt} [${citation.index}]`),
+  ].join("\n");
+}

--- a/server/tools/answer-retrieval.ts
+++ b/server/tools/answer-retrieval.ts
@@ -1,0 +1,97 @@
+/**
+ * Retrieval and traced citation-filtering for `brain_answer`.
+ *
+ * Extracted from `brain-answer.ts` (#780). The Langfuse span here is the reason
+ * the split exists: the filter's input, metadata, and per-candidate output are
+ * verbose enough to dominate the tool handler, while the decision they describe
+ * — which retrieved rows are safe to cite — is a single call to
+ * `selectEvidence`. Keeping the span next to that call keeps the observability
+ * shape and the selection it observes in one place.
+ */
+import { traceRetrievalSpanSync } from "../observability/langfuse-tracing.ts";
+import {
+  executeSearchWithSharedFallback,
+  type SearchMode,
+  type SearchRow,
+  type SearchSource,
+} from "./search-engine.ts";
+import { selectEvidence, type EvidenceSelection } from "./answer-evidence.ts";
+import type { MemoryToolDependencies } from "./types.ts";
+import type { NamespaceFilter } from "./read-scope.ts";
+import type { Tier } from "./search-constants.ts";
+
+/** The retrieval-relevant fields of a resolved `brain_answer` request. */
+interface RetrievalRequest {
+  query: string;
+  limit: number;
+  mode: SearchMode;
+  tier: Tier | undefined;
+  namespace: NamespaceFilter | undefined;
+  tables: readonly SearchSource[];
+}
+
+/**
+ * Run the shared recall stack for one resolved request.
+ *
+ * @throws Whatever the search engine throws; the caller maps it to an error
+ * result rather than an empty citation list.
+ */
+export function retrieveAnswerRows(
+  dependencies: MemoryToolDependencies,
+  request: RetrievalRequest,
+  options: { shared: boolean },
+): Promise<SearchRow[]> {
+  return executeSearchWithSharedFallback(
+    dependencies,
+    request.tables,
+    request.query,
+    request.limit,
+    request.mode,
+    request.tier,
+    0,
+    request.namespace,
+    {},
+    options.shared,
+  );
+}
+
+/** Select citable evidence from retrieved rows, recording the choice as a span. */
+export function selectCitableEvidence(rows: SearchRow[]): EvidenceSelection {
+  return traceRetrievalSpanSync({
+    name: "retrieval.citation_filter",
+    input: {
+      candidate_count: rows.length,
+      candidates: rows.map((row) => ({
+        row_id: row.id,
+        source_type: row.source_type,
+        namespace: row.namespace ?? null,
+        content_preview: row.content_preview,
+        distance: row.distance ?? null,
+        similarity: row.distance === undefined ? null : 1 - row.distance,
+        bm25_score: row.fts_rank ?? null,
+      })),
+    },
+    metadata: {
+      stage: "filtering",
+      filter_names: ["missing_source_ref", "empty_excerpt"],
+    },
+    run: () => selectEvidence(rows),
+    output: ({ evidence }) => {
+      const selected = new Set(evidence.map((item) => item.row.id));
+      return {
+        selected_count: evidence.length,
+        selected_row_ids: evidence.map((item) => item.row.id),
+        candidates: rows.map((row) => {
+          const chosen = selected.has(row.id);
+          let filteredBy: string | null = null;
+          if (!chosen) {
+            filteredBy = row.source_ref
+              ? "empty_excerpt"
+              : "missing_source_ref";
+          }
+          return { row_id: row.id, chosen, filtered_by: filteredBy };
+        }),
+      };
+    },
+  });
+}

--- a/server/tools/brain-answer.ts
+++ b/server/tools/brain-answer.ts
@@ -16,31 +16,43 @@
  * are how the tool says what it does NOT know: evidence older than the staleness
  * window, rows retrieved but not safely citable, fewer citable records than
  * requested, and evidence that contradicts itself. Dropping them would leave a
- * confident-looking answer with its caveats silently removed.
+ * confident-looking answer with its caveats silently removed. The shaping of all
+ * of that lives in `answer-evidence.ts`; this file owns the request path.
  */
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { canRead } from "../auth/permissions.ts";
 import {
   authIdentity,
   errorResult,
   textResult,
   type MemoryToolDependencies,
 } from "./types.ts";
-import { canReadNamespace, namespaceFilterFor } from "./read-scope.ts";
+import {
+  canReadNamespace,
+  namespaceFilterFor,
+  type NamespaceFilter,
+} from "./read-scope.ts";
 import { isSharedNamespace } from "./shared-namespace.ts";
 import type { Tier } from "./search-constants.ts";
+import { setActiveMcpTraceMetadata } from "../observability/langfuse-tracing.ts";
 import {
-  setActiveMcpTraceMetadata,
-  traceRetrievalSpanSync,
-} from "../observability/langfuse-tracing.ts";
-import {
-  executeSearchWithSharedFallback,
   readableSearchSources,
   type SearchMode,
   type SearchRow,
-  type SourceRef,
+  type SearchSource,
 } from "./search-engine.ts";
+import { respondToSearchFailure } from "./tool-failure.ts";
+import {
+  buildCitations,
+  gapMessage,
+  renderAnswer,
+  uncertaintyFor,
+  type Evidence,
+} from "./answer-evidence.ts";
+import {
+  retrieveAnswerRows,
+  selectCitableEvidence,
+} from "./answer-retrieval.ts";
 
 const NAMESPACE_DENIED = "Permission denied: namespace read access denied";
 const NOT_AUTHENTICATED = "Permission denied: not authenticated";
@@ -49,123 +61,171 @@ const NO_READABLE_TABLES = "Permission denied: no readable tables";
 /** Default staleness window; evidence older than this is flagged, not dropped. */
 const DEFAULT_MAX_AGE_DAYS = 180;
 const DEFAULT_EVIDENCE_LIMIT = 5;
-/** Longest excerpt quoted per citation. */
-const MAX_EXCERPT_CHARS = 500;
 
-interface Citation {
-  index: number;
-  source_ref: SourceRef;
-  excerpt: string;
-  score: number;
-  stale: boolean;
+/** The request as this tool resolves it, after auth and namespace scoping. */
+interface AnswerRequest {
+  query: string;
+  limit: number;
+  mode: SearchMode;
+  tier: Tier | undefined;
+  maxAgeDays: number;
+  namespace: NamespaceFilter | undefined;
+  requestedNamespace: string | undefined;
+  tables: readonly SearchSource[];
+  includeRaw: boolean;
 }
 
-interface Evidence {
-  row: SearchRow;
-  excerpt: string;
-  source_ref: SourceRef;
-}
-
-/**
- * Clamp a relevance score into a finite `[0,1]`.
- *
- * Neither raw input is bounded: `ts_rank_cd` is only *typically* below 1, and
- * cosine distance can exceed 1, which makes `1 - distance` negative. Clamping at
- * this consumer boundary keeps the emitted score a comparable relevance value
- * rather than an artifact of whichever arm produced it.
- */
-function clampScore(value: number): number {
-  if (!Number.isFinite(value)) return 0;
-  return Math.min(1, Math.max(0, value));
-}
-
-/** Relevance score for one row, from whichever arm ranked it. */
-function scoreFor(row: SearchRow): number {
-  return clampScore(
-    row.distance != null ? 1 - row.distance : (row.fts_rank ?? 0.5),
-  );
-}
-
-/** Collapse whitespace and bound one row's quotable excerpt. */
-function excerptFor(row: SearchRow): string | null {
-  const excerpt = (row.content_preview ?? "")
-    .replace(/\s+/g, " ")
+/** The `brain_answer` input schema; frozen shape, defaults documented inline. */
+const BRAIN_ANSWER_INPUT_SCHEMA = {
+  query: z.string().min(1).describe("Question to answer from memory"),
+  namespace: z
+    .string()
     .trim()
-    .slice(0, MAX_EXCERPT_CHARS);
-  return excerpt.length > 0 ? excerpt : null;
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Optional namespace filter; must be readable by caller"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(25)
+    .optional()
+    .describe("Maximum evidence entries to cite (default 5)"),
+  search_mode: z
+    .enum(["hybrid", "vector", "keyword"])
+    .optional()
+    .describe("Retrieval mode (default hybrid)"),
+  tier: z
+    .enum(["hot", "warm", "cold"])
+    .optional()
+    .describe("Optional cognitive tier filter"),
+  max_age_days: z
+    .number()
+    .int()
+    .min(1)
+    .max(3650)
+    .optional()
+    .describe("Evidence older than this is flagged stale (default 180)"),
+  include_raw: z
+    .boolean()
+    .optional()
+    .describe("Include raw retrieved rows for debugging (default false)"),
+};
+
+type BrainAnswerArgs = {
+  query: string;
+  namespace?: string | undefined;
+  limit?: number | undefined;
+  search_mode?: string | undefined;
+  tier?: string | undefined;
+  max_age_days?: number | undefined;
+  include_raw?: boolean | undefined;
+};
+
+/** The no-evidence response, used when retrieval returned nothing at all. */
+function noEvidenceResult(query: string): ReturnType<typeof textResult> {
+  return textResult({
+    query,
+    answer: null,
+    evidence_count: 0,
+    citations: [],
+    known_gaps: [gapMessage(query)],
+    uncertainty: ["No readable evidence was available to cite."],
+  });
+}
+
+/** The response for rows that were retrieved but none of which were citable. */
+function noCitableEvidenceResult(options: {
+  query: string;
+  knownGaps: readonly string[];
+  rows: SearchRow[];
+  includeRaw: boolean;
+}): ReturnType<typeof textResult> {
+  const { query, knownGaps, rows, includeRaw } = options;
+  return textResult({
+    query,
+    answer: null,
+    evidence_count: 0,
+    citations: [],
+    known_gaps: [
+      ...knownGaps,
+      "No retrieved evidence had both citation metadata and usable preview text.",
+    ],
+    uncertainty: ["Readable rows were retrieved, but none were safe to cite."],
+    raw_results: includeRaw ? rows : undefined,
+  });
+}
+
+/** The cited answer, once at least one row survived selection. */
+function citedAnswerResult(options: {
+  request: AnswerRequest;
+  evidence: readonly Evidence[];
+  knownGaps: string[];
+  rows: SearchRow[];
+}): ReturnType<typeof textResult> {
+  const { request, evidence, knownGaps, rows } = options;
+  const citations = buildCitations(evidence, request.maxAgeDays);
+  const uncertainty = uncertaintyFor({
+    citations,
+    evidence,
+    retrievedCount: rows.length,
+    maxAgeDays: request.maxAgeDays,
+  });
+  if (evidence.length < request.limit) {
+    knownGaps.push(
+      `Only ${evidence.length} citable evidence entr${evidence.length === 1 ? "y was" : "ies were"} found for this query.`,
+    );
+  }
+  return textResult({
+    query: request.query,
+    answer: renderAnswer(citations),
+    evidence_count: evidence.length,
+    citations,
+    known_gaps: knownGaps,
+    uncertainty,
+    raw_results: request.includeRaw ? rows : undefined,
+  });
 }
 
 /**
- * Whether a row is older than the staleness window.
+ * Resolve the raw arguments into a scoped request, or the denial that stops it.
  *
- * A row with no usable timestamp counts as STALE. Age cannot be proven, and the
- * failure modes are asymmetric: flagging fresh evidence costs a caveat, while
- * silently presenting undateable evidence as current is the error this exists to
- * prevent.
+ * #433 defect 1: brain_answer could not see `ob_session_events` at all. It
+ * filtered ALL_TABLES — the PHYSICAL-table list, which drives PERMISSIONS and
+ * the write paths — so the session-event corpus was structurally absent from
+ * every question this tool answered. "What happened in the last day" answered
+ * from months-old thoughts while the day's events sat unread. The selection now
+ * lives in ONE exported function so a new recall source cannot reach one caller
+ * and miss another, which is the shape of this defect.
  */
-function isStale(row: SearchRow, maxAgeDays: number): boolean {
-  const raw = row.source_ref?.last_updated_at ?? row.source_ref?.created_at;
-  if (!raw) return true;
-  const parsed = new Date(raw);
-  if (Number.isNaN(parsed.getTime())) return true;
-  return Date.now() - parsed.getTime() > maxAgeDays * 86_400_000;
-}
+function resolveRequest(
+  args: BrainAnswerArgs,
+  identity: ReturnType<typeof authIdentity>,
+): { request: AnswerRequest } | { denial: string } {
+  if (!identity) return { denial: NOT_AUTHENTICATED };
 
-/** Normalize a "use X" target so the two polarities compare on equal footing. */
-function normalizeUseTarget(target: string): string {
-  return target
-    .toLowerCase()
-    .replace(/[`~"'()]/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-/** Collect every normalized target matched by a polarity pattern. */
-function useTargets(text: string, pattern: RegExp): Set<string> {
-  const targets = new Set<string>();
-  for (const match of text.matchAll(pattern)) {
-    const target = normalizeUseTarget(match[1] ?? "");
-    if (target) targets.add(target);
+  const requestedNamespace = args.namespace;
+  if (requestedNamespace && !canReadNamespace(identity, requestedNamespace)) {
+    return { denial: NAMESPACE_DENIED };
   }
-  return targets;
-}
 
-/**
- * Detect evidence that both endorses and forbids the same target.
- *
- * A deliberately shallow lexical check, and it is reported as UNCERTAINTY rather
- * than resolved: two records saying "use X" and "never use X" are usually a
- * superseded decision, and picking a winner by recency would silently discard a
- * still-current constraint. The tool surfaces the conflict and lets the caller
- * decide.
- */
-function hasConflictingUseTargets(evidence: readonly Evidence[]): boolean {
-  const negative = new Set<string>();
-  const affirmative = new Set<string>();
-  for (const item of evidence) {
-    const lower = item.excerpt.toLowerCase();
-    for (const target of useTargets(
-      lower,
-      /\b(?:should not|must not|do not|don't|never)\s+use\s+([^.;,]+)/g,
-    )) {
-      negative.add(target);
-    }
-    for (const target of useTargets(
-      lower,
-      /\b(?<!not\s)(?:should\s+use|must\s+use|use)\s+([^.;,]+)/g,
-    )) {
-      affirmative.add(target);
-    }
-  }
-  for (const target of negative) {
-    if (affirmative.has(target)) return true;
-  }
-  return false;
-}
+  const tables = readableSearchSources(identity.role);
+  if (tables.length === 0) return { denial: NO_READABLE_TABLES };
 
-/** The exact no-evidence gap sentence; frozen by the parity contract. */
-function gapMessage(query: string): string {
-  return `No readable Open Brain evidence was found for: ${query}`;
+  return {
+    request: {
+      query: args.query,
+      limit: args.limit ?? DEFAULT_EVIDENCE_LIMIT,
+      mode: (args.search_mode as SearchMode | undefined) ?? "hybrid",
+      tier: args.tier as Tier | undefined,
+      maxAgeDays: args.max_age_days ?? DEFAULT_MAX_AGE_DAYS,
+      namespace: namespaceFilterFor(identity, requestedNamespace),
+      requestedNamespace,
+      tables,
+      includeRaw: args.include_raw === true,
+    },
+  };
 }
 
 export function registerBrainAnswerTool(
@@ -177,42 +237,7 @@ export function registerBrainAnswerTool(
     {
       description:
         "Render cited evidence from readable Open Brain rows only. Returns extractive bullets plus known gaps and uncertainty.",
-      inputSchema: {
-        query: z.string().min(1).describe("Question to answer from memory"),
-        namespace: z
-          .string()
-          .trim()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe("Optional namespace filter; must be readable by caller"),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(25)
-          .optional()
-          .describe("Maximum evidence entries to cite (default 5)"),
-        search_mode: z
-          .enum(["hybrid", "vector", "keyword"])
-          .optional()
-          .describe("Retrieval mode (default hybrid)"),
-        tier: z
-          .enum(["hot", "warm", "cold"])
-          .optional()
-          .describe("Optional cognitive tier filter"),
-        max_age_days: z
-          .number()
-          .int()
-          .min(1)
-          .max(3650)
-          .optional()
-          .describe("Evidence older than this is flagged stale (default 180)"),
-        include_raw: z
-          .boolean()
-          .optional()
-          .describe("Include raw retrieved rows for debugging (default false)"),
-      },
+      inputSchema: BRAIN_ANSWER_INPUT_SCHEMA,
       annotations: {
         title: "Brain Answer",
         readOnlyHint: true,
@@ -221,201 +246,50 @@ export function registerBrainAnswerTool(
       },
     },
     async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      if (!identity) return errorResult(NOT_AUTHENTICATED);
+      const resolved = resolveRequest(
+        args as BrainAnswerArgs,
+        authIdentity(extra.authInfo),
+      );
+      if ("denial" in resolved) return errorResult(resolved.denial);
+      const { request } = resolved;
 
-      const requestedNamespace = args.namespace;
-      if (
-        requestedNamespace &&
-        !canReadNamespace(identity, requestedNamespace)
-      ) {
-        return errorResult(NAMESPACE_DENIED);
-      }
-
-      // #433 defect 1: brain_answer could not see `ob_session_events` at all.
-      // It filtered ALL_TABLES -- the PHYSICAL-table list, which drives
-      // PERMISSIONS and the write paths -- so the session-event corpus was
-      // structurally absent from every question this tool answered. "What
-      // happened in the last day" answered from months-old thoughts while the
-      // day's events sat unread. The selection now lives in ONE exported
-      // function so a new recall source cannot reach one caller and miss
-      // another, which is the shape of this defect.
-      const tables = readableSearchSources(identity.role);
-      if (tables.length === 0) return errorResult(NO_READABLE_TABLES);
-
-      const query = args.query;
-      const limit = args.limit ?? DEFAULT_EVIDENCE_LIMIT;
-      const mode = (args.search_mode as SearchMode | undefined) ?? "hybrid";
-      const tier = args.tier as Tier | undefined;
-      const maxAgeDays = args.max_age_days ?? DEFAULT_MAX_AGE_DAYS;
-      const namespace = namespaceFilterFor(identity, requestedNamespace);
-      setActiveMcpTraceMetadata({ resolved_namespace: namespace ?? null });
+      setActiveMcpTraceMetadata({
+        resolved_namespace: request.namespace ?? null,
+      });
 
       let rows: SearchRow[];
       try {
-        rows = await executeSearchWithSharedFallback(
-          dependencies,
-          tables,
-          query,
-          limit,
-          mode,
-          tier,
-          0,
-          namespace,
-          {},
-          requestedNamespace !== undefined &&
-            isSharedNamespace(requestedNamespace),
-        );
+        rows = await retrieveAnswerRows(dependencies, request, {
+          shared:
+            request.requestedNamespace !== undefined &&
+            isSharedNamespace(request.requestedNamespace),
+        });
       } catch (error) {
         // Retrieval failed. An empty citation list here would read as "the brain
         // knows nothing about this", which is a different and much worse claim.
-        dependencies.logger.error(
-          {
-            namespace,
-            mode,
-            tier,
-            error_message:
-              error instanceof Error ? error.message : String(error),
-          },
-          "brain_answer_retrieval_failed",
-        );
-        return errorResult(
-          error instanceof Error ? error.message : String(error),
-        );
-      }
-
-      if (rows.length === 0) {
-        return textResult({
-          query,
-          answer: null,
-          evidence_count: 0,
-          citations: [],
-          known_gaps: [gapMessage(query)],
-          uncertainty: ["No readable evidence was available to cite."],
+        return respondToSearchFailure({
+          logger: dependencies.logger,
+          event: "brain_answer_retrieval_failed",
+          error,
+          namespace: request.namespace,
+          mode: request.mode,
+          tier: request.tier,
         });
       }
 
-      const filtered = traceRetrievalSpanSync({
-        name: "retrieval.citation_filter",
-        input: {
-          candidate_count: rows.length,
-          candidates: rows.map((row) => ({
-            row_id: row.id,
-            source_type: row.source_type,
-            namespace: row.namespace ?? null,
-            content_preview: row.content_preview,
-            distance: row.distance ?? null,
-            similarity: row.distance === undefined ? null : 1 - row.distance,
-            bm25_score: row.fts_rank ?? null,
-          })),
-        },
-        metadata: {
-          stage: "filtering",
-          filter_names: ["missing_source_ref", "empty_excerpt"],
-        },
-        run: () => {
-          const evidence: Evidence[] = [];
-          const knownGaps: string[] = [];
-          for (const row of rows) {
-            const excerpt = excerptFor(row);
-            if (!row.source_ref || !excerpt) {
-              knownGaps.push(
-                `Skipped ${row.source_type}:${row.id} because it lacked citation metadata or usable preview text.`,
-              );
-              continue;
-            }
-            evidence.push({ row, excerpt, source_ref: row.source_ref });
-          }
-          return { evidence, knownGaps };
-        },
-        output: ({ evidence }) => {
-          const selected = new Set(evidence.map((item) => item.row.id));
-          return {
-            selected_count: evidence.length,
-            selected_row_ids: evidence.map((item) => item.row.id),
-            candidates: rows.map((row) => {
-              const chosen = selected.has(row.id);
-              let filteredBy: string | null = null;
-              if (!chosen) {
-                filteredBy = row.source_ref
-                  ? "empty_excerpt"
-                  : "missing_source_ref";
-              }
-              return { row_id: row.id, chosen, filtered_by: filteredBy };
-            }),
-          };
-        },
-      });
-      const { evidence, knownGaps } = filtered;
-      const uncertainty: string[] = [];
+      if (rows.length === 0) return noEvidenceResult(request.query);
 
+      const { evidence, knownGaps } = selectCitableEvidence(rows);
       if (evidence.length === 0) {
-        return textResult({
-          query,
-          answer: null,
-          evidence_count: 0,
-          citations: [],
-          known_gaps: [
-            ...knownGaps,
-            "No retrieved evidence had both citation metadata and usable preview text.",
-          ],
-          uncertainty: [
-            "Readable rows were retrieved, but none were safe to cite.",
-          ],
-          raw_results: args.include_raw ? rows : undefined,
+        return noCitableEvidenceResult({
+          query: request.query,
+          knownGaps,
+          rows,
+          includeRaw: request.includeRaw,
         });
       }
 
-      const citations: Citation[] = evidence.map((item, index) => ({
-        index: index + 1,
-        source_ref: item.source_ref,
-        excerpt: item.excerpt,
-        score: scoreFor(item.row),
-        stale: isStale(item.row, maxAgeDays),
-      }));
-
-      const staleCount = citations.filter((citation) => citation.stale).length;
-      if (staleCount > 0) {
-        uncertainty.push(
-          `${staleCount} cited entr${staleCount === 1 ? "y is" : "ies are"} older than ${maxAgeDays} days or missing a usable timestamp.`,
-        );
-      }
-      if (hasConflictingUseTargets(evidence)) {
-        uncertainty.push(
-          "Retrieved evidence contains both affirmative and negative wording; verify whether these are truly contradictory before treating this as settled.",
-        );
-      }
-      if (evidence.length < rows.length) {
-        uncertainty.push(
-          "Some retrieved rows were omitted because they were not safe to cite.",
-        );
-      }
-      if (evidence.length < limit) {
-        knownGaps.push(
-          `Only ${evidence.length} citable evidence entr${evidence.length === 1 ? "y was" : "ies were"} found for this query.`,
-        );
-      }
-
-      // Extractive by construction: every bullet is a stored excerpt followed by
-      // the index of the citation it came from. No sentence here originates in
-      // this tool.
-      const answer = [
-        "Cited Open Brain evidence:",
-        "",
-        ...citations.map(
-          (citation) => `- ${citation.excerpt} [${citation.index}]`,
-        ),
-      ].join("\n");
-
-      return textResult({
-        query,
-        answer,
-        evidence_count: evidence.length,
-        citations,
-        known_gaps: knownGaps,
-        uncertainty,
-        raw_results: args.include_raw ? rows : undefined,
-      });
+      return citedAnswerResult({ request, evidence, knownGaps, rows });
     },
   );
 }


### PR DESCRIPTION
## Summary

- `server/tools/brain-answer.ts` had 4 oxlint findings: an unused `canRead`
  import, `registerBrainAnswerTool` at 227 lines, and the inline handler at 173
  lines and complexity 23. All four are cleared with no behavior change.
- Split along the seams that already existed rather than by line count.
  `answer-evidence.ts` holds the pure shaping — scoring, excerpting, staleness,
  the conflicting-use-target check, evidence selection, citation numbering, the
  uncertainty sentences, and the extractive answer body. It needs no server,
  transport, or database, and it is the part worth reading on its own when
  asking what `brain_answer` will and will not claim.
- `answer-retrieval.ts` holds the search call and the Langfuse
  `retrieval.citation_filter` span. The span's input, metadata, and
  per-candidate output are what dominated the handler, while the decision they
  describe is one call to `selectEvidence`; the two belong together.
- Reuse, per the maximum-reuse ruling: retrieval-failure handling now calls
  `respondToSearchFailure` from `server/tools/tool-failure.ts`, which lane 2
  extracted naming `brain-answer.ts:268-283` as its intended second caller. The
  catch shape matched exactly — same logged fields, same `isError` result.
- No behavior change: the input schema, every default, every emitted string, the
  `brain_answer_retrieval_failed` event name, and all three response shapes are
  byte-identical. Existing tests are unmodified.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED, on the untouched file:

```
server/tools/brain-answer.ts:23:10: error eslint(no-unused-vars): Identifier 'canRead' is imported but never used.
server/tools/brain-answer.ts:171:8: error eslint(max-lines-per-function): The function `registerBrainAnswerTool` has too many lines (227). Maximum allowed is 100.
server/tools/brain-answer.ts:223:5: error eslint(complexity): async function has a complexity of 23. Maximum allowed is 10.
server/tools/brain-answer.ts:223:5: error eslint(max-lines-per-function): The async function has too many lines (173). Maximum allowed is 100.
```

`DONE_MEANS_780_FILES=server/tools/brain-answer.ts bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 1.

GREEN, on the committed tree:

- `./node_modules/.bin/oxlint --deny-warnings` over all three touched files -> exit 0
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated src/tools/__tests__/brain-answer.test.ts server/tools/search-read-scope.test.ts server/tools/` -> 176 pass, 0 fail, 574 expect() calls, 18 files
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived, 3 files) -> exit 0

## Critical Self-Review

- Highest-risk behavior: the three response shapes. `brain_answer` output is
  consumed as a contract, so a moved field or a reworded gap sentence would be a
  silent break. Each of the three is now one named function whose object literal
  is a direct transcription of the block it replaced;
  `src/tools/__tests__/brain-answer.test.ts` exercises all three and passes
  unmodified.
- Assumptions that could be wrong: that `respondToSearchFailure` is behaviorally
  identical to the inline catch. Checked field by field rather than assumed —
  both compute `error instanceof Error ? error.message : String(error)`, log
  `{ namespace, mode, tier, error_message }` against the same event name, and
  return `errorResult(message)`. The one difference is that `tier` is typed
  `string | undefined` there and `Tier | undefined` here, which is a widening,
  not a change.
- Missing/weak tests: no new test was added. Every extracted function is called
  on a path the existing suite already drives, and the lane rule is to add a
  test only for public behavior the suite does not already exercise. The honest
  gap is that `answer-evidence.ts` is now independently testable and has no
  direct unit test of its own; that is new headroom, not a regression.
- Security/permission risk: the auth and namespace checks moved into
  `resolveRequest` but kept their order and their exact denial strings —
  identity first, then `canReadNamespace` on a requested namespace, then a
  readable-source check. `namespaceFilterFor` is still what produces the scope
  actually passed to the search. `server/tools/search-read-scope.test.ts` and
  the namespace-denial coverage in the run above pass.
- Migration/deploy risk: none. No schema, no SQL, no migration.
- Downstream client/runtime risk: not applicable. No MCP tool name, input
  schema, or output field changed, so no rtech-mcps, mcp2cli, or Hermes handoff
  is triggered. `contracts/parity-paths.txt` lists `python/openbrain-memory/`,
  `clients/ts/`, `contracts/`, `src/contract.ts`, and `src/contract-schemas.ts`;
  this branch touches none of them.
- Rollback/cleanup concern: a single commit adding two files and rewriting one.
  Reverting it restores the prior file exactly.
- Fixes made before PR: `tsc` rejected `request.tables as string[]` against
  `readonly SearchSource[]`; replaced the cast with the real exported
  `SearchSource` type rather than widening the signature to accept it.
- Known residual risk: `src/tools/brain-answer.ts` is a twin of this file and
  still carries the same private copies of `clampScore`, `scoreFor`,
  `excerptFor`, `isStale`, `hasConflictingUseTargets`, and `gapMessage`. This
  lane is scoped to the `server/` file and does not touch it, so the duplication
  is unchanged, not newly introduced — but it is real and worth its own lane.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a lint-standard refactor with no behavior change and no review finding to record.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no
  runtime, transport, or tool-contract surface changed; the isolated suite is
  the applicable evidence.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: `contracts/parity-paths.txt`
  does not cover `server/tools/`, and no fixture-backed contract surface is
  touched by this branch.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Rollout is not applicable: `docs/downstream-rollout.md` scopes the gate to MCP
  tool, schema, protocol, and client-facing changes. This branch changes none of
  those — the `brain_answer` tool name, input schema, annotations, and every
  output field are identical, so no downstream consumer can observe the change.
