### PR TITLE
refactor(entities): bring server/tools/entities.ts to the lint standard (#780)

### DIFF
--- a/server/tools/entities.ts
+++ b/server/tools/entities.ts
@@ -9,7 +9,7 @@
  * that predicate is exactly the isolation bug class the repo rules call out.
  */
 import { z } from "zod";
-import { toSql } from "pgvector/pg";
+import type { PoolClient } from "pg";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canDelete, canRead, canWrite } from "../auth/permissions.ts";
 import {
@@ -17,76 +17,44 @@ import {
   namespacePredicate,
 } from "../auth/namespace-policy.ts";
 import type { AuthIdentity } from "../auth/types.ts";
-import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
+import {
+  registerLinkEntities,
+  registerUnlinkEntities,
+} from "./entity-links.ts";
+import { registerHydrateEntities } from "./entity-hydrate.ts";
+import {
+  applyNamespaceScope,
+  embedQuietly,
+  ENTITY_COLUMNS,
+  graphUuid,
+  metadataSchema,
+  resolveWriteNamespace,
+  SqlFilters,
+  writeNamespaceSchema,
+} from "./entity-shared.ts";
 
-/**
- * Graph node UUID.
- *
- * Deliberately more permissive than `z.string().uuid()`: existing graph rows
- * carry ids that do not all set the RFC 4122 version/variant nibbles, and a
- * strict check would make those rows unfetchable. Format is still enforced.
- */
-const RELAXED_UUID = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-export const graphUuid = z.string().regex(RELAXED_UUID, "Invalid UUID");
-
-const ENTITY_COLUMNS = `id, entity_type, name, canonical_id, namespace, metadata,
-  created_by, created_at, updated_at`;
-
-/**
- * Graph link relations from `009_knowledge_graph.sql`.
- *
- * A Zod enum rather than a free string: `relation` participates in the link
- * uniqueness key, so an unlisted value is a write that the database rejects
- * rather than one the boundary catches.
- */
-const LINK_RELATIONS = [
-  "artifact",
-  "depends_on",
-  "supersedes",
-  "caused_by",
-  "same_lane",
-  "adjacent",
-  "mentions",
-  "implemented_by",
-  "blocked_by",
-  "decided_by",
-  "relates_to",
-  "contradicts",
-  "duplicates",
-  "supplements",
-] as const;
-
-/** Caller-supplied JSON metadata, shaped exactly as current-src shapes it. */
-const metadataSchema = z
-  .record(z.string().max(100), z.unknown())
-  .optional()
-  .refine(
-    (value) =>
-      !value ||
-      (Object.keys(value).length <= 50 && JSON.stringify(value).length <= 100_000),
-    { message: "metadata: max 50 keys, max 100KB total" },
-  )
-  .describe("Arbitrary JSON metadata; max 50 keys, max 100KB total");
-
-/**
- * Resolve the namespace a graph mutation will write to.
- *
- * The default is the caller's own lane, and a requested namespace is checked
- * against the auth-derived policy rather than trusted -- a caller-supplied
- * namespace is an input, never an authorization.
- */
-function resolveWriteNamespace(
-  identity: AuthIdentity,
-  requested: string | undefined,
-): { namespace: string } | { denied: string } {
-  const namespace = requested ?? identity.clientId;
-  if (!canTargetNamespace(identity, "write", namespace)) {
-    return { denied: "namespace write denied" };
-  }
-  return { namespace };
-}
+export { graphUuid };
 
 export function registerEntityTools(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
+  registerGetEntity(server, dependencies);
+  registerUpsertEntity(server, dependencies);
+  registerListEntities(server, dependencies);
+  registerLinkEntities(server, dependencies);
+  registerUnlinkEntities(server, dependencies);
+  registerHydrateEntities(server, dependencies);
+  registerArchiveEntity(server, dependencies);
+}
+
+function registerGetEntity(
   server: McpServer,
   dependencies: MemoryToolDependencies,
 ): void {
@@ -121,7 +89,12 @@ export function registerEntityTools(
       return textResult(rows[0]);
     },
   );
+}
 
+function registerUpsertEntity(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
   server.registerTool(
     "upsert_entity",
     {
@@ -133,13 +106,11 @@ export function registerEntityTools(
           .string()
           .min(1)
           .max(200)
-          .describe('Entity type, e.g. "host", "workflow", "service", "agent", "project"'),
+          .describe(
+            'Entity type, e.g. "host", "workflow", "service", "agent", "project"',
+          ),
         name: z.string().min(1).max(500).describe("Entity name"),
-        namespace: z
-          .string()
-          .max(500)
-          .optional()
-          .describe("Namespace for isolation (defaults to agent's clientId)"),
+        namespace: writeNamespaceSchema,
         canonical_id: z
           .string()
           .max(500)
@@ -212,25 +183,60 @@ export function registerEntityTools(
       });
     },
   );
+}
 
