### PR TITLE
refactor(scan-namespace): bring server/tools/scan-namespace.ts to the lint standard (#780)

### DIFF
--- a/server/tools/scan-namespace.ts
+++ b/server/tools/scan-namespace.ts
@@ -62,6 +62,229 @@ function isScanIdentity(identity: AuthIdentity): boolean {
   );
 }
 
+const scanNamespaceInputSchema = {
+  namespace: z.string().min(1).max(500).describe("Agent namespace to scan"),
+  target_namespace: z
+    .string()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe(
+      "Namespace to check for existing promoted duplicates (default shared-kb)",
+    ),
+  table: tableEnum.optional().describe("Limit scan to a specific table"),
+  since: z
+    .string()
+    .optional()
+    .describe("Only entries created after this ISO date"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe(
+      `Max entries to scan per table (default ${DEFAULT_ENTRIES_PER_TABLE})`,
+    ),
+};
+
+const scanNamespaceAnnotations = {
+  title: "Scan Namespace",
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+interface ScanScope {
+  readonly tables: readonly ResourceTable[];
+  readonly perTable: number;
+  readonly scanned: string;
+  readonly targetPhysical: string;
+  readonly targetCanonical: string;
+  readonly since: string | undefined;
+}
+
+interface ScanArgs {
+  readonly namespace: string;
+  readonly target_namespace?: string;
+  readonly table?: string;
+  readonly since?: string;
+  readonly limit?: number;
+}
+
+/**
+ * Resolve the read scope for one scan, or the reason the caller may not have it.
+ *
+ * Cross-namespace visibility is the promotion identities' surface. The role
+ * gate runs first so an unprivileged caller never learns whether the namespace
+ * it named exists.
+ *
+ * @returns The resolved scope, or a `denied` message to return verbatim.
+ */
+function resolveScanScope(
+  identity: AuthIdentity | null | undefined,
+  args: ScanArgs,
+): { scope: ScanScope } | { denied: string } {
+  if (!identity || !isScanIdentity(identity)) {
+    return {
+      denied: "Permission denied: admin, ob-admin, or promoter role required",
+    };
+  }
+  if (!canTargetNamespace(identity, "read", args.namespace)) {
+    return { denied: "Permission denied: namespace read access denied" };
+  }
+
+  const shared = sharedNamespaceConfig();
+  const target = args.target_namespace ?? shared.sharedNamespace;
+  if (!canTargetNamespace(identity, "read", target)) {
+    return { denied: "Permission denied: target namespace read access denied" };
+  }
+
+  const targetPhysical = physicalNamespace(target);
+  return {
+    scope: {
+      tables: args.table ? [args.table as ResourceTable] : ALL_TABLES,
+      perTable: args.limit ?? DEFAULT_ENTRIES_PER_TABLE,
+      // The scanned namespace is bound as a PARAMETER on every statement, not
+      // resolved once and trusted: it is the only thing scoping this read, and
+      // the role gate above proves the caller may target it, not that a later
+      // statement stays inside it.
+      scanned: physicalNamespace(args.namespace),
+      targetPhysical,
+      targetCanonical: canonicalNamespace(targetPhysical),
+      since: args.since,
+    },
+  };
+}
+
+/** @returns Nominated rows in one table, newest first, within the scan scope. */
+async function queryNominatedRows(
+  dependencies: MemoryToolDependencies,
+  table: ResourceTable,
+  scope: ScanScope,
+): Promise<Record<string, unknown>[]> {
+  const values: unknown[] = [scope.scanned, scope.perTable];
+  if (scope.since !== undefined) values.push(scope.since);
+  const sinceFilter =
+    scope.since !== undefined ? " AND t.created_at >= $3" : "";
+
+  const { rows } = await dependencies.pool.query(
+    `SELECT t.id, t.content_hash, t.namespace, t.created_at,
+            ${promotionMetadataSelect(table)} AS metadata
+       FROM ${table} t
+      WHERE t.namespace = $1
+        AND t.archived_at IS NULL${explicitSharedNominationSqlPredicate(table)}${sinceFilter}
+      ORDER BY t.created_at DESC
+      LIMIT $2`,
+    values,
+  );
+  return rows;
+}
+
+/**
+ * @returns The id of an entry in the target namespace with the same content, if
+ * one exists.
+ */
+async function findTargetDuplicateId(
+  dependencies: MemoryToolDependencies,
+  table: ResourceTable,
+  contentHash: unknown,
+  targetPhysical: string,
+): Promise<string | undefined> {
+  if (!contentHash) return undefined;
+  const { rows: existing } = await dependencies.pool.query(
+    `SELECT id FROM ${table}
+      WHERE content_hash = $1 AND namespace = $2 AND archived_at IS NULL
+      LIMIT 1`,
+    [contentHash, targetPhysical],
+  );
+  return (existing[0] as { id: string } | undefined)?.id;
+}
+
+/**
+ * Sort one table's rows into candidates and already-promoted duplicates.
+ *
+ * An entry whose content already exists in the target is reported as a
+ * duplicate INSTEAD of a candidate, so a promoter working the list top to
+ * bottom never re-promotes something already there.
+ */
+async function collectTable(options: {
+  dependencies: MemoryToolDependencies;
+  table: ResourceTable;
+  scope: ScanScope;
+  candidates: Candidate[];
+  duplicates: Duplicate[];
+}): Promise<void> {
+  const { dependencies, table, scope, candidates, duplicates } = options;
+  const rows = await queryNominatedRows(dependencies, table, scope);
+
+  for (const row of rows) {
+    const existingId = await findTargetDuplicateId(
+      dependencies,
+      table,
+      row.content_hash,
+      scope.targetPhysical,
+    );
+    if (existingId) {
+      duplicates.push({
+        table,
+        id: row.id as string,
+        target_namespace: scope.targetCanonical,
+        existing_target_id: existingId,
+        created_at: row.created_at,
+      });
+      continue;
+    }
+
+    if (
+      isExplicitSharedNomination(row.metadata as Record<string, unknown> | null)
+    ) {
+      candidates.push({
+        table,
+        id: row.id as string,
+        created_at: row.created_at,
+      });
+    }
+  }
+}
+
+async function handleScanNamespace(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity | null | undefined,
+  args: ScanArgs,
+) {
+  const resolved = resolveScanScope(identity, args);
+  if ("denied" in resolved) return errorResult(resolved.denied);
+  const { scope } = resolved;
+
+  const candidates: Candidate[] = [];
+  const duplicates: Duplicate[] = [];
+  for (const table of scope.tables) {
+    await collectTable({ dependencies, table, scope, candidates, duplicates });
+  }
+
+  dependencies.logger.info(
+    {
+      tool: "scan_namespace",
+      namespace: scope.scanned,
+      targetNamespace: scope.targetCanonical,
+      candidates: candidates.length,
+      duplicates: duplicates.length,
+    },
+    "tool_result",
+  );
+  return textResult({
+    namespace: args.namespace,
+    target_namespace: scope.targetCanonical,
+    candidates,
+    duplicates,
+    summary: {
+      candidates: candidates.length,
+      duplicates: duplicates.length,
+    },
+  });
+}
+
 export function registerScanNamespaceTool(
   server: McpServer,
   dependencies: MemoryToolDependencies,
@@ -72,143 +295,10 @@ export function registerScanNamespaceTool(
       description:
         "Scan an agent namespace for pending explicit shared-kb nominations. " +
         "Returns nominated candidates and duplicates in the target namespace.",
-      inputSchema: {
-        namespace: z
-          .string()
-          .min(1)
-          .max(500)
-          .describe("Agent namespace to scan"),
-        target_namespace: z
-          .string()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe(
-            "Namespace to check for existing promoted duplicates (default shared-kb)",
-          ),
-        table: tableEnum.optional().describe("Limit scan to a specific table"),
-        since: z
-          .string()
-          .optional()
-          .describe("Only entries created after this ISO date"),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(
-            `Max entries to scan per table (default ${DEFAULT_ENTRIES_PER_TABLE})`,
-          ),
-      },
-      annotations: {
-        title: "Scan Namespace",
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      inputSchema: scanNamespaceInputSchema,
+      annotations: scanNamespaceAnnotations,
     },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      // Cross-namespace visibility is the promotion identities' surface. The
-      // role gate runs first so an unprivileged caller never learns whether the
-      // namespace it named exists.
-      if (!identity || !isScanIdentity(identity)) {
-        return errorResult(
-          "Permission denied: admin, ob-admin, or promoter role required",
-        );
-      }
-      if (!canTargetNamespace(identity, "read", args.namespace)) {
-        return errorResult("Permission denied: namespace read access denied");
-      }
-
-      const shared = sharedNamespaceConfig();
-      const target = args.target_namespace ?? shared.sharedNamespace;
-      if (!canTargetNamespace(identity, "read", target)) {
-        return errorResult(
-          "Permission denied: target namespace read access denied",
-        );
-      }
-      const targetPhysical = physicalNamespace(target);
-      const targetCanonical = canonicalNamespace(targetPhysical);
-
-      const tables = args.table ? [args.table as ResourceTable] : ALL_TABLES;
-      const perTable = args.limit ?? DEFAULT_ENTRIES_PER_TABLE;
-      // The scanned namespace is bound as a PARAMETER on every statement, not
-      // resolved once and trusted: it is the only thing scoping this read, and
-      // the role gate above proves the caller may target it, not that a later
-      // statement stays inside it.
-      const scanned = physicalNamespace(args.namespace);
-
-      const candidates: Candidate[] = [];
-      const duplicates: Duplicate[] = [];
-
-      for (const table of tables) {
-        const values: unknown[] = [scanned, perTable];
-        if (args.since !== undefined) values.push(args.since);
-        const sinceFilter = args.since !== undefined ? " AND t.created_at >= $3" : "";
-
-        const { rows } = await dependencies.pool.query(
-          `SELECT t.id, t.content_hash, t.namespace, t.created_at,
-                  ${promotionMetadataSelect(table)} AS metadata
-             FROM ${table} t
-            WHERE t.namespace = $1
-              AND t.archived_at IS NULL${explicitSharedNominationSqlPredicate(table)}${sinceFilter}
-            ORDER BY t.created_at DESC
-            LIMIT $2`,
-          values,
-        );
-
-        for (const row of rows) {
-          // An entry whose content already exists in the target is reported as a
-          // duplicate INSTEAD of a candidate, so a promoter working the list top
-          // to bottom never re-promotes something already there.
-          if (row.content_hash) {
-            const { rows: existing } = await dependencies.pool.query(
-              `SELECT id FROM ${table}
-                WHERE content_hash = $1 AND namespace = $2 AND archived_at IS NULL
-                LIMIT 1`,
-              [row.content_hash, targetPhysical],
-            );
-            const match = existing[0] as { id: string } | undefined;
-            if (match) {
-              duplicates.push({
-                table,
-                id: row.id,
-                target_namespace: targetCanonical,
-                existing_target_id: match.id,
-                created_at: row.created_at,
-              });
-              continue;
-            }
-          }
-
-          if (isExplicitSharedNomination(row.metadata as Record<string, unknown> | null)) {
-            candidates.push({ table, id: row.id, created_at: row.created_at });
-          }
-        }
-      }
-
-      dependencies.logger.info(
-        {
-          tool: "scan_namespace",
-          namespace: scanned,
-          targetNamespace: targetCanonical,
-          candidates: candidates.length,
-          duplicates: duplicates.length,
-        },
-        "tool_result",
-      );
-      return textResult({
-        namespace: args.namespace,
-        target_namespace: targetCanonical,
-        candidates,
-        duplicates,
-        summary: {
-          candidates: candidates.length,
-          duplicates: duplicates.length,
-        },
-      });
-    },
+    async (args, extra) =>
+      handleScanNamespace(dependencies, authIdentity(extra.authInfo), args),
   );
 }


### PR DESCRIPTION
## Summary

- oxlint flagged three findings on `server/tools/scan-namespace.ts`: `registerScanNamespaceTool` at 132 lines (max 100), the inline handler at complexity 15 (max 10), and a four-deep block at 174:13 (max 3). All three came from one shape — the whole tool, schema through result, lived inside the `registerTool` call.
- Following the shape landed for `search-brain` and `search-all` (011bf24): the input schema and annotations are module consts with the description strings unchanged, `registerScanNamespaceTool` is registration only, and the handler is split into named module-level helpers — `resolveScanScope` (role gate, target resolution, scan scope), `queryNominatedRows`, `findTargetDuplicateId`, and `collectTable`.
- Extracting the duplicate lookup is what flattens the nesting: the early return on a missing `content_hash` replaces the enclosing block. `collectTable` takes an options object rather than five positional parameters.
- No behavior change. Schemas, defaults, permission strings, both SQL statements, the `tool_result` log fields, and the response shape are identical. `target_namespace` still resolves through `sharedNamespaceConfig()`, and the scanned namespace stays a bound parameter on every statement rather than being interpolated.
- Reuse was checked before writing anything: `normalizeSearchArgs` (`server/tools/search-request.ts`) and `respondToSearchFailure` (`server/tools/tool-failure.ts`) do not fit — this tool takes no query/mode/offset args and has no catch block. `read-scope.ts` is not applicable either; this tool gates on `canTargetNamespace` from `server/auth/namespace-policy.ts`, which it already imported. With no second caller today, the new helpers stay private to this file rather than becoming a shared module. One file changed; nothing else is touched.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED (untouched file, before any edit):

```
server/tools/scan-namespace.ts:65:8: error eslint(max-lines-per-function): The function `registerScanNamespaceTool` has too many lines (132). Maximum allowed is 100.
server/tools/scan-namespace.ts:111:5: error eslint(complexity): async function has a complexity of 15. Maximum allowed is 10.
server/tools/scan-namespace.ts:174:13: error eslint(max-depth): Blocks are nested too deeply (4). Maximum allowed is 3.
```

`DONE_MEANS_780_FILES=server/tools/scan-namespace.ts bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 1.

GREEN (re-run on the committed tree, after the pre-commit prettier hook reformatted the staged file):

- `./node_modules/.bin/oxlint --deny-warnings server/tools/scan-namespace.ts` -> 0 findings, exit 0
- `bunx tsc --noEmit` -> clean, exit 0
- `bun run test:isolated src/tools/__tests__/scan-namespace.test.ts server/tools` -> 169 pass, 0 fail, 556 expect() calls, 18 files (isolated database `ob_isolated_38275_mtaf7fzsw3`, dropped on teardown)
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived) -> `PASS: every file this branch touched under server/ lints clean.`, exit 0

Existing tests are unmodified. No lint disable comments were added.

## Critical Self-Review

- Highest-risk behavior: the namespace read scope. `resolveScanScope` now returns the scope that the two SQL statements consume, so a mistake there would widen what a promoter can see. The three permission checks run in the same order as before (role gate, then scanned namespace, then target namespace) and return byte-identical strings; the scanned namespace is still `physicalNamespace(args.namespace)` bound as `$1`, and the target is still `physicalNamespace(target)` bound as `$2`, never interpolated.
- Assumptions that could be wrong: that no caller outside `server/tools/index.ts` reaches into this module. Checked — `rg` finds `registerScanNamespaceTool` only in that one import site, and every new helper is module-private (not exported), so nothing new is reachable.
- Missing/weak tests: this is a pure restructuring with no new branch, so no new test is warranted; the existing suite already covers the role gate, the duplicate-vs-candidate split, and the `target_namespace` default. What the suite does NOT pin is the `since` filter's `$3` binding, which was true before this change and remains so — the parameter list construction is copied verbatim into `queryNominatedRows`, unchanged.
- Security/permission risk: unchanged and specifically preserved. The role gate still runs before any namespace is echoed, so an unprivileged caller still cannot learn whether a namespace exists. `target_namespace` is honored as before, and legacy `collab` remains an internal migration source reached only through `physicalNamespace`/`canonicalNamespace` — this change adds no path around them.
- Migration/deploy risk: none. No schema, no migration, no config, no startup path.
- Downstream client/runtime risk: none. The MCP tool name, description string, input schema, annotations, and response JSON are byte-identical, so no contract a downstream client reads has moved.
- Rollback/cleanup concern: single-file, single-commit revert with no state to unwind.
- Fixes made before PR: the first pass gave `collectTable` five positional parameters (oxlint `max-params`, max 4) and typed the identity as `AuthIdentity | null` while `authIdentity()` returns `AuthIdentity | undefined` (TS2345). Both were fixed before commit — options object, and the widened `AuthIdentity | null | undefined`.
- Known residual risk: low. Behavior rests on the restructuring being faithful rather than on a new test; the argument is the identical SQL, identical strings, and the unmodified suite passing.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no new review finding — it is the same lint-shape refactor already recorded for search-brain and search-all under #780, and re-filing it would duplicate an existing entry rather than teach the next swarm anything.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime behavior, schema, or transport surface changed — the isolated-database suite plus typecheck is the whole exercisable surface of this diff.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the only changed file is `server/tools/scan-namespace.ts`, which is outside every path in `contracts/parity-paths.txt` (`python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, `src/contract-schemas.ts`). The tool's wire contract is unchanged, so no fixture has anything to record.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable, all four: `docs/downstream-rollout.md` scopes rollout to MCP tool/schema/protocol/client-facing changes. This diff changes none of them — the `scan_namespace` tool name, description, input schema, annotations, and response JSON are identical before and after, so no downstream client sees any difference and there is nothing for a canary to exercise.
