### PR TITLE
refactor(curation): bring server/tools/curation.ts to the lint standard (#780)

### DIFF
--- a/server/tools/curation.ts
+++ b/server/tools/curation.ts
@@ -9,13 +9,24 @@
  * admin-tier role. Planning never mutates: that is the exact call shape the
  * dream-cycle design depends on, because a planning pass that silently archived
  * would make the whole cycle unreviewable and irreversible.
+ *
+ * The three scan modes share one helper, `collectScan`, because they differ
+ * only in their query and how a row becomes a finding. The dry-run decision
+ * itself is NOT part of that shared code: each caller passes its own
+ * `onArchive`, and the `vague` mode passes none at all, so report-only stays a
+ * property of the call site rather than a flag the shared helper interprets.
  */
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canDelete, canRead } from "../auth/permissions.ts";
 import { namespacePredicate } from "../auth/namespace-policy.ts";
 import type { AuthIdentity, ResourceTable } from "../auth/types.ts";
-import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import { authorize } from "./memory-helpers.ts";
 import {
   ALL_TABLES,
@@ -67,7 +78,199 @@ async function archiveRow(
   );
 }
 
-export function registerCurationTools(
+/** One scan mode's query and the shape it turns a row into. */
+interface ScanSpec<Finding> {
+  dependencies: MemoryToolDependencies;
+  /** SQL to run, and the values its placeholders bind. */
+  query: { text: string; values: readonly unknown[] };
+  /**
+   * The row's id, when the mode may archive it. Omitted by report-only modes,
+   * which is what keeps `vague` non-mutating without a flag.
+   */
+  archiveId?: (row: Record<string, unknown>) => string;
+  /** Runs only when the mode may archive AND the caller opted into mutation. */
+  onArchive?: (id: string) => Promise<void>;
+  /** Builds the finding, given the action label the archive decision produced. */
+  toFinding: (row: Record<string, unknown>, action: string) => Finding;
+  /** Label used when nothing was archived for this row. */
+  reportAction: string;
+}
+
+/**
+ * Run one scan mode and collect its findings.
+ *
+ * @returns The findings, and how many rows were archived while collecting them.
+ */
+async function collectScan<Finding>(
+  spec: ScanSpec<Finding>,
+): Promise<{ findings: Finding[]; archived: number; scanned: number }> {
+  const { rows } = await spec.dependencies.pool.query(spec.query.text, [
+    ...spec.query.values,
+  ]);
+  const findings: Finding[] = [];
+  let archived = 0;
+  for (const row of rows) {
+    let action = spec.reportAction;
+    const id = spec.archiveId?.(row);
+    if (spec.onArchive && id !== undefined) {
+      await spec.onArchive(id);
+      action = "archived";
+      archived++;
+    }
+    findings.push(spec.toFinding(row, action));
+  }
+  return { findings, archived, scanned: rows.length };
+}
+
+/** Inputs every per-table scan shares. */
+interface ScanContext {
+  dependencies: MemoryToolDependencies;
+  identity: AuthIdentity;
+  table: ResourceTable;
+  rowsPerTable: number;
+  /** Present only when the caller opted into mutation AND is admin-tier. */
+  archive?: (id: string) => Promise<void>;
+}
+
+/** Detect near-identical pairs in one table, archiving the older on opt-in. */
+async function scanDuplicates(
+  context: ScanContext,
+): Promise<{
+  findings: CurateResult["duplicates"];
+  archived: number;
+  scanned: number;
+}> {
+  const readPredicate = namespacePredicate(context.identity, "read", 3);
+  return collectScan({
+    dependencies: context.dependencies,
+    query: {
+      text: `SELECT a.id AS id_a, b.id AS id_b, a.embedding <=> b.embedding AS distance
+               FROM ${context.table} a
+               JOIN ${context.table} b ON a.id < b.id
+                AND b.archived_at IS NULL AND b.embedding IS NOT NULL
+                AND b.namespace = a.namespace
+              WHERE a.archived_at IS NULL AND a.embedding IS NOT NULL
+                AND a.embedding <=> b.embedding < $1
+                ${qualifyNamespacePredicate(readPredicate, "a.namespace", 3)}
+              ORDER BY distance ASC
+              FETCH FIRST $2 ROWS ONLY`,
+      values: [
+        DUPLICATE_THRESHOLD,
+        context.rowsPerTable,
+        ...readPredicate.values,
+      ],
+    },
+    archiveId: (row) => String(row.id_a),
+    onArchive: context.archive,
+    reportAction: "would_archive_older",
+    toFinding: (row, action) => ({
+      table: context.table,
+      entry_a: String(row.id_a),
+      entry_b: String(row.id_b),
+      distance: Number(row.distance),
+      action,
+    }),
+  });
+}
+
+/** Flag entries never accessed and older than the stale window. */
+async function scanStale(
+  context: ScanContext,
+): Promise<{
+  findings: CurateResult["stale"];
+  archived: number;
+  scanned: number;
+}> {
+  const readPredicate = namespacePredicate(context.identity, "read", 3);
+  return collectScan({
+    dependencies: context.dependencies,
+    query: {
+      text: `SELECT id, ${CONTENT_PREVIEW[context.table]} AS content_preview
+               FROM ${context.table}
+              WHERE archived_at IS NULL
+                AND created_at < NOW() - INTERVAL '1 day' * $1
+                AND COALESCE(access_count, 0) = 0
+                ${readPredicate.clause}
+              FETCH FIRST $2 ROWS ONLY`,
+      values: [STALE_DAYS, context.rowsPerTable, ...readPredicate.values],
+    },
+    archiveId: (row) => String(row.id),
+    onArchive: context.archive,
+    reportAction: "would_flag",
+    toFinding: (row, action) => ({
+      table: context.table,
+      id: String(row.id),
+      preview: previewOf(row.content_preview),
+      action,
+    }),
+  });
+}
+
+/**
+ * Flag low-value untagged entries.
+ *
+ * Passes no `onArchive`, so vague entries are ALWAYS report-only even when
+ * `dry_run` is false -- the same guarantee the previous inline branch made by
+ * simply having no mutation path.
+ */
+async function scanVague(
+  context: ScanContext,
+): Promise<{
+  findings: CurateResult["vague"];
+  archived: number;
+  scanned: number;
+}> {
+  const readPredicate = namespacePredicate(context.identity, "read", 2);
+  return collectScan({
+    dependencies: context.dependencies,
+    query: {
+      text: `SELECT id, ${CONTENT_PREVIEW[context.table]} AS content_preview
+               FROM ${context.table}
+              WHERE archived_at IS NULL
+                AND (usefulness_score IS NULL OR usefulness_score < 0.3)
+                AND (tags IS NULL OR array_length(tags, 1) IS NULL)
+                ${readPredicate.clause}
+              FETCH FIRST $1 ROWS ONLY`,
+      values: [context.rowsPerTable, ...readPredicate.values],
+    },
+    reportAction: "flagged_for_review",
+    toFinding: (row) => ({
+      table: context.table,
+      id: String(row.id),
+      preview: previewOf(row.content_preview),
+      action: "flagged_for_review",
+    }),
+  });
+}
+
+/** Run every mode the request selected across one table, folding into `result`. */
+async function curateTable(
+  context: ScanContext,
+  mode: string,
+  result: CurateResult,
+): Promise<void> {
+  if (mode === "duplicates" || mode === "all") {
+    const scan = await scanDuplicates(context);
+    result.duplicates.push(...scan.findings);
+    result.summary.duplicates_found += scan.scanned;
+    result.summary.archived += scan.archived;
+  }
+  if (mode === "stale" || mode === "all") {
+    const scan = await scanStale(context);
+    result.stale.push(...scan.findings);
+    result.summary.stale_found += scan.scanned;
+    result.summary.archived += scan.archived;
+  }
+  if (mode === "vague" || mode === "all") {
+    const scan = await scanVague(context);
+    result.vague.push(...scan.findings);
+    result.summary.vague_found += scan.scanned;
+    result.summary.archived += scan.archived;
+  }
+}
+
+/** Register `curate_entries`: the dry-run-by-default discovery surface. */
+function registerCurateEntries(
   server: McpServer,
   dependencies: MemoryToolDependencies,
 ): void {
@@ -98,13 +301,24 @@ export function registerCurationTools(
       const rowsPerTable = args.rows_per_table ?? 20;
 
       // The mutating wrapper is admin-only. Planning callers never reach here.
-      if (!dryRun && identity.role !== "admin" && identity.role !== "ob-admin") {
-        return errorResult("Permission denied: admin permission required for dry_run=false");
+      if (
+        !dryRun &&
+        identity.role !== "admin" &&
+        identity.role !== "ob-admin"
+      ) {
+        return errorResult(
+          "Permission denied: admin permission required for dry_run=false",
+        );
       }
 
-      const requested: readonly ResourceTable[] = args.table ? [args.table] : ALL_TABLES;
-      const accessible = requested.filter((table) => canRead(identity.role, table));
-      if (accessible.length === 0) return errorResult("Permission denied: no readable tables");
+      const requested: readonly ResourceTable[] = args.table
+        ? [args.table]
+        : ALL_TABLES;
+      const accessible = requested.filter((table) =>
+        canRead(identity.role, table),
+      );
+      if (accessible.length === 0)
+        return errorResult("Permission denied: no readable tables");
 
       const result: CurateResult = {
         mode: args.mode,
@@ -113,97 +327,30 @@ export function registerCurationTools(
         duplicates: [],
         stale: [],
         vague: [],
-        summary: { duplicates_found: 0, stale_found: 0, vague_found: 0, archived: 0 },
+        summary: {
+          duplicates_found: 0,
+          stale_found: 0,
+          vague_found: 0,
+          archived: 0,
+        },
       };
 
       for (const table of accessible) {
-        const preview = CONTENT_PREVIEW[table];
-
-        if (args.mode === "duplicates" || args.mode === "all") {
-          const readPredicate = namespacePredicate(identity, "read", 3);
-          const { rows } = await dependencies.pool.query(
-            `SELECT a.id AS id_a, b.id AS id_b, a.embedding <=> b.embedding AS distance
-               FROM ${table} a
-               JOIN ${table} b ON a.id < b.id
-                AND b.archived_at IS NULL AND b.embedding IS NOT NULL
-                AND b.namespace = a.namespace
-              WHERE a.archived_at IS NULL AND a.embedding IS NOT NULL
-                AND a.embedding <=> b.embedding < $1
-                ${qualifyNamespacePredicate(readPredicate, "a.namespace", 3)}
-              ORDER BY distance ASC
-              FETCH FIRST $2 ROWS ONLY`,
-            [DUPLICATE_THRESHOLD, rowsPerTable, ...readPredicate.values],
-          );
-          for (const row of rows) {
-            let action = "would_archive_older";
-            if (!dryRun) {
-              await archiveRow(dependencies, identity, table, row.id_a);
-              action = "archived";
-              result.summary.archived++;
-            }
-            result.duplicates.push({
-              table,
-              entry_a: row.id_a,
-              entry_b: row.id_b,
-              distance: Number(row.distance),
-              action,
-            });
-          }
-          result.summary.duplicates_found += rows.length;
-        }
-
-        if (args.mode === "stale" || args.mode === "all") {
-          const readPredicate = namespacePredicate(identity, "read", 3);
-          const { rows } = await dependencies.pool.query(
-            `SELECT id, ${preview} AS content_preview
-               FROM ${table}
-              WHERE archived_at IS NULL
-                AND created_at < NOW() - INTERVAL '1 day' * $1
-                AND COALESCE(access_count, 0) = 0
-                ${readPredicate.clause}
-              FETCH FIRST $2 ROWS ONLY`,
-            [STALE_DAYS, rowsPerTable, ...readPredicate.values],
-          );
-          for (const row of rows) {
-            let action = "would_flag";
-            if (!dryRun) {
-              await archiveRow(dependencies, identity, table, row.id);
-              action = "archived";
-              result.summary.archived++;
-            }
-            result.stale.push({
-              table,
-              id: row.id,
-              preview: previewOf(row.content_preview),
-              action,
-            });
-          }
-          result.summary.stale_found += rows.length;
-        }
-
-        if (args.mode === "vague" || args.mode === "all") {
-          const readPredicate = namespacePredicate(identity, "read", 2);
-          const { rows } = await dependencies.pool.query(
-            `SELECT id, ${preview} AS content_preview
-               FROM ${table}
-              WHERE archived_at IS NULL
-                AND (usefulness_score IS NULL OR usefulness_score < 0.3)
-                AND (tags IS NULL OR array_length(tags, 1) IS NULL)
-                ${readPredicate.clause}
-              FETCH FIRST $1 ROWS ONLY`,
-            [rowsPerTable, ...readPredicate.values],
-          );
-          for (const row of rows) {
-            // Vague entries are ALWAYS report-only, even when dry_run is false.
-            result.vague.push({
-              table,
-              id: row.id,
-              preview: previewOf(row.content_preview),
-              action: "flagged_for_review",
-            });
-          }
-          result.summary.vague_found += rows.length;
-        }
+        await curateTable(
+          {
+            dependencies,
+            identity,
+            table,
+            rowsPerTable,
+            // The ONLY place mutation is wired in. Dry-run leaves it undefined,
+            // so no scan below has an archive path to take at all.
+            archive: dryRun
+              ? undefined
+              : (id: string) => archiveRow(dependencies, identity, table, id),
+          },
+          args.mode,
+          result,
+        );
       }
 
       dependencies.logger.info(
@@ -213,7 +360,13 @@ export function registerCurationTools(
       return textResult(result);
     },
   );
+}
 
+/** Register `archive_entry`: explicit single-row soft delete. */
+function registerArchiveEntry(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
   server.registerTool(
     "archive_entry",
     {
@@ -243,7 +396,10 @@ export function registerCurationTools(
         [args.id, ...predicate.values],
       );
       if (rows.length === 0) {
-        dependencies.logger.info({ tool: "archive_entry", table: args.table }, "tool_noop");
+        dependencies.logger.info(
+          { tool: "archive_entry", table: args.table },
+          "tool_noop",
+        );
         return textResult("Already archived or not found");
       }
       dependencies.logger.info(
@@ -253,7 +409,13 @@ export function registerCurationTools(
       return textResult({ id: rows[0].id, table: args.table, archived: true });
     },
   );
+}
 
+/** Register `rate_entry`: usefulness scoring under the write predicate. */
+function registerRateEntry(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
   server.registerTool(
     "rate_entry",
     {
@@ -273,7 +435,12 @@ export function registerCurationTools(
     },
     async (args, extra) => {
       const identity = authIdentity(extra.authInfo);
-      const auth = authorize(identity, "write", args.table, `cannot write to ${args.table}`);
+      const auth = authorize(
+        identity,
+        "write",
+        args.table,
+        `cannot write to ${args.table}`,
+      );
       if (!auth.ok) return auth.response;
       const predicate = namespacePredicate(auth.identity, "write", 3);
       const { rows } = await dependencies.pool.query(
@@ -283,7 +450,10 @@ export function registerCurationTools(
         [args.score, args.id, ...predicate.values],
       );
       if (rows.length === 0) {
-        dependencies.logger.info({ tool: "rate_entry", table: args.table }, "tool_noop");
+        dependencies.logger.info(
+          { tool: "rate_entry", table: args.table },
+          "tool_noop",
+        );
         return errorResult("Cannot rate archived entry");
       }
       dependencies.logger.info(
@@ -297,4 +467,13 @@ export function registerCurationTools(
       });
     },
   );
+}
+
+export function registerCurationTools(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
+  registerCurateEntries(server, dependencies);
+  registerArchiveEntry(server, dependencies);
+  registerRateEntry(server, dependencies);
 }


### PR DESCRIPTION
## Summary

- `server/tools/curation.ts` carried five oxlint findings. `registerCurationTools` was 217 lines, its `curate_entries` handler was 111 lines at complexity 20, and two blocks nested four deep.
- Split the single registrar into three per-tool registrars (`registerCurateEntries`, `registerArchiveEntry`, `registerRateEntry`), each owning one `server.registerTool` call.
- Collapsed the three near-identical scan blocks into one `collectScan` helper plus a `scanDuplicates` / `scanStale` / `scanVague` trio. The two nesting findings clear because the per-row loop now lives in the helper instead of inside a `for` inside an `if` inside the handler.
- No behavior change: schemas, defaults, error strings, SQL text, and the `tool_result` / `tool_noop` log event names are byte-identical to `origin/main`.
- No new dependency, no disable comment, no other file touched.

**The dry-run default is preserved structurally, not by a flag.** `archive` is wired in at exactly one call site — the one that already proved the caller passed `dry_run: false` and holds an admin-tier role. A dry-run request leaves it `undefined`, so no scan has an archive path to take at all. `scanVague` passes no archive callback under any conditions, which is the same always-report-only guarantee the previous inline branch made by simply having no mutation path. Reviewers should check that claim first; it is the one that matters.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED (untouched file, `./node_modules/.bin/oxlint --deny-warnings server/tools/curation.ts`), 5 findings verbatim:

```
server/tools/curation.ts:70:8: error eslint(max-lines-per-function): The function `registerCurationTools` has too many lines (217). Maximum allowed is 100.
server/tools/curation.ts:92:5: error eslint(complexity): async function has a complexity of 20. Maximum allowed is 10.
server/tools/curation.ts:92:5: error eslint(max-lines-per-function): The async function has too many lines (111). Maximum allowed is 100.
server/tools/curation.ts:139:13: error eslint(max-depth): Blocks are nested too deeply (4). Maximum allowed is 3.
server/tools/curation.ts:169:13: error eslint(max-depth): Blocks are nested too deeply (4). Maximum allowed is 3.
```

RED done-means: `DONE_MEANS_780_FILES=server/tools/curation.ts bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 1.

GREEN, all run against the committed content (the pre-commit hook reformatted with prettier, so every check below was re-run after the commit rather than before it):

- `./node_modules/.bin/oxlint --deny-warnings server/tools/curation.ts` -> exit 0, zero findings
- `bunx tsc --noEmit` -> exit 0, zero output
- `bun run test:isolated server/tools` -> 163 pass, 0 fail, 534 expect() calls, 17 files; isolated database `ob_isolated_32739_mtaeo4blva` created, migrated, and dropped
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived, 1 file) -> exit 0

## Critical Self-Review

- Highest-risk behavior: the dry-run boundary in `curate_entries`. Previously each scan branch decided inline whether to archive; now the decision is hoisted to one `archive` callback built once per table. The risk is that hoisting widens it — that a mode which never archived now can. Checked: `scanVague` passes no `onArchive`, and `collectScan` archives only when `spec.onArchive && id !== undefined`, so vague stays report-only on both conditions independently.
- Assumptions that could be wrong: that `result.summary.duplicates_found` etc. counted rows scanned rather than findings pushed. In the original these are always equal (every row pushes exactly one finding), so `scanned` reproduces it; if a future scan ever filters rows the two would diverge, which is why `collectScan` returns them as separate numbers rather than one.
- Missing/weak tests: no test added. `collectScan` and the scan trio are private to this file and have no public behavior the existing suites do not already drive through the `curate_entries` handler, so a new test would assert on an internal seam rather than a contract. The dry-run guarantee is worth a dedicated regression test, but writing one is a behavior-coverage change outside this lint-only lane and would need a fixture the current suite does not have.
- Security/permission risk: the auth-derived namespace predicates are unchanged in derivation and placement. `namespacePredicate(identity, "read", 3)` for duplicates and stale, `"read", 2` for vague, `"write", 2` inside `archiveRow`, and the same `qualifyNamespacePredicate` call for the self-join — each still built inside the scan that uses it, with the same start-parameter index, so no placeholder numbering shifted. The admin-tier check on `dry_run: false` is untouched and still precedes every query.
- Migration/deploy risk: none. No schema, no migration, no config, no startup path.
- Downstream client/runtime risk: not applicable. No MCP tool name, description, input schema, annotation, result shape, or error string changed, so nothing a client can observe moved. `contracts/parity-paths.txt` lists `python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, `src/contract-schemas.ts`; this branch touches none of them.
- Rollback/cleanup concern: single-file, single-commit, no state — revert the commit.
- Fixes made before PR: none needed; oxlint was clean on the first refactor pass and tsc and the suite were green before the commit and again after prettier reformatted it.
- Known residual risk: the no-behavior-change claim rests on reading the diff plus a green `server/tools` suite, not on a test that specifically pins `dry_run: false` archiving the right rows. If the existing suite does not exercise the mutating branch, a defect there would not have been caught by this run.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: a mechanical lint refactor with no behavior change surfaced no new review pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, schema, or client-facing surface changed; the tools register and behave identically.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: `contracts/parity-paths.txt` names `python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, and `src/contract-schemas.ts`. This branch touches only `server/tools/curation.ts`, which is not a parity path, and no contract fixture describes it.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Downstream rollout is not applicable. `docs/downstream-rollout.md` scopes rollout to MCP tool, schema, protocol, and client-facing changes. This PR moves code within one server file and changes no tool name, input schema, annotation, result shape, or error string, so no downstream client can observe it.
