### PR TITLE
refactor(promotion): bring server/tools/promotion.ts to the lint standard (#780)

### DIFF
--- a/server/tools/promotion.ts
+++ b/server/tools/promotion.ts
@@ -24,7 +24,10 @@ import { canRead } from "../auth/permissions.ts";
 import { namespacePredicate } from "../auth/namespace-policy.ts";
 import type { AuthIdentity, ResourceTable } from "../auth/types.ts";
 import type { AuthInfo } from "../../src/types.ts";
-import { canonicalNamespace, sharedNamespaceConfig } from "../../src/shared-namespace.ts";
+import {
+  canonicalNamespace,
+  sharedNamespaceConfig,
+} from "../../src/shared-namespace.ts";
 import { classifyShareCandidate } from "../../src/sharing.ts";
 import { promoteEntry } from "../../src/promotion-service.ts";
 import {
@@ -61,18 +64,380 @@ function promotionAuth(identity: AuthIdentity): AuthInfo {
     role: identity.role,
     clientId: identity.clientId,
     tokenClientId: identity.tokenClientId,
-    namespaceSource: identity.namespaceSource === "delegated" ? "header" : "token",
+    namespaceSource:
+      identity.namespaceSource === "delegated" ? "header" : "token",
   };
 }
 
 /** @returns The text a classifier fed for this row. */
-function shareContent(table: PromotableTable, row: Record<string, unknown>): string {
+function shareContent(
+  table: PromotableTable,
+  row: Record<string, unknown>,
+): string {
   if (table === "decisions") {
     const title = (row.title as string | null) ?? "";
     const rationale = (row.rationale as string | null) ?? "";
     return `${title} ${rationale}`.trim();
   }
   return (row.content as string | null) ?? "";
+}
+
+/** @returns Whether this identity may attempt a shared-truth promotion. */
+function isPromotionIdentity(identity: AuthIdentity): boolean {
+  return (
+    identity.role === "promoter" ||
+    identity.role === "admin" ||
+    identity.role === "ob-admin"
+  );
+}
+
+/** Frozen `list_namespaces` argument contract: the names and types are the API. */
+const listNamespacesInputSchema = {
+  raw: z
+    .boolean()
+    .optional()
+    .describe(
+      "Return physical namespace names instead of canonical public names",
+    ),
+};
+
+/** Tool annotations; `list_namespaces` reads and never mutates. */
+const listNamespacesAnnotations = {
+  title: "List Namespaces",
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+/** Frozen `promote_shared` argument contract: the names, types, and rule values are the API. */
+const promoteSharedInputSchema = {
+  table: z
+    .enum(PROMOTABLE_TABLES)
+    .describe("Source table holding the entry to promote"),
+  id: z.string().uuid().describe("Source entry id"),
+  target_namespace: z
+    .string()
+    .trim()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe(
+      "Shared namespace to promote into. Defaults to the canonical shared " +
+        "namespace. The legacy 'collab' name is an internal migration source " +
+        "only and is refused as a target.",
+    ),
+  reason: z
+    .string()
+    .min(1)
+    .max(2000)
+    .optional()
+    .describe("Why this entry is being promoted to shared truth"),
+  dry_run: z
+    .boolean()
+    .optional()
+    .describe("Preview without writing to shared-kb (default true)"),
+};
+
+/** Tool annotations; `promote_shared` writes, but re-promoting is idempotent. */
+const promoteSharedAnnotations = {
+  title: "Promote To Shared KB",
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+/** One namespace's rolled-up counts across every readable table. */
+interface NamespaceTotals {
+  total: number;
+  per_table: Record<string, number>;
+}
+
+/**
+ * Count live entries per namespace in every table this role may read.
+ *
+ * @returns One row set per readable table, each carrying `table_name`,
+ * `namespace`, and `count`.
+ */
+function countNamespaceRows(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  tables: readonly ResourceTable[],
+): Promise<Record<string, unknown>[][]> {
+  return Promise.all(
+    tables.map(async (table) => {
+      const predicate = namespacePredicate(identity, "read", 1);
+      const { rows } = await dependencies.pool.query(
+        `SELECT '${table}' AS table_name, namespace, COUNT(*) AS count
+           FROM ${table}
+          WHERE archived_at IS NULL${predicate.clause}
+          GROUP BY namespace
+          ORDER BY count DESC`,
+        [...predicate.values],
+      );
+      return rows;
+    }),
+  );
+}
+
+/**
+ * Fold per-table counts into one entry per reported namespace.
+ *
+ * Folding legacy names onto the canonical one can collide two physical
+ * namespaces into a single reported lane, so counts are SUMMED per table rather
+ * than overwritten.
+ *
+ * @returns Namespaces with their totals, most entries first.
+ */
+function foldNamespaceCounts(
+  results: Record<string, unknown>[][],
+  raw: boolean | undefined,
+): Array<{ namespace: string } & NamespaceTotals> {
+  const byNamespace = new Map<string, NamespaceTotals>();
+  for (const rows of results) {
+    for (const row of rows) {
+      const physical = String(row.namespace);
+      const name = raw ? physical : canonicalNamespace(physical);
+      const entry = byNamespace.get(name) ?? { total: 0, per_table: {} };
+      const count = Number(row.count);
+      entry.total += count;
+      entry.per_table[String(row.table_name)] =
+        (entry.per_table[String(row.table_name)] ?? 0) + count;
+      byNamespace.set(name, entry);
+    }
+  }
+
+  return [...byNamespace.entries()]
+    .map(([namespace, data]) => ({
+      namespace,
+      total: data.total,
+      per_table: data.per_table,
+    }))
+    .sort((a, b) => b.total - a.total);
+}
+
+/** @returns The namespace inventory, or an error result when nothing is readable. */
+async function handleListNamespaces(
+  dependencies: MemoryToolDependencies,
+  args: { raw?: boolean },
+  authInfo: unknown,
+): Promise<ReturnType<typeof textResult>> {
+  const identity = authIdentity(authInfo as Parameters<typeof authIdentity>[0]);
+  if (!identity) return errorResult("Permission denied: not authenticated");
+  const accessible = ALL_TABLES.filter((table) =>
+    canRead(identity.role, table),
+  );
+  if (accessible.length === 0) {
+    return errorResult("Permission denied: no readable tables");
+  }
+
+  const results = await countNamespaceRows(dependencies, identity, accessible);
+  const namespaces = foldNamespaceCounts(results, args.raw);
+
+  dependencies.logger.info(
+    { tool: "list_namespaces", namespaceCount: namespaces.length },
+    "tool_result",
+  );
+  return textResult({ namespace_count: namespaces.length, namespaces });
+}
+
+/** A promotion request that cleared identity and target-namespace checks. */
+interface PromotionTarget {
+  identity: AuthIdentity;
+  target: string;
+}
+
+/**
+ * Check that the caller may promote and that the target namespace is writable.
+ *
+ * Defense in depth: refused here before any read, and `promoteEntry` re-checks
+ * write authority for the target namespace on its own.
+ *
+ * @returns The authorized target, or the error result that refused it.
+ */
+function authorizePromotion(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity | undefined,
+  requestedNamespace: string | undefined,
+): PromotionTarget | ReturnType<typeof errorResult> {
+  if (!identity || !isPromotionIdentity(identity)) {
+    dependencies.logger.warn(
+      { tool: "promote_shared", role: identity?.role },
+      "promote_shared_denied",
+    );
+    return errorResult(
+      "Permission denied: shared-kb promotion requires the promoter, admin, or ob-admin identity",
+    );
+  }
+
+  const shared = sharedNamespaceConfig();
+  const target = requestedNamespace ?? shared.canonicalSharedNamespace;
+  // The legacy name is a migration SOURCE, never a write target: accepting
+  // it here would recreate the two-names-for-one-lane split that the
+  // canonical-namespace decision exists to end.
+  //
+  // `collab` is refused UNCONDITIONALLY, not just when it is the configured
+  // legacy name. `legacySharedNamespace` defaults to empty, so a
+  // config-gated check would silently allow `collab` as a target in exactly
+  // the default deployment -- the rule is about the name, not the setting.
+  if (
+    target === LEGACY_SHARED_NAMESPACE ||
+    target === shared.legacySharedNamespace
+  ) {
+    return errorResult(
+      `Permission denied: '${target}' is a legacy migration source and cannot be a promotion target; use '${shared.canonicalSharedNamespace}'`,
+    );
+  }
+
+  return { identity, target };
+}
+
+/** @returns True when authorization returned a refusal rather than a target. */
+function isRefusal(
+  outcome: PromotionTarget | ReturnType<typeof errorResult>,
+): outcome is ReturnType<typeof errorResult> {
+  return !("identity" in outcome);
+}
+
+/**
+ * Read the source row under the caller's own read scope.
+ *
+ * `table` is a validated enum, so the branch is an allowlist rather than
+ * interpolation of caller text.
+ *
+ * @returns The row, or undefined when it is missing or archived.
+ */
+async function loadPromotionSource(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  table: PromotableTable,
+  id: string,
+): Promise<Record<string, unknown> | undefined> {
+  const contentColumns = table === "decisions" ? "title, rationale" : "content";
+  const predicate = namespacePredicate(identity, "read", 2);
+  const { rows } = await dependencies.pool.query(
+    `SELECT id, ${contentColumns}, tags, extracted_metadata
+       FROM ${table as ResourceTable}
+      WHERE id = $1 AND archived_at IS NULL${predicate.clause}`,
+    [id, ...predicate.values],
+  );
+  return rows.length === 0 ? undefined : (rows[0] as Record<string, unknown>);
+}
+
+/** Everything the promotion call itself needs once the request is authorized. */
+interface RunPromotionOptions {
+  dependencies: MemoryToolDependencies;
+  identity: AuthIdentity;
+  table: PromotableTable;
+  id: string;
+  target: string;
+  reason: string | undefined;
+  dryRun: boolean;
+  classification: string;
+}
+
+/** @returns The promotion result, or the error result its failure maps to. */
+async function runPromotion(
+  options: RunPromotionOptions,
+): Promise<ReturnType<typeof textResult>> {
+  const {
+    dependencies,
+    identity,
+    table,
+    id,
+    target,
+    reason,
+    dryRun,
+    classification,
+  } = options;
+  try {
+    const result = await promoteEntry(
+      dependencies.pool,
+      table,
+      id,
+      target,
+      reason,
+      promotionAuth(identity),
+      { dryRun },
+    );
+    dependencies.logger.info(
+      { tool: "promote_shared", id, status: result.status, dryRun },
+      "tool_result",
+    );
+    return textResult({ classification, ...result });
+  } catch (error) {
+    const statusCode = (error as { statusCode?: number }).statusCode;
+    const message = error instanceof Error ? error.message : String(error);
+    dependencies.logger.warn(
+      { tool: "promote_shared", id, statusCode },
+      "promote_shared_error",
+    );
+    return errorResult(
+      statusCode && statusCode < 500
+        ? `Permission denied: ${message}`
+        : `Promotion failed: ${message}`,
+    );
+  }
+}
+
+/** The `promote_shared` arguments, as validated by its input schema. */
+interface PromoteSharedArgs {
+  table: PromotableTable;
+  id: string;
+  target_namespace?: string;
+  reason?: string;
+  dry_run?: boolean;
+}
+
+/** @returns The promotion outcome, or the error result that refused it. */
+async function handlePromoteShared(
+  dependencies: MemoryToolDependencies,
+  args: PromoteSharedArgs,
+  authInfo: unknown,
+): Promise<ReturnType<typeof textResult>> {
+  const outcome = authorizePromotion(
+    dependencies,
+    authIdentity(authInfo as Parameters<typeof authIdentity>[0]),
+    args.target_namespace,
+  );
+  if (isRefusal(outcome)) return outcome;
+
+  const row = await loadPromotionSource(
+    dependencies,
+    outcome.identity,
+    args.table,
+    args.id,
+  );
+  if (!row) return errorResult("Source entry not found or archived");
+
+  const decision = classifyShareCandidate({
+    content: shareContent(args.table, row),
+    tags: (row.tags as string[] | null) ?? undefined,
+    metadata:
+      (row.extracted_metadata as Record<string, unknown> | null) ?? undefined,
+  });
+
+  // An authorized identity is permission to promote SHAREABLE content, not
+  // permission to override this gate.
+  if (decision === "reject-secret" || decision === "reject-private") {
+    dependencies.logger.warn(
+      { tool: "promote_shared", id: args.id, decision },
+      "promote_shared_refused",
+    );
+    return errorResult(
+      `Refused: entry classified as ${decision} and cannot be promoted to shared truth`,
+    );
+  }
+
+  return runPromotion({
+    dependencies,
+    identity: outcome.identity,
+    table: args.table,
+    id: args.id,
+    target: outcome.target,
+    reason: args.reason,
+    dryRun: args.dry_run ?? true,
+    classification: decision,
+  });
 }
 
 export function registerPromotionTools(
@@ -84,76 +449,10 @@ export function registerPromotionTools(
     {
       description:
         "List all namespaces with entry counts per table. Useful for understanding data distribution across agents/users.",
-      inputSchema: {
-        raw: z
-          .boolean()
-          .optional()
-          .describe("Return physical namespace names instead of canonical public names"),
-      },
-      annotations: {
-        title: "List Namespaces",
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      inputSchema: listNamespacesInputSchema,
+      annotations: listNamespacesAnnotations,
     },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      if (!identity) return errorResult("Permission denied: not authenticated");
-      const accessible = ALL_TABLES.filter((table) => canRead(identity.role, table));
-      if (accessible.length === 0) {
-        return errorResult("Permission denied: no readable tables");
-      }
-
-      const results = await Promise.all(
-        accessible.map(async (table) => {
-          const predicate = namespacePredicate(identity, "read", 1);
-          const { rows } = await dependencies.pool.query(
-            `SELECT '${table}' AS table_name, namespace, COUNT(*) AS count
-               FROM ${table}
-              WHERE archived_at IS NULL${predicate.clause}
-              GROUP BY namespace
-              ORDER BY count DESC`,
-            [...predicate.values],
-          );
-          return rows;
-        }),
-      );
-
-      // Folding legacy names onto the canonical one can collide two physical
-      // namespaces into a single reported lane, so counts are SUMMED per table
-      // rather than overwritten.
-      const byNamespace = new Map<
-        string,
-        { total: number; per_table: Record<string, number> }
-      >();
-      for (const rows of results) {
-        for (const row of rows) {
-          const physical = String(row.namespace);
-          const name = args.raw ? physical : canonicalNamespace(physical);
-          const entry = byNamespace.get(name) ?? { total: 0, per_table: {} };
-          const count = Number(row.count);
-          entry.total += count;
-          entry.per_table[String(row.table_name)] =
-            (entry.per_table[String(row.table_name)] ?? 0) + count;
-          byNamespace.set(name, entry);
-        }
-      }
-
-      const namespaces = [...byNamespace.entries()]
-        .map(([namespace, data]) => ({
-          namespace,
-          total: data.total,
-          per_table: data.per_table,
-        }))
-        .sort((a, b) => b.total - a.total);
-
-      dependencies.logger.info(
-        { tool: "list_namespaces", namespaceCount: namespaces.length },
-        "tool_result",
-      );
-      return textResult({ namespace_count: namespaces.length, namespaces });
-    },
+    (args, extra) => handleListNamespaces(dependencies, args, extra.authInfo),
   );
 
   server.registerTool(
@@ -164,142 +463,9 @@ export function registerPromotionTools(
         "namespace (shared truth). Requires the promoter, admin, or ob-admin identity. " +
         "Classifies the entry first and REFUSES secrets or person-private " +
         "content. Dry-run by default.",
-      inputSchema: {
-        table: z.enum(PROMOTABLE_TABLES).describe("Source table holding the entry to promote"),
-        id: z.string().uuid().describe("Source entry id"),
-        target_namespace: z
-          .string()
-          .trim()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe(
-            "Shared namespace to promote into. Defaults to the canonical shared " +
-              "namespace. The legacy 'collab' name is an internal migration source " +
-              "only and is refused as a target.",
-          ),
-        reason: z
-          .string()
-          .min(1)
-          .max(2000)
-          .optional()
-          .describe("Why this entry is being promoted to shared truth"),
-        dry_run: z
-          .boolean()
-          .optional()
-          .describe("Preview without writing to shared-kb (default true)"),
-      },
-      annotations: {
-        title: "Promote To Shared KB",
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      inputSchema: promoteSharedInputSchema,
+      annotations: promoteSharedAnnotations,
     },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      // Defense in depth: refused here before any read, and `promoteEntry`
-      // re-checks write authority for the target namespace on its own.
-      if (!identity || !isPromotionIdentity(identity)) {
-        dependencies.logger.warn(
-          { tool: "promote_shared", role: identity?.role },
-          "promote_shared_denied",
-        );
-        return errorResult(
-          "Permission denied: shared-kb promotion requires the promoter, admin, or ob-admin identity",
-        );
-      }
-
-      const shared = sharedNamespaceConfig();
-      const target = args.target_namespace ?? shared.canonicalSharedNamespace;
-      // The legacy name is a migration SOURCE, never a write target: accepting
-      // it here would recreate the two-names-for-one-lane split that the
-      // canonical-namespace decision exists to end.
-      //
-      // `collab` is refused UNCONDITIONALLY, not just when it is the configured
-      // legacy name. `legacySharedNamespace` defaults to empty, so a
-      // config-gated check would silently allow `collab` as a target in exactly
-      // the default deployment -- the rule is about the name, not the setting.
-      if (target === LEGACY_SHARED_NAMESPACE || target === shared.legacySharedNamespace) {
-        return errorResult(
-          `Permission denied: '${target}' is a legacy migration source and cannot be a promotion target; use '${shared.canonicalSharedNamespace}'`,
-        );
-      }
-
-      // Read the source for classification under the caller's own read scope.
-      // `table` is a validated enum, so the branch is an allowlist rather than
-      // interpolation of caller text.
-      const contentColumns = args.table === "decisions" ? "title, rationale" : "content";
-      const predicate = namespacePredicate(identity, "read", 2);
-      const { rows } = await dependencies.pool.query(
-        `SELECT id, ${contentColumns}, tags, extracted_metadata
-           FROM ${args.table as ResourceTable}
-          WHERE id = $1 AND archived_at IS NULL${predicate.clause}`,
-        [args.id, ...predicate.values],
-      );
-      if (rows.length === 0) return errorResult("Source entry not found or archived");
-
-      const row = rows[0] as Record<string, unknown>;
-      const decision = classifyShareCandidate({
-        content: shareContent(args.table, row),
-        tags: (row.tags as string[] | null) ?? undefined,
-        metadata: (row.extracted_metadata as Record<string, unknown> | null) ?? undefined,
-      });
-
-      // An authorized identity is permission to promote SHAREABLE content, not
-      // permission to override this gate.
-      if (decision === "reject-secret" || decision === "reject-private") {
-        dependencies.logger.warn(
-          { tool: "promote_shared", id: args.id, decision },
-          "promote_shared_refused",
-        );
-        return errorResult(
-          `Refused: entry classified as ${decision} and cannot be promoted to shared truth`,
-        );
-      }
-
-      try {
-        const result = await promoteEntry(
-          dependencies.pool,
-          args.table,
-          args.id,
-          target,
-          args.reason,
-          promotionAuth(identity),
-          { dryRun: args.dry_run ?? true },
-        );
-        dependencies.logger.info(
-          {
-            tool: "promote_shared",
-            id: args.id,
-            status: result.status,
-            dryRun: args.dry_run ?? true,
-          },
-          "tool_result",
-        );
-        return textResult({ classification: decision, ...result });
-      } catch (error) {
-        const statusCode = (error as { statusCode?: number }).statusCode;
-        const message = error instanceof Error ? error.message : String(error);
-        dependencies.logger.warn(
-          { tool: "promote_shared", id: args.id, statusCode },
-          "promote_shared_error",
-        );
-        return errorResult(
-          statusCode && statusCode < 500
-            ? `Permission denied: ${message}`
-            : `Promotion failed: ${message}`,
-        );
-      }
-    },
-  );
-}
-
-/** @returns Whether this identity may attempt a shared-truth promotion. */
-function isPromotionIdentity(identity: AuthIdentity): boolean {
-  return (
-    identity.role === "promoter" ||
-    identity.role === "admin" ||
-    identity.role === "ob-admin"
+    (args, extra) => handlePromoteShared(dependencies, args, extra.authInfo),
   );
 }


### PR DESCRIPTION
## Summary

- `server/tools/promotion.ts` carried two oxlint findings: `registerPromotionTools` at 191 lines (max 100) and the `promote_shared` handler at complexity 19 (max 10). Both are cleared.
- Same shape as `search-brain.ts` (lane 2) and `search-all.ts` (011bf24): both input schemas and both annotation objects hoist to module consts with byte-identical description strings, and each handler becomes a named module-level function, so the `registerTool` bodies are registration only.
- `promote_shared` splits along its own steps: `authorizePromotion` (identity check plus the unconditional legacy-target refusal), `loadPromotionSource` (the read under the caller's own scope), `runPromotion` (the service call and its error mapping, taking an options object instead of eight positional arguments). `list_namespaces` splits into `countNamespaceRows` and `foldNamespaceCounts`.
- No behavior change: schemas, defaults, error strings, SQL text, and the `tool_result` / `promote_shared_denied` / `promote_shared_refused` / `promote_shared_error` log event names are identical.
- Follow-up, deliberately NOT done here: `promotionAuth`, `isPromotionIdentity`, and the `LEGACY_SHARED_NAMESPACE` constant are duplicated in `server/tools/promote-entry.ts`. That file is owned by a concurrent #780 lane, so extracting a shared module now would collide. It should be extracted once both lanes land.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED (untouched file, before any edit):

```
server/tools/promotion.ts:78:8: error eslint(max-lines-per-function): The function `registerPromotionTools` has too many lines (191). Maximum allowed is 100.
server/tools/promotion.ts:199:5: error eslint(complexity): async function has a complexity of 19. Maximum allowed is 10.
```

`DONE_MEANS_780_FILES=server/tools/promotion.ts bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 1.

GREEN (re-run on the COMMITTED tree, after the pre-commit prettier pass):

- `./node_modules/.bin/oxlint --deny-warnings server/tools/promotion.ts` -> exit 0
- `bunx tsc --noEmit` -> exit 0
- `bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 0, `PASS: every file this branch touched under server/ lints clean.`
- `bun run test:isolated server/tools/promotion.pg.test.ts server/tools/ported-tools-scope.test.ts src/tools/__tests__/list-namespaces.test.ts src/tools/__tests__/promote-shared.test.ts server/tools` -> 177 pass, 0 fail, 578 expect() calls, 19 files. No test file was modified.

Python package is untouched, so its checks are not applicable. No schema, transport, or contract surface moved, so no live smoke applies.

## Critical Self-Review

- Highest-risk behavior: the namespace read predicate. `namespacePredicate(identity, "read", 1)` in `countNamespaceRows` and `(identity, "read", 2)` in `loadPromotionSource` keep their original placeholder offsets, because each query still binds the same parameters ahead of the predicate values. Moving one into a helper with the wrong offset would produce a silently mis-scoped read rather than an error. `ported-tools-scope.test.ts` and `promotion.pg.test.ts` both exercise the scoped paths and pass.
- Assumptions that could be wrong: that `authIdentity` accepts the `extra.authInfo` value unchanged through the new `unknown` parameter. It is cast back to `Parameters<typeof authIdentity>[0]` at the single call site in each handler, and `tsc --noEmit` is clean, so the shape reaching it is the same object the inline handler received.
- Missing/weak tests: none added, by design. This is a pure structural change with no new branch, so a new test would pin the refactor's shape rather than any behavior. The existing 177 tests are the regression surface and were left unmodified.
- Security/permission risk: `authorizePromotion` now returns either a target or an error result, so a caller that forgot to check would proceed unauthorized. `isRefusal` is a type predicate and `tsc` rejects using the union as a `PromotionTarget` without narrowing, so the mistake is a compile error rather than a runtime hole. The unconditional `collab` refusal and the pre-read identity check keep their original order.
- Migration/deploy risk: none. No migration, no config, no startup path touched.
- Downstream client/runtime risk: none. Tool names, descriptions, input schemas, annotations, and both success and error payload shapes are unchanged, so no client sees a different contract.
- Rollback/cleanup concern: single-file, single-commit revert.
- Fixes made before PR: the first draft passed eight positional arguments to the promotion call; that broke the four-parameter rule, so `runPromotion` takes a `RunPromotionOptions` object.
- Known residual risk: the `promote-entry.ts` duplication named in the summary is still live in both files. It is a follow-up, not a regression introduced here.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new failure pattern surfaced; this is a structural refactor with no behavior change and no review finding to record.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no contract, transport, or schema surface changed, so a live smoke would exercise nothing this PR touched.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no path in `contracts/parity-paths.txt` is touched. The only changed file is `server/tools/promotion.ts`, which is server-runtime internal structure, not a shared contract.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: `docs/downstream-rollout.md` scopes rollout to MCP tool, schema, protocol, and client-facing changes. This PR changes none of them. `git diff origin/main...HEAD --name-only` is exactly one file, and the tool descriptions, input schemas, and annotations in it are string-identical to `origin/main`.
