### PR TITLE
refactor(lanes): bring server/tools/lanes.ts to the lint standard (#780)

### DIFF
--- a/server/tools/lanes.ts
+++ b/server/tools/lanes.ts
@@ -1,53 +1,78 @@
+/**
+ * `lane_upsert` and `lane_load` — the durable session-lane surface.
+ *
+ * Design authority: `src/db/migrations/012_session_lanes.sql` (the row shape and
+ * the `(namespace, session_key)` conflict target), `docs/memory-contract.md`
+ * (lanes are the durable half of Codex session memory), and
+ * `docs/decisions/channel-scoped-recall.md` (lane filters are the direct-field
+ * path, distinct from semantic recall).
+ *
+ * BOTH TOOLS ARE NAMESPACE-SCOPED SERVER-SIDE. The namespace written and the
+ * namespace read both come from `authorize`, never from the raw argument, so a
+ * caller naming another tenant's namespace is refused rather than served.
+ *
+ * `lane_upsert` IS A MERGE, NOT A REPLACE. Every updatable column is written
+ * through `COALESCE(EXCLUDED.x, ob_session_lanes.x)`, so an omitted argument
+ * leaves the stored value alone instead of nulling it — that is what lets an
+ * agent update one field of a live lane without restating the whole row (#162
+ * is the regression where an omitted `status` wrongly failed to create a lane).
+ * `metadata` is the exception: it concatenates rather than replaces.
+ */
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { authIdentity, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import { authorize, contentHash, embeddingFields } from "./memory-helpers.ts";
 
 const laneFields = `id, session_key, namespace, status, agent, source, channel_id,
   thread_id, project, topic, current_context_md, metadata, created_by,
   created_at, updated_at, ended_at`;
 
-export function registerLaneTools(
-  server: McpServer,
-  dependencies: MemoryToolDependencies,
-): void {
-  server.registerTool(
-    "lane_upsert",
-    {
-      description: "Create or update a durable session lane by namespace and session key",
-      inputSchema: {
-        session_key: z.string().min(1).max(500),
-        namespace: z.string().optional(),
-        status: z.enum(["active", "wrapped", "archived"]).optional(),
-        agent: z.string().max(500).optional(),
-        source: z.string().max(500).optional(),
-        channel_id: z.string().max(500).optional(),
-        thread_id: z.string().max(500).optional(),
-        project: z.string().max(500).optional(),
-        topic: z.string().max(500).optional(),
-        current_context_md: z.string().max(100_000).optional(),
-        metadata: z.record(z.string().max(100), z.unknown()).optional(),
-      },
-      annotations: {
-        title: "Upsert Session Lane",
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
-    },
-    async (args, extra) => {
-      const auth = authorize(
-        authIdentity(extra.authInfo),
-        "write",
-        "sessions",
-        "cannot write to session lanes",
-        args.namespace,
-      );
-      if (!auth.ok) return auth.response;
-      const context = args.current_context_md || args.topic || "";
-      const embedded = await embeddingFields(dependencies, context);
-      const rows = await dependencies.pool.query(
-        `INSERT INTO ob_session_lanes
+/** Frozen `lane_upsert` argument contract: the names, types, and rule values are the API. */
+const laneUpsertInputSchema = {
+  session_key: z.string().min(1).max(500),
+  namespace: z.string().optional(),
+  status: z.enum(["active", "wrapped", "archived"]).optional(),
+  agent: z.string().max(500).optional(),
+  source: z.string().max(500).optional(),
+  channel_id: z.string().max(500).optional(),
+  thread_id: z.string().max(500).optional(),
+  project: z.string().max(500).optional(),
+  topic: z.string().max(500).optional(),
+  current_context_md: z.string().max(100_000).optional(),
+  metadata: z.record(z.string().max(100), z.unknown()).optional(),
+};
+
+/** Tool annotations; `lane_upsert` writes, but re-running it converges. */
+const laneUpsertAnnotations = {
+  title: "Upsert Session Lane",
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+/** Frozen `lane_load` argument contract: the names, types, and rule values are the API. */
+const laneLoadInputSchema = {
+  session_key: z.string().optional(),
+  namespace: z.string().optional(),
+  project: z.string().optional(),
+  agent: z.string().optional(),
+  channel_id: z.string().optional(),
+  status: z.enum(["active", "wrapped", "archived"]).optional(),
+};
+
+/** Tool annotations; `lane_load` reads and never mutates. */
+const laneLoadAnnotations = {
+  title: "Load Session Lane",
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+const LANE_UPSERT_SQL = `INSERT INTO ob_session_lanes
            (session_key, namespace, status, agent, source, channel_id, thread_id,
             project, topic, current_context_md, metadata, embedding, content_hash,
             embedded_at, embedding_model, created_by)
@@ -66,91 +91,226 @@ export function registerLaneTools(
            content_hash = COALESCE(EXCLUDED.content_hash, ob_session_lanes.content_hash),
            embedded_at = COALESCE(EXCLUDED.embedded_at, ob_session_lanes.embedded_at),
            embedding_model = COALESCE(EXCLUDED.embedding_model, ob_session_lanes.embedding_model)
-         RETURNING id, (xmax = 0) AS is_new, status, updated_at`,
-        [
-          args.session_key,
-          auth.namespace,
-          args.status ?? "active",
-          args.agent ?? null,
-          args.source ?? null,
-          args.channel_id ?? null,
-          args.thread_id ?? null,
-          args.project ?? null,
-          args.topic ?? null,
-          args.current_context_md ?? null,
-          JSON.stringify(args.metadata ?? {}),
-          embedded.embedding,
-          context ? contentHash(`${args.session_key}|${context}`) : null,
-          embedded.embeddedAt,
-          embedded.model,
-          auth.identity.clientId,
-        ],
-      );
-      const row = rows.rows[0];
-      dependencies.logger.info({ tool: "lane_upsert", namespace: auth.namespace }, "tool_result");
-      return textResult({
-        id: row.id,
-        session_key: args.session_key,
-        namespace: auth.namespace,
-        status: row.status,
-        is_new: row.is_new,
-        embedded: embedded.embedded,
-        updated_at: row.updated_at,
-      });
+         RETURNING id, (xmax = 0) AS is_new, status, updated_at`;
+
+/** The `lane_upsert` arguments after the tool schema has parsed them. */
+type LaneUpsertArgs = {
+  [K in keyof typeof laneUpsertInputSchema]: z.infer<
+    (typeof laneUpsertInputSchema)[K]
+  >;
+};
+
+/** The `lane_load` arguments after the tool schema has parsed them. */
+type LaneLoadArgs = {
+  [K in keyof typeof laneLoadInputSchema]: z.infer<
+    (typeof laneLoadInputSchema)[K]
+  >;
+};
+
+/** The embedding columns as `embeddingFields` returns them. */
+type LaneEmbedding = Awaited<ReturnType<typeof embeddingFields>>;
+
+/**
+ * The text a lane embeds on.
+ *
+ * The explicit context wins over the topic, and an absent pair embeds nothing —
+ * that empty string is what later suppresses both the embedding and the hash.
+ *
+ * @returns The context text, or an empty string when the lane carries neither.
+ */
+function laneEmbedContext(args: LaneUpsertArgs): string {
+  return args.current_context_md || args.topic || "";
+}
+
+/** The optional lane columns, with `undefined` normalized to SQL `NULL`. */
+const LANE_NULLABLE_COLUMNS = [
+  "agent",
+  "source",
+  "channel_id",
+  "thread_id",
+  "project",
+  "topic",
+  "current_context_md",
+] as const;
+
+/**
+ * Normalize the optional lane columns to the values the statement binds.
+ *
+ * Each `undefined` becomes SQL `NULL`, which is what the statement's `COALESCE`
+ * arms then read as "leave the stored value alone".
+ *
+ * @returns The seven optional column values, in the order the SQL names them.
+ */
+function laneNullableValues(args: LaneUpsertArgs): unknown[] {
+  return LANE_NULLABLE_COLUMNS.map((column) => args[column] ?? null);
+}
+
+/**
+ * Build the positional parameters for the upsert, in the order the SQL names them.
+ *
+ * @returns The 16 bind values for `LANE_UPSERT_SQL`.
+ */
+function laneUpsertValues(options: {
+  args: LaneUpsertArgs;
+  namespace: string;
+  clientId: string;
+  context: string;
+  embedded: LaneEmbedding;
+}): unknown[] {
+  const { args, namespace, clientId, context, embedded } = options;
+  return [
+    args.session_key,
+    namespace,
+    args.status ?? "active",
+    ...laneNullableValues(args),
+    JSON.stringify(args.metadata ?? {}),
+    embedded.embedding,
+    context ? contentHash(`${args.session_key}|${context}`) : null,
+    embedded.embeddedAt,
+    embedded.model,
+    clientId,
+  ];
+}
+
+/** A `WHERE` clause and the values its placeholders refer to. */
+interface LaneQueryPredicate {
+  conditions: string[];
+  values: unknown[];
+}
+
+/**
+ * Build the `lane_load` predicate from the direct-field filters that were supplied.
+ *
+ * Namespace and status are always constrained; the remaining four are appended
+ * only when present, so an omitted filter widens the query rather than matching
+ * `NULL`.
+ *
+ * @returns The conditions and their positional values, index-aligned.
+ */
+function laneLoadPredicate(
+  args: LaneLoadArgs,
+  namespace: string,
+): LaneQueryPredicate {
+  const values: unknown[] = [namespace, args.status ?? "active"];
+  const conditions = ["namespace = $1", "status = $2"];
+  const filters: Array<[unknown, string]> = [
+    [args.session_key, "session_key"],
+    [args.project, "project"],
+    [args.agent, "agent"],
+    [args.channel_id, "channel_id"],
+  ];
+  for (const [value, column] of filters) {
+    if (value === undefined) continue;
+    values.push(value);
+    conditions.push(`${column} = $${values.length}`);
+  }
+  return { conditions, values };
+}
+
+/**
+ * Write the lane and shape the tool response.
+ *
+ * @returns The upsert result, or the authorization refusal when the caller
+ *   may not write session lanes in the resolved namespace.
+ */
+async function handleLaneUpsert(
+  dependencies: MemoryToolDependencies,
+  args: LaneUpsertArgs,
+  authInfo: unknown,
+): Promise<ReturnType<typeof textResult>> {
+  const auth = authorize(
+    authIdentity(authInfo),
+    "write",
+    "sessions",
+    "cannot write to session lanes",
+    args.namespace,
+  );
+  if (!auth.ok) return auth.response;
+  const context = laneEmbedContext(args);
+  const embedded = await embeddingFields(dependencies, context);
+  const rows = await dependencies.pool.query(
+    LANE_UPSERT_SQL,
+    laneUpsertValues({
+      args,
+      namespace: auth.namespace,
+      clientId: auth.identity.clientId,
+      context,
+      embedded,
+    }),
+  );
+  const row = rows.rows[0];
+  dependencies.logger.info(
+    { tool: "lane_upsert", namespace: auth.namespace },
+    "tool_result",
+  );
+  return textResult({
+    id: row.id,
+    session_key: args.session_key,
+    namespace: auth.namespace,
+    status: row.status,
+    is_new: row.is_new,
+    embedded: embedded.embedded,
+    updated_at: row.updated_at,
+  });
+}
+
+/**
+ * Read the matching lanes and shape the tool response.
+ *
+ * @returns The matching lanes, an explicit empty-with-message result when none
+ *   match, or the authorization refusal.
+ */
+async function handleLaneLoad(
+  dependencies: MemoryToolDependencies,
+  args: LaneLoadArgs,
+  authInfo: unknown,
+): Promise<ReturnType<typeof textResult>> {
+  const auth = authorize(
+    authIdentity(authInfo),
+    "read",
+    "sessions",
+    "cannot read session lanes",
+    args.namespace,
+  );
+  if (!auth.ok) return auth.response;
+  const { conditions, values } = laneLoadPredicate(args, auth.namespace);
+  const rows = await dependencies.pool.query(
+    `SELECT ${laneFields} FROM ob_session_lanes
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY updated_at DESC`,
+    values,
+  );
+  if (rows.rows.length === 0) {
+    return textResult({
+      lanes: [],
+      message: "No lanes found matching filters",
+    });
+  }
+  return textResult({ lanes: rows.rows, count: rows.rows.length });
+}
+
+export function registerLaneTools(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
+  server.registerTool(
+    "lane_upsert",
+    {
+      description:
+        "Create or update a durable session lane by namespace and session key",
+      inputSchema: laneUpsertInputSchema,
+      annotations: laneUpsertAnnotations,
     },
+    async (args, extra) => handleLaneUpsert(dependencies, args, extra.authInfo),
   );
 
   server.registerTool(
     "lane_load",
     {
       description: "Load durable session lanes by direct fields",
-      inputSchema: {
-        session_key: z.string().optional(),
-        namespace: z.string().optional(),
-        project: z.string().optional(),
-        agent: z.string().optional(),
-        channel_id: z.string().optional(),
-        status: z.enum(["active", "wrapped", "archived"]).optional(),
-      },
-      annotations: {
-        title: "Load Session Lane",
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      inputSchema: laneLoadInputSchema,
+      annotations: laneLoadAnnotations,
     },
-    async (args, extra) => {
-      const auth = authorize(
-        authIdentity(extra.authInfo),
-        "read",
-        "sessions",
-        "cannot read session lanes",
-        args.namespace,
-      );
-      if (!auth.ok) return auth.response;
-      const values: unknown[] = [auth.namespace, args.status ?? "active"];
-      const conditions = ["namespace = $1", "status = $2"];
-      const filters: Array<[unknown, string]> = [
-        [args.session_key, "session_key"],
-        [args.project, "project"],
-        [args.agent, "agent"],
-        [args.channel_id, "channel_id"],
-      ];
-      for (const [value, column] of filters) {
-        if (value === undefined) continue;
-        values.push(value);
-        conditions.push(`${column} = $${values.length}`);
-      }
-      const rows = await dependencies.pool.query(
-        `SELECT ${laneFields} FROM ob_session_lanes
-          WHERE ${conditions.join(" AND ")}
-          ORDER BY updated_at DESC`,
-        values,
-      );
-      if (rows.rows.length === 0) {
-        return textResult({ lanes: [], message: "No lanes found matching filters" });
-      }
-      return textResult({ lanes: rows.rows, count: rows.rows.length });
-    },
+    async (args, extra) => handleLaneLoad(dependencies, args, extra.authInfo),
   );
 }


### PR DESCRIPTION
## Summary

- `registerLaneTools` ran 146 lines and the `lane_upsert` handler scored 14 on complexity; both exceeded the repo rules (100 lines, complexity 10). The two tool bodies were inline, so the schemas, annotations, SQL, and every branch lived inside one registration function.
- Both tools now follow the shape lanes 2 and 3 established on `server/tools/search-brain.ts` and `server/tools/search-all.ts`: input schemas and annotations hoisted to module consts with their description strings unchanged, the upsert statement hoisted to `LANE_UPSERT_SQL`, and each handler extracted to a named module-level function that `registerLaneTools` only registers.
- `laneUpsertValues` takes an options object instead of five positional parameters, and the seven optional columns normalize through `laneNullableValues` — that split is what brings the upsert path under the complexity rule, since each `??` counted against it.
- No behavior change: the SQL text, the parameter order, the tool descriptions, the annotations, the `tool_result` log event, and the no-match message are byte-identical to the previous file.
- No other file is touched. No helper was extracted to a shared module because no second caller exists now; `normalizeSearchArgs` and `respondToSearchFailure` were both checked and neither fits (this file has no search-shaped arguments and no try/catch failure path).

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED (untouched file):

```
server/tools/lanes.ts:10:8: error eslint(max-lines-per-function): The function `registerLaneTools` has too many lines (146). Maximum allowed is 100.
server/tools/lanes.ts:38:5: error eslint(complexity): async function has a complexity of 14. Maximum allowed is 10.
```

`DONE_MEANS_780_FILES=server/tools/lanes.ts bash scripts/done-means/780-touched-files-lint-clean.sh` exited 1.

GREEN (committed tree, re-run after the pre-commit prettier hook reformatted the file):

- `./node_modules/.bin/oxlint --deny-warnings server/tools/lanes.ts` -> exit 0
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived) -> exit 0, PASS
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated src/tools/__tests__/lane-upsert.test.ts src/tools/__tests__/lane-load.test.ts src/contract.test.ts server/tools` -> 212 pass, 0 fail, 833 expect() calls, 20 files

## Critical Self-Review

- Highest-risk behavior: the `lane_upsert` bind order. The 16 positional values now come from `laneUpsertValues`, and a reordering would silently write the wrong column. Guarded by keeping the array literal in the original order with the seven optional columns spliced in via `LANE_NULLABLE_COLUMNS`, declared in the same SQL order, and by the passing `lane-upsert` tests which assert the written row.
- Assumptions that could be wrong: that `args[column] ?? null` over `LANE_NULLABLE_COLUMNS` is exactly equivalent to the seven hand-written `?? null` expressions. It is — the columns are all `string | undefined` in the schema — but a future column typed to allow `null` explicitly would need re-checking.
- Missing/weak tests: no new tests were added, because this change asserts no new behavior. The existing `lane-upsert.test.ts` and `lane-load.test.ts` pin the write shape and the filter predicate and were left unmodified; `src/tools/lane-load.ts` reports 100% and `lane-upsert.ts` 96% line coverage in this run.
- Security/permission risk: none introduced. Both handlers still call `authorize` as their first statement and still return `auth.response` on refusal before any query runs; the namespace bound into both statements is still `auth.namespace`, never the raw argument.
- Migration/deploy risk: none. No schema, no migration, no config.
- Downstream client/runtime risk: none. The tool names, descriptions, input schemas, annotations, and result shapes are unchanged, so no client sees a different contract.
- Rollback/cleanup concern: single-file, single-commit; revert is clean.
- Fixes made before PR: the first refactor left `laneUpsertValues` at complexity 11 because all eleven nullish operators still lived in one function. Split out `laneNullableValues` and re-linted before committing.
- Known residual risk: low. The change is mechanical extraction with no logic moved across a branch.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane found no new failure pattern — it applied the extraction shape lanes 2 and 3 already recorded, and the one self-caught miss (complexity counts every `??`) is already visible in the lint rule itself.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, schema, or data-path behavior changed; the tools register with identical descriptions and schemas.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no path in `contracts/parity-paths.txt` is touched. This commit changes exactly one file, `server/tools/lanes.ts`, which is outside `python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, and `src/contract-schemas.ts`. The tool contract itself is unchanged, so the existing fixtures remain correct — `src/contract.test.ts` was run and passes.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable: this is an internal refactor with no MCP tool, schema, protocol, or client-facing change. `lane_upsert` and `lane_load` publish the same names, descriptions, input schemas, annotations, and result shapes as before, so no downstream consumer observes a difference. `src/contract.test.ts` passing is the evidence the published contract did not move.
