### PR TITLE
refactor(recovery-wal): bring server/realtime/recovery-wal.ts to the lint standard (#780)

### DIFF
--- a/server/realtime/recovery-wal-journal.ts
+++ b/server/realtime/recovery-wal-journal.ts
@@ -1,0 +1,53 @@
+/**
+ * The journal file itself: reading rows, appending one, rewriting the whole
+ * thing.
+ *
+ * Isolated from the store because this is the only code that touches the disk.
+ * Keeping the three filesystem calls together makes the durability surface one
+ * short file to audit, rather than three calls scattered through a store whose
+ * other job is in-memory bookkeeping.
+ */
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import type { RecoveryWalRecord } from "./recovery-wal-types.ts";
+
+export function journalExists(walPath: string): boolean {
+  return existsSync(walPath);
+}
+
+/** Non-blank rows, in order. A torn tail simply yields one row that will not parse. */
+export function readJournalRows(walPath: string): string[] {
+  if (!existsSync(walPath)) return [];
+  return readFileSync(walPath, "utf8")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+export function appendJournalRecord(
+  walPath: string,
+  record: RecoveryWalRecord,
+): void {
+  mkdirSync(dirname(walPath), { recursive: true });
+  appendFileSync(walPath, `${JSON.stringify(record)}\n`, "utf8");
+}
+
+/** Rewrite the journal as exactly these records, replacing whatever was there. */
+export function rewriteJournal(
+  walPath: string,
+  records: RecoveryWalRecord[],
+): void {
+  mkdirSync(dirname(walPath), { recursive: true });
+  writeFileSync(
+    walPath,
+    records.map((record) => JSON.stringify(record)).join("\n") +
+      (records.length > 0 ? "\n" : ""),
+    "utf8",
+  );
+}

--- a/server/realtime/recovery-wal-records.ts
+++ b/server/realtime/recovery-wal-records.ts
@@ -1,0 +1,132 @@
+/**
+ * Structural validation for recovery WAL journal rows.
+ *
+ * This is the trust boundary for a file on disk: every field is checked before
+ * it becomes live state, so a hand-edited or torn WAL cannot inject an item
+ * with an unknown status or a broken scope.
+ *
+ * The checks live here, apart from the store, because they are pure predicates
+ * over untrusted JSON with no store state behind them, and because the same
+ * row shape is validated by more than one copy of the WAL reader. One
+ * definition is the point — a second private copy is how two readers start
+ * disagreeing about what a valid row is.
+ */
+import type { NormalizedWorkingSetScope } from "./working-set.ts";
+import {
+  RECOVERY_WAL_ACTIONS,
+  RECOVERY_WAL_LABEL,
+  RECOVERY_WAL_STATUSES,
+  type RecoveryWalItem,
+  type RecoveryWalRecord,
+} from "./recovery-wal-types.ts";
+
+const RECOVERY_WAL_STATUS_SET = new Set<string>(RECOVERY_WAL_STATUSES);
+const RECOVERY_WAL_ACTION_SET = new Set<string>(RECOVERY_WAL_ACTIONS);
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function isRecoveryWalStatus(value: unknown): boolean {
+  return typeof value === "string" && RECOVERY_WAL_STATUS_SET.has(value);
+}
+
+export function isRecoveryWalAction(value: unknown): boolean {
+  return typeof value === "string" && RECOVERY_WAL_ACTION_SET.has(value);
+}
+
+/** A parseable ISO timestamp. */
+function isTimestamp(value: unknown): boolean {
+  return typeof value === "string" && Number.isFinite(Date.parse(value));
+}
+
+/** A timestamp, or an explicit null. Several fields are nullable this way. */
+function isNullableTimestamp(value: unknown): boolean {
+  return value === null || isTimestamp(value);
+}
+
+/** A string with non-whitespace content. Every scope field must be one. */
+function isNonBlankString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isNullableString(value: unknown): boolean {
+  return value === null || typeof value === "string";
+}
+
+const SCOPE_REQUIRED_FIELDS = [
+  "namespace",
+  "agent",
+  "platform",
+  "server_id",
+  "channel_id",
+  "session_key",
+] as const;
+
+export function isNormalizedScope(
+  value: unknown,
+): value is NormalizedWorkingSetScope {
+  if (!isRecord(value)) return false;
+  if (!SCOPE_REQUIRED_FIELDS.every((field) => isNonBlankString(value[field]))) {
+    return false;
+  }
+  return value.thread_id === null || isNonBlankString(value.thread_id);
+}
+
+/**
+ * Each item field paired with the predicate that must accept it. A table keeps
+ * the check flat: adding a field is one row, and no reader has to trace a
+ * twenty-clause boolean to learn what a valid item is.
+ */
+const ITEM_FIELD_CHECKS: Array<[string, (value: unknown) => boolean]> = [
+  ["id", (value) => typeof value === "string"],
+  ["label", (value) => value === RECOVERY_WAL_LABEL],
+  ["status", isRecoveryWalStatus],
+  ["content", (value) => typeof value === "string"],
+  ["trace_id", isNullableString],
+  ["source_ref", isNullableString],
+  ["metadata", isRecord],
+  ["created_at", isTimestamp],
+  ["updated_at", isTimestamp],
+  ["expires_at", isTimestamp],
+  ["reviewed_at", isNullableTimestamp],
+  ["last_action", (value) => value === null || isRecoveryWalAction(value)],
+];
+
+export function isRecoveryWalItem(value: unknown): value is RecoveryWalItem {
+  if (!isRecord(value)) return false;
+  return ITEM_FIELD_CHECKS.every(([field, accepts]) => accepts(value[field]));
+}
+
+function isMarkRecord(record: Record<string, unknown>): boolean {
+  return (
+    typeof record.id === "string" &&
+    isRecoveryWalAction(record.action) &&
+    isRecoveryWalStatus(record.status) &&
+    isNullableTimestamp(record.reviewed_at) &&
+    isTimestamp(record.updated_at)
+  );
+}
+
+export function isRecoveryWalRecord(
+  record: unknown,
+): record is RecoveryWalRecord {
+  if (!isRecord(record)) return false;
+  if (!isNormalizedScope(record.scope)) return false;
+  if (record.op === "append") return isRecoveryWalItem(record.item);
+  if (record.op === "mark") return isMarkRecord(record);
+  if (record.op === "purge") {
+    return record.id === undefined || typeof record.id === "string";
+  }
+  return false;
+}
+
+export function parseWalRecord(row: string): RecoveryWalRecord | null {
+  try {
+    const record: unknown = JSON.parse(row);
+    if (isRecoveryWalRecord(record)) return record;
+  } catch {
+    return null;
+  }
+  return null;
+}

--- a/server/realtime/recovery-wal-results.ts
+++ b/server/realtime/recovery-wal-results.ts
@@ -1,0 +1,65 @@
+/**
+ * The shapes the recovery WAL store returns.
+ *
+ * They sit apart from the store because they are the module's public contract
+ * — locked by `get-contract.test.ts` and by the context-pack fixtures — and a
+ * contract is easier to keep still when it is not interleaved with the
+ * implementation that happens to produce it.
+ */
+import type {
+  NormalizedWorkingSetScope,
+  WorkingSetScopeDenial,
+} from "./working-set.ts";
+import type {
+  RECOVERY_WAL_LABEL,
+  RECOVERY_WAL_SCHEMA,
+  RecoveryWalBudget,
+  RecoveryWalContextItem,
+  RecoveryWalCounters,
+  RecoveryWalItem,
+} from "./recovery-wal-types.ts";
+
+export interface RecoveryWalAppendResult {
+  accepted: boolean;
+  reason?:
+    | "content_too_large"
+    | "empty_content"
+    | "invalid_status"
+    | "metadata_too_large";
+  item?: RecoveryWalItem;
+  counters: RecoveryWalCounters;
+}
+
+export interface RecoveryWalMarkResult {
+  accepted: boolean;
+  reason?: "invalid_action" | "invalid_status" | "not_found";
+  item?: RecoveryWalItem;
+  purged?: boolean;
+  counters: RecoveryWalCounters;
+}
+
+export interface RecoveryWalContextSection {
+  schema: typeof RECOVERY_WAL_SCHEMA;
+  label: typeof RECOVERY_WAL_LABEL;
+  exact_scope_required: true;
+  not_durable_memory: true;
+  not_searchable_recall: true;
+  unreviewed_quarantine: true;
+  scope: NormalizedWorkingSetScope;
+  pending_count: number;
+  items: RecoveryWalContextItem[];
+  item_count: number;
+  budget: RecoveryWalBudget;
+  counters: RecoveryWalCounters;
+  wal_path_configured: boolean;
+}
+
+export interface RecoveryWalContextPackFragment {
+  recovery: RecoveryWalContextSection;
+  warnings: {
+    scope_denials: WorkingSetScopeDenial[];
+  };
+  budget: {
+    recovery: RecoveryWalBudget;
+  };
+}

--- a/server/realtime/recovery-wal-store-parts.ts
+++ b/server/realtime/recovery-wal-store-parts.ts
@@ -1,0 +1,149 @@
+/**
+ * Pure state operations over recovery WAL sessions.
+ *
+ * These are the parts of the store that only read or rearrange the in-memory
+ * session map. They are functions rather than methods because they need no
+ * store identity, and pulling them out is what keeps `RecoveryWalStore` a
+ * coordinator instead of a container for every loop the module has.
+ *
+ * Nothing here writes the journal; the store owns that, so the ordering of
+ * "mutate, then journal" stays visible in one place.
+ */
+import type { Logger } from "pino";
+import {
+  workingSetScopeKey,
+  type NormalizedWorkingSetScope,
+} from "./working-set.ts";
+import type {
+  RecoveryWalBudget,
+  RecoveryWalContextItem,
+  RecoveryWalItem,
+  RecoveryWalStatus,
+} from "./recovery-wal-types.ts";
+
+export interface RecoveryWalSession {
+  scope: NormalizedWorkingSetScope;
+  items: RecoveryWalItem[];
+  updated_at_ms: number;
+}
+
+export type RecoveryWalSessions = Map<string, RecoveryWalSession>;
+
+/** Only these two statuses are "still awaiting review" and therefore emitted. */
+const PENDING_STATUSES = new Set<RecoveryWalStatus>([
+  "active",
+  "recovery_pending",
+]);
+
+export function isPendingAt(item: RecoveryWalItem, nowMs: number): boolean {
+  return (
+    PENDING_STATUSES.has(item.status) && Date.parse(item.expires_at) > nowMs
+  );
+}
+
+export function oldestSession(
+  sessions: RecoveryWalSessions,
+): RecoveryWalSession | null {
+  let oldest: RecoveryWalSession | null = null;
+  for (const session of sessions.values()) {
+    if (!oldest || session.updated_at_ms < oldest.updated_at_ms) {
+      oldest = session;
+    }
+  }
+  return oldest;
+}
+
+export function globalItemCount(sessions: RecoveryWalSessions): number {
+  let count = 0;
+  for (const session of sessions.values()) count += session.items.length;
+  return count;
+}
+
+/** Drop a session once its last item is gone, so empty keys never accumulate. */
+export function deleteIfEmpty(
+  sessions: RecoveryWalSessions,
+  session: RecoveryWalSession,
+): void {
+  if (session.items.length === 0) {
+    sessions.delete(workingSetScopeKey(session.scope));
+  }
+}
+
+export function contextItemFor(
+  item: RecoveryWalItem,
+  budget: RecoveryWalBudget,
+): RecoveryWalContextItem {
+  const preview =
+    item.content.length > budget.max_preview_chars
+      ? item.content.slice(0, budget.max_preview_chars)
+      : item.content;
+  return {
+    id: item.id,
+    label: item.label,
+    status: item.status,
+    content_preview: preview,
+    content_length: item.content.length,
+    content_truncated: item.content.length > preview.length,
+    trace_id: item.trace_id,
+    source_ref: item.source_ref,
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+    expires_at: item.expires_at,
+    reviewed_at: item.reviewed_at,
+    last_action: item.last_action,
+    metadata: item.metadata,
+  };
+}
+
+/**
+ * Apply the live size budgets to a replayed state that predates them, and
+ * report how many items that cost. The journal is NOT written here: replay
+ * rewrites it wholesale by compaction afterwards, so a per-item purge row
+ * would only be journalling a file that is about to be replaced.
+ */
+export function enforceReplayBudgets(
+  sessions: RecoveryWalSessions,
+  budget: RecoveryWalBudget,
+): number {
+  let trimmed = 0;
+  for (const [key, session] of sessions.entries()) {
+    const overflow = session.items.length - budget.max_items_per_session;
+    if (overflow > 0) {
+      session.items.splice(0, overflow);
+      trimmed += overflow;
+    }
+    if (session.items.length === 0) sessions.delete(key);
+  }
+  while (globalItemCount(sessions) > budget.max_global_items) {
+    const oldest = oldestSession(sessions);
+    if (!oldest) return trimmed;
+    if (oldest.items.shift()) trimmed += 1;
+    deleteIfEmpty(sessions, oldest);
+  }
+  while (sessions.size > budget.max_sessions) {
+    const oldest = oldestSession(sessions);
+    if (!oldest) return trimmed;
+    trimmed += oldest.items.length;
+    sessions.delete(workingSetScopeKey(oldest.scope));
+  }
+  return trimmed;
+}
+
+/** See the identical note in working-set.ts: null means "unserializable", not "big". */
+export function serializedJsonLength(
+  value: unknown,
+  logger: Logger | undefined,
+): number | null {
+  try {
+    return JSON.stringify(value).length;
+  } catch (error) {
+    logger?.warn(
+      {
+        value_type: typeof value,
+        error_name: error instanceof Error ? error.name : typeof error,
+      },
+      "recovery_wal_metadata_unserializable",
+    );
+    return null;
+  }
+}

--- a/server/realtime/recovery-wal-types.ts
+++ b/server/realtime/recovery-wal-types.ts
@@ -1,0 +1,122 @@
+/**
+ * The recovery WAL vocabulary: statuses, actions, the record shapes, and the
+ * budget defaults.
+ *
+ * These are split from the store so the structural validators
+ * (`recovery-wal-records.ts`) can name the same shapes without importing the
+ * store, and so the journal's on-disk vocabulary has exactly one definition.
+ */
+import type { NormalizedWorkingSetScope } from "./working-set.ts";
+
+export const RECOVERY_WAL_LABEL = "quarantined_recovery" as const;
+export const RECOVERY_WAL_SCHEMA = "openbrain.recovery_wal.v1" as const;
+
+export const RECOVERY_WAL_STATUSES = [
+  "active",
+  "wrapped",
+  "recovery_pending",
+  "reviewed",
+  "compacted",
+  "discarded",
+  "expired",
+] as const;
+
+export type RecoveryWalStatus = (typeof RECOVERY_WAL_STATUSES)[number];
+
+export const RECOVERY_WAL_ACTIONS = [
+  "review",
+  "use_for_current_session",
+  "compact_to_wrap",
+  "promote_candidates",
+  "discard",
+  "defer",
+] as const;
+
+export type RecoveryWalAction = (typeof RECOVERY_WAL_ACTIONS)[number];
+
+export interface RecoveryWalBudget {
+  ttl_ms: number;
+  max_sessions: number;
+  max_items_per_session: number;
+  max_global_items: number;
+  max_content_chars: number;
+  max_metadata_chars: number;
+  max_preview_chars: number;
+}
+
+export interface RecoveryWalCounters {
+  dropped: number;
+  expired: number;
+  trimmed: number;
+  marked: number;
+  purged: number;
+}
+
+export interface RecoveryWalItemInput {
+  id?: string;
+  content: string;
+  status?: RecoveryWalStatus;
+  trace_id?: string | null;
+  source_ref?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RecoveryWalItem {
+  id: string;
+  label: typeof RECOVERY_WAL_LABEL;
+  status: RecoveryWalStatus;
+  content: string;
+  trace_id: string | null;
+  source_ref: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+  expires_at: string;
+  reviewed_at: string | null;
+  last_action: RecoveryWalAction | null;
+}
+
+export type RecoveryWalRecord =
+  | { op: "append"; scope: NormalizedWorkingSetScope; item: RecoveryWalItem }
+  | {
+      op: "mark";
+      scope: NormalizedWorkingSetScope;
+      id: string;
+      action: RecoveryWalAction;
+      status: RecoveryWalStatus;
+      reviewed_at: string | null;
+      updated_at: string;
+    }
+  | { op: "purge"; scope: NormalizedWorkingSetScope; id?: string };
+
+export const DEFAULT_RECOVERY_WAL_BUDGET: RecoveryWalBudget = {
+  ttl_ms: 24 * 60 * 60 * 1000,
+  max_sessions: 128,
+  max_items_per_session: 50,
+  max_global_items: 2048,
+  max_content_chars: 8000,
+  max_metadata_chars: 2000,
+  max_preview_chars: 1000,
+};
+
+/**
+ * The read shape. Note it carries a bounded `content_preview`, never the full
+ * body: the context pack surfaces enough to decide whether the record is worth
+ * reviewing, and review is where the whole body belongs.
+ */
+export interface RecoveryWalContextItem {
+  id: string;
+  label: typeof RECOVERY_WAL_LABEL;
+  status: RecoveryWalStatus;
+  content_preview: string;
+  content_length: number;
+  content_truncated: boolean;
+  trace_id: string | null;
+  source_ref: string | null;
+  created_at: string;
+  updated_at: string;
+  expires_at: string;
+  reviewed_at: RecoveryWalItem["reviewed_at"];
+  last_action: RecoveryWalAction | null;
+  metadata: Record<string, unknown>;
+}

--- a/server/realtime/recovery-wal.ts
+++ b/server/realtime/recovery-wal.ts
@@ -18,15 +18,12 @@
  * never SILENT about it: a corrupt WAL and a clean one used to produce
  * identical startups, which made vanished recovery items indistinguishable from
  * an empty journal. Skipped rows are counted and logged.
+ *
+ * The vocabulary lives in `recovery-wal-types.ts`, the journal-row validators
+ * in `recovery-wal-records.ts`, and the pure session-map operations in
+ * `recovery-wal-store-parts.ts`. This file is the store that sequences them and
+ * owns every journal write.
  */
-import {
-  appendFileSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  writeFileSync,
-} from "node:fs";
-import { dirname } from "node:path";
 import type { Logger } from "pino";
 import {
   compareWorkingSetScope,
@@ -37,140 +34,83 @@ import {
   type WorkingSetScope,
   type WorkingSetScopeDenial,
 } from "./working-set.ts";
+import {
+  DEFAULT_RECOVERY_WAL_BUDGET,
+  RECOVERY_WAL_ACTIONS,
+  RECOVERY_WAL_LABEL,
+  RECOVERY_WAL_SCHEMA,
+  RECOVERY_WAL_STATUSES,
+  type RecoveryWalAction,
+  type RecoveryWalBudget,
+  type RecoveryWalContextItem,
+  type RecoveryWalCounters,
+  type RecoveryWalItem,
+  type RecoveryWalItemInput,
+  type RecoveryWalRecord,
+  type RecoveryWalStatus,
+} from "./recovery-wal-types.ts";
+import {
+  appendJournalRecord,
+  journalExists,
+  readJournalRows,
+  rewriteJournal,
+} from "./recovery-wal-journal.ts";
+import {
+  isRecoveryWalAction,
+  isRecoveryWalStatus,
+  parseWalRecord,
+} from "./recovery-wal-records.ts";
+import type {
+  RecoveryWalAppendResult,
+  RecoveryWalContextPackFragment,
+  RecoveryWalContextSection,
+  RecoveryWalMarkResult,
+} from "./recovery-wal-results.ts";
+import {
+  contextItemFor,
+  deleteIfEmpty,
+  serializedJsonLength,
+  enforceReplayBudgets,
+  globalItemCount,
+  isPendingAt,
+  oldestSession,
+  type RecoveryWalSession,
+  type RecoveryWalSessions,
+} from "./recovery-wal-store-parts.ts";
 
-export const RECOVERY_WAL_LABEL = "quarantined_recovery" as const;
-export const RECOVERY_WAL_SCHEMA = "openbrain.recovery_wal.v1" as const;
-
-export const RECOVERY_WAL_STATUSES = [
-  "active",
-  "wrapped",
-  "recovery_pending",
-  "reviewed",
-  "compacted",
-  "discarded",
-  "expired",
-] as const;
-
-export type RecoveryWalStatus = (typeof RECOVERY_WAL_STATUSES)[number];
-
-export const RECOVERY_WAL_ACTIONS = [
-  "review",
-  "use_for_current_session",
-  "compact_to_wrap",
-  "promote_candidates",
-  "discard",
-  "defer",
-] as const;
-
-export type RecoveryWalAction = (typeof RECOVERY_WAL_ACTIONS)[number];
-
-export interface RecoveryWalBudget {
-  ttl_ms: number;
-  max_sessions: number;
-  max_items_per_session: number;
-  max_global_items: number;
-  max_content_chars: number;
-  max_metadata_chars: number;
-  max_preview_chars: number;
-}
-
-export interface RecoveryWalCounters {
-  dropped: number;
-  expired: number;
-  trimmed: number;
-  marked: number;
-  purged: number;
-}
-
-export interface RecoveryWalItemInput {
-  id?: string;
-  content: string;
-  status?: RecoveryWalStatus;
-  trace_id?: string | null;
-  source_ref?: string | null;
-  metadata?: Record<string, unknown>;
-}
-
-export interface RecoveryWalItem {
-  id: string;
-  label: typeof RECOVERY_WAL_LABEL;
-  status: RecoveryWalStatus;
-  content: string;
-  trace_id: string | null;
-  source_ref: string | null;
-  metadata: Record<string, unknown>;
-  created_at: string;
-  updated_at: string;
-  expires_at: string;
-  reviewed_at: string | null;
-  last_action: RecoveryWalAction | null;
-}
-
-export interface RecoveryWalAppendResult {
-  accepted: boolean;
-  reason?:
-    | "content_too_large"
-    | "empty_content"
-    | "invalid_status"
-    | "metadata_too_large";
-  item?: RecoveryWalItem;
-  counters: RecoveryWalCounters;
-}
-
-export interface RecoveryWalMarkResult {
-  accepted: boolean;
-  reason?: "invalid_action" | "invalid_status" | "not_found";
-  item?: RecoveryWalItem;
-  purged?: boolean;
-  counters: RecoveryWalCounters;
-}
+export {
+  DEFAULT_RECOVERY_WAL_BUDGET,
+  RECOVERY_WAL_ACTIONS,
+  RECOVERY_WAL_LABEL,
+  RECOVERY_WAL_SCHEMA,
+  RECOVERY_WAL_STATUSES,
+};
+export type {
+  RecoveryWalAppendResult,
+  RecoveryWalContextPackFragment,
+  RecoveryWalContextSection,
+  RecoveryWalMarkResult,
+};
+export type {
+  RecoveryWalAction,
+  RecoveryWalBudget,
+  RecoveryWalContextItem,
+  RecoveryWalCounters,
+  RecoveryWalItem,
+  RecoveryWalItemInput,
+  RecoveryWalStatus,
+};
 
 /**
- * The read shape. Note it carries a bounded `content_preview`, never the full
- * body: the context pack surfaces enough to decide whether the record is worth
- * reviewing, and review is where the whole body belongs.
+ * What `mark` is being asked to record. Action and status travel with `purge`
+ * and `now` in one object so a call site reads as named fields rather than a
+ * run of same-typed positional strings.
  */
-export interface RecoveryWalContextItem {
-  id: string;
-  label: typeof RECOVERY_WAL_LABEL;
+export interface RecoveryWalMarkDecision {
+  action: RecoveryWalAction;
   status: RecoveryWalStatus;
-  content_preview: string;
-  content_length: number;
-  content_truncated: boolean;
-  trace_id: string | null;
-  source_ref: string | null;
-  created_at: string;
-  updated_at: string;
-  expires_at: string;
-  reviewed_at: string | null;
-  last_action: RecoveryWalAction | null;
-  metadata: Record<string, unknown>;
-}
-
-export interface RecoveryWalContextSection {
-  schema: typeof RECOVERY_WAL_SCHEMA;
-  label: typeof RECOVERY_WAL_LABEL;
-  exact_scope_required: true;
-  not_durable_memory: true;
-  not_searchable_recall: true;
-  unreviewed_quarantine: true;
-  scope: NormalizedWorkingSetScope;
-  pending_count: number;
-  items: RecoveryWalContextItem[];
-  item_count: number;
-  budget: RecoveryWalBudget;
-  counters: RecoveryWalCounters;
-  wal_path_configured: boolean;
-}
-
-export interface RecoveryWalContextPackFragment {
-  recovery: RecoveryWalContextSection;
-  warnings: {
-    scope_denials: WorkingSetScopeDenial[];
-  };
-  budget: {
-    recovery: RecoveryWalBudget;
-  };
+  purge?: boolean;
+  now?: Date;
 }
 
 export interface RecoveryWalStoreOptions {
@@ -179,72 +119,11 @@ export interface RecoveryWalStoreOptions {
   logger?: Logger;
 }
 
-interface RecoveryWalSession {
-  scope: NormalizedWorkingSetScope;
-  items: RecoveryWalItem[];
-  updated_at_ms: number;
-}
-
-type RecoveryWalRecord =
-  | { op: "append"; scope: NormalizedWorkingSetScope; item: RecoveryWalItem }
-  | {
-      op: "mark";
-      scope: NormalizedWorkingSetScope;
-      id: string;
-      action: RecoveryWalAction;
-      status: RecoveryWalStatus;
-      reviewed_at: string | null;
-      updated_at: string;
-    }
-  | { op: "purge"; scope: NormalizedWorkingSetScope; id?: string };
-
-const RECOVERY_WAL_STATUS_SET = new Set<string>(RECOVERY_WAL_STATUSES);
-const RECOVERY_WAL_ACTION_SET = new Set<string>(RECOVERY_WAL_ACTIONS);
-
-/** Only these two statuses are "still awaiting review" and therefore emitted. */
-const PENDING_STATUSES = new Set<RecoveryWalStatus>([
-  "active",
-  "recovery_pending",
-]);
-
-export const DEFAULT_RECOVERY_WAL_BUDGET: RecoveryWalBudget = {
-  ttl_ms: 24 * 60 * 60 * 1000,
-  max_sessions: 128,
-  max_items_per_session: 50,
-  max_global_items: 2048,
-  max_content_chars: 8000,
-  max_metadata_chars: 2000,
-  max_preview_chars: 1000,
-};
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
-}
-
-/** See the identical note in working-set.ts: null means "unserializable", not "big". */
-function serializedJsonLength(
-  value: unknown,
-  logger: Logger | undefined,
-): number | null {
-  try {
-    return JSON.stringify(value).length;
-  } catch (error) {
-    logger?.warn(
-      {
-        value_type: typeof value,
-        error_name: error instanceof Error ? error.name : typeof error,
-      },
-      "recovery_wal_metadata_unserializable",
-    );
-    return null;
-  }
-}
-
 export class RecoveryWalStore {
   readonly budget: RecoveryWalBudget;
   readonly walPath: string | null;
   private readonly logger: Logger | undefined;
-  private sessions = new Map<string, RecoveryWalSession>();
+  private sessions: RecoveryWalSessions = new Map();
   private counters: RecoveryWalCounters = {
     dropped: 0,
     expired: 0,
@@ -268,29 +147,10 @@ export class RecoveryWalStore {
   ): RecoveryWalAppendResult {
     this.purgeExpired(now);
 
-    const status = input.status ?? "active";
-    if (!RECOVERY_WAL_STATUS_SET.has(status)) {
+    const rejection = this.rejectionFor(input);
+    if (rejection) {
       this.counters.dropped += 1;
-      return this.rejectedAppend("invalid_status");
-    }
-
-    const content = input.content.trim();
-    if (content.length === 0) {
-      this.counters.dropped += 1;
-      return this.rejectedAppend("empty_content");
-    }
-    if (content.length > this.budget.max_content_chars) {
-      this.counters.dropped += 1;
-      return this.rejectedAppend("content_too_large");
-    }
-    const metadata = input.metadata ?? {};
-    const metadataChars = serializedJsonLength(metadata, this.logger);
-    if (
-      metadataChars === null ||
-      metadataChars > this.budget.max_metadata_chars
-    ) {
-      this.counters.dropped += 1;
-      return this.rejectedAppend("metadata_too_large");
+      return this.rejectedAppend(rejection);
     }
 
     const normalizedScope = normalizeWorkingSetScope(scope);
@@ -301,20 +161,7 @@ export class RecoveryWalStore {
       items: [],
       updated_at_ms: nowMs,
     };
-    const item: RecoveryWalItem = {
-      id: input.id ?? `rw-${this.nextId++}`,
-      label: RECOVERY_WAL_LABEL,
-      status,
-      content,
-      trace_id: input.trace_id ?? null,
-      source_ref: input.source_ref ?? null,
-      metadata,
-      created_at: now.toISOString(),
-      updated_at: now.toISOString(),
-      expires_at: new Date(nowMs + this.budget.ttl_ms).toISOString(),
-      reviewed_at: null,
-      last_action: null,
-    };
+    const item = this.newItem(input, now);
 
     session.items.push(item);
     session.updated_at_ms = nowMs;
@@ -328,6 +175,52 @@ export class RecoveryWalStore {
   }
 
   /**
+   * The one place an append is refused, so the reason a record is turned away
+   * is a single readable list rather than a run of early returns interleaved
+   * with the construction of the record that is not going to exist.
+   */
+  private rejectionFor(
+    input: RecoveryWalItemInput,
+  ): NonNullable<RecoveryWalAppendResult["reason"]> | null {
+    const status = input.status ?? "active";
+    if (!isRecoveryWalStatus(status)) return "invalid_status";
+
+    const content = input.content.trim();
+    if (content.length === 0) return "empty_content";
+    if (content.length > this.budget.max_content_chars) {
+      return "content_too_large";
+    }
+
+    const metadataChars = serializedJsonLength(
+      input.metadata ?? {},
+      this.logger,
+    );
+    if (metadataChars === null) return "metadata_too_large";
+    if (metadataChars > this.budget.max_metadata_chars) {
+      return "metadata_too_large";
+    }
+    return null;
+  }
+
+  private newItem(input: RecoveryWalItemInput, now: Date): RecoveryWalItem {
+    const timestamp = now.toISOString();
+    return {
+      id: input.id ?? `rw-${this.nextId++}`,
+      label: RECOVERY_WAL_LABEL,
+      status: input.status ?? "active",
+      content: input.content.trim(),
+      trace_id: input.trace_id ?? null,
+      source_ref: input.source_ref ?? null,
+      metadata: input.metadata ?? {},
+      created_at: timestamp,
+      updated_at: timestamp,
+      expires_at: new Date(now.getTime() + this.budget.ttl_ms).toISOString(),
+      reviewed_at: null,
+      last_action: null,
+    };
+  }
+
+  /**
    * Record a review decision, or purge the record outright. `mark` is the ONLY
    * way a quarantined record leaves the pending set, and it never writes durable
    * memory — promotion, if it happens at all, is a separate authorized path.
@@ -335,18 +228,15 @@ export class RecoveryWalStore {
   mark(
     scope: WorkingSetScope,
     id: string,
-    action: RecoveryWalAction,
-    status: RecoveryWalStatus,
-    options: { purge?: boolean; now?: Date } = {},
+    decision: RecoveryWalMarkDecision,
   ): RecoveryWalMarkResult {
-    this.purgeExpired(options.now ?? new Date());
+    const { action, status } = decision;
+    this.purgeExpired(decision.now ?? new Date());
 
-    if (!RECOVERY_WAL_ACTION_SET.has(action)) {
+    if (!isRecoveryWalAction(action))
       return this.rejectedMark("invalid_action");
-    }
-    if (!RECOVERY_WAL_STATUS_SET.has(status)) {
+    if (!isRecoveryWalStatus(status))
       return this.rejectedMark("invalid_status");
-    }
 
     const normalizedScope = normalizeWorkingSetScope(scope);
     const key = workingSetScopeKey(normalizedScope);
@@ -354,15 +244,40 @@ export class RecoveryWalStore {
     const item = session?.items.find((candidate) => candidate.id === id);
     if (!session || !item) return this.rejectedMark("not_found");
 
-    if (options.purge) {
-      session.items = session.items.filter((candidate) => candidate.id !== id);
-      if (session.items.length === 0) this.sessions.delete(key);
-      this.counters.purged += 1;
-      this.writeWal({ op: "purge", scope: normalizedScope, id });
-      return { accepted: true, purged: true, counters: this.getCounters() };
-    }
+    if (decision.purge) return this.purgeMarked(session, item, normalizedScope);
+    return this.applyDecision(session, item, {
+      action,
+      status,
+      scope: normalizedScope,
+      now: decision.now ?? new Date(),
+    });
+  }
 
-    const now = options.now ?? new Date();
+  private purgeMarked(
+    session: RecoveryWalSession,
+    item: RecoveryWalItem,
+    scope: NormalizedWorkingSetScope,
+  ): RecoveryWalMarkResult {
+    session.items = session.items.filter(
+      (candidate) => candidate.id !== item.id,
+    );
+    deleteIfEmpty(this.sessions, session);
+    this.counters.purged += 1;
+    this.writeWal({ op: "purge", scope, id: item.id });
+    return { accepted: true, purged: true, counters: this.getCounters() };
+  }
+
+  private applyDecision(
+    session: RecoveryWalSession,
+    item: RecoveryWalItem,
+    decision: {
+      action: RecoveryWalAction;
+      status: RecoveryWalStatus;
+      scope: NormalizedWorkingSetScope;
+      now: Date;
+    },
+  ): RecoveryWalMarkResult {
+    const { action, status, scope, now } = decision;
     item.status = status;
     item.last_action = action;
     item.updated_at = now.toISOString();
@@ -376,8 +291,8 @@ export class RecoveryWalStore {
     this.counters.marked += 1;
     this.writeWal({
       op: "mark",
-      scope: normalizedScope,
-      id,
+      scope,
+      id: item.id,
       action,
       status,
       reviewed_at: item.reviewed_at,
@@ -396,7 +311,7 @@ export class RecoveryWalStore {
     const normalizedScope = normalizeWorkingSetScope(scope);
     const key = workingSetScopeKey(normalizedScope);
     const items = (this.sessions.get(key)?.items ?? []).filter((item) =>
-      this.isPendingAt(item, nowMs),
+      isPendingAt(item, nowMs),
     );
 
     return {
@@ -409,7 +324,7 @@ export class RecoveryWalStore {
         unreviewed_quarantine: true,
         scope: normalizedScope,
         pending_count: items.length,
-        items: items.map((item) => this.contextItemFor(item)),
+        items: items.map((item) => contextItemFor(item, this.budget)),
         item_count: items.length,
         budget: this.budget,
         counters: this.getCounters(),
@@ -434,29 +349,6 @@ export class RecoveryWalStore {
     reason: NonNullable<RecoveryWalMarkResult["reason"]>,
   ): RecoveryWalMarkResult {
     return { accepted: false, reason, counters: this.getCounters() };
-  }
-
-  private contextItemFor(item: RecoveryWalItem): RecoveryWalContextItem {
-    const preview =
-      item.content.length > this.budget.max_preview_chars
-        ? item.content.slice(0, this.budget.max_preview_chars)
-        : item.content;
-    return {
-      id: item.id,
-      label: item.label,
-      status: item.status,
-      content_preview: preview,
-      content_length: item.content.length,
-      content_truncated: item.content.length > preview.length,
-      trace_id: item.trace_id,
-      source_ref: item.source_ref,
-      created_at: item.created_at,
-      updated_at: item.updated_at,
-      expires_at: item.expires_at,
-      reviewed_at: item.reviewed_at,
-      last_action: item.last_action,
-      metadata: item.metadata,
-    };
   }
 
   /**
@@ -500,44 +392,26 @@ export class RecoveryWalStore {
   }
 
   private trimGlobal(): void {
-    while (this.globalItemCount() > this.budget.max_global_items) {
-      const oldest = this.oldestSession();
+    while (globalItemCount(this.sessions) > this.budget.max_global_items) {
+      const oldest = oldestSession(this.sessions);
       if (!oldest) return;
       const removed = oldest.items.shift();
       if (removed) {
         this.counters.trimmed += 1;
         this.writeWal({ op: "purge", scope: oldest.scope, id: removed.id });
       }
-      if (oldest.items.length === 0) {
-        this.sessions.delete(workingSetScopeKey(oldest.scope));
-      }
+      deleteIfEmpty(this.sessions, oldest);
     }
   }
 
   private trimSessions(): void {
     while (this.sessions.size > this.budget.max_sessions) {
-      const oldest = this.oldestSession();
+      const oldest = oldestSession(this.sessions);
       if (!oldest) return;
       this.counters.trimmed += oldest.items.length;
       this.writeWal({ op: "purge", scope: oldest.scope });
       this.sessions.delete(workingSetScopeKey(oldest.scope));
     }
-  }
-
-  private oldestSession(): RecoveryWalSession | null {
-    let oldest: RecoveryWalSession | null = null;
-    for (const session of this.sessions.values()) {
-      if (!oldest || session.updated_at_ms < oldest.updated_at_ms) {
-        oldest = session;
-      }
-    }
-    return oldest;
-  }
-
-  private globalItemCount(): number {
-    let count = 0;
-    for (const session of this.sessions.values()) count += session.items.length;
-    return count;
   }
 
   /** Same-namespace near misses only, and only lanes that actually hold pending work. */
@@ -550,7 +424,7 @@ export class RecoveryWalStore {
     for (const [key, session] of this.sessions.entries()) {
       if (key === requestedKey) continue;
       if (session.scope.namespace !== requestedScope.namespace) continue;
-      if (!session.items.some((item) => this.isPendingAt(item, nowMs))) continue;
+      if (!session.items.some((item) => isPendingAt(item, nowMs))) continue;
       const reasons = compareWorkingSetScope(requestedScope, session.scope);
       if (reasons.length > 0) {
         denials.push({
@@ -560,12 +434,6 @@ export class RecoveryWalStore {
       }
     }
     return denials;
-  }
-
-  private isPendingAt(item: RecoveryWalItem, nowMs: number): boolean {
-    return (
-      PENDING_STATUSES.has(item.status) && Date.parse(item.expires_at) > nowMs
-    );
   }
 
   /**
@@ -579,12 +447,20 @@ export class RecoveryWalStore {
    * representative cause (the rest are nearly always the same fault).
    */
   private loadWal(): void {
-    if (!this.walPath || !existsSync(this.walPath)) return;
-    const rows = readFileSync(this.walPath, "utf8")
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean);
+    if (!this.walPath || !journalExists(this.walPath)) return;
+    const rows = readJournalRows(this.walPath);
 
+    this.logReplay(rows.length, this.replayRows(rows));
+    this.enforceReplayBudgets();
+    this.compactWal();
+  }
+
+  /** Apply every row, tallying the two ways a row can fail to land. */
+  private replayRows(rows: string[]): {
+    unparseable: number;
+    unapplicable: number;
+    firstApplyError: unknown;
+  } {
     let unparseable = 0;
     let unapplicable = 0;
     let firstApplyError: unknown;
@@ -601,53 +477,42 @@ export class RecoveryWalStore {
         if (firstApplyError === undefined) firstApplyError = error;
       }
     }
-    if (unparseable > 0 || unapplicable > 0) {
-      this.logger?.warn(
-        {
-          rows_total: rows.length,
-          rows_unparseable: unparseable,
-          rows_unapplicable: unapplicable,
-          error_name:
-            firstApplyError instanceof Error
-              ? firstApplyError.name
-              : firstApplyError === undefined
-                ? null
-                : typeof firstApplyError,
-        },
-        "recovery_wal_rows_skipped",
-      );
-    } else {
-      this.logger?.debug({ rows_total: rows.length }, "recovery_wal_replayed");
+    return { unparseable, unapplicable, firstApplyError };
+  }
+
+  private logReplay(
+    rowsTotal: number,
+    outcome: {
+      unparseable: number;
+      unapplicable: number;
+      firstApplyError: unknown;
+    },
+  ): void {
+    const { unparseable, unapplicable, firstApplyError } = outcome;
+    if (unparseable === 0 && unapplicable === 0) {
+      this.logger?.debug({ rows_total: rowsTotal }, "recovery_wal_replayed");
+      return;
     }
-    this.enforceReplayBudgets();
-    this.compactWal();
+    this.logger?.warn(
+      {
+        rows_total: rowsTotal,
+        rows_unparseable: unparseable,
+        rows_unapplicable: unapplicable,
+        error_name: replayErrorName(firstApplyError),
+      },
+      "recovery_wal_rows_skipped",
+    );
   }
 
   private writeWal(record: RecoveryWalRecord): void {
     if (!this.walPath) return;
-    mkdirSync(dirname(this.walPath), { recursive: true });
-    appendFileSync(this.walPath, `${JSON.stringify(record)}\n`, "utf8");
+    appendJournalRecord(this.walPath, record);
   }
 
   private applyWalRecord(record: RecoveryWalRecord): void {
     const key = workingSetScopeKey(record.scope);
     if (record.op === "append") {
-      // A record that exceeds the CURRENT budget is dropped on replay rather
-      // than admitted: the live budget is authoritative, not the one in force
-      // when the row was written.
-      if (!this.isReplayItemWithinBudget(record.item)) {
-        this.counters.dropped += 1;
-        return;
-      }
-      const session = this.sessions.get(key) ?? {
-        scope: record.scope,
-        items: [],
-        updated_at_ms: Date.parse(record.item.updated_at),
-      };
-      session.items.push(record.item);
-      session.updated_at_ms = Date.parse(record.item.updated_at);
-      this.sessions.set(key, session);
-      this.trackNextId(record.item.id);
+      this.applyAppendRecord(key, record.scope, record.item);
       return;
     }
     const session = this.sessions.get(key);
@@ -668,6 +533,30 @@ export class RecoveryWalStore {
     session.updated_at_ms = Date.parse(record.updated_at);
   }
 
+  private applyAppendRecord(
+    key: string,
+    scope: NormalizedWorkingSetScope,
+    item: RecoveryWalItem,
+  ): void {
+    // A record that exceeds the CURRENT budget is dropped on replay rather
+    // than admitted: the live budget is authoritative, not the one in force
+    // when the row was written.
+    if (!this.isReplayItemWithinBudget(item)) {
+      this.counters.dropped += 1;
+      return;
+    }
+    const updatedAtMs = Date.parse(item.updated_at);
+    const session = this.sessions.get(key) ?? {
+      scope,
+      items: [],
+      updated_at_ms: updatedAtMs,
+    };
+    session.items.push(item);
+    session.updated_at_ms = updatedAtMs;
+    this.sessions.set(key, session);
+    this.trackNextId(item.id);
+  }
+
   private isReplayItemWithinBudget(item: RecoveryWalItem): boolean {
     const metadataChars = serializedJsonLength(item.metadata, this.logger);
     return (
@@ -679,29 +568,7 @@ export class RecoveryWalStore {
 
   /** Apply the live size budgets to a replayed state that predates them. */
   private enforceReplayBudgets(): void {
-    for (const [key, session] of this.sessions.entries()) {
-      const overflow = session.items.length - this.budget.max_items_per_session;
-      if (overflow > 0) {
-        session.items.splice(0, overflow);
-        this.counters.trimmed += overflow;
-      }
-      if (session.items.length === 0) this.sessions.delete(key);
-    }
-    while (this.globalItemCount() > this.budget.max_global_items) {
-      const oldest = this.oldestSession();
-      if (!oldest) return;
-      const removed = oldest.items.shift();
-      if (removed) this.counters.trimmed += 1;
-      if (oldest.items.length === 0) {
-        this.sessions.delete(workingSetScopeKey(oldest.scope));
-      }
-    }
-    while (this.sessions.size > this.budget.max_sessions) {
-      const oldest = this.oldestSession();
-      if (!oldest) return;
-      this.counters.trimmed += oldest.items.length;
-      this.sessions.delete(workingSetScopeKey(oldest.scope));
-    }
+    this.counters.trimmed += enforceReplayBudgets(this.sessions, this.budget);
   }
 
   /** Keep generated ids monotonic across a replay so a new item cannot collide. */
@@ -714,104 +581,17 @@ export class RecoveryWalStore {
   /** Rewrite the journal as the current live state: bounded growth, same result on replay. */
   compactWal(): void {
     if (!this.walPath) return;
-    mkdirSync(dirname(this.walPath), { recursive: true });
     const records: RecoveryWalRecord[] = [];
     for (const session of this.sessions.values()) {
       for (const item of session.items) {
         records.push({ op: "append", scope: session.scope, item });
       }
     }
-    writeFileSync(
-      this.walPath,
-      records.map((record) => JSON.stringify(record)).join("\n") +
-        (records.length > 0 ? "\n" : ""),
-      "utf8",
-    );
+    rewriteJournal(this.walPath, records);
   }
 }
 
-function parseWalRecord(row: string): RecoveryWalRecord | null {
-  try {
-    const record: unknown = JSON.parse(row);
-    if (isRecoveryWalRecord(record)) return record;
-  } catch {
-    return null;
-  }
-  return null;
-}
-
-/**
- * Structural validation of a journal row. This is the trust boundary for a file
- * on disk: every field is checked before it becomes live state, so a hand-edited
- * or torn WAL cannot inject an item with an unknown status or a broken scope.
- */
-function isRecoveryWalRecord(record: unknown): record is RecoveryWalRecord {
-  if (!isRecord(record)) return false;
-  if (!isNormalizedScope(record.scope)) return false;
-  if (record.op === "append") return isRecoveryWalItem(record.item);
-  if (record.op === "mark") {
-    return (
-      typeof record.id === "string" &&
-      typeof record.action === "string" &&
-      RECOVERY_WAL_ACTION_SET.has(record.action) &&
-      typeof record.status === "string" &&
-      RECOVERY_WAL_STATUS_SET.has(record.status) &&
-      (record.reviewed_at === null ||
-        (typeof record.reviewed_at === "string" &&
-          Number.isFinite(Date.parse(record.reviewed_at)))) &&
-      typeof record.updated_at === "string" &&
-      Number.isFinite(Date.parse(record.updated_at))
-    );
-  }
-  if (record.op === "purge") {
-    return record.id === undefined || typeof record.id === "string";
-  }
-  return false;
-}
-
-function isRecoveryWalItem(value: unknown): value is RecoveryWalItem {
-  return (
-    isRecord(value) &&
-    typeof value.id === "string" &&
-    value.label === RECOVERY_WAL_LABEL &&
-    typeof value.status === "string" &&
-    RECOVERY_WAL_STATUS_SET.has(value.status) &&
-    typeof value.content === "string" &&
-    (value.trace_id === null || typeof value.trace_id === "string") &&
-    (value.source_ref === null || typeof value.source_ref === "string") &&
-    isRecord(value.metadata) &&
-    typeof value.created_at === "string" &&
-    Number.isFinite(Date.parse(value.created_at)) &&
-    typeof value.updated_at === "string" &&
-    Number.isFinite(Date.parse(value.updated_at)) &&
-    typeof value.expires_at === "string" &&
-    Number.isFinite(Date.parse(value.expires_at)) &&
-    (value.reviewed_at === null ||
-      (typeof value.reviewed_at === "string" &&
-        Number.isFinite(Date.parse(value.reviewed_at)))) &&
-    (value.last_action === null ||
-      (typeof value.last_action === "string" &&
-        RECOVERY_WAL_ACTION_SET.has(value.last_action)))
-  );
-}
-
-function isNormalizedScope(value: unknown): value is NormalizedWorkingSetScope {
-  return (
-    isRecord(value) &&
-    typeof value.namespace === "string" &&
-    value.namespace.trim().length > 0 &&
-    typeof value.agent === "string" &&
-    value.agent.trim().length > 0 &&
-    typeof value.platform === "string" &&
-    value.platform.trim().length > 0 &&
-    typeof value.server_id === "string" &&
-    value.server_id.trim().length > 0 &&
-    typeof value.channel_id === "string" &&
-    value.channel_id.trim().length > 0 &&
-    (value.thread_id === null ||
-      (typeof value.thread_id === "string" &&
-        value.thread_id.trim().length > 0)) &&
-    typeof value.session_key === "string" &&
-    value.session_key.trim().length > 0
-  );
+function replayErrorName(error: unknown): string | null {
+  if (error === undefined) return null;
+  return error instanceof Error ? error.name : typeof error;
 }

--- a/server/tools/realtime-append.ts
+++ b/server/tools/realtime-append.ts
@@ -92,7 +92,22 @@ function realtimeResult(
   };
 }
 
+/**
+ * Each tool gets its own registration function. They were one block, which
+ * grew past the point where a reader could see where one tool ended and the
+ * next began; the schemas and handlers are unchanged by the split.
+ */
 export function registerRealtimeAppendTools(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
+  registerWorkingSetAppendTool(server, dependencies);
+  registerRecoveryWalAppendTool(server, dependencies);
+  registerRecoveryWalMarkTool(server, dependencies);
+}
+
+/** RAM-only scoped working-set append. */
+function registerWorkingSetAppendTool(
   server: McpServer,
   dependencies: MemoryToolDependencies,
 ): void {
@@ -166,7 +181,13 @@ export function registerRealtimeAppendTools(
       );
     },
   );
+}
 
+/** Quarantined recovery WAL append. */
+function registerRecoveryWalAppendTool(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
   server.registerTool(
     "recovery_wal_append",
     {
@@ -228,7 +249,13 @@ export function registerRealtimeAppendTools(
       );
     },
   );
+}
 
+/** Review decision or purge on one quarantined record. */
+function registerRecoveryWalMarkTool(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
   server.registerTool(
     "recovery_wal_mark",
     {
@@ -269,9 +296,11 @@ export function registerRealtimeAppendTools(
       const result = recoveryWalStoreFor(dependencies).mark(
         storeScope(auth.namespace, args),
         args.id,
-        args.action,
-        args.status,
-        { purge: args.purge ?? false },
+        {
+          action: args.action,
+          status: args.status,
+          purge: args.purge ?? false,
+        },
       );
 
       return realtimeResult(


### PR DESCRIPTION
## Summary

- `server/realtime/recovery-wal.ts` carried eight oxlint findings: one max-lines, five complexity, and one max-params (two of them on `mark`). Cleared by splitting the module along seams it already had, not by shuffling lines to get under a number.
- The store was doing four jobs in one file. Each is now its own module: `recovery-wal-types.ts` (the journal's on-disk vocabulary), `recovery-wal-records.ts` (structural validators for a row), `recovery-wal-journal.ts` (the three filesystem calls), `recovery-wal-store-parts.ts` (pure operations over the session map), and `recovery-wal-results.ts` (the returned shapes, which are the module's public contract).
- `isRecoveryWalItem` was a twenty-clause boolean at complexity 23. It is now a field/predicate table, so adding a field is one row rather than one more clause.
- `append`, `mark`, and `loadWal` shed their inline runs into named helpers (`rejectionFor`, `newItem`, `purgeMarked`, `applyDecision`, `replayRows`, `logReplay`).
- `mark` took five positional arguments, two of them same-typed strings that were easy to transpose. Action and status now travel in the options object it already had, as `RecoveryWalMarkDecision`.
- The validators in `recovery-wal-records.ts` were byte-identical to the copy in `src/realtime/recovery-wal.ts`. They now have one home on the server side, so the twin can import them rather than keep a private copy when that lane runs.

**One file outside the target was touched: `server/tools/realtime-append.ts`.** It is `mark`'s only caller, so the signature change required updating it. While there, its three inline `registerTool` blocks became three named functions, which clears the pre-existing `max-lines-per-function` finding (185 lines before this change, 187 after the call-site edit) that the diff-derived check would otherwise have inherited. Schemas and handlers in that file are unchanged by the split.

No behavior moves: schemas, defaults, error strings, log event names, and rotation/append semantics are identical. The empty-but-present journal still reaches compaction, which an early return on zero rows would have skipped.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED, on the untouched file:

```
$ ./node_modules/.bin/oxlint --deny-warnings server/realtime/recovery-wal.ts
server/realtime/recovery-wal.ts:817:2: error eslint(max-lines): File has too many lines (692). help: Maximum allowed is 500.
server/realtime/recovery-wal.ts:264:9: error eslint(complexity): method `append` has a complexity of 13. Maximum allowed is 10.
server/realtime/recovery-wal.ts:335:7: error eslint(complexity): method `mark` has a complexity of 13. Maximum allowed is 10.
server/realtime/recovery-wal.ts:335:7: error eslint(max-params): Function has too many parameters (5). Maximum allowed is 4.
server/realtime/recovery-wal.ts:581:18: error eslint(complexity): private method `loadWal` has a complexity of 13. Maximum allowed is 10.
server/realtime/recovery-wal.ts:748:1: error eslint(complexity): function `isRecoveryWalRecord` has a complexity of 16. Maximum allowed is 10.
server/realtime/recovery-wal.ts:772:1: error eslint(complexity): function `isRecoveryWalItem` has a complexity of 23. Maximum allowed is 10.
server/realtime/recovery-wal.ts:798:1: error eslint(complexity): function `isNormalizedScope` has a complexity of 16. Maximum allowed is 10.

$ DONE_MEANS_780_FILES=server/realtime/recovery-wal.ts bash scripts/done-means/780-touched-files-lint-clean.sh
FAIL: oxlint reported findings in the file(s) listed above.
-> exit 1
```

GREEN, on this branch:

```
$ bash scripts/done-means/780-touched-files-lint-clean.sh
linting 7 file(s) from: git diff --name-only origin/main...HEAD
PASS: every file this branch touched under server/ lints clean.
-> exit 0

$ bunx tsc --noEmit
-> exit 0, no output

$ bun run test:isolated src/realtime/recovery-wal.test.ts server/tools/dependency-arrival.test.ts src/tools/__tests__/get-contract.test.ts src/contract.test.ts
34 pass, 0 fail, 289 expect() calls, across 4 files
-> tests exited 0
```

The two suites that pin this file, `src/realtime/recovery-wal.test.ts` and `server/tools/dependency-arrival.test.ts`, are unmodified.

## Critical Self-Review

- Highest-risk behavior: WAL replay at construction. `loadWal` used to return early only when the file did not exist, so an existing-but-empty journal still reached `compactWal()`. An obvious "return if zero rows" simplification would have silently skipped that; the split preserves it via an explicit `journalExists` check, and the empty-journal path is covered by the existing recovery-wal suite.
- Assumptions that could be wrong: that `mark` has exactly one caller. Verified by `rg -n "\.mark\(" server/ src/ scripts/ --type ts` -- four hits, of which one is the server caller updated here, two are the src-twin test, and one is `src/tools/agent-context-pack.ts` calling the src twin, which this change does not touch. `bunx tsc --noEmit` returning clean is the second check on that.
- Missing/weak tests: no new test is added. Every extracted helper is a pure move of code the existing suites already drive through `RecoveryWalStore`'s public surface -- `append`, `mark`, `buildContextPackFragment`, and replay via the constructor. Adding a test that re-asserts a moved private function would test the refactor, not a behavior. The one genuinely new public surface is `RecoveryWalMarkDecision`, and `recovery-wal.test.ts` exercises both its mark-and-purge and mark-and-review paths.
- Security/permission risk: none added. The validators in `recovery-wal-records.ts` are the trust boundary for an on-disk file, and the table rewrite of `isRecoveryWalItem` checks the same twelve fields with the same predicates -- `label` still must equal the literal, status and action still check against their sets, timestamps still must parse. `isNormalizedScope` still requires all six scope fields non-blank and `thread_id` either null or non-blank. Namespace isolation is unchanged; this module never reads a namespace predicate.
- Migration/deploy risk: none. No SQL, no schema, no migration. The on-disk journal format is byte-identical, so a WAL written by the old code replays under the new code and vice versa.
- Downstream client/runtime risk: none. No MCP tool name, description, input schema, output shape, or error string changed. `src/contract.test.ts` and `src/tools/__tests__/get-contract.test.ts` both pass, which is what locks the client-facing contract.
- Rollback/cleanup concern: a single commit, revertible whole. The five new files are additive; nothing else imports them yet.
- Fixes made before PR: caught that my first cut of `loadWal` returned early on zero rows and would have skipped compaction of an existing empty journal -- corrected before commit. Also caught that extracting result types into their own module left `RECOVERY_WAL_LABEL` and `RECOVERY_WAL_SCHEMA` imported as types while used in `typeof` position, and fixed the import.
- Known residual risk: `src/realtime/recovery-wal.ts` still carries its own copy of these validators. This PR does not change that file, so the duplication is unchanged rather than worsened -- but the src twin now has a shared module to import from when its own lint lane runs, and it should, instead of keeping the private copy.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a lint-standard refactor with no behavior change and produced no MEDIUM+ finding.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, schema, or data-path behavior changed; the change is internal module structure proven by typecheck, the contract tests, and the two pinning suites.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the diff touches none of the paths in `contracts/parity-paths.txt` (`python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, `src/contract-schemas.ts`). All seven changed files are under `server/`, and the shapes those contracts lock are re-exported unchanged from `server/realtime/recovery-wal.ts`, which `src/contract.ts` imports -- verified green by `src/contract.test.ts` and `src/tools/__tests__/get-contract.test.ts`.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Downstream rollout is **not applicable**. The gate applies to MCP tool, schema, protocol, or client-facing changes. This PR changes none: no tool name, description, input schema, annotation, output payload, or error string differs, and `src/contract.test.ts` plus `src/tools/__tests__/get-contract.test.ts` pass unmodified, which is the check that would catch a contract move. The only cross-file edit, `server/tools/realtime-append.ts`, changes how three tools are registered (three named functions instead of one inline block) and not what they register.
