### PR TITLE
refactor(session-events): bring server/tools/session-events.ts to the lint standard (#780)

### DIFF
--- a/server/tools/session-event-provenance.ts
+++ b/server/tools/session-event-provenance.ts
@@ -1,0 +1,51 @@
+import type { AuthIdentity } from "../auth/types.ts";
+
+/**
+ * Writer provenance for a session-event write.
+ *
+ * `append_session_event` (this directory's `session-events.ts`) and
+ * `ingest_conversation_facts` both stamp the same four fields onto every
+ * `ob_session_events` row they insert, and each carried its own private copy of
+ * the derivation. The copies agreed on every value: `tokenClientId` is a
+ * required `string` on `AuthIdentity`, so the `?? clientId` fallback one copy
+ * carried could never fire.
+ *
+ * This lives in its own module rather than in `memory-helpers.ts` so that the
+ * shared declaration is importable without widening the #780 lane's touched-file
+ * set -- `memory-helpers.ts` carries its own separate lint finding that a
+ * different rung of the sweep owns.
+ */
+export function writerProvenance(identity: AuthIdentity): {
+  writer_identity: string;
+  token_identity: string;
+  delegated_agent_id: null;
+  namespace_source: "token" | "header";
+} {
+  return {
+    writer_identity: identity.clientId,
+    token_identity: identity.tokenClientId,
+    delegated_agent_id: null,
+    namespace_source:
+      identity.namespaceSource === "delegated" ? "header" : "token",
+  };
+}
+
+/**
+ * The `_openbrain.writer` envelope both session-event writers nest inside the
+ * metadata they persist. Kept beside `writerProvenance` because the two are
+ * always used together and the field renaming between them is the coupling.
+ */
+export function openBrainWriterMetadata(
+  provenance: ReturnType<typeof writerProvenance>,
+): { _openbrain: { writer: Record<string, unknown> } } {
+  return {
+    _openbrain: {
+      writer: {
+        client_id: provenance.writer_identity,
+        token_client_id: provenance.token_identity,
+        agent_id: provenance.delegated_agent_id,
+        namespace_source: provenance.namespace_source,
+      },
+    },
+  };
+}

--- a/server/tools/session-events.ts
+++ b/server/tools/session-events.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import {
   authorize,
   contentHash,
@@ -8,6 +13,188 @@ import {
   EVENT_TYPES,
   IMPORTANCE_LEVELS,
 } from "./memory-helpers.ts";
+import {
+  openBrainWriterMetadata,
+  writerProvenance,
+} from "./session-event-provenance.ts";
+
+/**
+ * The tool's declared input shape, lifted out of the registration call so the
+ * registration body stays readable. Values and constraints are unchanged.
+ */
+const INPUT_SCHEMA = {
+  session_key: z.string().min(1).max(500),
+  namespace: z.string().max(500).optional(),
+  create_if_missing: z.boolean().optional(),
+  agent: z.string().max(500).optional(),
+  platform: z.string().max(500).optional(),
+  server_id: z.string().max(500).optional(),
+  channel_id: z.string().max(500).optional(),
+  thread_id: z.string().max(500).optional(),
+  project: z.string().max(500).optional(),
+  topic: z.string().max(500).optional(),
+  event_type: z.enum(EVENT_TYPES),
+  content: z.string().min(1).max(50_000),
+  source: z.string().max(500).optional(),
+  artifact_path: z.string().max(2000).optional(),
+  transcript_ref: z.string().max(2000).optional(),
+  transcript: z.string().max(50_000).optional(),
+  occurred_at: z.string().datetime({ offset: true }).optional(),
+  importance: z.enum(IMPORTANCE_LEVELS).optional(),
+  metadata: z.record(z.string().max(100), z.unknown()).optional(),
+};
+
+type EventArgs = z.infer<z.ZodObject<typeof INPUT_SCHEMA>>;
+
+type LaneRow = { id: unknown; status: unknown };
+
+/**
+ * Resolve the lane this event belongs to, creating it when the caller opted in.
+ *
+ * Returned separately from the insert so the handler reads as three steps
+ * (resolve lane, embed, insert) rather than one branch-heavy block. `created`
+ * reports whether THIS call inserted the lane, which the response echoes.
+ */
+async function resolveLane(
+  dependencies: MemoryToolDependencies,
+  args: EventArgs,
+  namespace: string,
+  clientId: string,
+): Promise<{ lane: LaneRow | undefined; created: boolean }> {
+  const lanes = await dependencies.pool.query(
+    `SELECT id, status FROM ob_session_lanes
+          WHERE namespace = $1 AND session_key = $2`,
+    [namespace, args.session_key],
+  );
+  const existing = lanes.rows[0];
+  if (existing || !args.create_if_missing)
+    return { lane: existing, created: false };
+
+  const created = await dependencies.pool.query(
+    `INSERT INTO ob_session_lanes
+             (session_key, namespace, status, agent, source, channel_id, thread_id,
+              project, topic, metadata, created_by)
+           VALUES ($1, $2, 'active', $3, $4, $5, $6, $7, $8, $9::jsonb, $10)
+           ON CONFLICT (namespace, session_key) DO NOTHING
+           RETURNING id, status`,
+    [
+      args.session_key,
+      namespace,
+      args.agent ?? null,
+      args.platform ?? null,
+      args.channel_id ?? null,
+      args.thread_id ?? null,
+      args.project ?? null,
+      args.topic ?? null,
+      JSON.stringify(args.server_id ? { server_id: args.server_id } : {}),
+      clientId,
+    ],
+  );
+  const lane = created.rows[0];
+  return { lane, created: Boolean(lane) };
+}
+
+/**
+ * Insert the event row, returning `undefined` when the idempotency conflict
+ * target swallowed it -- the caller reports that as a duplicate.
+ */
+async function insertEvent(options: {
+  dependencies: MemoryToolDependencies;
+  args: EventArgs;
+  laneId: unknown;
+  importance: string;
+  metadata: Record<string, unknown>;
+  clientId: string;
+}): Promise<{ id: unknown; created_at: unknown } | undefined> {
+  const { dependencies, args, laneId, importance, metadata, clientId } =
+    options;
+  const embedded = await embeddingFields(dependencies, args.content);
+  const events = await dependencies.pool.query(
+    `INSERT INTO ob_session_events
+           (lane_id, event_type, content, source, artifact_path, transcript_ref,
+            transcript, occurred_at, importance, metadata, embedding, content_hash,
+            embedded_at, embedding_model, created_by)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12, $13, $14, $15)
+         ON CONFLICT (lane_id, content_hash) WHERE content_hash IS NOT NULL DO NOTHING
+         RETURNING id, created_at`,
+    [
+      laneId,
+      args.event_type,
+      args.content,
+      args.source ?? null,
+      args.artifact_path ?? null,
+      args.transcript_ref ?? null,
+      args.transcript ?? null,
+      args.occurred_at ?? null,
+      importance,
+      JSON.stringify(metadata),
+      embedded.embedding,
+      contentHash(args.content),
+      embedded.embeddedAt,
+      embedded.model,
+      clientId,
+    ],
+  );
+  return events.rows[0];
+}
+
+async function appendSessionEvent(
+  dependencies: MemoryToolDependencies,
+  args: EventArgs,
+  extra: { authInfo?: unknown },
+) {
+  const auth = authorize(
+    authIdentity(extra.authInfo),
+    "write",
+    "sessions",
+    "cannot write to session events",
+    args.namespace,
+  );
+  if (!auth.ok) return auth.response;
+
+  const { lane, created: laneCreated } = await resolveLane(
+    dependencies,
+    args,
+    auth.namespace,
+    auth.identity.clientId,
+  );
+  if (!lane) {
+    return errorResult(
+      JSON.stringify({
+        error: "scope_validation",
+        message: `Lane not found for session_key "${args.session_key}" in namespace "${auth.namespace}"`,
+        retryable: false,
+      }),
+    );
+  }
+
+  const importance = args.importance ?? "warm";
+  const provenance = writerProvenance(auth.identity);
+  const event = await insertEvent({
+    dependencies,
+    args,
+    laneId: lane.id,
+    importance,
+    metadata: { ...args.metadata, ...openBrainWriterMetadata(provenance) },
+    clientId: auth.identity.clientId,
+  });
+  if (!event) return textResult({ duplicate: true, ...provenance });
+
+  dependencies.logger.info(
+    { tool: "append_session_event", event_id: event.id },
+    "tool_result",
+  );
+  return textResult({
+    event_id: event.id,
+    lane_id: lane.id,
+    lane_created: laneCreated,
+    event_type: args.event_type,
+    importance,
+    created_at: event.created_at,
+    transcript_ref: args.transcript_ref ?? null,
+    ...provenance,
+  });
+}
 
 export function registerSessionEventTool(
   server: McpServer,
@@ -17,27 +204,7 @@ export function registerSessionEventTool(
     "append_session_event",
     {
       description: "Append an idempotent event to a persistent session lane",
-      inputSchema: {
-        session_key: z.string().min(1).max(500),
-        namespace: z.string().max(500).optional(),
-        create_if_missing: z.boolean().optional(),
-        agent: z.string().max(500).optional(),
-        platform: z.string().max(500).optional(),
-        server_id: z.string().max(500).optional(),
-        channel_id: z.string().max(500).optional(),
-        thread_id: z.string().max(500).optional(),
-        project: z.string().max(500).optional(),
-        topic: z.string().max(500).optional(),
-        event_type: z.enum(EVENT_TYPES),
-        content: z.string().min(1).max(50_000),
-        source: z.string().max(500).optional(),
-        artifact_path: z.string().max(2000).optional(),
-        transcript_ref: z.string().max(2000).optional(),
-        transcript: z.string().max(50_000).optional(),
-        occurred_at: z.string().datetime({ offset: true }).optional(),
-        importance: z.enum(IMPORTANCE_LEVELS).optional(),
-        metadata: z.record(z.string().max(100), z.unknown()).optional(),
-      },
+      inputSchema: INPUT_SCHEMA,
       annotations: {
         title: "Append Session Event",
         readOnlyHint: false,
@@ -45,111 +212,6 @@ export function registerSessionEventTool(
         idempotentHint: true,
       },
     },
-    async (args, extra) => {
-      const auth = authorize(
-        authIdentity(extra.authInfo),
-        "write",
-        "sessions",
-        "cannot write to session events",
-        args.namespace,
-      );
-      if (!auth.ok) return auth.response;
-      const lanes = await dependencies.pool.query(
-        `SELECT id, status FROM ob_session_lanes
-          WHERE namespace = $1 AND session_key = $2`,
-        [auth.namespace, args.session_key],
-      );
-      let lane = lanes.rows[0];
-      let laneCreated = false;
-      if (!lane && args.create_if_missing) {
-        const created = await dependencies.pool.query(
-          `INSERT INTO ob_session_lanes
-             (session_key, namespace, status, agent, source, channel_id, thread_id,
-              project, topic, metadata, created_by)
-           VALUES ($1, $2, 'active', $3, $4, $5, $6, $7, $8, $9::jsonb, $10)
-           ON CONFLICT (namespace, session_key) DO NOTHING
-           RETURNING id, status`,
-          [
-            args.session_key,
-            auth.namespace,
-            args.agent ?? null,
-            args.platform ?? null,
-            args.channel_id ?? null,
-            args.thread_id ?? null,
-            args.project ?? null,
-            args.topic ?? null,
-            JSON.stringify(args.server_id ? { server_id: args.server_id } : {}),
-            auth.identity.clientId,
-          ],
-        );
-        lane = created.rows[0];
-        laneCreated = Boolean(lane);
-      }
-      if (!lane) {
-        return errorResult(JSON.stringify({
-          error: "scope_validation",
-          message: `Lane not found for session_key "${args.session_key}" in namespace "${auth.namespace}"`,
-          retryable: false,
-        }));
-      }
-      const importance = args.importance ?? "warm";
-      const embedded = await embeddingFields(dependencies, args.content);
-      const provenance = {
-        writer_identity: auth.identity.clientId,
-        token_identity: auth.identity.tokenClientId,
-        delegated_agent_id: null,
-        namespace_source: auth.identity.namespaceSource === "delegated" ? "header" : "token",
-      };
-      const metadata = {
-        ...(args.metadata ?? {}),
-        _openbrain: {
-          writer: {
-            client_id: provenance.writer_identity,
-            token_client_id: provenance.token_identity,
-            agent_id: provenance.delegated_agent_id,
-            namespace_source: provenance.namespace_source,
-          },
-        },
-      };
-      const events = await dependencies.pool.query(
-        `INSERT INTO ob_session_events
-           (lane_id, event_type, content, source, artifact_path, transcript_ref,
-            transcript, occurred_at, importance, metadata, embedding, content_hash,
-            embedded_at, embedding_model, created_by)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12, $13, $14, $15)
-         ON CONFLICT (lane_id, content_hash) WHERE content_hash IS NOT NULL DO NOTHING
-         RETURNING id, created_at`,
-        [
-          lane.id,
-          args.event_type,
-          args.content,
-          args.source ?? null,
-          args.artifact_path ?? null,
-          args.transcript_ref ?? null,
-          args.transcript ?? null,
-          args.occurred_at ?? null,
-          importance,
-          JSON.stringify(metadata),
-          embedded.embedding,
-          contentHash(args.content),
-          embedded.embeddedAt,
-          embedded.model,
-          auth.identity.clientId,
-        ],
-      );
-      const event = events.rows[0];
-      if (!event) return textResult({ duplicate: true, ...provenance });
-      dependencies.logger.info({ tool: "append_session_event", event_id: event.id }, "tool_result");
-      return textResult({
-        event_id: event.id,
-        lane_id: lane.id,
-        lane_created: laneCreated,
-        event_type: args.event_type,
-        importance,
-        created_at: event.created_at,
-        transcript_ref: args.transcript_ref ?? null,
-        ...provenance,
-      });
-    },
+    async (args, extra) => appendSessionEvent(dependencies, args, extra),
   );
 }


### PR DESCRIPTION
## Summary

- Clears all four oxlint findings on `server/tools/session-events.ts` with no behavior change. The Zod schema and its constraints, the default importance, the error strings, every SQL statement, and the `tool_result` log event name are unchanged.
- `registerSessionEventTool` shrank from 144 lines to the registration itself: the input schema moved to a module-level `INPUT_SCHEMA` constant, and the handler body moved out of the `registerTool` call.
- The complexity-22, 106-line handler split along the three steps it already performed. `resolveLane` owns the select-then-maybe-insert of the lane and reports whether this call created it; `insertEvent` owns the embedding call and the event insert, taking an options object because the six values it needs exceed the four-parameter standard; `appendSessionEvent` sequences the three and builds the response.
- The `no-useless-fallback-in-spread` finding went away on its own: spreading `undefined` into an object literal adds nothing, so the empty-object fallback and the bare spread produce identical objects.
- **Reuse.** The writer-provenance derivation and the `_openbrain.writer` envelope were inlined here and also existed as a private copy in `server/tools/ingest-conversation-facts.ts`. The two agreed on every value -- `tokenClientId` is a required `string` on `AuthIdentity`, so the `?? clientId` fallback the other copy carried could never fire. Both now have one shared declaration to import, in the new `server/tools/session-event-provenance.ts`. It is a new sibling rather than an addition to `memory-helpers.ts` because that file carries its own unrelated `max-params` finding on `authorize` that another rung of this sweep owns, and touching it would pull that finding into this branch's diff-derived check.
- **Duplication noted, not touched.** `server/tools/ingest-conversation-facts.ts` still declares its own `writerProvenance` at line 81 and re-spells the `_openbrain.writer` envelope at line 312. This PR is scoped to one file, so that copy is left in place; the shared module it should import now exists, and collapsing it is a one-import follow-up for whichever lane owns that file.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED, on untouched `origin/main` content -- `./node_modules/.bin/oxlint --deny-warnings server/tools/session-events.ts` reported four findings verbatim:

```
server/tools/session-events.ts:12:8: error eslint(max-lines-per-function): The function `registerSessionEventTool` has too many lines (144). Maximum allowed is 100.
server/tools/session-events.ts:48:5: error eslint(complexity): async function has a complexity of 22. Maximum allowed is 10.
server/tools/session-events.ts:48:5: error eslint(max-lines-per-function): The async function has too many lines (106). Maximum allowed is 100.
server/tools/session-events.ts:104:9: error unicorn(no-useless-fallback-in-spread): Empty fallbacks in spreads are unnecessary
```

`DONE_MEANS_780_FILES=server/tools/session-events.ts bash scripts/done-means/780-touched-files-lint-clean.sh` on that content exits **1**.

GREEN, on this branch head:

- `./node_modules/.bin/oxlint --deny-warnings server/tools/session-events.ts server/tools/session-event-provenance.ts` exits **0**, no findings.
- `bunx tsc --noEmit` exits **0**, no diagnostics.
- `bun run test:isolated server/tools server/application/sdk-protocol.pg.test.ts` -- **175 pass, 0 fail**, 597 expect() calls, 18 files, against its own freshly created and dropped database. No existing test was modified.
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived, 2 files) exits **0**; the same check with the explicit override also exits **0**.

Python package checks are not applicable -- nothing under `python/openbrain-memory/` is touched. Live smoke is not applicable -- no deployed behavior changes.

## Critical Self-Review

- Highest-risk behavior: the metadata spread. Dropping the empty-object fallback is only safe because spreading `undefined` into an object literal is a no-op; if `args.metadata` could ever be a non-object truthy value the two forms would diverge, but the schema pins it to an optional `z.record`, so it is either an object or `undefined`.
- Assumptions that could be wrong: that `AuthIdentity.tokenClientId` is non-optional, which is what makes the shared `writerProvenance` byte-identical to both former copies. Read from `server/auth/types.ts:13` -- it is `readonly tokenClientId: string`, so the `?? clientId` fallback in the ingest copy was already dead.
- Missing/weak tests: no test was added. The two extracted helpers have no public behavior the existing suites do not already drive -- `sdk-protocol.pg.test.ts` exercises `append_session_event` end to end, including lane creation, the duplicate path, and the provenance fields in the response, which is exactly what `resolveLane`, `insertEvent`, and `writerProvenance` produce. A unit test over them would re-assert the same values one layer down.
- Security/permission risk: none introduced. The `authorize` call, its arguments, and the early return on failure are unchanged and still run before any query. The namespace predicate still comes from `auth.namespace` and is still passed to both lane queries.
- Migration/deploy risk: none. No schema change, no migration, no config change.
- Downstream client/runtime risk: none. The tool name, description, annotations, input schema, and both response shapes are unchanged, so no client sees a different contract.
- Rollback/cleanup concern: the new `server/tools/session-event-provenance.ts` is the only added file; reverting the commit removes it and restores the inlined derivation. Nothing else imports it yet.
- Fixes made before PR: the first draft added the shared helper to `memory-helpers.ts`, which pulled that file's pre-existing `max-params` finding on `authorize` into the diff-derived check and failed it. Moved to a sibling module and restored `memory-helpers.ts` to its `origin/main` content. The first draft also typed the args with `z.objectOutputType`, which Zod v4 no longer exports; `bunx tsc --noEmit` caught it and it is now `z.infer<z.ZodObject<typeof INPUT_SCHEMA>>`.
- Known residual risk: low. The duplicate `writerProvenance` in `ingest-conversation-facts.ts` remains, so the two can still drift until that file's lane collapses it.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a lint-debt refactor with no behavior change and produced no review finding a future swarm would need to check for.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no deployed behavior, schema, or contract changes; the change is internal structure within one tool module.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: checked `contracts/parity-paths.txt` -- neither `server/tools/session-events.ts` nor `server/tools/session-event-provenance.ts` is listed, so no parity fixture covers these paths. The tool's wire contract is unchanged regardless.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Downstream rollout is **not applicable**. `docs/downstream-rollout.md` scopes rollout to MCP tool, schema, protocol, or client-facing changes. This PR changes none of them: `append_session_event` keeps its name, description, annotations, input schema, and both response shapes byte-identical, so no downstream client, cached skill, or Hermes runtime observes any difference.
