### PR TITLE
refactor(decompose-entry): bring server/tools/decompose-entry.ts to the lint standard (#780)

### DIFF
--- a/server/tools/decompose-entry.ts
+++ b/server/tools/decompose-entry.ts
@@ -72,6 +72,179 @@ interface ReplacementWriteResult {
   readonly intraBatchDuplicates: string[];
 }
 
+/** Frozen `decompose_entry` argument contract: the names, types, and rule values are the API. */
+const decomposeEntryInputSchema = {
+  table: tableEnum,
+  id: z.string().uuid(),
+  max_chunk_chars: z
+    .number()
+    .int()
+    .min(500)
+    .max(8000)
+    .optional()
+    .describe("Maximum proposed replacement size in characters"),
+  overlap_chars: z
+    .number()
+    .int()
+    .min(0)
+    .max(1000)
+    .optional()
+    .describe("Character overlap between proposed replacements"),
+  dry_run: z
+    .boolean()
+    .optional()
+    .describe("Defaults true. false requires apply_mode=write_replacements."),
+  apply_mode: z
+    .enum(["write_replacements"])
+    .optional()
+    .describe("Required with dry_run=false to write replacement thoughts"),
+};
+
+/** Tool annotations; a plan never mutates and an apply is additive, so a repeat is idempotent. */
+const decomposeEntryAnnotations = {
+  title: "Decompose Entry",
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+type DecomposeEntryArgs = z.infer<
+  z.ZodObject<typeof decomposeEntryInputSchema>
+>;
+
+/** Chunk sizing after defaults, or a caller-facing reason the pair is unusable. */
+interface ChunkSizing {
+  readonly maxChunkChars: number;
+  readonly overlapChars: number;
+  readonly rejection?: string;
+}
+
+/**
+ * Resolve the request's guard rails before any database work.
+ *
+ * An apply request missing its explicit mode is refused outright rather than
+ * quietly downgraded to a plan, and an overlap that cannot produce progress is
+ * refused rather than silently clamped.
+ */
+function resolveChunkSizing(args: DecomposeEntryArgs): ChunkSizing {
+  const maxChunkChars = args.max_chunk_chars ?? DEFAULT_DECOMPOSITION_MAX_CHARS;
+  const overlapChars =
+    args.overlap_chars ?? DEFAULT_DECOMPOSITION_OVERLAP_CHARS;
+  if (overlapChars >= maxChunkChars) {
+    return {
+      maxChunkChars,
+      overlapChars,
+      rejection: "overlap_chars must be less than max_chunk_chars",
+    };
+  }
+  return { maxChunkChars, overlapChars };
+}
+
+/** @returns The source row, or `undefined` when it is absent or archived. */
+async function loadSourceRow(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  args: DecomposeEntryArgs,
+): Promise<
+  { id: unknown; namespace: unknown; content_text: unknown } | undefined
+> {
+  const predicate = namespacePredicate(identity, "read", 2);
+  const { rows } = await dependencies.pool.query(
+    `SELECT id, namespace, ${SOURCE_CONTENT_SQL[args.table]} AS content_text
+       FROM ${args.table}
+      WHERE id = $1 AND archived_at IS NULL${predicate.clause}`,
+    [args.id, ...predicate.values],
+  );
+  return rows[0];
+}
+
+/** The zeroed-but-successful apply body for a plan that proposed nothing. */
+function emptyApplyResult(plan: DecompositionPlan): Record<string, unknown> {
+  return {
+    ...plan,
+    dry_run: false,
+    written_ids: [],
+    skipped_duplicates: [],
+    intra_batch_duplicates: [],
+    fully_written: true,
+    apply_summary: {
+      requested_writes: 0,
+      written_count: 0,
+      preexisting_duplicate_count: 0,
+      intra_batch_duplicate_count: 0,
+      fully_written: true,
+      source_row_mutation: "unchanged",
+    },
+  };
+}
+
+/** Write the planned replacements and shape the applied response body. */
+async function applyPlan(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  namespace: string,
+  plan: DecompositionPlan,
+): Promise<Record<string, unknown>> {
+  const applied = await writeReplacementThoughts(
+    dependencies,
+    identity,
+    namespace,
+    plan,
+  );
+  dependencies.logger.info(
+    { tool: "decompose_entry", written: applied.writtenIds.length },
+    "tool_result",
+  );
+  const applySummary = buildApplySummary(plan, applied);
+  return {
+    ...plan,
+    status: "applied",
+    dry_run: false,
+    written_ids: applied.writtenIds,
+    skipped_duplicates: applied.skippedDuplicates,
+    intra_batch_duplicates: applied.intraBatchDuplicates,
+    fully_written: applySummary.fully_written,
+    apply_summary: applySummary,
+  };
+}
+
+async function handleDecomposeEntry(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  args: DecomposeEntryArgs,
+): Promise<ReturnType<typeof textResult>> {
+  const applying = args.dry_run === false;
+  if (applying && args.apply_mode !== "write_replacements") {
+    return errorResult("dry_run=false requires apply_mode=write_replacements");
+  }
+
+  const sizing = resolveChunkSizing(args);
+  if (sizing.rejection) return errorResult(sizing.rejection);
+
+  const row = await loadSourceRow(dependencies, identity, args);
+  if (!row) return errorResult("Entry not found or archived");
+
+  const namespace = String(row.namespace);
+  const plan = planEntryDecomposition({
+    table: args.table,
+    id: String(row.id),
+    namespace,
+    content: String(row.content_text ?? ""),
+    maxChunkChars: sizing.maxChunkChars,
+    overlapChars: sizing.overlapChars,
+  });
+
+  if (!applying) return textResult(plan);
+
+  const denial = applyDenialReason(identity, namespace);
+  if (denial) return errorResult(`Permission denied: ${denial}`);
+
+  if (plan.proposed_replacements.length === 0) {
+    return textResult(emptyApplyResult(plan));
+  }
+  return textResult(await applyPlan(dependencies, identity, namespace, plan));
+}
+
 export function registerDecomposeEntryTool(
   server: McpServer,
   dependencies: MemoryToolDependencies,
@@ -82,124 +255,15 @@ export function registerDecomposeEntryTool(
       description:
         "Plan dry-run-first decomposition of an oversized entry into smaller linked thoughts. " +
         "No writes occur unless dry_run=false and apply_mode=write_replacements.",
-      inputSchema: {
-        table: tableEnum,
-        id: z.string().uuid(),
-        max_chunk_chars: z
-          .number()
-          .int()
-          .min(500)
-          .max(8000)
-          .optional()
-          .describe("Maximum proposed replacement size in characters"),
-        overlap_chars: z
-          .number()
-          .int()
-          .min(0)
-          .max(1000)
-          .optional()
-          .describe("Character overlap between proposed replacements"),
-        dry_run: z
-          .boolean()
-          .optional()
-          .describe("Defaults true. false requires apply_mode=write_replacements."),
-        apply_mode: z
-          .enum(["write_replacements"])
-          .optional()
-          .describe("Required with dry_run=false to write replacement thoughts"),
-      },
-      annotations: {
-        title: "Decompose Entry",
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      inputSchema: decomposeEntryInputSchema,
+      annotations: decomposeEntryAnnotations,
     },
     async (args, extra) => {
       const identity = authIdentity(extra.authInfo);
       if (!identity || !canRead(identity.role, args.table)) {
         return errorResult(`Permission denied: cannot read ${args.table}`);
       }
-
-      // Checked BEFORE any work: an apply request that is missing its explicit
-      // mode is refused outright rather than quietly downgraded to a plan.
-      const applying = args.dry_run === false;
-      if (applying && args.apply_mode !== "write_replacements") {
-        return errorResult("dry_run=false requires apply_mode=write_replacements");
-      }
-
-      const maxChunkChars = args.max_chunk_chars ?? DEFAULT_DECOMPOSITION_MAX_CHARS;
-      const overlapChars = args.overlap_chars ?? DEFAULT_DECOMPOSITION_OVERLAP_CHARS;
-      if (overlapChars >= maxChunkChars) {
-        return errorResult("overlap_chars must be less than max_chunk_chars");
-      }
-
-      const predicate = namespacePredicate(identity, "read", 2);
-      const { rows } = await dependencies.pool.query(
-        `SELECT id, namespace, ${SOURCE_CONTENT_SQL[args.table]} AS content_text
-           FROM ${args.table}
-          WHERE id = $1 AND archived_at IS NULL${predicate.clause}`,
-        [args.id, ...predicate.values],
-      );
-      const row = rows[0];
-      if (!row) return errorResult("Entry not found or archived");
-
-      const namespace = String(row.namespace);
-      const plan = planEntryDecomposition({
-        table: args.table,
-        id: String(row.id),
-        namespace,
-        content: String(row.content_text ?? ""),
-        maxChunkChars,
-        overlapChars,
-      });
-
-      if (!applying) return textResult(plan);
-
-      const denial = applyDenialReason(identity, namespace);
-      if (denial) return errorResult(`Permission denied: ${denial}`);
-
-      // Nothing to write is still a successful apply, reported with a zeroed
-      // summary so a caller can distinguish it from a refusal.
-      if (plan.proposed_replacements.length === 0) {
-        return textResult({
-          ...plan,
-          dry_run: false,
-          written_ids: [],
-          skipped_duplicates: [],
-          intra_batch_duplicates: [],
-          fully_written: true,
-          apply_summary: {
-            requested_writes: 0,
-            written_count: 0,
-            preexisting_duplicate_count: 0,
-            intra_batch_duplicate_count: 0,
-            fully_written: true,
-            source_row_mutation: "unchanged",
-          },
-        });
-      }
-
-      const applied = await writeReplacementThoughts(
-        dependencies,
-        identity,
-        namespace,
-        plan,
-      );
-      dependencies.logger.info(
-        { tool: "decompose_entry", written: applied.writtenIds.length },
-        "tool_result",
-      );
-      return textResult({
-        ...plan,
-        status: "applied",
-        dry_run: false,
-        written_ids: applied.writtenIds,
-        skipped_duplicates: applied.skippedDuplicates,
-        intra_batch_duplicates: applied.intraBatchDuplicates,
-        fully_written: buildApplySummary(plan, applied).fully_written,
-        apply_summary: buildApplySummary(plan, applied),
-      });
+      return handleDecomposeEntry(dependencies, identity, args);
     },
   );
 }
@@ -245,7 +309,7 @@ async function writeReplacementThoughts(
         intraBatchDuplicates.push(alreadyWritten);
         continue;
       }
-      const insertedId = await insertReplacement(
+      const insertedId = await insertReplacement({
         client,
         dependencies,
         identity,
@@ -253,7 +317,7 @@ async function writeReplacementThoughts(
         plan,
         proposal,
         hash,
-      );
+      });
       if (insertedId) {
         writtenIds.push(insertedId);
         writtenIdsByHash.set(hash, insertedId);
@@ -277,16 +341,27 @@ async function writeReplacementThoughts(
   }
 }
 
+/** Everything one replacement insert needs; grouped so the call site stays readable. */
+interface ReplacementInsert {
+  readonly client: PoolClient;
+  readonly dependencies: MemoryToolDependencies;
+  readonly identity: AuthIdentity;
+  readonly namespace: string;
+  readonly plan: DecompositionPlan;
+  readonly proposal: ReplacementProposal;
+  readonly hash: string;
+}
+
 /** @returns The new row id, or `undefined` when the hash already existed. */
-async function insertReplacement(
-  client: PoolClient,
-  dependencies: MemoryToolDependencies,
-  identity: AuthIdentity,
-  namespace: string,
-  plan: DecompositionPlan,
-  proposal: ReplacementProposal,
-  hash: string,
-): Promise<string | undefined> {
+async function insertReplacement({
+  client,
+  dependencies,
+  identity,
+  namespace,
+  plan,
+  proposal,
+  hash,
+}: ReplacementInsert): Promise<string | undefined> {
   const embedding = await dependencies.embedFn(proposal.content);
   const { rows } = await client.query(
     `INSERT INTO thoughts


### PR DESCRIPTION
## Summary

- Wave-2 lane of the #780 lint sweep: brings `server/tools/decompose-entry.ts` fully to the lint standard, with no behavior change.
- Schema and annotations hoisted to `decomposeEntryInputSchema` / `decomposeEntryAnnotations` module consts with byte-identical description strings; `registerDecomposeEntryTool` is now registration plus the read permission check (was 119 lines).
- The handler is split into named module-level helpers — `resolveChunkSizing`, `loadSourceRow`, `emptyApplyResult`, `applyPlan` — sequenced by `handleDecomposeEntry` (complexity was 13).
- `insertReplacement` takes a `ReplacementInsert` options object instead of seven positional parameters.
- Follows the shape landed for `search-brain.ts` and `search-all.ts` (011bf24). One file touched; no other file changed.

Reuse check, per the maximum-reuse ruling: `normalizeSearchArgs` (`server/tools/search-request.ts`) and `respondToSearchFailure` (`server/tools/tool-failure.ts`) were read and rejected — this tool has no search arguments and no catch-and-report path, so neither fits. Every new helper has exactly one caller, so all of them stay private to this file rather than moving to a shared module.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED (untouched file, before any edit):

```
server/tools/decompose-entry.ts:75:8: error eslint(max-lines-per-function): The function `registerDecomposeEntryTool` has too many lines (119). Maximum allowed is 100.
server/tools/decompose-entry.ts:118:5: error eslint(complexity): async function has a complexity of 13. Maximum allowed is 10.
server/tools/decompose-entry.ts:281:33: error eslint(max-params): Function 'insertReplacement' has too many parameters (7). Maximum allowed is 4.
```

`DONE_MEANS_780_FILES=server/tools/decompose-entry.ts bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 1.

GREEN (re-run on the committed tree, after the pre-commit prettier pass):

- `./node_modules/.bin/oxlint --deny-warnings server/tools/decompose-entry.ts` -> exit 0, no findings
- `bunx tsc --noEmit` -> exit 0, clean
- `bun run test:isolated server/tools/decompose-entry.pg.test.ts src/tools/__tests__/decompose-entry.pg.test.ts src/tools/__tests__/decompose-entry.test.ts src/contract.test.ts server/tools` -> 188 pass, 0 fail, 865 expect() calls across 20 files
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived) -> exit 0

Python package checks are not applicable: nothing under `python/openbrain-memory/` is touched. A live smoke is not applicable: the wire contract is unchanged, so there is nothing new to smoke.

## Critical Self-Review

- Highest-risk behavior: the dry-run default. Writing still requires BOTH `dry_run: false` AND `apply_mode: "write_replacements"`, and that pair is checked first in `handleDecomposeEntry` exactly as it was checked first in the old inline handler. Planning still runs through the pool-free `planEntryDecomposition`, so the planning path still cannot write.
- Assumptions that could be wrong: that `z.infer<z.ZodObject<typeof schema>>` gives the same argument type the MCP SDK hands the callback. `bunx tsc --noEmit` is the evidence — the call site passes `args` straight through, so a mismatch would be a type error rather than a silent runtime difference.
- Missing/weak tests: no new tests were added, deliberately — a refactor that adds tests is hiding a behavior change. The existing decompose-entry pg and unit suites plus `src/contract.test.ts` are the pin, and they pass unmodified.
- Security/permission risk: the namespace predicate moved into `loadSourceRow` and the write-side checks stay in `applyDenialReason`; both are still server-side, still auth-derived, and neither the predicate arguments nor the `canWrite`/`canTargetNamespace` pair changed. The read check stays in the registered callback so it runs before any helper.
- Migration/deploy risk: none. No SQL statement, migration, or schema is altered; the two SQL strings are byte-identical to the pre-refactor text.
- Downstream client/runtime risk: none. Tool name, description, input schema, annotations, error strings, response literals, and the `tool_result` log event name are all unchanged, so no client sees a difference.
- Rollback/cleanup concern: single-file, single-commit, revertable on its own.
- Fixes made before PR: the first pass typed the args with `z.objectOutputType`, which does not exist in the repo's zod v4 and also left the table index as `any`; both were caught by `tsc` and replaced with `z.infer<z.ZodObject<...>>` before commit.
- Known residual risk: low. The one thing a reviewer should eyeball is that `applyPlan` now computes `buildApplySummary` once and reuses it for both `fully_written` and `apply_summary`, where the old code called it twice — the function is pure over its two arguments, so the values are identical.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no new review finding — it is a mechanical application of the shape already recorded by the wave-1 lanes, and the one self-caught defect (a zod v3 type helper under zod v4) was caught by the existing typecheck gate rather than revealing a missing check.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the change is internal function structure with an unchanged wire contract, so a live check would exercise nothing this PR altered.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no path in `contracts/parity-paths.txt` is touched — the diff is one file, `server/tools/decompose-entry.ts`, which is outside `python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, and `src/contract-schemas.ts`. `src/contract.test.ts` was run anyway and passes.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Downstream rollout is not applicable. `docs/downstream-rollout.md` scopes rollout to MCP tool/schema/protocol/client-facing changes; this PR changes none of those. The registered tool name, description string, input schema (same keys, same zod rules, same `.describe()` text), annotations, and every response field are identical before and after, so rtech-mcps, mcp2cli, and the Hermes runtime see no contract movement and need no refresh or canary.
