### PR TITLE
refactor(promote-entry): bring server/tools/promote-entry.ts to the lint standard (#780)

### DIFF
--- a/server/tools/promote-entry.ts
+++ b/server/tools/promote-entry.ts
@@ -66,7 +66,8 @@ function promotionAuth(identity: AuthIdentity): AuthInfo {
   return {
     role: identity.role,
     clientId: identity.clientId,
-    namespaceSource: identity.namespaceSource === "delegated" ? "header" : "token",
+    namespaceSource:
+      identity.namespaceSource === "delegated" ? "header" : "token",
   } as AuthInfo;
 }
 
@@ -77,6 +78,158 @@ function isPromotionIdentity(identity: AuthIdentity): boolean {
     identity.role === "ob-admin" ||
     identity.role === "promoter"
   );
+}
+
+/** Input schema for `promote_entry`. */
+const promoteEntryInputSchema = {
+  table: tableEnum.describe("Source table"),
+  id: z.string().uuid().describe("Source entry UUID"),
+  reason: z
+    .string()
+    .max(1000)
+    .optional()
+    .describe("Why this entry is being promoted"),
+  target_namespace: z
+    .string()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Target namespace (default: shared-kb)"),
+  dry_run: z
+    .boolean()
+    .optional()
+    .describe(
+      "Return a promotion report without inserting into the target namespace (default true)",
+    ),
+};
+
+/** MCP annotations for `promote_entry`. */
+const promoteEntryAnnotations = {
+  title: "Promote Entry",
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+/** The already-validated arguments this tool's helpers operate on. */
+interface PromoteEntryArgs {
+  table: string;
+  id: string;
+  reason?: string;
+  target_namespace?: string;
+  dry_run?: boolean;
+}
+
+/**
+ * Resolve the promotion target, refusing the legacy shared name.
+ *
+ * @returns The resolved target namespace, or a refusal message when the
+ * requested target is the pre-rename shared namespace.
+ */
+function resolvePromotionTarget(
+  requested: string | undefined,
+): { target: string } | { refusal: string } {
+  const shared = sharedNamespaceConfig();
+  const target = requested ?? shared.sharedNamespace;
+  // The legacy name is a migration SOURCE, never a write target: accepting
+  // it would recreate the two-names-for-one-lane split the canonical
+  // namespace decision exists to end.
+  if (
+    target === LEGACY_SHARED_NAMESPACE ||
+    target === shared.legacySharedNamespace
+  ) {
+    return {
+      refusal: `Permission denied: '${target}' is a legacy migration source and cannot be a promotion target; use '${shared.canonicalSharedNamespace}'`,
+    };
+  }
+  return { target };
+}
+
+/**
+ * Map a promotion throw onto a caller-safe error result, logging the failure.
+ *
+ * @returns The tool error response for the failed promotion.
+ */
+function respondToPromotionFailure(options: {
+  dependencies: MemoryToolDependencies;
+  args: PromoteEntryArgs;
+  target: string;
+  dryRun: boolean;
+  error: unknown;
+}): ReturnType<typeof errorResult> {
+  const { dependencies, args, target, dryRun, error } = options;
+  // A promotion that never happened used to leave no trace while a
+  // successful one did; silence meaning failure is exactly backwards.
+  dependencies.logger.error(
+    {
+      tool: "promote_entry",
+      table: args.table,
+      sourceId: args.id,
+      targetNamespace: target,
+      dryRun,
+      errorName: error instanceof Error ? error.name : "unknown",
+    },
+    "promote_entry_failed",
+  );
+  // The promotion service marks DELIBERATE rejections with a statusCode
+  // and a curated message, and those are the contract. An error without
+  // one is an unexpected throw whose message is raw driver text --
+  // relation names, connection detail, quoted parameter values -- and
+  // must not reach a caller.
+  const statusCode = (error as { statusCode?: unknown }).statusCode;
+  return errorResult(
+    typeof statusCode === "number" && error instanceof Error
+      ? error.message
+      : "Promotion failed due to an internal error",
+  );
+}
+
+/**
+ * Run the promotion through the owning service and shape its report.
+ *
+ * @returns The promotion report, or an error result when the service throws.
+ */
+async function runPromotion(options: {
+  dependencies: MemoryToolDependencies;
+  args: PromoteEntryArgs;
+  identity: AuthIdentity;
+  target: string;
+}): Promise<ReturnType<typeof textResult> | ReturnType<typeof errorResult>> {
+  const { dependencies, args, identity, target } = options;
+  const dryRun = args.dry_run ?? true;
+  try {
+    const result = await promoteEntry(
+      dependencies.pool,
+      args.table as ResourceTable,
+      args.id,
+      target,
+      args.reason,
+      promotionAuth(identity),
+      { dryRun },
+    );
+    dependencies.logger.info(
+      {
+        tool: "promote_entry",
+        table: args.table,
+        sourceId: args.id,
+        newId: result.new_id,
+        existingId: result.existing_id,
+        targetNamespace: result.target_namespace,
+        status: result.status,
+        dryRun: result.dry_run,
+      },
+      "tool_result",
+    );
+    return textResult(result);
+  } catch (error) {
+    return respondToPromotionFailure({
+      dependencies,
+      args,
+      target,
+      dryRun,
+      error,
+    });
+  }
 }
 
 export function registerPromoteEntryTool(
@@ -90,33 +243,8 @@ export function registerPromoteEntryTool(
         "Promote an entry from an agent namespace to shared-kb or another target namespace. " +
         "Copies the entry with provenance tracking and detects duplicate target rows. " +
         "Dry-run by default.",
-      inputSchema: {
-        table: tableEnum.describe("Source table"),
-        id: z.string().uuid().describe("Source entry UUID"),
-        reason: z
-          .string()
-          .max(1000)
-          .optional()
-          .describe("Why this entry is being promoted"),
-        target_namespace: z
-          .string()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe("Target namespace (default: shared-kb)"),
-        dry_run: z
-          .boolean()
-          .optional()
-          .describe(
-            "Return a promotion report without inserting into the target namespace (default true)",
-          ),
-      },
-      annotations: {
-        title: "Promote Entry",
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      inputSchema: promoteEntryInputSchema,
+      annotations: promoteEntryAnnotations,
     },
     async (args, extra) => {
       const identity = authIdentity(extra.authInfo);
@@ -132,68 +260,15 @@ export function registerPromoteEntryTool(
         );
       }
 
-      const shared = sharedNamespaceConfig();
-      const target = args.target_namespace ?? shared.sharedNamespace;
-      // The legacy name is a migration SOURCE, never a write target: accepting
-      // it would recreate the two-names-for-one-lane split the canonical
-      // namespace decision exists to end.
-      if (target === LEGACY_SHARED_NAMESPACE || target === shared.legacySharedNamespace) {
-        return errorResult(
-          `Permission denied: '${target}' is a legacy migration source and cannot be a promotion target; use '${shared.canonicalSharedNamespace}'`,
-        );
-      }
+      const resolved = resolvePromotionTarget(args.target_namespace);
+      if ("refusal" in resolved) return errorResult(resolved.refusal);
 
-      const dryRun = args.dry_run ?? true;
-      try {
-        const result = await promoteEntry(
-          dependencies.pool,
-          args.table as ResourceTable,
-          args.id,
-          target,
-          args.reason,
-          promotionAuth(identity),
-          { dryRun },
-        );
-        dependencies.logger.info(
-          {
-            tool: "promote_entry",
-            table: args.table,
-            sourceId: args.id,
-            newId: result.new_id,
-            existingId: result.existing_id,
-            targetNamespace: result.target_namespace,
-            status: result.status,
-            dryRun: result.dry_run,
-          },
-          "tool_result",
-        );
-        return textResult(result);
-      } catch (error) {
-        // A promotion that never happened used to leave no trace while a
-        // successful one did; silence meaning failure is exactly backwards.
-        dependencies.logger.error(
-          {
-            tool: "promote_entry",
-            table: args.table,
-            sourceId: args.id,
-            targetNamespace: target,
-            dryRun,
-            errorName: error instanceof Error ? error.name : "unknown",
-          },
-          "promote_entry_failed",
-        );
-        // The promotion service marks DELIBERATE rejections with a statusCode
-        // and a curated message, and those are the contract. An error without
-        // one is an unexpected throw whose message is raw driver text --
-        // relation names, connection detail, quoted parameter values -- and
-        // must not reach a caller.
-        const statusCode = (error as { statusCode?: unknown }).statusCode;
-        return errorResult(
-          typeof statusCode === "number" && error instanceof Error
-            ? error.message
-            : "Promotion failed due to an internal error",
-        );
-      }
+      return runPromotion({
+        dependencies,
+        args,
+        identity,
+        target: resolved.target,
+      });
     },
   );
 }


