### PR TITLE
refactor(tier-mutations): bring server/tools/tier-mutations.ts to the lint standard (#780)

### DIFF
--- a/server/tools/tier-mutations.ts
+++ b/server/tools/tier-mutations.ts
@@ -44,6 +44,74 @@ import { tableEnum, tierEnum } from "./curation-helpers.ts";
  */
 const BULK_ENTRIES_PER_CALL = 100;
 
+const setTierInputSchema = {
+  table: tableEnum.describe("Table containing the entry"),
+  id: z.string().uuid().describe("UUID of the entry to update"),
+  tier: tierEnum.describe(
+    "Cognitive tier: hot (front-of-mind, boosted), warm (default), cold (deprioritized)",
+  ),
+};
+
+const setTierAnnotations = {
+  title: "Set Tier",
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+const bulkSetTierInputSchema = {
+  entries: z
+    .array(
+      z.object({
+        id: z.string().uuid().describe("UUID of the entry"),
+        table: tableEnum.describe("Table containing the entry"),
+        tier: tierEnum.describe("Target cognitive tier"),
+      }),
+    )
+    .min(1)
+    .max(BULK_ENTRIES_PER_CALL)
+    .describe(`Array of entries to update (max ${BULK_ENTRIES_PER_CALL})`),
+};
+
+const bulkSetTierAnnotations = {
+  title: "Bulk Set Tier",
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+const bulkArchiveInputSchema = {
+  entries: z
+    .array(
+      z.object({
+        id: z.string().uuid().describe("UUID of the entry to archive"),
+        table: tableEnum.describe("Table containing the entry"),
+      }),
+    )
+    .min(1)
+    .max(BULK_ENTRIES_PER_CALL)
+    .describe(`Array of entries to archive (max ${BULK_ENTRIES_PER_CALL})`),
+};
+
+const bulkArchiveAnnotations = {
+  title: "Bulk Archive",
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: true,
+};
+
+const demoteEntryInputSchema = {
+  table: tableEnum.describe("Table name"),
+  id: z.string().uuid().describe("UUID of the promoted entry to demote"),
+};
+
+const demoteEntryAnnotations = {
+  title: "Demote Entry",
+  readOnlyHint: false,
+  destructiveHint: true,
+  idempotentHint: true,
+};
+
 export function registerTierMutationTools(
   server: McpServer,
   dependencies: MemoryToolDependencies,
@@ -53,54 +121,10 @@ export function registerTierMutationTools(
     {
       description:
         "Set the cognitive tier (hot/warm/cold) for a brain entry. Hot entries are boosted in search, cold entries are deprioritized. Requires write permission.",
-      inputSchema: {
-        table: tableEnum.describe("Table containing the entry"),
-        id: z.string().uuid().describe("UUID of the entry to update"),
-        tier: tierEnum.describe(
-          "Cognitive tier: hot (front-of-mind, boosted), warm (default), cold (deprioritized)",
-        ),
-      },
-      annotations: {
-        title: "Set Tier",
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      inputSchema: setTierInputSchema,
+      annotations: setTierAnnotations,
     },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      const table = args.table as ResourceTable;
-      if (!identity || !canWrite(identity.role, table)) {
-        return errorResult(`Permission denied: cannot write to ${table}`);
-      }
-
-      // `table` reaches an interpolated position only after `tableEnum` has
-      // narrowed it to one of five compile-time literals.
-      const predicate = namespacePredicate(identity, "write", 3);
-      const { rows } = await dependencies.pool.query(
-        `UPDATE ${table} SET tier = $1
-          WHERE id = $2 AND archived_at IS NULL${predicate.clause}
-          RETURNING id, tier`,
-        [args.tier, args.id, ...predicate.values],
-      );
-
-      // Not-mine and not-there collapse to ONE string, so this tool cannot be
-      // used to probe which UUIDs exist in a namespace the caller cannot write.
-      if (rows.length === 0) {
-        dependencies.logger.info(
-          { tool: "set_tier", table, matched: 0 },
-          "set_tier_noop",
-        );
-        return errorResult("Entry not found or archived");
-      }
-
-      const row = rows[0] as { id: string; tier: string };
-      dependencies.logger.info(
-        { tool: "set_tier", table, id: row.id, tier: row.tier },
-        "tool_result",
-      );
-      return textResult({ id: row.id, table, tier: row.tier });
-    },
+    async (args, extra) => handleSetTier(dependencies, args, extra),
   );
 
   server.registerTool(
@@ -108,60 +132,10 @@ export function registerTierMutationTools(
     {
       description:
         "Set cognitive tiers for multiple entries in a single transaction. Max 100 entries per call.",
-      inputSchema: {
-        entries: z
-          .array(
-            z.object({
-              id: z.string().uuid().describe("UUID of the entry"),
-              table: tableEnum.describe("Table containing the entry"),
-              tier: tierEnum.describe("Target cognitive tier"),
-            }),
-          )
-          .min(1)
-          .max(BULK_ENTRIES_PER_CALL)
-          .describe(`Array of entries to update (max ${BULK_ENTRIES_PER_CALL})`),
-      },
-      annotations: {
-        title: "Bulk Set Tier",
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      inputSchema: bulkSetTierInputSchema,
+      annotations: bulkSetTierAnnotations,
     },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      if (!identity) return errorResult("Permission denied: not authenticated");
-
-      const entries = args.entries;
-      // Every referenced table is permission-checked BEFORE the transaction
-      // opens. Checking inside the loop would let a partially-authorized batch
-      // do real work and then roll back, which is a slower way to reach the
-      // same refusal and leaves a write burst in the WAL on the way.
-      for (const table of new Set(entries.map((entry) => entry.table))) {
-        if (!canWrite(identity.role, table as ResourceTable)) {
-          return errorResult(`Permission denied: cannot write to ${table}`);
-        }
-      }
-
-      const predicate = namespacePredicate(identity, "write", 3);
-      const result = await runBulkTransaction(
-        dependencies,
-        "bulk_set_tier",
-        entries,
-        (entry) => ({
-          sql: `UPDATE ${entry.table as ResourceTable} SET tier = $1
-                 WHERE id = $2 AND archived_at IS NULL${predicate.clause}`,
-          values: [entry.tier, entry.id, ...predicate.values],
-        }),
-      );
-      if (!result.ok) return result.response;
-
-      dependencies.logger.info(
-        { tool: "bulk_set_tier", requested: entries.length, updated: result.affected },
-        "tool_result",
-      );
-      return textResult({ requested: entries.length, updated: result.affected });
-    },
+    async (args, extra) => handleBulkSetTier(dependencies, args, extra),
   );
 
   server.registerTool(
@@ -169,58 +143,10 @@ export function registerTierMutationTools(
     {
       description:
         "Soft-delete multiple entries in a single transaction. Max 100 entries per call.",
-      inputSchema: {
-        entries: z
-          .array(
-            z.object({
-              id: z.string().uuid().describe("UUID of the entry to archive"),
-              table: tableEnum.describe("Table containing the entry"),
-            }),
-          )
-          .min(1)
-          .max(BULK_ENTRIES_PER_CALL)
-          .describe(`Array of entries to archive (max ${BULK_ENTRIES_PER_CALL})`),
-      },
-      annotations: {
-        title: "Bulk Archive",
-        readOnlyHint: false,
-        destructiveHint: true,
-        idempotentHint: true,
-      },
+      inputSchema: bulkArchiveInputSchema,
+      annotations: bulkArchiveAnnotations,
     },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      if (!identity) return errorResult("Permission denied: not authenticated");
-
-      const entries = args.entries;
-      // Archiving is a DELETE-class operation, so the delete permission is the
-      // authority here, not write. `discord` can write thoughts and must not be
-      // able to archive them.
-      for (const table of new Set(entries.map((entry) => entry.table))) {
-        if (!canDelete(identity.role, table as ResourceTable)) {
-          return errorResult(`Permission denied: cannot delete from ${table}`);
-        }
-      }
-
-      const predicate = namespacePredicate(identity, "delete", 2);
-      const result = await runBulkTransaction(
-        dependencies,
-        "bulk_archive",
-        entries,
-        (entry) => ({
-          sql: `UPDATE ${entry.table as ResourceTable} SET archived_at = NOW()
-                 WHERE id = $1 AND archived_at IS NULL${predicate.clause}`,
-          values: [entry.id, ...predicate.values],
-        }),
-      );
-      if (!result.ok) return result.response;
-
-      dependencies.logger.info(
-        { tool: "bulk_archive", requested: entries.length, archived: result.affected },
-        "tool_result",
-      );
-      return textResult({ requested: entries.length, archived: result.affected });
-    },
+    async (args, extra) => handleBulkArchive(dependencies, args, extra),
   );
 
   server.registerTool(
@@ -229,73 +155,253 @@ export function registerTierMutationTools(
       description:
         "Archive a previously promoted entry, reversing a promotion. " +
         "Only works on entries that have promoted_from provenance metadata. Admin and ob-admin only.",
-      inputSchema: {
-        table: tableEnum.describe("Table name"),
-        id: z.string().uuid().describe("UUID of the promoted entry to demote"),
-      },
-      annotations: {
-        title: "Demote Entry",
-        readOnlyHint: false,
-        destructiveHint: true,
-        idempotentHint: true,
-      },
+      inputSchema: demoteEntryInputSchema,
+      annotations: demoteEntryAnnotations,
     },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      // Demotion reverses shared truth, so it is gated on the break-glass
-      // identities by ROLE rather than the table permission matrix: a promoter
-      // may promote INTO shared-kb but may not unwind what is already there.
-      if (!identity || (identity.role !== "admin" && identity.role !== "ob-admin")) {
-        return errorResult("Permission denied: admin or ob-admin role required");
-      }
-
-      const table = args.table as ResourceTable;
-      const notFound = errorResult("Entry not found or already archived");
-
-      const readPredicate = namespacePredicate(identity, "read", 2);
-      const { rows } = await dependencies.pool.query(
-        `SELECT id, namespace, promoted_from FROM ${table}
-          WHERE id = $1 AND archived_at IS NULL${readPredicate.clause}`,
-        [args.id, ...readPredicate.values],
-      );
-      if (rows.length === 0) return notFound;
-
-      const provenance = (rows[0] as { promoted_from: unknown }).promoted_from;
-      if (!provenance) {
-        return errorResult("Entry was not promoted — cannot demote");
-      }
-
-      // The UPDATE re-derives its own predicate rather than trusting the SELECT
-      // that just passed. The read scope is WIDER than the write scope (it
-      // includes shared-kb), so reusing the read predicate here would let an
-      // entry that is merely readable be archived.
-      const writePredicate = namespacePredicate(identity, "delete", 2);
-      const { rowCount } = await dependencies.pool.query(
-        `UPDATE ${table} SET archived_at = NOW()
-          WHERE id = $1 AND archived_at IS NULL${writePredicate.clause}`,
-        [args.id, ...writePredicate.values],
-      );
-      if ((rowCount ?? 0) === 0) return notFound;
-
-      const source = provenance as { source_id?: unknown; source_namespace?: unknown };
-      dependencies.logger.info(
-        {
-          tool: "demote_entry",
-          table,
-          id: args.id,
-          sourceId: source.source_id,
-          sourceNamespace: source.source_namespace,
-        },
-        "tool_result",
-      );
-      return textResult({
-        status: "demoted",
-        archived_id: args.id,
-        source_id: source.source_id,
-        source_namespace: source.source_namespace,
-      });
-    },
+    async (args, extra) => handleDemoteEntry(dependencies, args, extra),
   );
+}
+
+/** Minimal shape of the handler `extra` argument these tools read. */
+interface HandlerExtra {
+  authInfo?: Parameters<typeof authIdentity>[0];
+}
+
+/**
+ * Check one permission per DISTINCT table referenced by a bulk batch.
+ *
+ * Both bulk tools check every referenced table BEFORE their transaction opens.
+ * Checking inside the loop would let a partially-authorized batch do real work
+ * and then roll back, which is a slower way to reach the same refusal and
+ * leaves a write burst in the WAL on the way.
+ *
+ * @param entries Batch entries, each naming the table it targets.
+ * @param permitted Role check for one table: `canWrite` or `canDelete`.
+ * @param denial Builds the observed current-src refusal string for a table.
+ * @returns The denial envelope for the first unauthorized table, else `undefined`.
+ */
+function denyUnauthorizedTables(
+  entries: readonly { table: string }[],
+  permitted: (table: ResourceTable) => boolean,
+  denial: (table: string) => string,
+): ReturnType<typeof errorResult> | undefined {
+  for (const table of new Set(entries.map((entry) => entry.table))) {
+    if (!permitted(table as ResourceTable)) {
+      return errorResult(denial(table));
+    }
+  }
+  return undefined;
+}
+
+/** `set_tier`: retier ONE entry the caller may write, in its own namespace. */
+async function handleSetTier(
+  dependencies: MemoryToolDependencies,
+  args: { table: string; id: string; tier: string },
+  extra: HandlerExtra,
+) {
+  const identity = authIdentity(extra.authInfo);
+  const table = args.table as ResourceTable;
+  if (!identity || !canWrite(identity.role, table)) {
+    return errorResult(`Permission denied: cannot write to ${table}`);
+  }
+
+  // `table` reaches an interpolated position only after `tableEnum` has
+  // narrowed it to one of five compile-time literals.
+  const predicate = namespacePredicate(identity, "write", 3);
+  const { rows } = await dependencies.pool.query(
+    `UPDATE ${table} SET tier = $1
+          WHERE id = $2 AND archived_at IS NULL${predicate.clause}
+          RETURNING id, tier`,
+    [args.tier, args.id, ...predicate.values],
+  );
+
+  // Not-mine and not-there collapse to ONE string, so this tool cannot be
+  // used to probe which UUIDs exist in a namespace the caller cannot write.
+  if (rows.length === 0) {
+    dependencies.logger.info(
+      { tool: "set_tier", table, matched: 0 },
+      "set_tier_noop",
+    );
+    return errorResult("Entry not found or archived");
+  }
+
+  const row = rows[0] as { id: string; tier: string };
+  dependencies.logger.info(
+    { tool: "set_tier", table, id: row.id, tier: row.tier },
+    "tool_result",
+  );
+  return textResult({ id: row.id, table, tier: row.tier });
+}
+
+/** `bulk_set_tier`: retier a batch in ONE transaction, all-or-nothing. */
+async function handleBulkSetTier(
+  dependencies: MemoryToolDependencies,
+  args: { entries: { id: string; table: string; tier: string }[] },
+  extra: HandlerExtra,
+) {
+  const identity = authIdentity(extra.authInfo);
+  if (!identity) return errorResult("Permission denied: not authenticated");
+
+  const entries = args.entries;
+  const denied = denyUnauthorizedTables(
+    entries,
+    (table) => canWrite(identity.role, table),
+    (table) => `Permission denied: cannot write to ${table}`,
+  );
+  if (denied) return denied;
+
+  const predicate = namespacePredicate(identity, "write", 3);
+  const result = await runBulkTransaction(
+    dependencies,
+    "bulk_set_tier",
+    entries,
+    (entry) => ({
+      sql: `UPDATE ${entry.table as ResourceTable} SET tier = $1
+                 WHERE id = $2 AND archived_at IS NULL${predicate.clause}`,
+      values: [entry.tier, entry.id, ...predicate.values],
+    }),
+  );
+  if (!result.ok) return result.response;
+
+  dependencies.logger.info(
+    {
+      tool: "bulk_set_tier",
+      requested: entries.length,
+      updated: result.affected,
+    },
+    "tool_result",
+  );
+  return textResult({ requested: entries.length, updated: result.affected });
+}
+
+/** `bulk_archive`: soft-delete a batch in ONE transaction, all-or-nothing. */
+async function handleBulkArchive(
+  dependencies: MemoryToolDependencies,
+  args: { entries: { id: string; table: string }[] },
+  extra: HandlerExtra,
+) {
+  const identity = authIdentity(extra.authInfo);
+  if (!identity) return errorResult("Permission denied: not authenticated");
+
+  const entries = args.entries;
+  // Archiving is a DELETE-class operation, so the delete permission is the
+  // authority here, not write. `discord` can write thoughts and must not be
+  // able to archive them.
+  const denied = denyUnauthorizedTables(
+    entries,
+    (table) => canDelete(identity.role, table),
+    (table) => `Permission denied: cannot delete from ${table}`,
+  );
+  if (denied) return denied;
+
+  const predicate = namespacePredicate(identity, "delete", 2);
+  const result = await runBulkTransaction(
+    dependencies,
+    "bulk_archive",
+    entries,
+    (entry) => ({
+      sql: `UPDATE ${entry.table as ResourceTable} SET archived_at = NOW()
+                 WHERE id = $1 AND archived_at IS NULL${predicate.clause}`,
+      values: [entry.id, ...predicate.values],
+    }),
+  );
+  if (!result.ok) return result.response;
+
+  dependencies.logger.info(
+    {
+      tool: "bulk_archive",
+      requested: entries.length,
+      archived: result.affected,
+    },
+    "tool_result",
+  );
+  return textResult({ requested: entries.length, archived: result.affected });
+}
+
+/**
+ * Archive the promoted entry, re-deriving the write predicate.
+ *
+ * The UPDATE re-derives its own predicate rather than trusting the SELECT that
+ * just passed. The read scope is WIDER than the write scope (it includes
+ * shared-kb), so reusing the read predicate here would let an entry that is
+ * merely readable be archived.
+ *
+ * @returns Rows affected by the archiving UPDATE.
+ */
+async function archiveDemotedEntry(
+  dependencies: MemoryToolDependencies,
+  identity: NonNullable<ReturnType<typeof authIdentity>>,
+  table: ResourceTable,
+  id: string,
+): Promise<number> {
+  const writePredicate = namespacePredicate(identity, "delete", 2);
+  const { rowCount } = await dependencies.pool.query(
+    `UPDATE ${table} SET archived_at = NOW()
+          WHERE id = $1 AND archived_at IS NULL${writePredicate.clause}`,
+    [id, ...writePredicate.values],
+  );
+  return rowCount ?? 0;
+}
+
+/** `demote_entry`: reverse a promotion, break-glass roles only. */
+async function handleDemoteEntry(
+  dependencies: MemoryToolDependencies,
+  args: { table: string; id: string },
+  extra: HandlerExtra,
+) {
+  const identity = authIdentity(extra.authInfo);
+  // Demotion reverses shared truth, so it is gated on the break-glass
+  // identities by ROLE rather than the table permission matrix: a promoter
+  // may promote INTO shared-kb but may not unwind what is already there.
+  if (
+    !identity ||
+    (identity.role !== "admin" && identity.role !== "ob-admin")
+  ) {
+    return errorResult("Permission denied: admin or ob-admin role required");
+  }
+
+  const table = args.table as ResourceTable;
+  const notFound = errorResult("Entry not found or already archived");
+
+  const readPredicate = namespacePredicate(identity, "read", 2);
+  const { rows } = await dependencies.pool.query(
+    `SELECT id, namespace, promoted_from FROM ${table}
+          WHERE id = $1 AND archived_at IS NULL${readPredicate.clause}`,
+    [args.id, ...readPredicate.values],
+  );
+  if (rows.length === 0) return notFound;
+
+  const provenance = (rows[0] as { promoted_from: unknown }).promoted_from;
+  if (!provenance) {
+    return errorResult("Entry was not promoted — cannot demote");
+  }
+
+  if (
+    (await archiveDemotedEntry(dependencies, identity, table, args.id)) === 0
+  ) {
+    return notFound;
+  }
+
+  const source = provenance as {
+    source_id?: unknown;
+    source_namespace?: unknown;
+  };
+  dependencies.logger.info(
+    {
+      tool: "demote_entry",
+      table,
+      id: args.id,
+      sourceId: source.source_id,
+      sourceNamespace: source.source_namespace,
+    },
+    "tool_result",
+  );
+  return textResult({
+    status: "demoted",
+    archived_id: args.id,
+    source_id: source.source_id,
+    source_namespace: source.source_namespace,
+  });
 }
 
 type BulkOutcome =


### PR DESCRIPTION
## Summary

- `#780` lint sweep, one file: `server/tools/tier-mutations.ts`. `registerTierMutationTools` was 218 lines against the 100-line rule, because all four tool handlers (`set_tier`, `bulk_set_tier`, `bulk_archive`, `demote_entry`) were written inline inside the registration call.
- Each tool's `inputSchema` and `annotations` are hoisted to module consts with the description strings byte-identical; each handler is now a named module-level function; `registerTierMutationTools` is registration only.
- Two private helpers come out of the handlers: `denyUnauthorizedTables` (the per-distinct-table permission scan both bulk tools ran identically, parameterised by `canWrite` vs `canDelete` and the observed denial-string builder) and `archiveDemotedEntry` (the second half of `demote_entry`, which re-derives the delete-scope predicate rather than trusting the wider read predicate the preceding SELECT passed).
- No behavior change: schemas, defaults, SQL text, error strings, and the `set_tier_noop` / `tool_result` / `bulk_transaction_error` log event names are unchanged. The explicit-opt-in property is untouched — there is still no planning path into these handlers, so nothing here is reachable from a DreamEngine dry run.
- No file other than the target was modified.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED (untouched file, before any edit):

```
server/tools/tier-mutations.ts:47:8: error eslint(max-lines-per-function): The function `registerTierMutationTools` has too many lines (218). Maximum allowed is 100. help: Consider splitting it into smaller functions.
```

`DONE_MEANS_780_FILES=server/tools/tier-mutations.ts bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 1.

GREEN (re-run on the COMMITTED tree, after the pre-commit prettier pass):

- `./node_modules/.bin/oxlint --deny-warnings server/tools/tier-mutations.ts` -> no findings, exit 0
- `bunx tsc --noEmit` -> exit 0
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived, 1 file) -> `PASS`, exit 0
- `bun run test:isolated src/ob-admin-role.test.ts src/tools/__tests__/demote-entry.test.ts src/tools/__tests__/bulk-set-tier.pg.test.ts src/tools/__tests__/bulk-set-tier.test.ts src/tools/__tests__/namespace-isolation-matrix.test.ts src/tools/__tests__/bulk-archive.test.ts server/tools` -> 212 pass, 0 fail, 760 expect() calls, 23 files. Existing tests unmodified.

Python package is untouched, so its checks are not applicable. No live smoke: no deployed surface changes.

## Critical Self-Review

- Highest-risk behavior: the namespace predicate on each UPDATE. `bulk_archive` and `demote_entry`'s write step use `namespacePredicate(identity, "delete", 2)` while `set_tier` and `bulk_set_tier` use `"write", 3` — the operation and the parameter offset differ per call site and both had to move with their statement. They did; the SQL strings and predicate calls are carried verbatim into the extracted functions.
- Assumptions that could be wrong: that `memory-helpers.authorize` is not a valid reuse here. I read it — it resolves and permission-checks a caller-supplied namespace, and none of these four tools accepts a namespace argument, so routing through it would introduce a check current behavior does not perform. Rejected on that basis rather than on convenience.
- Missing/weak tests: this change adds no test, because it is meant to be behavior-preserving and the existing suite is the pin. The weakness that remains is that `denyUnauthorizedTables`' short-circuit ordering — first unauthorized table in `Set` iteration order wins — is not directly asserted anywhere; it matches the loop it replaced, but a batch spanning two unauthorized tables would not detect a swap in which denial string is returned.
- Security/permission risk: the isolation boundary is the point of this file, so the risk is a predicate silently widening. Two specific hazards were checked: `handleDemoteEntry` still re-derives a delete-scope predicate for its UPDATE instead of reusing the wider read predicate (`archiveDemotedEntry` carries that comment with it), and the bulk permission scan still runs entirely BEFORE `runBulkTransaction` opens its transaction, so a partially-authorized batch still refuses without doing work.
- Migration/deploy risk: none. No schema, no migration, no config, no wire contract.
- Downstream client/runtime risk: none — see Downstream Rollout below.
- Rollback/cleanup concern: single-file, single-commit, revert is clean.
- Fixes made before PR: none needed beyond the refactor; oxlint and tsc were clean on the first run of the rewritten file.
- Known residual risk: `HandlerExtra` is a locally-declared minimal shape (`authInfo` only) rather than the SDK's own handler-extra type. It compiles and matches what these handlers read, but it is narrower than what the SDK passes; a future handler needing another field of `extra` must widen it rather than assume it is complete.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new MEDIUM+ defect pattern was found — this is a behavior-preserving structural change to satisfy an existing lint rule, and the isolation invariants it moves are already documented in the file header and in `docs/decisions/privilege-isolation-closed-brain.md`.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no deployed surface, wire contract, or database behavior changes; the tool set, schemas, and responses are identical.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no path in `contracts/parity-paths.txt` is touched. The diff is one file, `server/tools/tier-mutations.ts`, which is outside `python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, and `src/contract-schemas.ts`. The published tool schemas are unchanged in any case.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable on every downstream line for one reason: this PR changes no MCP tool name, no input schema, no annotation value, no response shape, and no error string. The four tools advertise exactly what they advertised before — the schema objects were relocated to module consts, not edited. Nothing a client validates against or caches has moved, so there is no handoff, no cache refresh, and no canary to run.
