### PR TITLE
refactor(adjacent-context): bring server/tools/adjacent-context.ts to the lint standard (#780)

### DIFF
--- a/server/tools/adjacent-context.ts
+++ b/server/tools/adjacent-context.ts
@@ -26,19 +26,22 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../auth/permissions.ts";
-import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import { canReadNamespace } from "./read-scope.ts";
 import { physicalNamespace } from "./shared-namespace.ts";
 import { LINK_RELATIONS } from "./search-constants.ts";
 
 const DIRECTIONS = ["outgoing", "incoming", "both"] as const;
+type Direction = (typeof DIRECTIONS)[number];
 const GRAPH_READ_DENIED = "Permission denied: cannot read link graph";
 
 /** UUID shape accepted for the source node id. */
-const graphUuid = z
-  .string()
-  .uuid()
-  .describe("UUID of the source node");
+const graphUuid = z.string().uuid().describe("UUID of the source node");
 
 interface LinkRow {
   id: string;
@@ -56,99 +59,129 @@ interface LinkRow {
   to_canonical_id: string | null;
 }
 
-export function registerAdjacentContextTool(
-  server: McpServer,
-  dependencies: MemoryToolDependencies,
-): void {
-  server.registerTool(
-    "adjacent_context",
-    {
-      description:
-        "Find entities and entries linked to a given node. " +
-        "Traverses the knowledge graph from a source node in one or both directions.",
-      inputSchema: {
-        type: z.string().min(1).max(200).describe("Type of the source node"),
-        id: graphUuid,
-        namespace: z
-          .string()
-          .max(500)
-          .optional()
-          .describe("Namespace for isolation (defaults to agent's clientId)"),
-        relation: z
-          .enum(LINK_RELATIONS)
-          .optional()
-          .describe("Filter by relation type"),
-        direction: z
-          .enum(DIRECTIONS)
-          .optional()
-          .describe(
-            'Traversal direction: "outgoing", "incoming", or "both" (default)',
-          ),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(200)
-          .optional()
-          .describe("Maximum links to return (default 50)"),
-      },
-      annotations: {
-        title: "Adjacent Context",
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
-    },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      // The link graph spans every table, so the broadest read permission gates
-      // it: a role that cannot read sessions cannot traverse edges into them.
-      if (!identity || !canRead(identity.role, "sessions")) {
-        dependencies.logger.warn(
-          { role: identity?.role ?? "none" },
-          "adjacent_context_denied",
-        );
-        return errorResult(GRAPH_READ_DENIED);
-      }
+/** One returned edge, already restated from the source node's perspective. */
+interface AdjacentLink {
+  id: string;
+  direction: string;
+  relation: string;
+  weight: number;
+  linked_type: string;
+  linked_id: string;
+  linked_name: string | null;
+  canonical_id: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
 
-      const requestedNamespace = args.namespace ?? identity.clientId;
-      if (!canReadNamespace(identity, requestedNamespace)) {
-        return errorResult(
-          `Permission denied: cannot read namespace '${requestedNamespace}'`,
-        );
-      }
-      const namespace = physicalNamespace(requestedNamespace);
-      const direction = args.direction ?? "both";
-      const limit = args.limit ?? 50;
+/** Frozen `adjacent_context` argument contract: the names, types, and rule values are the API. */
+const adjacentContextInputSchema = {
+  type: z.string().min(1).max(200).describe("Type of the source node"),
+  id: graphUuid,
+  namespace: z
+    .string()
+    .max(500)
+    .optional()
+    .describe("Namespace for isolation (defaults to agent's clientId)"),
+  relation: z
+    .enum(LINK_RELATIONS)
+    .optional()
+    .describe("Filter by relation type"),
+  direction: z
+    .enum(DIRECTIONS)
+    .optional()
+    .describe(
+      'Traversal direction: "outgoing", "incoming", or "both" (default)',
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe("Maximum links to return (default 50)"),
+};
 
-      // $1/$2 are the source node; every later index is assigned in bind order
-      // so an optional filter cannot shift a predicate onto the wrong parameter.
-      const params: unknown[] = [args.type, args.id];
-      const edgeCondition =
-        direction === "outgoing"
-          ? "l.from_type = $1 AND l.from_id = $2"
-          : direction === "incoming"
-            ? "l.to_type = $1 AND l.to_id = $2"
-            : "(l.from_type = $1 AND l.from_id = $2) OR (l.to_type = $1 AND l.to_id = $2)";
+/** Tool annotations; `adjacent_context` reads and never mutates. */
+const adjacentContextAnnotations = {
+  title: "Adjacent Context",
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+};
 
-      params.push(namespace);
-      const namespaceCondition = `l.namespace = $${params.length}`;
+/** The handler's arguments after the documented defaults are applied. */
+interface AdjacentContextRequest {
+  type: string;
+  id: string;
+  relation: string | undefined;
+  direction: Direction;
+  limit: number;
+}
 
-      let relationCondition = "";
-      if (args.relation) {
-        params.push(args.relation);
-        relationCondition = ` AND l.relation = $${params.length}`;
-      }
+/**
+ * Apply the documented argument defaults.
+ *
+ * @returns The normalized request; the defaults are part of the frozen contract.
+ */
+function normalizeAdjacentArgs(args: {
+  type: string;
+  id: string;
+  relation?: string;
+  direction?: Direction;
+  limit?: number;
+}): AdjacentContextRequest {
+  return {
+    type: args.type,
+    id: args.id,
+    relation: args.relation,
+    direction: args.direction ?? "both",
+    limit: args.limit ?? 50,
+  };
+}
 
-      params.push(limit);
-      const limitRef = `$${params.length}`;
+/** A parameterized statement: the SQL text and the values bound to it, in order. */
+interface AdjacencyQuery {
+  sql: string;
+  params: unknown[];
+}
 
-      // The entity joins are LEFT joins plus an IS NOT NULL guard rather than
-      // inner joins: an edge whose endpoint is a non-entity row (a thought, a
-      // decision) has no ob_entities match and must still be returned, while an
-      // edge pointing at an archived or deleted ENTITY must be filtered out.
-      // An inner join would silently drop the first case along with the second.
-      const sql = `SELECT
+/**
+ * Build the one-hop adjacency statement for a request.
+ *
+ * @returns The SQL and its bind values, in the order the placeholders were assigned.
+ */
+function buildAdjacencyQuery(
+  request: AdjacentContextRequest,
+  namespace: string,
+): AdjacencyQuery {
+  // $1/$2 are the source node; every later index is assigned in bind order
+  // so an optional filter cannot shift a predicate onto the wrong parameter.
+  const params: unknown[] = [request.type, request.id];
+  const edgeCondition =
+    request.direction === "outgoing"
+      ? "l.from_type = $1 AND l.from_id = $2"
+      : request.direction === "incoming"
+        ? "l.to_type = $1 AND l.to_id = $2"
+        : "(l.from_type = $1 AND l.from_id = $2) OR (l.to_type = $1 AND l.to_id = $2)";
+
+  params.push(namespace);
+  const namespaceCondition = `l.namespace = $${params.length}`;
+
+  let relationCondition = "";
+  if (request.relation) {
+    params.push(request.relation);
+    relationCondition = ` AND l.relation = $${params.length}`;
+  }
+
+  params.push(request.limit);
+  const limitRef = `$${params.length}`;
+
+  // The entity joins are LEFT joins plus an IS NOT NULL guard rather than
+  // inner joins: an edge whose endpoint is a non-entity row (a thought, a
+  // decision) has no ob_entities match and must still be returned, while an
+  // edge pointing at an archived or deleted ENTITY must be filtered out.
+  // An inner join would silently drop the first case along with the second.
+  const sql = `SELECT
   l.id,
   l.from_type,
   l.from_id,
@@ -181,39 +214,126 @@ WHERE (${edgeCondition})
 ORDER BY l.weight DESC, l.created_at DESC
 LIMIT ${limitRef}`;
 
-      try {
-        const { rows } = await dependencies.pool.query<LinkRow>(sql, params);
-        const links = rows.map((row) => {
-          // Reported from the CALLER's perspective, not the row's storage order.
-          const isOutgoing =
-            row.from_type === args.type && row.from_id === args.id;
-          return {
-            id: row.id,
-            direction: isOutgoing ? "outgoing" : "incoming",
-            relation: row.relation,
-            weight: row.weight,
-            linked_type: isOutgoing ? row.to_type : row.from_type,
-            linked_id: isOutgoing ? row.to_id : row.from_id,
-            linked_name: isOutgoing ? row.to_name : row.from_name,
-            canonical_id: isOutgoing ? row.to_canonical_id : row.from_canonical_id,
-            metadata: row.metadata ?? {},
-            created_at: row.created_at,
-          };
-        });
+  return { sql, params };
+}
 
-        dependencies.logger.info(
-          { namespace, direction, count: links.length },
-          "adjacent_context_ok",
-        );
-        return textResult({ links, count: links.length });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        dependencies.logger.error(
-          { namespace, direction, error_message: message },
-          "adjacent_context_db_error",
-        );
-        return errorResult(`Database error during adjacency lookup: ${message}`);
-      }
+/**
+ * Restate one stored edge from the perspective of the node that was asked about.
+ *
+ * @returns The link with `direction` and `linked_*` fields relative to the source node.
+ */
+function linkFromSourcePerspective(
+  row: LinkRow,
+  request: AdjacentContextRequest,
+): AdjacentLink {
+  // Reported from the CALLER's perspective, not the row's storage order.
+  const isOutgoing =
+    row.from_type === request.type && row.from_id === request.id;
+  return {
+    id: row.id,
+    direction: isOutgoing ? "outgoing" : "incoming",
+    relation: row.relation,
+    weight: row.weight,
+    linked_type: isOutgoing ? row.to_type : row.from_type,
+    linked_id: isOutgoing ? row.to_id : row.from_id,
+    linked_name: isOutgoing ? row.to_name : row.from_name,
+    canonical_id: isOutgoing ? row.to_canonical_id : row.from_canonical_id,
+    metadata: row.metadata ?? {},
+    created_at: row.created_at,
+  };
+}
+
+/**
+ * Resolve the namespace this request may read, or the denial that stops it.
+ *
+ * @returns The physical namespace to bind, or the error response to return instead.
+ */
+function authorizeAdjacencyRead(
+  identity: ReturnType<typeof authIdentity>,
+  dependencies: MemoryToolDependencies,
+  requestedFromArgs: string | undefined,
+): { namespace: string } | { denied: ReturnType<typeof errorResult> } {
+  // The link graph spans every table, so the broadest read permission gates
+  // it: a role that cannot read sessions cannot traverse edges into them.
+  if (!identity || !canRead(identity.role, "sessions")) {
+    dependencies.logger.warn(
+      { role: identity?.role ?? "none" },
+      "adjacent_context_denied",
+    );
+    return { denied: errorResult(GRAPH_READ_DENIED) };
+  }
+
+  const requestedNamespace = requestedFromArgs ?? identity.clientId;
+  if (!canReadNamespace(identity, requestedNamespace)) {
+    return {
+      denied: errorResult(
+        `Permission denied: cannot read namespace '${requestedNamespace}'`,
+      ),
+    };
+  }
+  return { namespace: physicalNamespace(requestedNamespace) };
+}
+
+/**
+ * Run the adjacency statement and shape its rows into the tool response.
+ *
+ * @returns The link payload, or the error response when the query fails.
+ */
+async function runAdjacencyLookup(options: {
+  dependencies: MemoryToolDependencies;
+  request: AdjacentContextRequest;
+  namespace: string;
+}): Promise<ReturnType<typeof textResult>> {
+  const { dependencies, request, namespace } = options;
+  const { sql, params } = buildAdjacencyQuery(request, namespace);
+  const { direction } = request;
+
+  try {
+    const { rows } = await dependencies.pool.query<LinkRow>(sql, params);
+    const links = rows.map((row) => linkFromSourcePerspective(row, request));
+
+    dependencies.logger.info(
+      { namespace, direction, count: links.length },
+      "adjacent_context_ok",
+    );
+    return textResult({ links, count: links.length });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    dependencies.logger.error(
+      { namespace, direction, error_message: message },
+      "adjacent_context_db_error",
+    );
+    return errorResult(`Database error during adjacency lookup: ${message}`);
+  }
+}
+
+export function registerAdjacentContextTool(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
+  server.registerTool(
+    "adjacent_context",
+    {
+      description:
+        "Find entities and entries linked to a given node. " +
+        "Traverses the knowledge graph from a source node in one or both directions.",
+      inputSchema: adjacentContextInputSchema,
+      annotations: adjacentContextAnnotations,
+    },
+    async (args, extra) => {
+      const identity = authIdentity(extra.authInfo);
+      const scope = authorizeAdjacencyRead(
+        identity,
+        dependencies,
+        args.namespace,
+      );
+      if ("denied" in scope) return scope.denied;
+
+      return await runAdjacencyLookup({
+        dependencies,
+        request: normalizeAdjacentArgs(args),
+        namespace: scope.namespace,
+      });
     },
   );
 }


### PR DESCRIPTION
## Summary

- `registerAdjacentContextTool` ran 143 lines with a complexity-14 inline handler, because the argument schema, the annotations, the SQL construction, the row reshaping, and the authorization were all written inside the `server.registerTool` call. This applies the shape lane 2 (`search-brain`) and lane 3 (`search-all`, 011bf24) established: schema and annotations hoisted to module consts with their description strings carried over verbatim, and the handler body split into named module-level helpers.
- New private helpers in the same file: `normalizeAdjacentArgs` (documented defaults: direction `both`, 50), `authorizeAdjacencyRead` (resolves the readable namespace or returns the denial), `buildAdjacencyQuery` (statement plus bind values in bind order), `linkFromSourcePerspective` (restates one row relative to the source node), `runAdjacencyLookup` (executes, shapes, logs; takes an options object).
- No behavior change and no other existing file touched. The twin at `src/tools/adjacent-context.ts` is a near-duplicate of this file and is deliberately left alone; that duplication is pre-existing and out of scope for this lane.
- No shared module was extracted, because no second caller exists now and the two obvious reuse candidates would have moved behavior: `server/tools/search-request.ts` `normalizeSearchArgs` defaults `limit` to 10 and carries offset/mode/tier arguments this tool does not publish, and `server/tools/tool-failure.ts` `respondToSearchFailure` logs `mode`/`tier` and returns the bare driver message rather than this tool's `Database error during adjacency lookup: ` prefixed one.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED, on the untouched file at `origin/main`:

```
server/tools/adjacent-context.ts:59:8: error eslint(max-lines-per-function): The function `registerAdjacentContextTool` has too many lines (143). Maximum allowed is 100.
server/tools/adjacent-context.ts:102:5: error eslint(complexity): async function has a complexity of 14. Maximum allowed is 10.
```

`DONE_MEANS_780_FILES=server/tools/adjacent-context.ts bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 1.

GREEN, re-run on the COMMITTED tree after the pre-commit prettier hook reformatted it:

- `./node_modules/.bin/oxlint --deny-warnings server/tools/adjacent-context.ts` -> exit 0, no findings
- `bunx tsc --noEmit` -> exit 0
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived) -> exit 0
- `bun run test:isolated server/tools/search-read-scope.test.ts src/tools/__tests__/adjacent-context.test.ts server/tools` -> 178 pass, 0 fail, 582 expect() calls across 18 files. No test file was modified.

Behavior parity was checked by diff against `HEAD`, not by eye: the SQL template body is byte-identical, and the set of error strings and log event names (`adjacent_context_denied`, `adjacent_context_ok`, `adjacent_context_db_error`) is identical.

## Critical Self-Review

- Highest-risk behavior: the namespace predicate. `adjacent_context` reads the explicit link graph across every table, so the `l.namespace = $n` bind and the `canReadNamespace` check ahead of it are the isolation boundary. Moving the authorization into `authorizeAdjacencyRead` had to preserve both the ORDER (role check, then namespace read check, then `physicalNamespace`) and the fact that the physical mapping happens after the check, never before. `server/tools/search-read-scope.test.ts` pins exactly this and passes.
- Assumptions that could be wrong: that no caller outside `registerAdjacentContextTool` depended on the previous inline structure. Nothing was exported that was not exported before, so the module's public surface is unchanged; the assumption is that the twin in `src/tools/` is a genuine duplicate rather than a divergent implementation this change should have tracked. I did not verify the two are line-for-line equal, only that the server copy is the one #780 named.
- Missing/weak tests: no new test was added, deliberately, since this is a no-behavior-change refactor and the existing suite is the regression net. The weak spot is that `linkFromSourcePerspective`'s direction inference for a self-referential edge (from and to both matching the source node) is exercised by no test before or after this change; that gap is pre-existing and unchanged.
- Security/permission risk: low but real, since the change relocates a permission check. The role gate (`canRead(identity.role, "sessions")`), the denial log with `role`, the namespace read check, and the two distinct denial strings are all preserved verbatim and diff-verified. A `!identity` request still returns the graph-read denial rather than falling through.
- Migration/deploy risk: none. No schema, no migration, no config, no dependency change.
- Downstream client/runtime risk: none. The tool name, its description string, its input schema field names/types/rules, and its annotations are unchanged, so the MCP contract clients see is identical.
- Rollback/cleanup concern: none beyond reverting the single commit; one file, no shared module introduced, nothing for another lane to unwind.
- Fixes made before PR: re-ran oxlint, tsc, the done-means script, and the test selection on the COMMITTED tree rather than the working tree, because the pre-commit prettier hook rewrites staged files and a working-tree pass is not evidence about what landed.
- Known residual risk: `src/tools/adjacent-context.ts` still carries the same 143-line/complexity-14 shape. It is untouched by design and will need its own lane.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no new MEDIUM+ finding — it is a structural refactor with diff-verified behavior parity, and the lint standard it applies is already the #780 sprint's own recorded practice.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime behavior, schema, or contract changed, so a live smoke would exercise nothing this PR altered.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no path in `contracts/parity-paths.txt` is touched. The single changed file is `server/tools/adjacent-context.ts`, which is outside `python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, and `src/contract-schemas.ts`. The `adjacent_context` fixture in `contracts/server/server-recall-family.fixture.json` needs no update, since the tool's published shape and responses are unchanged.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable in every row: downstream rollout is triggered by MCP tool/schema/protocol/client-facing changes. This PR changes none of those — the tool name, description, input schema, annotations, response shape, and error strings are all diff-verified identical to `origin/main`, so no downstream client can observe this change.