### PR DESCRIPTION
## Summary

- `server/tools/promote-entry.ts` carried the two remaining lint findings in the file: `registerPromoteEntryTool` ran 104 lines (maximum 100) and its handler had a complexity of 12 (maximum 10). This brings the file to the standard using the shape lanes 2 and 3 established on `search-brain.ts` and `search-all.ts`.
- The input schema and the MCP annotations move to module consts (`promoteEntryInputSchema`, `promoteEntryAnnotations`) with byte-identical description strings; `registerPromoteEntryTool` shrinks to registration alone.
- The handler body splits into three named module-level helpers: `resolvePromotionTarget` (default target plus the legacy-namespace refusal), `runPromotion` (the service call and its success log), and `respondToPromotionFailure` (the failure log and the statusCode-gated message selection). The two multi-argument helpers take an options object.
- No behavior change. The description string, every schema field and its `.describe()` text, the dry-run default of `true`, the legacy-namespace refusal covering both the hardcoded `collab` and the configured `legacySharedNamespace`, the `promote_entry_denied` / `tool_result` / `promote_entry_failed` event names and their field sets, and both caller-facing error strings are unchanged.
- Reuse was checked first and declined with a reason. `respondToSearchFailure` (`server/tools/tool-failure.ts`) logs a search-shaped record (`namespace`/`mode`/`tier`) and always returns the error's own message, whereas this catch logs promotion fields and deliberately withholds an unmarked error's raw driver text — adopting it would change what reaches a caller. `normalizeSearchArgs` (`server/tools/search-request.ts`) has no promotion-shaped defaults to share. No second caller exists for either new helper, so both stay private to this file.
- Exactly one file is touched: `server/tools/promote-entry.ts`. No helper was moved out and no other file was edited.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED (untouched file, before any edit):

