### PR TITLE
refactor(ingest-conversation-facts): bring server/tools/ingest-conversation-facts.ts to the lint standard (#780)

### DIFF
--- a/server/tools/ingest-conversation-facts.ts
+++ b/server/tools/ingest-conversation-facts.ts
@@ -37,7 +37,11 @@ import { physicalNamespace } from "../../src/shared-namespace.ts";
 import { contentHash, EMBEDDING_MODEL } from "../../src/embedding.ts";
 import { containsSecret } from "../../src/sharing.ts";
 import { resolveIngestionEligibility } from "../../src/source-registry.ts";
-import { authIdentity, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import {
   conversationIngestSchema,
   findRawTranscriptKey,
@@ -45,6 +49,7 @@ import {
   safeErrorClass,
   type ConversationFactEventType,
   type ConversationIngestArgs,
+  type Queryable,
   type UnitDisposition,
 } from "./conversation-facts-contract.ts";
 
@@ -79,7 +84,8 @@ function ingestError(
 
 /** Writer provenance, mirroring `append_session_event`. */
 function writerProvenance(identity: AuthIdentity) {
-  const namespaceSource = identity.namespaceSource === "delegated" ? "header" : "token";
+  const namespaceSource =
+    identity.namespaceSource === "delegated" ? "header" : "token";
   return {
     writer_identity: identity.clientId,
     token_identity: identity.tokenClientId ?? identity.clientId,
@@ -93,8 +99,490 @@ function registryAuth(identity: AuthIdentity): AuthInfo {
   return {
     role: identity.role,
     clientId: identity.clientId,
-    namespaceSource: identity.namespaceSource === "delegated" ? "header" : "token",
+    namespaceSource:
+      identity.namespaceSource === "delegated" ? "header" : "token",
   } as AuthInfo;
+}
+
+/** What every gate and step below needs: the pool, the logger, and who is asking. */
+interface IngestContext {
+  readonly dependencies: MemoryToolDependencies;
+  readonly identity: AuthIdentity;
+  readonly namespace: string;
+}
+
+/** A gate either refuses with a structured error, or passes and returns nothing. */
+type Refusal = ReturnType<typeof ingestError>;
+
+/**
+ * Gates 1 and 2 of the four: server-side auth, then namespace write authority.
+ *
+ * Returns the resolved physical namespace on success. Kept together because the
+ * namespace is not known until the auth identity is, and neither answer is
+ * usable without the other.
+ */
+function resolveWriteTarget(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity | undefined,
+  args: ConversationIngestArgs,
+): { namespace: string } | { refusal: Refusal } {
+  // Conversation facts land in the session journal, so the sessions write
+  // permission is the authority. No input flag can route around it.
+  if (!identity || !canWrite(identity.role, "sessions")) {
+    dependencies.logger.warn(
+      { tool: "ingest_conversation_facts", role: identity?.role ?? "none" },
+      "ingest_conversation_facts_denied",
+    );
+    return {
+      refusal: ingestError(
+        "auth_denied",
+        "Permission denied: cannot write conversation facts",
+        false,
+      ),
+    };
+  }
+
+  const requested = args.namespace ?? identity.clientId;
+  if (!canTargetNamespace(identity, "write", requested)) {
+    return {
+      refusal: ingestError(
+        "namespace_denied",
+        `Permission denied: ${identity.role} role cannot write to namespace '${requested}'`,
+        false,
+        { namespace: requested },
+      ),
+    };
+  }
+
+  return { namespace: physicalNamespace(requested) };
+}
+
+/**
+ * Gate 3, shape half: the recursive raw-transcript key scan.
+ *
+ * Defense in depth. The strict schema already rejects unknown keys before the
+ * handler runs; the scan covers a nested raw body a future permissive field
+ * could carry as opaque JSON.
+ */
+function refuseRawTranscript(
+  context: IngestContext,
+  rawArgs: unknown,
+): Refusal | undefined {
+  const rawKey = findRawTranscriptKey(rawArgs);
+  if (!rawKey) return undefined;
+
+  const { dependencies, namespace } = context;
+  dependencies.logger.warn(
+    { tool: "ingest_conversation_facts", namespace },
+    "ingest_conversation_facts_raw_rejected",
+  );
+  return ingestError(
+    "raw_transcript_rejected",
+    "Raw transcript bodies, turn/message arrays, and bulk conversation " +
+      "payloads are not accepted; supply only distilled facts.",
+    false,
+    { namespace, rejected_key: rawKey },
+  );
+}
+
+/**
+ * Gate 3, content half: the secret scan.
+ *
+ * Runs over the WHOLE batch before anything is written, so a credential in the
+ * last unit cannot land after the first nine committed. Only the index is
+ * surfaced; the content is never logged.
+ */
+function refuseSecrets(
+  context: IngestContext,
+  facts: ConversationIngestArgs["facts"],
+): Refusal | undefined {
+  const { dependencies, namespace } = context;
+  for (const [index, fact] of facts.entries()) {
+    if (
+      containsSecret(fact.content) ||
+      (fact.source_locator !== undefined && containsSecret(fact.source_locator))
+    ) {
+      dependencies.logger.warn(
+        { tool: "ingest_conversation_facts", namespace, factIndex: index },
+        "ingest_conversation_facts_secret_rejected",
+      );
+      return ingestError(
+        "secret_rejected",
+        "A distilled unit contains credential-like material and was rejected",
+        false,
+        { namespace, fact_index: index },
+      );
+    }
+  }
+  return undefined;
+}
+
+/** The approved source row this batch is bound to. */
+type ApprovedSource = Awaited<
+  ReturnType<typeof resolveIngestionEligibility>
+>["data"];
+
+/**
+ * Gate 4, approval half: the explicit-approval check through the single
+ * source-registry authority.
+ *
+ * `target_namespace` binds the check to the exact namespace, so it can never
+ * resolve a foreign namespace's approved source.
+ */
+async function resolveApprovedSource(
+  context: IngestContext,
+  externalId: string,
+): Promise<{ source: NonNullable<ApprovedSource> } | { refusal: Refusal }> {
+  const { dependencies, identity, namespace } = context;
+  const eligibility = await resolveIngestionEligibility(
+    dependencies.pool,
+    registryAuth(identity),
+    {
+      source_kind: "conversation",
+      external_id: externalId,
+      target_namespace: namespace,
+    },
+  );
+  if (!eligibility.ok || !eligibility.data) {
+    return {
+      refusal: ingestError(
+        "source_not_approved",
+        "Conversation source is not approved and active in this namespace",
+        false,
+        { namespace, code: eligibility.code ?? "not_found" },
+      ),
+    };
+  }
+  return { source: eligibility.data };
+}
+
+/**
+ * Gate 4, scope half: the seven-coordinate isolation boundary, enforced as one
+ * parameterized predicate.
+ *
+ * The lane must ALREADY exist: this contract does not create lanes, so a scope
+ * typo cannot quietly open a new one.
+ */
+async function resolveTargetLane(
+  context: IngestContext,
+  scope: ConversationIngestArgs["scope"],
+): Promise<{ laneId: string } | { refusal: Refusal }> {
+  const { dependencies, namespace } = context;
+  const { rows: laneRows } = await dependencies.pool.query(
+    `SELECT id, status FROM ob_session_lanes
+      WHERE namespace = $1
+        AND session_key = $2
+        AND agent = $3
+        AND source = $4
+        AND metadata->>'server_id' = $5
+        AND channel_id = $6
+        AND thread_id IS NOT DISTINCT FROM $7::text`,
+    [
+      namespace,
+      scope.session_key,
+      scope.agent,
+      scope.platform,
+      scope.server_id,
+      scope.channel_id,
+      scope.thread_id,
+    ],
+  );
+  const lane = laneRows[0] as { id: unknown; status: unknown } | undefined;
+  if (!lane) {
+    return {
+      refusal: ingestError(
+        "scope_validation",
+        "No durable lane matches the exact seven-coordinate scope in this " +
+          "namespace; conversation facts require an existing scoped lane",
+        false,
+        { namespace, session_key: scope.session_key },
+      ),
+    };
+  }
+  if (lane.status === "archived") {
+    return {
+      refusal: ingestError(
+        "scope_validation",
+        "Target lane is archived; reactivate before ingesting facts",
+        false,
+        { namespace, session_key: scope.session_key },
+      ),
+    };
+  }
+  return { laneId: String(lane.id) };
+}
+
+/** One distilled unit with its content hash and (best-effort) vector. */
+interface PreparedUnit {
+  fact: ConversationIngestArgs["facts"][number];
+  eventContentHash: string;
+  embedding: number[] | null;
+}
+
+/**
+ * Compute embeddings BEFORE the transaction opens.
+ *
+ * Embedding is a slow network call, and doing it inside the transaction would
+ * hold the batch's row locks for its full duration. A failure is non-fatal per
+ * unit -- the row is still written, without a vector -- and is logged as a
+ * content-free class.
+ */
+async function prepareUnits(
+  context: IngestContext,
+  facts: ConversationIngestArgs["facts"],
+): Promise<PreparedUnit[]> {
+  const { dependencies, namespace } = context;
+  const prepared: PreparedUnit[] = facts.map((fact) => ({
+    fact,
+    eventContentHash: contentHash(fact.content),
+    embedding: null,
+  }));
+  for (const unit of prepared) {
+    try {
+      unit.embedding = await dependencies.embedFn(unit.fact.content);
+    } catch (error) {
+      dependencies.logger.warn(
+        {
+          tool: "ingest_conversation_facts",
+          namespace,
+          errorClass: safeErrorClass(error),
+        },
+        "ingest_conversation_facts_embed_error",
+      );
+    }
+  }
+  return prepared;
+}
+
+/** What one accepted unit became, as reported back to the caller. */
+interface WrittenUnit {
+  event_id: string;
+  event_type: ConversationFactEventType;
+  duplicate: boolean;
+  disposition: UnitDisposition;
+}
+
+/** Everything the insert loop needs that is not the unit itself. */
+interface WriteTarget {
+  readonly laneId: string;
+  readonly source: NonNullable<ApprovedSource>;
+  readonly provenance: ReturnType<typeof writerProvenance>;
+  readonly scope: ConversationIngestArgs["scope"];
+  readonly clientId: string;
+}
+
+/** The metadata envelope one row carries: source pointers plus writer provenance. */
+function unitMetadata(target: WriteTarget, unit: PreparedUnit) {
+  const { source, provenance } = target;
+  return {
+    conversation_ingest: true,
+    source_id: source.id,
+    source_kind: source.source_kind,
+    source_external_id: source.external_id,
+    ...(unit.fact.source_locator !== undefined
+      ? { source_locator: unit.fact.source_locator }
+      : {}),
+    _openbrain: {
+      writer: {
+        client_id: provenance.writer_identity,
+        token_client_id: provenance.token_identity,
+        agent_id: provenance.delegated_agent_id,
+        namespace_source: provenance.namespace_source,
+      },
+    },
+  };
+}
+
+/**
+ * Insert one distilled unit, or resolve it against the row already stored.
+ *
+ * `ON CONFLICT ... DO NOTHING` returns no row when the same lane already holds
+ * this content hash. That is not a no-op: the unit may carry structural
+ * evidence the stored row lacks, so the decision is made INSIDE the caller's
+ * transaction rather than dropped silently.
+ */
+async function writeUnit(
+  client: Queryable & { query: PoolClientQuery },
+  target: WriteTarget,
+  unit: PreparedUnit,
+): Promise<WrittenUnit> {
+  const { fact, eventContentHash, embedding } = unit;
+  const { rows } = await client.query(
+    `INSERT INTO ob_session_events
+       (lane_id, event_type, content, source, importance, metadata,
+        embedding, content_hash, embedded_at, embedding_model, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10, $11)
+     ON CONFLICT (lane_id, content_hash) WHERE content_hash IS NOT NULL
+       DO NOTHING
+     RETURNING id`,
+    [
+      target.laneId,
+      fact.event_type,
+      fact.content,
+      target.scope.platform,
+      fact.importance ?? "warm",
+      JSON.stringify(unitMetadata(target, unit)),
+      embedding ? toSql(embedding) : null,
+      eventContentHash,
+      embedding ? new Date().toISOString() : null,
+      embedding ? EMBEDDING_MODEL : null,
+      target.clientId,
+    ],
+  );
+
+  const inserted = rows[0] as { id: unknown } | undefined;
+  if (inserted) {
+    return {
+      event_id: String(inserted.id),
+      event_type: fact.event_type,
+      duplicate: false,
+      disposition: "stored",
+    };
+  }
+
+  const merged = await mergeDuplicateEvidence(
+    client,
+    target.laneId,
+    eventContentHash,
+    fact,
+  );
+  return {
+    event_id: merged.eventId,
+    event_type: fact.event_type,
+    duplicate: true,
+    disposition: merged.kind,
+  };
+}
+
+type PoolClientQuery = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: Array<Record<string, unknown>> }>;
+
+/**
+ * Write the whole batch inside one transaction.
+ *
+ * The batch is all-or-nothing, including the duplicate readback and any
+ * evidence merge: a mid-batch failure rolls back every prior insert, so the
+ * receipt can never claim progress that was discarded.
+ */
+async function writeBatch(
+  context: IngestContext,
+  target: WriteTarget,
+  prepared: PreparedUnit[],
+): Promise<WrittenUnit[]> {
+  const { dependencies, namespace } = context;
+  if (typeof dependencies.pool.connect !== "function") {
+    throw new Error(
+      "ingest_conversation_facts requires a transactional pg pool",
+    );
+  }
+  const client = await dependencies.pool.connect();
+  const written: WrittenUnit[] = [];
+
+  try {
+    await client.query("BEGIN");
+    for (const unit of prepared) {
+      written.push(await writeUnit(client, target, unit));
+    }
+    await client.query("COMMIT");
+  } catch (error) {
+    try {
+      await client.query("ROLLBACK");
+    } catch (rollbackError) {
+      dependencies.logger.warn(
+        {
+          tool: "ingest_conversation_facts",
+          namespace,
+          errorClass: safeErrorClass(rollbackError),
+        },
+        "ingest_conversation_facts_rollback_failed",
+      );
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
+
+  return written;
+}
+
+/** The content-free receipt, plus the matching `tool_result` log line. */
+function ingestReceipt(
+  context: IngestContext,
+  target: WriteTarget,
+  written: WrittenUnit[],
+  submitted: number,
+) {
+  const { dependencies, namespace } = context;
+  const ingested = written.filter((unit) => !unit.duplicate).length;
+  const evidenceMerged = written.filter(
+    (unit) => unit.disposition === "duplicate_evidence_merged",
+  ).length;
+  const evidenceNotStored = written.filter(
+    (unit) => unit.disposition === "evidence_not_stored",
+  ).length;
+
+  dependencies.logger.info(
+    {
+      tool: "ingest_conversation_facts",
+      namespace,
+      laneId: target.laneId,
+      sourceId: target.source.id,
+      submitted,
+      ingested,
+      duplicates: written.length - ingested,
+      evidenceMerged,
+      evidenceNotStored,
+    },
+    "tool_result",
+  );
+  return textResult({
+    ok: true,
+    namespace,
+    lane_id: target.laneId,
+    source_id: target.source.id,
+    submitted,
+    ingested,
+    duplicates: written.length - ingested,
+    evidence_merged: evidenceMerged,
+    evidence_not_stored: evidenceNotStored,
+    events: written,
+    ...target.provenance,
+  });
+}
+
+/**
+ * Everything past the two synchronous gates: source approval, scope, embedding,
+ * the transactional write, and the receipt.
+ *
+ * Split from the handler so the database-error boundary stays one `try` around
+ * one call rather than around two hundred lines.
+ */
+async function ingestApprovedBatch(
+  context: IngestContext,
+  args: ConversationIngestArgs,
+) {
+  const sourceResult = await resolveApprovedSource(
+    context,
+    args.source_ref.external_id,
+  );
+  if ("refusal" in sourceResult) return sourceResult.refusal;
+
+  const laneResult = await resolveTargetLane(context, args.scope);
+  if ("refusal" in laneResult) return laneResult.refusal;
+
+  const target: WriteTarget = {
+    laneId: laneResult.laneId,
+    source: sourceResult.source,
+    provenance: writerProvenance(context.identity),
+    scope: args.scope,
+    clientId: context.identity.clientId,
+  };
+
+  const prepared = await prepareUnits(context, args.facts);
+  const written = await writeBatch(context, target, prepared);
+  return ingestReceipt(context, target, written, args.facts.length);
 }
 
 export function registerIngestConversationFactsTool(
@@ -124,311 +612,29 @@ export function registerIngestConversationFactsTool(
       const identity = authIdentity(extra.authInfo);
       const args = rawArgs as ConversationIngestArgs;
 
-      // Conversation facts land in the session journal, so the sessions write
-      // permission is the authority. No input flag can route around it.
-      if (!identity || !canWrite(identity.role, "sessions")) {
-        dependencies.logger.warn(
-          { tool: "ingest_conversation_facts", role: identity?.role ?? "none" },
-          "ingest_conversation_facts_denied",
-        );
-        return ingestError(
-          "auth_denied",
-          "Permission denied: cannot write conversation facts",
-          false,
-        );
-      }
+      const target = resolveWriteTarget(dependencies, identity, args);
+      if ("refusal" in target) return target.refusal;
+      const context: IngestContext = {
+        dependencies,
+        // `resolveWriteTarget` refuses an absent identity above, so it is
+        // present on every path that reaches here.
+        identity: identity as AuthIdentity,
+        namespace: target.namespace,
+      };
 
-      const requested = args.namespace ?? identity.clientId;
-      if (!canTargetNamespace(identity, "write", requested)) {
-        return ingestError(
-          "namespace_denied",
-          `Permission denied: ${identity.role} role cannot write to namespace '${requested}'`,
-          false,
-          { namespace: requested },
-        );
-      }
-      const namespace = physicalNamespace(requested);
+      const rawRefusal = refuseRawTranscript(context, rawArgs);
+      if (rawRefusal) return rawRefusal;
 
-      // Defense in depth. The strict schema already rejects unknown keys before
-      // this handler runs; the scan covers a nested raw body a future permissive
-      // field could carry as opaque JSON.
-      const rawKey = findRawTranscriptKey(rawArgs);
-      if (rawKey) {
-        dependencies.logger.warn(
-          { tool: "ingest_conversation_facts", namespace },
-          "ingest_conversation_facts_raw_rejected",
-        );
-        return ingestError(
-          "raw_transcript_rejected",
-          "Raw transcript bodies, turn/message arrays, and bulk conversation " +
-            "payloads are not accepted; supply only distilled facts.",
-          false,
-          { namespace, rejected_key: rawKey },
-        );
-      }
-
-      // The secret scan runs over the WHOLE batch before anything is written, so
-      // a credential in the last unit cannot land after the first nine committed.
-      // Only the index is surfaced; the content is never logged.
-      for (let index = 0; index < args.facts.length; index += 1) {
-        const fact = args.facts[index]!;
-        if (
-          containsSecret(fact.content) ||
-          (fact.source_locator !== undefined && containsSecret(fact.source_locator))
-        ) {
-          dependencies.logger.warn(
-            { tool: "ingest_conversation_facts", namespace, factIndex: index },
-            "ingest_conversation_facts_secret_rejected",
-          );
-          return ingestError(
-            "secret_rejected",
-            "A distilled unit contains credential-like material and was rejected",
-            false,
-            { namespace, fact_index: index },
-          );
-        }
-      }
+      const secretRefusal = refuseSecrets(context, args.facts);
+      if (secretRefusal) return secretRefusal;
 
       try {
-        // Explicit-approval gate through the single source-registry authority.
-        // `target_namespace` binds the check to the exact namespace, so it can
-        // never resolve a foreign namespace's approved source.
-        const eligibility = await resolveIngestionEligibility(
-          dependencies.pool,
-          registryAuth(identity),
-          {
-            source_kind: "conversation",
-            external_id: args.source_ref.external_id,
-            target_namespace: namespace,
-          },
-        );
-        if (!eligibility.ok || !eligibility.data) {
-          return ingestError(
-            "source_not_approved",
-            "Conversation source is not approved and active in this namespace",
-            false,
-            { namespace, code: eligibility.code ?? "not_found" },
-          );
-        }
-        const source = eligibility.data;
-
-        // The seven-coordinate isolation boundary, enforced as one parameterized
-        // predicate. The lane must ALREADY exist: this contract does not create
-        // lanes, so a scope typo cannot quietly open a new one.
-        const { rows: laneRows } = await dependencies.pool.query(
-          `SELECT id, status FROM ob_session_lanes
-            WHERE namespace = $1
-              AND session_key = $2
-              AND agent = $3
-              AND source = $4
-              AND metadata->>'server_id' = $5
-              AND channel_id = $6
-              AND thread_id IS NOT DISTINCT FROM $7::text`,
-          [
-            namespace,
-            args.scope.session_key,
-            args.scope.agent,
-            args.scope.platform,
-            args.scope.server_id,
-            args.scope.channel_id,
-            args.scope.thread_id,
-          ],
-        );
-        const lane = laneRows[0] as { id: unknown; status: unknown } | undefined;
-        if (!lane) {
-          return ingestError(
-            "scope_validation",
-            "No durable lane matches the exact seven-coordinate scope in this " +
-              "namespace; conversation facts require an existing scoped lane",
-            false,
-            { namespace, session_key: args.scope.session_key },
-          );
-        }
-        if (lane.status === "archived") {
-          return ingestError(
-            "scope_validation",
-            "Target lane is archived; reactivate before ingesting facts",
-            false,
-            { namespace, session_key: args.scope.session_key },
-          );
-        }
-
-        const laneId = String(lane.id);
-        const provenance = writerProvenance(identity);
-
-        // Embeddings are computed BEFORE the transaction opens. Embedding is a
-        // slow network call, and doing it inside the transaction would hold the
-        // batch's row locks for its full duration. A failure is non-fatal per
-        // unit -- the row is still written, without a vector -- and is logged as
-        // a content-free class.
-        const prepared = args.facts.map((fact) => ({
-          fact,
-          eventContentHash: contentHash(fact.content),
-          embedding: null as number[] | null,
-        }));
-        for (const unit of prepared) {
-          try {
-            unit.embedding = await dependencies.embedFn(unit.fact.content);
-          } catch (error) {
-            dependencies.logger.warn(
-              {
-                tool: "ingest_conversation_facts",
-                namespace,
-                errorClass: safeErrorClass(error),
-              },
-              "ingest_conversation_facts_embed_error",
-            );
-          }
-        }
-
-        // The batch is all-or-nothing, including the duplicate readback and any
-        // evidence merge: a mid-batch failure rolls back every prior insert, so
-        // the receipt can never claim progress that was discarded.
-        if (typeof dependencies.pool.connect !== "function") {
-          throw new Error(
-            "ingest_conversation_facts requires a transactional pg pool",
-          );
-        }
-        const client = await dependencies.pool.connect();
-        const written: Array<{
-          event_id: string;
-          event_type: ConversationFactEventType;
-          duplicate: boolean;
-          disposition: UnitDisposition;
-        }> = [];
-
-        try {
-          await client.query("BEGIN");
-
-          for (const { fact, eventContentHash, embedding } of prepared) {
-            const metadata = {
-              conversation_ingest: true,
-              source_id: source.id,
-              source_kind: source.source_kind,
-              source_external_id: source.external_id,
-              ...(fact.source_locator !== undefined
-                ? { source_locator: fact.source_locator }
-                : {}),
-              _openbrain: {
-                writer: {
-                  client_id: provenance.writer_identity,
-                  token_client_id: provenance.token_identity,
-                  agent_id: provenance.delegated_agent_id,
-                  namespace_source: provenance.namespace_source,
-                },
-              },
-            };
-
-            const { rows } = await client.query(
-              `INSERT INTO ob_session_events
-                 (lane_id, event_type, content, source, importance, metadata,
-                  embedding, content_hash, embedded_at, embedding_model, created_by)
-               VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9, $10, $11)
-               ON CONFLICT (lane_id, content_hash) WHERE content_hash IS NOT NULL
-                 DO NOTHING
-               RETURNING id`,
-              [
-                laneId,
-                fact.event_type,
-                fact.content,
-                args.scope.platform,
-                fact.importance ?? "warm",
-                JSON.stringify(metadata),
-                embedding ? toSql(embedding) : null,
-                eventContentHash,
-                embedding ? new Date().toISOString() : null,
-                embedding ? EMBEDDING_MODEL : null,
-                identity.clientId,
-              ],
-            );
-
-            const inserted = rows[0] as { id: unknown } | undefined;
-            if (inserted) {
-              written.push({
-                event_id: String(inserted.id),
-                event_type: fact.event_type,
-                duplicate: false,
-                disposition: "stored",
-              });
-              continue;
-            }
-
-            // Same lane, same content hash. Decide INSIDE the transaction
-            // whether this unit carries structural evidence the stored row lacks,
-            // and preserve it if so rather than dropping it silently.
-            const merged = await mergeDuplicateEvidence(
-              client,
-              laneId,
-              eventContentHash,
-              fact,
-            );
-            written.push({
-              event_id: merged.eventId,
-              event_type: fact.event_type,
-              duplicate: true,
-              disposition: merged.kind,
-            });
-          }
-
-          await client.query("COMMIT");
-        } catch (error) {
-          try {
-            await client.query("ROLLBACK");
-          } catch (rollbackError) {
-            dependencies.logger.warn(
-              {
-                tool: "ingest_conversation_facts",
-                namespace,
-                errorClass: safeErrorClass(rollbackError),
-              },
-              "ingest_conversation_facts_rollback_failed",
-            );
-          }
-          throw error;
-        } finally {
-          client.release();
-        }
-
-        const ingested = written.filter((unit) => !unit.duplicate).length;
-        const evidenceMerged = written.filter(
-          (unit) => unit.disposition === "duplicate_evidence_merged",
-        ).length;
-        const evidenceNotStored = written.filter(
-          (unit) => unit.disposition === "evidence_not_stored",
-        ).length;
-
-        dependencies.logger.info(
-          {
-            tool: "ingest_conversation_facts",
-            namespace,
-            laneId,
-            sourceId: source.id,
-            submitted: args.facts.length,
-            ingested,
-            duplicates: written.length - ingested,
-            evidenceMerged,
-            evidenceNotStored,
-          },
-          "tool_result",
-        );
-        return textResult({
-          ok: true,
-          namespace,
-          lane_id: laneId,
-          source_id: source.id,
-          submitted: args.facts.length,
-          ingested,
-          duplicates: written.length - ingested,
-          evidence_merged: evidenceMerged,
-          evidence_not_stored: evidenceNotStored,
-          events: written,
-          ...provenance,
-        });
+        return await ingestApprovedBatch(context, args);
       } catch (error) {
         dependencies.logger.error(
           {
             tool: "ingest_conversation_facts",
-            namespace,
+            namespace: context.namespace,
             errorClass: safeErrorClass(error),
           },
           "ingest_conversation_facts_db_error",
@@ -439,7 +645,7 @@ export function registerIngestConversationFactsTool(
           "retryable_outage",
           "Database error during conversation-fact ingestion",
           true,
-          { namespace },
+          { namespace: context.namespace },
         );
       }
     },


### PR DESCRIPTION
## Summary

- Brings `server/tools/ingest-conversation-facts.ts` to the repo lint standard for #780. The MCP handler was one 279-line async closure with a complexity of 30, carrying all four gates, the embedding pass, the transactional insert loop, and the receipt in a single scope.
- Split along the boundaries the file's own header comment already names. Each gate is now a named function that either refuses with a structured error or passes: `resolveWriteTarget` (auth plus namespace authority), `refuseRawTranscript`, `refuseSecrets`, then `resolveApprovedSource` and `resolveTargetLane`. The write side is `prepareUnits`, `writeUnit`, `writeBatch`, and `ingestReceipt`, sequenced by `ingestApprovedBatch` so the database-error boundary wraps one call rather than two hundred lines.
- Helpers past two arguments take an `IngestContext` (pool, logger, resolved identity, physical namespace), so no signature reaches a fifth parameter.
- The forbidden non-null assertion is gone: the secret scan iterates `facts.entries()` instead of indexing `args.facts[index]!`. The 4-deep block in the insert loop flattens because the duplicate-evidence branch became its own function.
- **No behavior moves.** Schemas, defaults, error codes and messages, SQL text and parameter order, and every log event name are identical. The extraction is structural only.
- Reuse check before extracting, per the maximum-reuse ruling: `rg` across `server/tools/` and `src/tools/` shows `writerProvenance` and `registryAuth` are local to this file (the older `src/tools/` twin carries its own separate copies and is out of scope for this lane), and the genuinely shared pieces — schemas, the raw-key set, `mergeDuplicateEvidence`, `safeErrorClass` — already live in `server/tools/conversation-facts-contract.ts`, which this file imports. Nothing new earned a place there: every extracted function closes over this server's auth and dependency shapes, so hoisting one would create a shared symbol with a single caller.

Only the one target file is modified. No sibling file was added and no other file was touched.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED, on the untouched file at `origin/main` — 5 findings:

```
server/tools/ingest-conversation-facts.ts:100:8: error eslint(max-lines-per-function): The function `registerIngestConversationFactsTool` has too many lines (304). Maximum allowed is 100.
server/tools/ingest-conversation-facts.ts:123:5: error eslint(complexity): async function has a complexity of 30. Maximum allowed is 10.
server/tools/ingest-conversation-facts.ts:123:5: error eslint(max-lines-per-function): The async function has too many lines (279). Maximum allowed is 100.
server/tools/ingest-conversation-facts.ts:174:22: error typescript(no-non-null-assertion): Forbidden non-null assertion.
server/tools/ingest-conversation-facts.ts:346:13: error eslint(max-depth): Blocks are nested too deeply (4). Maximum allowed is 3.
```

`DONE_MEANS_780_FILES=server/tools/ingest-conversation-facts.ts bash scripts/done-means/780-touched-files-lint-clean.sh` on that tree exited 1 with `FAIL: oxlint reported findings in the file(s) listed above.`

GREEN, on this branch:

- `./node_modules/.bin/oxlint --deny-warnings server/tools/ingest-conversation-facts.ts` -> exit 0, no output. Only this file was modified, so it is the whole touched set.
- `bunx tsc --noEmit` -> exit 0.
- `bun run test:isolated src/tools/__tests__/ingest-conversation-facts.test.ts src/tools/__tests__/ingest-conversation-facts.pg.test.ts server/tools/` -> exit 0, **188 pass, 0 fail**, 713 expect() calls across 19 files, against a freshly created and migrated database. Existing tests are unmodified.
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived from `origin/main...HEAD`) -> exit 0, `PASS: every file this branch touched under server/ lints clean.`

Re-ran typecheck and the isolated suite after committing, because the pre-commit hook reformats with prettier and the receipt must describe the committed content, not the pre-hook content. Both still exit 0. File is 497 code lines, under the 500 standard.

No new test was added: every extracted function is a private helper whose behavior is already exercised end to end through the registered tool by the two `ingest-conversation-facts` suites, which cover each refusal path and the duplicate-merge dispositions. A new unit test over a private helper would pin the refactor's shape rather than any behavior, and would have to be deleted the next time the seams move.

## Critical Self-Review

- Highest-risk behavior: the transactional write loop. `writeBatch` still opens the client, runs `BEGIN`, loops, and `COMMIT`s, with `ROLLBACK` in `catch` and `client.release()` in `finally` — the all-or-nothing property and the release are preserved exactly. The risk in a split like this is a rollback path that stops covering the loop; here the loop and both handlers stayed inside the same function, and only the per-unit insert moved out into `writeUnit`, which is called from inside the `try`. So a throw from `writeUnit` still unwinds through the same `ROLLBACK`.
- Assumptions that could be wrong: (1) that `identity` is non-undefined once `resolveWriteTarget` returns a namespace. That is true by construction — the function refuses `!identity` on its first branch — but it is expressed as an `as AuthIdentity` cast at the call site with a comment, because narrowing does not flow out of the helper's return type. A future edit that adds a passing path to `resolveWriteTarget` without an identity would make the cast a lie. (2) That prettier's reformat did not alter semantics; checked by re-running typecheck and the suite after the commit.
- Missing/weak tests: `server/tools/` has no test file that directly names `registerIngestConversationFactsTool`. The coverage the receipt cites for this contract runs through the `src/tools/` twin's suites and the shared `conversation-facts-contract.ts`. That gap predates this PR and is not widened by it, but it does mean the server registration wrapper itself is covered only indirectly.
- Security/permission risk: this file IS a security boundary — four gates, one of them namespace isolation. The gates are unchanged in content, in order, and in their refusal shapes. `resolveWriteTarget` runs auth then namespace, then the raw-transcript scan, then the whole-batch secret scan, then source approval and the seven-coordinate lane predicate, exactly as before. The SQL is byte-identical including the `$1..$7` parameter order and `IS NOT DISTINCT FROM $7::text`, so no predicate was dropped or reordered. The secret scan still refuses the entire batch before any write.
- Migration/deploy risk: none. No schema change, no migration, no config, no new dependency.
- Downstream client/runtime risk: not applicable, with a reason rather than a shrug. `docs/downstream-rollout.md` scopes rollout to MCP tool/schema/protocol/client-facing changes. The tool name, description string, `inputSchema`, and annotations are unchanged; every response body is produced by the same `textResult`/`ingestError` calls with the same fields; every error code and message string is identical. Nothing crosses the wire differently, so rtech-mcps, mcp2cli, and the rtech-hermes runtime see no change.
- Rollback/cleanup concern: a single-commit, single-file, behavior-preserving refactor; reverting the commit fully restores the prior file. No state, no artifact, no partial migration to unwind.
- Known residual risk: the `as AuthIdentity` cast noted above is the one place where a compiler-checked invariant became a human-checked one — the alternative was to return the identity back out of `resolveWriteTarget`, which reads worse for the same guarantee. Also, the older `src/tools/ingest-conversation-facts.ts` twin still carries its own copies of `writerProvenance` and `registryAuth` and its own inlined contract, and still lints with 9 findings. That duplication is real and worth collapsing, but doing it here would be a behavior-bearing change to a second file outside this lane's scope.
- Fixes made before PR: none beyond the refactor itself; no defect surfaced during the split.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no review or post-merge finding surfaced a missed pattern here. This is a mechanical lint-standard sweep with no behavior change, so there is nothing for the next swarm to check for that the lint rules do not already enforce.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or schema behavior changes, so a live smoke would exercise the identical code path and prove nothing this branch could have broken.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: checked `contracts/parity-paths.txt`, which lists `python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, and `src/contract-schemas.ts`. This PR touches exactly one file, `server/tools/ingest-conversation-facts.ts`, which is under none of them, and the shared contract module it imports is unmodified. No fixture can have drifted.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All four are not applicable for one reason: nothing client-facing changed. The registered tool name, description, `inputSchema`, and annotations are identical, and every success and refusal payload is emitted by the same call with the same fields and the same strings. Downstream consumers cannot observe this diff.