+/** `list_entities` arguments, named so the handler reads as one screen of logic. */
+const LIST_ENTITIES_SCHEMA = {
+  entity_type: z
+    .string()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe("Optional entity type filter"),
+  name: z
+    .string()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Optional case-insensitive name substring"),
+  canonical_id: z
+    .string()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Optional canonical ID filter"),
+  namespace: z
+    .string()
+    .trim()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Optional namespace filter"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(250)
+    .optional()
+    .describe("Maximum entities to return (default 50)"),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Number of entities to skip (default 0)"),
+};
+
+function registerListEntities(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
   server.registerTool(
     "list_entities",
     {
       description:
         "List knowledge graph entities from ob_entities, optionally filtered by entity type, name substring, namespace, or canonical ID.",
-      inputSchema: {
-        entity_type: z.string().min(1).max(200).optional().describe("Optional entity type filter"),
-        name: z
-          .string()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe("Optional case-insensitive name substring"),
-        canonical_id: z.string().min(1).max(500).optional().describe("Optional canonical ID filter"),
-        namespace: z.string().trim().min(1).max(500).optional().describe("Optional namespace filter"),
-        limit: z.number().int().min(1).max(250).optional().describe("Maximum entities to return (default 50)"),
-        offset: z.number().int().min(0).optional().describe("Number of entities to skip (default 0)"),
-      },
+      inputSchema: LIST_ENTITIES_SCHEMA,
       annotations: {
         title: "List Entities",
         readOnlyHint: true,
@@ -245,43 +251,43 @@ export function registerEntityTools(
       }
       // A named namespace is checked BEFORE it narrows anything, so asking for
       // a foreign lane is refused rather than silently returning nothing.
-      if (args.namespace && !canTargetNamespace(identity, "read", args.namespace)) {
+      if (
+        args.namespace &&
+        !canTargetNamespace(identity, "read", args.namespace)
+      ) {
         return errorResult("Permission denied: namespace read access denied");
       }
 
-      const values: unknown[] = [];
-      const filters = ["archived_at IS NULL"];
-      if (args.namespace) {
-        values.push(args.namespace);
-        filters.push(`namespace = $${values.length}`);
-      } else {
-        const predicate = namespacePredicate(identity, "read", values.length + 1);
-        if (predicate.values.length > 0) {
-          values.push(...predicate.values);
-          filters.push(`namespace = ANY($${values.length}::text[])`);
-        }
-      }
+      const filters = new SqlFilters("archived_at IS NULL");
+      applyNamespaceScope(filters, identity, "read", args.namespace);
       if (args.entity_type) {
-        values.push(args.entity_type);
-        filters.push(`entity_type = $${values.length}`);
+        filters.add(
+          (placeholder) => `entity_type = ${placeholder}`,
+          args.entity_type,
+        );
       }
       if (args.name) {
-        values.push(`%${args.name}%`);
-        filters.push(`name ILIKE $${values.length}`);
+        filters.add(
+          (placeholder) => `name ILIKE ${placeholder}`,
+          `%${args.name}%`,
+        );
       }
       if (args.canonical_id) {
-        values.push(args.canonical_id);
-        filters.push(`canonical_id = $${values.length}`);
+        filters.add(
+          (placeholder) => `canonical_id = ${placeholder}`,
+          args.canonical_id,
+        );
       }
-      values.push(args.limit ?? 50, args.offset ?? 0);
+      const limitPlaceholder = filters.push(args.limit ?? 50);
+      const offsetPlaceholder = filters.push(args.offset ?? 0);
 
       const { rows } = await dependencies.pool.query(
         `SELECT ${ENTITY_COLUMNS}
            FROM ob_entities
-          WHERE ${filters.join(" AND ")}
+          WHERE ${filters.where()}
           ORDER BY updated_at DESC, created_at DESC
-          LIMIT $${values.length - 1} OFFSET $${values.length}`,
-        values,
+          LIMIT ${limitPlaceholder} OFFSET ${offsetPlaceholder}`,
+        filters.values,
       );
       dependencies.logger.info(
         { tool: "list_entities", returned: rows.length },
@@ -290,285 +296,62 @@ export function registerEntityTools(
       return textResult(rows);
     },
   );
+}
 
-  server.registerTool(
-    "link_entities",
-    {
-      description:
-        "Create a link between two entities or entries in the knowledge graph. " +
-        "Idempotent by namespace + from_type + from_id + to_type + to_id + relation.",
-      inputSchema: {
-        from_type: z
-          .string()
-          .min(1)
-          .max(200)
-          .describe('Source node type, e.g. "thought", "decision", "entity", "session"'),
-        from_id: graphUuid.describe("Source node UUID"),
-        to_type: z.string().min(1).max(200).describe("Target node type"),
-        to_id: graphUuid.describe("Target node UUID"),
-        relation: z.enum(LINK_RELATIONS).describe("Relationship type between the two nodes"),
-        namespace: z
-          .string()
-          .max(500)
-          .optional()
-          .describe("Namespace for isolation (defaults to agent's clientId)"),
-        weight: z.number().min(0).max(100).optional().describe("Relationship weight (default 1.0)"),
-        metadata: metadataSchema,
-      },
-      annotations: {
-        title: "Link Entities",
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
-    },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      if (!identity || !canWrite(identity.role, "sessions")) {
-        return errorResult("Permission denied: cannot write links");
-      }
-      // Refused at the boundary as well as by the table's own check, so the
-      // caller gets an explanation instead of a database error string.
-      if (args.from_type === args.to_type && args.from_id === args.to_id) {
-        return errorResult("Invalid link: cannot link a node to itself");
-      }
-      const target = resolveWriteNamespace(identity, args.namespace);
-      if ("denied" in target) {
-        return errorResult(`Permission denied: ${target.denied}`);
-      }
-
-      const { rows } = await dependencies.pool.query(
-        `INSERT INTO ob_links
-           (from_type, from_id, to_type, to_id, relation, weight, namespace, metadata, created_by)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)
-         ON CONFLICT (namespace, from_type, from_id, to_type, to_id, relation)
-         WHERE archived_at IS NULL
-         DO UPDATE SET
-           weight = EXCLUDED.weight,
-           metadata = ob_links.metadata || EXCLUDED.metadata,
-           archived_at = NULL,
-           updated_at = NOW()
-         RETURNING id, (xmax = 0) AS is_new, relation, weight, created_at`,
-        [
-          args.from_type,
-          args.from_id,
-          args.to_type,
-          args.to_id,
-          args.relation,
-          args.weight ?? 1.0,
-          target.namespace,
-          JSON.stringify(args.metadata ?? {}),
-          identity.clientId,
-        ],
-      );
-
-      const row = rows[0];
-      dependencies.logger.info(
-        { tool: "link_entities", id: row.id, isNew: row.is_new },
-        "tool_result",
-      );
-      return textResult({
-        id: row.id,
-        from_type: args.from_type,
-        from_id: args.from_id,
-        to_type: args.to_type,
-        to_id: args.to_id,
-        relation: row.relation,
-        weight: row.weight,
-        is_new: row.is_new,
-        created_at: row.created_at,
-      });
-    },
+/**
+ * Archive one entity and every active link that references it, in a caller-
+ * supplied transaction.
+ *
+ * @returns The tool result payload, or `null` when nothing matched.
+ */
+async function archiveEntityInTransaction(
+  client: PoolClient,
+  identity: AuthIdentity,
+  id: string,
+): Promise<{
+  id: string;
+  namespace: string;
+  archived: true;
+  links_archived: number;
+} | null> {
+  // The mutation predicate is applied to the UPDATE itself, not checked
+  // beforehand: an ID-based write that authorizes in a separate statement
+  // is the isolation bug class this repo's rules name explicitly.
+  const entityPredicate = namespacePredicate(identity, "delete", 2);
+  const { rows } = await client.query(
+    `UPDATE ob_entities
+        SET archived_at = NOW(), updated_at = NOW()
+      WHERE id = $1 AND archived_at IS NULL${entityPredicate.clause}
+      RETURNING id, namespace`,
+    [id, ...entityPredicate.values],
   );
 
-  server.registerTool(
-    "unlink_entities",
-    {
-      description:
-        "Soft-delete one active graph link, keyed the same way link_entities is idempotent: namespace + from_type + from_id + to_type + to_id + relation.",
-      inputSchema: {
-        from_type: z.string().min(1).max(200).describe("Source node type"),
-        from_id: graphUuid.describe("Source node UUID"),
-        to_type: z.string().min(1).max(200).describe("Target node type"),
-        to_id: graphUuid.describe("Target node UUID"),
-        relation: z.enum(LINK_RELATIONS).describe("Relationship type to remove"),
-        namespace: z
-          .string()
-          .max(500)
-          .optional()
-          .describe("Namespace for isolation (defaults to agent's clientId)"),
-      },
-      annotations: {
-        title: "Unlink Entities",
-        readOnlyHint: false,
-        destructiveHint: true,
-        idempotentHint: true,
-      },
-    },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      if (!identity || !canDelete(identity.role, "sessions")) {
-        return errorResult("Permission denied: cannot unlink entities");
-      }
-      const target = resolveWriteNamespace(identity, args.namespace);
-      if ("denied" in target) {
-        return errorResult(`Permission denied: ${target.denied}`);
-      }
+  if (rows.length === 0) return null;
 
-      // Soft delete: the row is retained with an `archived_at` stamp so the
-      // graph's history stays reconstructible.
-      const { rows } = await dependencies.pool.query(
-        `UPDATE ob_links
-            SET archived_at = NOW(), updated_at = NOW()
-          WHERE namespace = $1
-            AND from_type = $2
-            AND from_id = $3
-            AND to_type = $4
-            AND to_id = $5
-            AND relation = $6
-            AND archived_at IS NULL
-        RETURNING id`,
-        [
-          target.namespace,
-          args.from_type,
-          args.from_id,
-          args.to_type,
-          args.to_id,
-          args.relation,
-        ],
-      );
-
-      if (rows.length === 0) {
-        dependencies.logger.info({ tool: "unlink_entities", noop: true }, "tool_result");
-        // Not an error: unlinking something already unlinked is the requested
-        // end state, so a retry is safe.
-        return textResult("Already unlinked or not found");
-      }
-      dependencies.logger.info(
-        { tool: "unlink_entities", id: rows[0].id },
-        "tool_result",
-      );
-      return textResult({ id: rows[0].id, namespace: target.namespace, unlinked: true });
-    },
+  // The link sweep matches on the namespace the entity was actually found
+  // in, taken from the RETURNING row rather than re-derived from the
+  // caller, so the cascade cannot reach a neighbouring namespace.
+  const { rowCount } = await client.query(
+    `UPDATE ob_links
+        SET archived_at = NOW(), updated_at = NOW()
+      WHERE archived_at IS NULL
+        AND ((from_type = 'entity' AND from_id = $1) OR (to_type = 'entity' AND to_id = $1))
+        AND namespace = $2`,
+    [id, rows[0].namespace],
   );
 
-  server.registerTool(
-    "hydrate_entities",
-    {
-      description:
-        "Immediately refresh graph entity hydration by generating/updating embeddings for active ob_entities rows. " +
-        "Use after bulk imports or schema changes when entity search should be available right away.",
-      inputSchema: {
-        id: graphUuid.optional().describe("Optional entity UUID to hydrate"),
-        entity_type: z.string().min(1).max(200).optional().describe("Optional entity type filter"),
-        namespace: z
-          .string()
-          .max(500)
-          .optional()
-          .describe(
-            "Namespace to hydrate (defaults to caller writable namespace; admin/ob-admin may omit for all)",
-          ),
-        only_missing_embedding: z
-          .boolean()
-          .optional()
-          .describe("Only hydrate entities missing embeddings (default true)"),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe("Maximum entities to hydrate in one call (default 100, max 500)"),
-      },
-      annotations: {
-        title: "Hydrate Entities",
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
-    },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      if (!identity || !canWrite(identity.role, "sessions")) {
-        return errorResult("Permission denied: cannot hydrate entities");
-      }
-      if (args.namespace && !canTargetNamespace(identity, "write", args.namespace)) {
-        return errorResult("Permission denied: namespace write denied");
-      }
+  return {
+    id: rows[0].id,
+    namespace: rows[0].namespace,
+    archived: true,
+    links_archived: rowCount ?? 0,
+  };
+}
 
-      const values: unknown[] = [];
-      const filters = ["archived_at IS NULL"];
-      if (args.id) {
-        values.push(args.id);
-        filters.push(`id = $${values.length}`);
-      }
-      if (args.entity_type) {
-        values.push(args.entity_type);
-        filters.push(`entity_type = $${values.length}`);
-      }
-      const writePredicate = namespacePredicate(identity, "write", 1);
-      if (args.namespace) {
-        values.push(args.namespace);
-        filters.push(`namespace = $${values.length}`);
-      } else if (writePredicate.values.length > 0) {
-        values.push(...writePredicate.values);
-        filters.push(`namespace = ANY($${values.length}::text[])`);
-      }
-      if (args.only_missing_embedding ?? true) {
-        filters.push("embedding IS NULL");
-      }
-      values.push(args.limit ?? 100);
-
-      const { rows } = await dependencies.pool.query<{
-        id: string;
-        entity_type: string;
-        name: string;
-      }>(
-        `SELECT id, entity_type, name, namespace
-           FROM ob_entities
-          WHERE ${filters.join(" AND ")}
-          ORDER BY updated_at DESC, created_at DESC
-          LIMIT $${values.length}`,
-        values,
-      );
-
-      let hydrated = 0;
-      const failed: Array<{ id: string; error: string }> = [];
-      for (const row of rows) {
-        const embedding = await embedQuietly(
-          dependencies,
-          `${row.entity_type}: ${row.name}`,
-        );
-        if (!embedding) {
-          failed.push({ id: row.id, error: "embedding provider returned null" });
-          continue;
-        }
-        // The UPDATE re-applies the write predicate rather than trusting the
-        // SELECT: the two run in separate statements, so the row's namespace
-        // is re-proven at the moment of mutation.
-        const updateValues: unknown[] = [row.id, embedding];
-        let scoped = "";
-        if (writePredicate.values.length > 0) {
-          updateValues.push(...writePredicate.values);
-          scoped = ` AND namespace = ANY($${updateValues.length}::text[])`;
-        }
-        const { rowCount } = await dependencies.pool.query(
-          `UPDATE ob_entities
-              SET embedding = $2, updated_at = NOW()
-            WHERE id = $1 AND archived_at IS NULL${scoped}`,
-          updateValues,
-        );
-        hydrated += rowCount ?? 0;
-      }
-
-      dependencies.logger.info(
-        { tool: "hydrate_entities", matched: rows.length, hydrated, failed: failed.length },
-        "tool_result",
-      );
-      return textResult({ matched: rows.length, hydrated, failed });
-    },
-  );
-
+function registerArchiveEntity(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
   server.registerTool(
     "archive_entity",
     {
@@ -596,48 +379,24 @@ export function registerEntityTools(
       const client = await dependencies.pool.connect();
       try {
         await client.query("BEGIN");
-
-        // The mutation predicate is applied to the UPDATE itself, not checked
-        // beforehand: an ID-based write that authorizes in a separate statement
-        // is the isolation bug class this repo's rules name explicitly.
-        const entityPredicate = namespacePredicate(identity, "delete", 2);
-        const { rows } = await client.query(
-          `UPDATE ob_entities
-              SET archived_at = NOW(), updated_at = NOW()
-            WHERE id = $1 AND archived_at IS NULL${entityPredicate.clause}
-            RETURNING id, namespace`,
-          [args.id, ...entityPredicate.values],
+        const result = await archiveEntityInTransaction(
+          client,
+          identity,
+          args.id,
         );
+        await client.query("COMMIT");
 
-        if (rows.length === 0) {
+        if (!result) {
           // Already-archived and unreadable-namespace collapse to ONE non-error
           // string. Distinguishing them would let a caller probe which entity
           // ids exist in namespaces it has no authority over.
-          await client.query("COMMIT");
           return textResult("Already archived or not found");
         }
 
-        // The link sweep matches on the namespace the entity was actually found
-        // in, taken from the RETURNING row rather than re-derived from the
-        // caller, so the cascade cannot reach a neighbouring namespace.
-        const { rowCount } = await client.query(
-          `UPDATE ob_links
-              SET archived_at = NOW(), updated_at = NOW()
-            WHERE archived_at IS NULL
-              AND ((from_type = 'entity' AND from_id = $1) OR (to_type = 'entity' AND to_id = $1))
-              AND namespace = $2`,
-          [args.id, rows[0].namespace],
+        dependencies.logger.info(
+          { tool: "archive_entity", ...result },
+          "tool_result",
         );
-
-        await client.query("COMMIT");
-
-        const result = {
-          id: rows[0].id,
-          namespace: rows[0].namespace,
-          archived: true,
-          links_archived: rowCount ?? 0,
-        };
-        dependencies.logger.info({ tool: "archive_entity", ...result }, "tool_result");
         return textResult(result);
       } catch (error) {
         await client.query("ROLLBACK");
@@ -652,25 +411,4 @@ export function registerEntityTools(
       }
     },
   );
-}
-
-/**
- * Embed text, treating provider failure as absence rather than an error.
- *
- * @returns The pgvector literal, or `null` when the provider gave nothing.
- */
-async function embedQuietly(
-  dependencies: MemoryToolDependencies,
-  text: string,
-): Promise<string | null> {
-  try {
-    const embedding = await dependencies.embedFn(text);
-    return embedding ? toSql(embedding) : null;
-  } catch (error) {
-    dependencies.logger.warn(
-      { error: error instanceof Error ? error.message : String(error) },
-      "entity_embed_failed",
-    );
-    return null;
-  }
 }

--- a/server/tools/entity-hydrate.ts
+++ b/server/tools/entity-hydrate.ts
@@ -1,0 +1,203 @@
+/**
+ * The `hydrate_entities` tool over `ob_entities`.
+ *
+ * Hydration re-embeds rows whose vector is missing or stale. The vector is
+ * derived data, so a provider failure is reported per row rather than failing
+ * the call: the entity row itself is already durable.
+ *
+ * The write predicate is applied to the UPDATE statement, not checked once
+ * before the loop -- selection and mutation are separate statements, so each
+ * row's namespace is re-proven at the moment it is written.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canWrite } from "../auth/permissions.ts";
+import {
+  canTargetNamespace,
+  namespacePredicate,
+} from "../auth/namespace-policy.ts";
+import type { AuthIdentity } from "../auth/types.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
+import {
+  applyNamespaceScope,
+  embedQuietly,
+  graphUuid,
+  SqlFilters,
+} from "./entity-shared.ts";
+
+interface HydrateSelection {
+  id: string;
+  entity_type: string;
+  name: string;
+}
+
+/** Select the entity rows one `hydrate_entities` call will re-embed. */
+async function selectHydrationTargets(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  args: {
+    id?: string;
+    entity_type?: string;
+    namespace?: string;
+    only_missing_embedding?: boolean;
+    limit?: number;
+  },
+): Promise<HydrateSelection[]> {
+  const filters = new SqlFilters("archived_at IS NULL");
+  if (args.id) {
+    filters.add((placeholder) => `id = ${placeholder}`, args.id);
+  }
+  if (args.entity_type) {
+    filters.add(
+      (placeholder) => `entity_type = ${placeholder}`,
+      args.entity_type,
+    );
+  }
+  applyNamespaceScope(filters, identity, "write", args.namespace);
+  if (args.only_missing_embedding ?? true) {
+    filters.addBare("embedding IS NULL");
+  }
+  const limitPlaceholder = filters.push(args.limit ?? 100);
+
+  const { rows } = await dependencies.pool.query<HydrateSelection>(
+    `SELECT id, entity_type, name, namespace
+       FROM ob_entities
+      WHERE ${filters.where()}
+      ORDER BY updated_at DESC, created_at DESC
+      LIMIT ${limitPlaceholder}`,
+    filters.values,
+  );
+  return rows;
+}
+
+/**
+ * Write one refreshed embedding back, re-proving the row's namespace.
+ *
+ * The UPDATE re-applies the write predicate rather than trusting the SELECT:
+ * the two run in separate statements, so the row's namespace is re-proven at
+ * the moment of mutation.
+ *
+ * @returns How many rows the UPDATE actually touched.
+ */
+async function writeHydratedEmbedding(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  id: string,
+  embedding: string,
+): Promise<number> {
+  const updateValues: unknown[] = [id, embedding];
+  const writePredicate = namespacePredicate(identity, "write", 1);
+  let scoped = "";
+  if (writePredicate.values.length > 0) {
+    updateValues.push(...writePredicate.values);
+    scoped = ` AND namespace = ANY($${updateValues.length}::text[])`;
+  }
+  const { rowCount } = await dependencies.pool.query(
+    `UPDATE ob_entities
+        SET embedding = $2, updated_at = NOW()
+      WHERE id = $1 AND archived_at IS NULL${scoped}`,
+    updateValues,
+  );
+  return rowCount ?? 0;
+}
+
+export function registerHydrateEntities(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
+  server.registerTool(
+    "hydrate_entities",
+    {
+      description:
+        "Immediately refresh graph entity hydration by generating/updating embeddings for active ob_entities rows. " +
+        "Use after bulk imports or schema changes when entity search should be available right away.",
+      inputSchema: {
+        id: graphUuid.optional().describe("Optional entity UUID to hydrate"),
+        entity_type: z
+          .string()
+          .min(1)
+          .max(200)
+          .optional()
+          .describe("Optional entity type filter"),
+        namespace: z
+          .string()
+          .max(500)
+          .optional()
+          .describe(
+            "Namespace to hydrate (defaults to caller writable namespace; admin/ob-admin may omit for all)",
+          ),
+        only_missing_embedding: z
+          .boolean()
+          .optional()
+          .describe("Only hydrate entities missing embeddings (default true)"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(500)
+          .optional()
+          .describe(
+            "Maximum entities to hydrate in one call (default 100, max 500)",
+          ),
+      },
+      annotations: {
+        title: "Hydrate Entities",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const identity = authIdentity(extra.authInfo);
+      if (!identity || !canWrite(identity.role, "sessions")) {
+        return errorResult("Permission denied: cannot hydrate entities");
+      }
+      if (
+        args.namespace &&
+        !canTargetNamespace(identity, "write", args.namespace)
+      ) {
+        return errorResult("Permission denied: namespace write denied");
+      }
+
+      const rows = await selectHydrationTargets(dependencies, identity, args);
+
+      let hydrated = 0;
+      const failed: Array<{ id: string; error: string }> = [];
+      for (const row of rows) {
+        const embedding = await embedQuietly(
+          dependencies,
+          `${row.entity_type}: ${row.name}`,
+        );
+        if (!embedding) {
+          failed.push({
+            id: row.id,
+            error: "embedding provider returned null",
+          });
+          continue;
+        }
+        hydrated += await writeHydratedEmbedding(
+          dependencies,
+          identity,
+          row.id,
+          embedding,
+        );
+      }
+
+      dependencies.logger.info(
+        {
+          tool: "hydrate_entities",
+          matched: rows.length,
+          hydrated,
+          failed: failed.length,
+        },
+        "tool_result",
+      );
+      return textResult({ matched: rows.length, hydrated, failed });
+    },
+  );
+}

--- a/server/tools/entity-links.ts
+++ b/server/tools/entity-links.ts
@@ -1,0 +1,206 @@
+/**
+ * Graph link tools over `ob_links`.
+ *
+ * Links are gated on the `sessions` resource permission, matching the entity
+ * tools they connect: an edge is session-adjacent metadata rather than its own
+ * permission surface. Every mutation resolves its namespace through the
+ * auth-derived policy, so a caller-supplied namespace narrows a write it was
+ * already authorized for and never widens one.
+ */
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { canDelete, canWrite } from "../auth/permissions.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
+import {
+  graphUuid,
+  LINK_RELATIONS,
+  metadataSchema,
+  resolveWriteNamespace,
+  writeNamespaceSchema,
+} from "./entity-shared.ts";
+
+export function registerLinkEntities(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
+  server.registerTool(
+    "link_entities",
+    {
+      description:
+        "Create a link between two entities or entries in the knowledge graph. " +
+        "Idempotent by namespace + from_type + from_id + to_type + to_id + relation.",
+      inputSchema: {
+        from_type: z
+          .string()
+          .min(1)
+          .max(200)
+          .describe(
+            'Source node type, e.g. "thought", "decision", "entity", "session"',
+          ),
+        from_id: graphUuid.describe("Source node UUID"),
+        to_type: z.string().min(1).max(200).describe("Target node type"),
+        to_id: graphUuid.describe("Target node UUID"),
+        relation: z
+          .enum(LINK_RELATIONS)
+          .describe("Relationship type between the two nodes"),
+        namespace: writeNamespaceSchema,
+        weight: z
+          .number()
+          .min(0)
+          .max(100)
+          .optional()
+          .describe("Relationship weight (default 1.0)"),
+        metadata: metadataSchema,
+      },
+      annotations: {
+        title: "Link Entities",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const identity = authIdentity(extra.authInfo);
+      if (!identity || !canWrite(identity.role, "sessions")) {
+        return errorResult("Permission denied: cannot write links");
+      }
+      // Refused at the boundary as well as by the table's own check, so the
+      // caller gets an explanation instead of a database error string.
+      if (args.from_type === args.to_type && args.from_id === args.to_id) {
+        return errorResult("Invalid link: cannot link a node to itself");
+      }
+      const target = resolveWriteNamespace(identity, args.namespace);
+      if ("denied" in target) {
+        return errorResult(`Permission denied: ${target.denied}`);
+      }
+
+      const { rows } = await dependencies.pool.query(
+        `INSERT INTO ob_links
+           (from_type, from_id, to_type, to_id, relation, weight, namespace, metadata, created_by)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9)
+         ON CONFLICT (namespace, from_type, from_id, to_type, to_id, relation)
+         WHERE archived_at IS NULL
+         DO UPDATE SET
+           weight = EXCLUDED.weight,
+           metadata = ob_links.metadata || EXCLUDED.metadata,
+           archived_at = NULL,
+           updated_at = NOW()
+         RETURNING id, (xmax = 0) AS is_new, relation, weight, created_at`,
+        [
+          args.from_type,
+          args.from_id,
+          args.to_type,
+          args.to_id,
+          args.relation,
+          args.weight ?? 1.0,
+          target.namespace,
+          JSON.stringify(args.metadata ?? {}),
+          identity.clientId,
+        ],
+      );
+
+      const row = rows[0];
+      dependencies.logger.info(
+        { tool: "link_entities", id: row.id, isNew: row.is_new },
+        "tool_result",
+      );
+      return textResult({
+        id: row.id,
+        from_type: args.from_type,
+        from_id: args.from_id,
+        to_type: args.to_type,
+        to_id: args.to_id,
+        relation: row.relation,
+        weight: row.weight,
+        is_new: row.is_new,
+        created_at: row.created_at,
+      });
+    },
+  );
+}
+
+export function registerUnlinkEntities(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
+  server.registerTool(
+    "unlink_entities",
+    {
+      description:
+        "Soft-delete one active graph link, keyed the same way link_entities is idempotent: namespace + from_type + from_id + to_type + to_id + relation.",
+      inputSchema: {
+        from_type: z.string().min(1).max(200).describe("Source node type"),
+        from_id: graphUuid.describe("Source node UUID"),
+        to_type: z.string().min(1).max(200).describe("Target node type"),
+        to_id: graphUuid.describe("Target node UUID"),
+        relation: z
+          .enum(LINK_RELATIONS)
+          .describe("Relationship type to remove"),
+        namespace: writeNamespaceSchema,
+      },
+      annotations: {
+        title: "Unlink Entities",
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const identity = authIdentity(extra.authInfo);
+      if (!identity || !canDelete(identity.role, "sessions")) {
+        return errorResult("Permission denied: cannot unlink entities");
+      }
+      const target = resolveWriteNamespace(identity, args.namespace);
+      if ("denied" in target) {
+        return errorResult(`Permission denied: ${target.denied}`);
+      }
+
+      // Soft delete: the row is retained with an `archived_at` stamp so the
+      // graph's history stays reconstructible.
+      const { rows } = await dependencies.pool.query(
+        `UPDATE ob_links
+            SET archived_at = NOW(), updated_at = NOW()
+          WHERE namespace = $1
+            AND from_type = $2
+            AND from_id = $3
+            AND to_type = $4
+            AND to_id = $5
+            AND relation = $6
+            AND archived_at IS NULL
+        RETURNING id`,
+        [
+          target.namespace,
+          args.from_type,
+          args.from_id,
+          args.to_type,
+          args.to_id,
+          args.relation,
+        ],
+      );
+
+      if (rows.length === 0) {
+        dependencies.logger.info(
+          { tool: "unlink_entities", noop: true },
+          "tool_result",
+        );
+        // Not an error: unlinking something already unlinked is the requested
+        // end state, so a retry is safe.
+        return textResult("Already unlinked or not found");
+      }
+      dependencies.logger.info(
+        { tool: "unlink_entities", id: rows[0].id },
+        "tool_result",
+      );
+      return textResult({
+        id: rows[0].id,
+        namespace: target.namespace,
+        unlinked: true,
+      });
+    },
+  );
+}

--- a/server/tools/entity-shared.ts
+++ b/server/tools/entity-shared.ts
@@ -1,0 +1,193 @@
+/**
+ * Shared graph vocabulary and namespace resolution for the `ob_entities` and
+ * `ob_links` tools.
+ *
+ * These sit in one module rather than being restated per tool file so the
+ * schemas that define a write's uniqueness key -- the relation enum, the id
+ * format, the metadata shape -- cannot drift between the entity tools and the
+ * link tools that key off them.
+ */
+import { z } from "zod";
+import { toSql } from "pgvector/pg";
+import {
+  canTargetNamespace,
+  namespacePredicate,
+} from "../auth/namespace-policy.ts";
+import type { AuthIdentity } from "../auth/types.ts";
+import type { MemoryToolDependencies } from "./types.ts";
+
+/**
+ * Graph node UUID.
+ *
+ * Deliberately more permissive than `z.string().uuid()`: existing graph rows
+ * carry ids that do not all set the RFC 4122 version/variant nibbles, and a
+ * strict check would make those rows unfetchable. Format is still enforced.
+ */
+const RELAXED_UUID =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+export const graphUuid = z.string().regex(RELAXED_UUID, "Invalid UUID");
+
+export const ENTITY_COLUMNS = `id, entity_type, name, canonical_id, namespace, metadata,
+  created_by, created_at, updated_at`;
+
+/**
+ * Graph link relations from `009_knowledge_graph.sql`.
+ *
+ * A Zod enum rather than a free string: `relation` participates in the link
+ * uniqueness key, so an unlisted value is a write that the database rejects
+ * rather than one the boundary catches.
+ */
+export const LINK_RELATIONS = [
+  "artifact",
+  "depends_on",
+  "supersedes",
+  "caused_by",
+  "same_lane",
+  "adjacent",
+  "mentions",
+  "implemented_by",
+  "blocked_by",
+  "decided_by",
+  "relates_to",
+  "contradicts",
+  "duplicates",
+  "supplements",
+] as const;
+
+/** Caller-supplied JSON metadata, shaped exactly as current-src shapes it. */
+export const metadataSchema = z
+  .record(z.string().max(100), z.unknown())
+  .optional()
+  .refine(
+    (value) =>
+      !value ||
+      (Object.keys(value).length <= 50 &&
+        JSON.stringify(value).length <= 100_000),
+    { message: "metadata: max 50 keys, max 100KB total" },
+  )
+  .describe("Arbitrary JSON metadata; max 50 keys, max 100KB total");
+
+/** Namespace argument shared by every graph mutation. */
+export const writeNamespaceSchema = z
+  .string()
+  .max(500)
+  .optional()
+  .describe("Namespace for isolation (defaults to agent's clientId)");
+
+/**
+ * Resolve the namespace a graph mutation will write to.
+ *
+ * The default is the caller's own lane, and a requested namespace is checked
+ * against the auth-derived policy rather than trusted -- a caller-supplied
+ * namespace is an input, never an authorization.
+ */
+export function resolveWriteNamespace(
+  identity: AuthIdentity,
+  requested: string | undefined,
+): { namespace: string } | { denied: string } {
+  const namespace = requested ?? identity.clientId;
+  if (!canTargetNamespace(identity, "write", namespace)) {
+    return { denied: "namespace write denied" };
+  }
+  return { namespace };
+}
+
+/**
+ * Embed text, treating provider failure as absence rather than an error.
+ *
+ * @returns The pgvector literal, or `null` when the provider gave nothing.
+ */
+export async function embedQuietly(
+  dependencies: MemoryToolDependencies,
+  text: string,
+): Promise<string | null> {
+  try {
+    const embedding = await dependencies.embedFn(text);
+    return embedding ? toSql(embedding) : null;
+  } catch (error) {
+    dependencies.logger.warn(
+      { error: error instanceof Error ? error.message : String(error) },
+      "entity_embed_failed",
+    );
+    return null;
+  }
+}
+
+/**
+ * Accumulates `WHERE` fragments alongside their positional parameters.
+ *
+ * Written as one object because the two halves must stay in step: a fragment
+ * naming `$3` is only correct if the value it refers to is the third pushed,
+ * and hand-tracking that across a chain of optional filters is where the
+ * off-by-one lives.
+ */
+export class SqlFilters {
+  readonly values: unknown[] = [];
+  private readonly clauses: string[];
+
+  constructor(...initial: string[]) {
+    this.clauses = [...initial];
+  }
+
+  /** Append `<fragment built from the new placeholder>` with its value. */
+  add(build: (placeholder: string) => string, value: unknown): void {
+    this.values.push(value);
+    this.clauses.push(build(`$${this.values.length}`));
+  }
+
+  /** Append a fragment that needs no parameter of its own. */
+  addBare(clause: string): void {
+    this.clauses.push(clause);
+  }
+
+  /** Position the NEXT value would take, for a predicate builder that needs it. */
+  nextIndex(): number {
+    return this.values.length + 1;
+  }
+
+  /** Append several values at once and build one fragment from the last. */
+  addAll(
+    build: (placeholder: string) => string,
+    values: readonly unknown[],
+  ): void {
+    this.values.push(...values);
+    this.clauses.push(build(`$${this.values.length}`));
+  }
+
+  /** Push a trailing value with no clause, e.g. LIMIT/OFFSET. */
+  push(value: unknown): string {
+    this.values.push(value);
+    return `$${this.values.length}`;
+  }
+
+  where(): string {
+    return this.clauses.join(" AND ");
+  }
+}
+
+/**
+ * Narrow a query to the namespaces the caller may act in.
+ *
+ * A named namespace has already been authorized by the caller, so it narrows
+ * to exactly that one; otherwise the auth-derived predicate supplies the set.
+ * Shared because the list and hydrate paths must agree on this, and a
+ * divergence between them is a namespace leak rather than a style difference.
+ */
+export function applyNamespaceScope(
+  filters: SqlFilters,
+  identity: AuthIdentity,
+  action: "read" | "write",
+  requested: string | undefined,
+): void {
+  if (requested) {
+    filters.add((placeholder) => `namespace = ${placeholder}`, requested);
+    return;
+  }
+  const predicate = namespacePredicate(identity, action, filters.nextIndex());
+  if (predicate.values.length > 0) {
+    filters.addAll(
+      (placeholder) => `namespace = ANY(${placeholder}::text[])`,
+      predicate.values,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- `server/tools/entities.ts` carried all seven graph tools inline in one `registerEntityTools`, producing four oxlint findings: a 581-line file, a 516-line function, and the list/hydrate handlers at complexity 12 and 16.
- Split along the seam the `src/` twin already uses — one `registerX` per tool — and moved the link tools and the hydrate tool into siblings (`entity-links.ts`, `entity-hydrate.ts`).
- The vocabulary both sides share lives in one `entity-shared.ts` rather than a copy per file: the relation enum, the relaxed-UUID id schema, the metadata and write-namespace schemas, `resolveWriteNamespace`, `embedQuietly`, and `applyNamespaceScope`. These schemas define a write's uniqueness key, so drift between the entity and link sides would be a correctness bug, not a style difference.
- Complexity came down by naming what the handlers were doing by hand: `SqlFilters` keeps each `WHERE` fragment together with the positional parameter it refers to, `applyNamespaceScope` is the single place the list and hydrate paths agree on how a query is narrowed, and the archive transaction body and hydrate select/write steps are their own functions.
- No behavior change: schemas, defaults, error strings, SQL text, and log event names are byte-identical to the originals.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable — not applicable; no `python/openbrain-memory/` file is touched.
- [x] Live Open Brain smoke passed or is not applicable — not applicable; this is an internal file split with no wire-visible change.

RED (untouched file, `./node_modules/.bin/oxlint --deny-warnings server/tools/entities.ts`), 4 findings verbatim:

```
server/tools/entities.ts:676:2: error eslint(max-lines): File has too many lines (581). help: Maximum allowed is 500.
server/tools/entities.ts:89:8: error eslint(max-lines-per-function): The function `registerEntityTools` has too many lines (516). Maximum allowed is 100. help: Consider splitting it into smaller functions.
server/tools/entities.ts:241:5: error eslint(complexity): async function has a complexity of 12. Maximum allowed is 10.
server/tools/entities.ts:490:5: error eslint(complexity): async function has a complexity of 16. Maximum allowed is 10.
```

`DONE_MEANS_780_FILES=server/tools/entities.ts bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 1.

GREEN (committed, prettier-formatted tree):

- `bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 0, "PASS: every file this branch touched under server/ lints clean", 4 files linted.
- `./node_modules/.bin/oxlint --deny-warnings` on all four touched files -> exit 0.
- `bunx tsc --noEmit` -> exit 0.
- `bun run test:isolated server/tools` -> 163 pass, 0 fail, 17 files. Test files are unmodified.

## Critical Self-Review

- Highest-risk behavior: `hydrate_entities` and `list_entities` build their SQL positionally, so moving that construction into `SqlFilters` risks an off-by-one that silently binds a value to the wrong placeholder — which for the namespace fragment would be a cross-namespace read. `SqlFilters` is built specifically to make that unrepresentable: `add` pushes the value and derives the placeholder from the resulting length in one step, so a fragment cannot name an index its value does not occupy. The hydrate and archive paths are covered by `entities.pg.test.ts` and `entities-graph.pg.test.ts` against a real database, and both pass unmodified.
- Assumptions that could be wrong: that `registerEntityTools` and `graphUuid` were the only cross-file consumers of this module. Checked with `rg` across `server/` and `src/`; the importers are `server/tools/index.ts` and the two pg test files. `graphUuid` is re-exported from `entities.ts` so any consumer of the old path still resolves.
- Missing/weak tests: `SqlFilters` has no direct unit test. Its behavior is exercised end-to-end through the list and hydrate pg tests, which assert the returned rows and therefore the bindings; a standalone test would restate that. No new public behavior was introduced that the existing suites do not already drive, so per the repo's no-coverage-gate rule none was added.
- Security/permission risk: this is the one that matters here, and namespace predicates are a security boundary. They are unchanged and still auth-derived. Every ID-based read and mutation keeps its predicate on the statement itself rather than in a separate check: `get_entity` still applies `namespacePredicate(identity, "read", 2)` to its SELECT; `archive_entity` still applies `namespacePredicate(identity, "delete", 2)` to the UPDATE and still sweeps links using the namespace from the `RETURNING` row rather than one re-derived from the caller; the hydrate UPDATE still re-applies the write predicate rather than trusting its own SELECT, because the two are separate statements. `list_entities` still refuses a foreign named namespace before it narrows anything, so the answer stays "denied" rather than an empty result that leaks existence. `resolveWriteNamespace` still treats a caller-supplied namespace as an input checked against policy, never as an authorization. All SQL remains parameterized; `SqlFilters` interpolates only placeholders it generated itself, never caller data.
- Migration/deploy risk: none. No schema, migration, or config change.
- Downstream client/runtime risk: none. Tool names, input schemas, descriptions, annotations, result payloads, and error strings are unchanged, so the MCP surface is byte-identical. `contracts/parity-paths.txt` lists no entity path, so contract parity is runtime-specific here.
- Rollback/cleanup concern: revert of a single commit; the split is additive files plus one rewritten file, with no state to unwind.
- Fixes made before PR: the first commit passed lint pre-commit but the prettier hook then reflowed the long `.describe()` chains and pushed the file back over the length rule and `registerListEntities` back over the function rule. Caught by re-running the diff-derived done-means against the committed tree; resolved by hoisting the `list_entities` schema to a named constant and moving `hydrate_entities` into its own sibling. Every check reported here is from the post-format tree.
- Known residual risk: `applyNamespaceScope` is now shared between the list (read) and hydrate (write) paths, so a future change to it moves both. That is the intent — the two agreeing is the invariant — but it does mean the function is worth reviewing as a security-relevant seam rather than a formatting helper.
- SME review-memory update: [x] not applicable because: no review or post-merge issue exposed a missed pattern; this is a lint-standard refactor with no new finding class.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable — none surfaced; no behavior change.
- Live Open Brain checks: [x] not applicable because: no wire-visible, schema, or transport change; the MCP surface is identical.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: `contracts/parity-paths.txt` contains no entity path, and this change is an internal `server/` file split with no contract surface movement.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable

Notes/evidence:

- Downstream rollout is N/A because no MCP tool name, input schema, description, annotation, result payload, or error string changed. The rollout gate keys on client-facing contract movement; this commit moves only where the code lives inside `server/tools/`.