```
server/tools/promote-entry.ts:82:8: error eslint(max-lines-per-function): The function `registerPromoteEntryTool` has too many lines (104). Maximum allowed is 100.
server/tools/promote-entry.ts:121:5: error eslint(complexity): async function has a complexity of 12. Maximum allowed is 10.
```

`DONE_MEANS_780_FILES=server/tools/promote-entry.ts bash scripts/done-means/780-touched-files-lint-clean.sh` on that tree printed `FAIL: oxlint reported findings in the file(s) listed above.`

GREEN (re-run on the COMMITTED tree, after the pre-commit prettier pass, so the receipt matches what landed):

- `./node_modules/.bin/oxlint --deny-warnings server/tools/promote-entry.ts` -> exit 0, no findings
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated src/tools/__tests__/promote-entry.test.ts src/tools/__tests__/promote-entry.pg.test.ts server/tools` -> 173 pass, 0 fail, 582 expect() calls across 19 files; isolated database `ob_isolated_28014_mtaf6venkm` created, migrated, and dropped
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived against `origin/main...HEAD`) -> exit 0, `PASS: every file this branch touched under server/ lints clean.`

No existing test was modified. Python package: untouched, not applicable. Live smoke: not applicable — this is a pure in-process refactor with no schema, transport, or wire change.

## Critical Self-Review

- Highest-risk behavior: the legacy-namespace refusal. `promote_entry` must never accept the pre-rename shared name as a write TARGET while it remains valid as a migration SOURCE (AGENTS.md Coding Standards; `docs/decisions/shared-kb-canonical-namespace.md`). Moving that branch into `resolvePromotionTarget` is where a silent weakening would hide, so both arms of the original condition — the hardcoded `LEGACY_SHARED_NAMESPACE` and `shared.legacySharedNamespace` from config — were carried over verbatim, along with the refusal string that names the canonical namespace.
- Assumptions that could be wrong: that `resolvePromotionTarget`'s discriminated return (`{ target }` vs `{ refusal }`) is read correctly at the one call site. If a future caller checked truthiness of the object instead of `"refusal" in resolved`, a refusal would be treated as success. It is narrowed by an `in` check, which the typechecker enforces, and `bunx tsc --noEmit` passes.
- Missing/weak tests: no NEW test was added, because this lane must not change behavior and the existing suite already pins it — `src/tools/__tests__/promote-entry.test.ts` and `promote-entry.pg.test.ts` cover the role refusal, the legacy-target refusal, the dry-run default, and the failure-message gating. The genuinely weak spot is that `server/tools/promote-entry.ts` (the ported server copy) is exercised chiefly through `server/tools/ported-tools-scope.test.ts` rather than by a dedicated per-tool suite, so line-level coverage of the server copy is thinner than of the `src/` one. That gap predates this change and this refactor neither widens nor closes it.
- Security/permission risk: two permission gates run in this handler — the role check (`isPromotionIdentity`) and the legacy-target refusal — and both still execute before any read, in the same order, in the registration handler itself rather than inside a helper that a future edit could skip. `promoteEntry` in `src/promotion-service.ts` keeps its own independent re-check of write authority for the target namespace, so the defense-in-depth property described in the file header is intact. `target_namespace` still flows through unchanged to that service, which owns the namespace predicate.
- Migration/deploy risk: none. No SQL, no schema, no migration, no config key, no environment variable.
- Downstream client/runtime risk: none. The MCP tool name, description, input schema, annotations, result shape, and both error strings are unchanged, so no client sees a different contract. Nothing under `contracts/parity-paths.txt` is touched.
- Rollback/cleanup concern: a single-file, single-commit revert with no state to unwind.
- Fixes made before PR: the first pass placed the dry-run default inside the handler and passed it to `runPromotion` as a fifth positional parameter, which both exceeded the four-parameter maximum and split one decision across two functions; it was moved inside `runPromotion` and the call converted to an options object. The failure-log branch was verified to still receive the same `dryRun` value it logged before.
- Known residual risk: low, and it is reviewer attention rather than runtime — three new module-level helpers mean the reading order of the handler is no longer top-to-bottom in one block, so a reviewer confirming the log field sets has to look in two places. The field sets themselves are unchanged and can be diffed directly.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no new MEDIUM+ finding — it is a mechanical application of the file-shape pattern lanes 2 and 3 already recorded, and the reuse-declined-with-a-reason judgement is already the standing rule in the lane brief rather than a newly discovered one.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no wire, schema, or persistence behavior changes, so a live call would exercise nothing this diff touched.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no path in `contracts/parity-paths.txt` is touched — the diff is confined to `server/tools/promote-entry.ts`, and `python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, and `src/contract-schemas.ts` are all unmodified. The tool's contract surface (name, schema, annotations, result shape) is byte-identical, so no fixture could change.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Downstream rollout is NOT APPLICABLE for a stated reason, not by default. `docs/downstream-rollout.md` scopes the gate to MCP tool/schema/protocol/client-facing changes. This diff changes none of those: `promote_entry` keeps its name, its description string, every input field and `.describe()` text, its annotations block, its success payload, and both error strings. A client cannot observe this change, so there is no cache to refresh and no canary that could distinguish before from after.
