### PR TITLE
refactor(resolve-entry): bring server/tools/resolve-entry.ts to the lint standard (#780)

### DIFF
--- a/server/tools/resolve-entry.ts
+++ b/server/tools/resolve-entry.ts
@@ -10,10 +10,20 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../auth/permissions.ts";
-import { canTargetNamespace, namespacePredicate } from "../auth/namespace-policy.ts";
+import {
+  canTargetNamespace,
+  namespacePredicate,
+} from "../auth/namespace-policy.ts";
 import type { AuthIdentity, ResourceTable } from "../auth/types.ts";
-import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import { ALL_TABLES } from "./curation-helpers.ts";
+
+const NOT_AUTHENTICATED = "Permission denied: cannot resolve entries";
 
 const SOURCE_TYPE_BY_TABLE: Readonly<Record<ResourceTable, string>> = {
   thoughts: "thought",
@@ -23,7 +33,22 @@ const SOURCE_TYPE_BY_TABLE: Readonly<Record<ResourceTable, string>> = {
   sessions: "session",
 };
 
-type ResolveStatus = "found" | "archived" | "not_found_or_unreadable" | "not_readable";
+/** Frozen `resolve_entry` argument contract: the names and rule values are the API. */
+const resolveEntryInputSchema = {
+  id: z.string().uuid(),
+  namespace: z.string().min(1).max(500).optional(),
+};
+
+/** Tool annotations; `resolve_entry` reads and never mutates. */
+const resolveEntryAnnotations = {
+  title: "Resolve Entry",
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+type ResolveStatus =
+  "found" | "archived" | "not_found_or_unreadable" | "not_readable";
 
 interface ResolvedEntry {
   resolved: boolean;
@@ -32,9 +57,27 @@ interface ResolvedEntry {
   source_type: string | null;
   table: ResourceTable | null;
   namespace: string | null;
-  fetch_path: { tool: "get_entry"; arguments: { table: ResourceTable; id: string } } | null;
+  fetch_path: {
+    tool: "get_entry";
+    arguments: { table: ResourceTable; id: string };
+  } | null;
   checked_sources: string[];
   checked_tables: ResourceTable[];
+}
+
+/** One probe pass: which tables, archived or live, and where to record progress. */
+interface ProbeRequest {
+  identity: AuthIdentity;
+  id: string;
+  tables: readonly ResourceTable[];
+  requestedNamespace: string | undefined;
+  archived: boolean;
+  checkedTables: ResourceTable[];
+}
+
+interface ProbeHit {
+  table: ResourceTable;
+  namespace: string;
 }
 
 function unresolved(
@@ -56,28 +99,44 @@ function unresolved(
   };
 }
 
+/**
+ * Bind the namespace scope for one probe.
+ *
+ * This is the security boundary of an ID-based read: an explicit namespace is
+ * bound as a parameter only after {@link canTargetNamespace} has cleared it,
+ * and otherwise the auth-derived read predicate applies. Neither branch ever
+ * leaves the query unscoped, so an id alone can never reach a row the identity
+ * has no read authority over.
+ */
+function scopeParameters(
+  identity: AuthIdentity,
+  id: string,
+  requestedNamespace: string | undefined,
+): { params: unknown[]; clause: string } {
+  const params: unknown[] = [id];
+  if (requestedNamespace !== undefined) {
+    params.push(requestedNamespace);
+    return { params, clause: ` AND namespace = $${params.length}` };
+  }
+  const predicate = namespacePredicate(identity, "read", 2);
+  params.push(...predicate.values);
+  return { params, clause: predicate.clause };
+}
+
 /** Probe each readable table in order for the id, under read namespace scope. */
 async function findRow(
   dependencies: MemoryToolDependencies,
-  identity: AuthIdentity,
-  id: string,
-  tables: readonly ResourceTable[],
-  requestedNamespace: string | undefined,
-  archived: boolean,
-  checkedTables: ResourceTable[],
-): Promise<{ table: ResourceTable; namespace: string } | null> {
+  request: ProbeRequest,
+): Promise<ProbeHit | null> {
+  const { identity, id, tables, requestedNamespace, archived, checkedTables } =
+    request;
   for (const table of tables) {
     checkedTables.push(table);
-    const params: unknown[] = [id];
-    let clause = "";
-    if (requestedNamespace !== undefined) {
-      params.push(requestedNamespace);
-      clause = ` AND namespace = $${params.length}`;
-    } else {
-      const predicate = namespacePredicate(identity, "read", 2);
-      clause = predicate.clause;
-      params.push(...predicate.values);
-    }
+    const { params, clause } = scopeParameters(
+      identity,
+      id,
+      requestedNamespace,
+    );
     const { rows } = await dependencies.pool.query(
       `SELECT id, namespace FROM ${table}
         WHERE id = $1 AND archived_at IS ${archived ? "NOT NULL" : "NULL"}${clause}
@@ -85,13 +144,120 @@ async function findRow(
       params,
     );
     const row = rows[0] as { namespace?: unknown } | undefined;
-    if (typeof row?.namespace === "string") return { table, namespace: row.namespace };
+    if (typeof row?.namespace === "string")
+      return { table, namespace: row.namespace };
   }
   return null;
 }
 
 function uniqueTables(tables: readonly ResourceTable[]): ResourceTable[] {
   return Array.from(new Set(tables));
+}
+
+/** Shape the success payload; the first match in table order wins. */
+function resolvedHit(
+  id: string,
+  found: ProbeHit,
+  readableTables: readonly ResourceTable[],
+): ResolvedEntry {
+  // First match in table order wins; UUIDs are unique across source tables.
+  const checkedTables = uniqueTables(
+    readableTables.slice(0, readableTables.indexOf(found.table) + 1),
+  );
+  return {
+    resolved: true,
+    status: "found",
+    id,
+    source_type: SOURCE_TYPE_BY_TABLE[found.table],
+    table: found.table,
+    namespace: found.namespace,
+    fetch_path: { tool: "get_entry", arguments: { table: found.table, id } },
+    checked_sources: checkedTables.map((table) => SOURCE_TYPE_BY_TABLE[table]),
+    checked_tables: checkedTables,
+  };
+}
+
+/**
+ * Second pass for admin-tier identities only: report that an id exists but is
+ * archived. Non-admin callers never reach this, so archived rows stay invisible
+ * to them exactly as an absent row would be.
+ */
+async function resolveArchived(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  id: string,
+  scope: {
+    readableTables: readonly ResourceTable[];
+    requestedNamespace: string | undefined;
+  },
+): Promise<ResolvedEntry | null> {
+  if (identity.role !== "admin" && identity.role !== "ob-admin") return null;
+  const checkedTables: ResourceTable[] = [];
+  const archived = await findRow(dependencies, {
+    identity,
+    id,
+    tables: scope.readableTables,
+    requestedNamespace: scope.requestedNamespace,
+    archived: true,
+    checkedTables,
+  });
+  if (!archived) return null;
+  return {
+    ...unresolved(
+      "archived",
+      id,
+      uniqueTables([...scope.readableTables, ...checkedTables]),
+      archived.namespace,
+    ),
+    source_type: SOURCE_TYPE_BY_TABLE[archived.table],
+    table: archived.table,
+    namespace: archived.namespace,
+  };
+}
+
+/** Resolve one authenticated request end to end, live pass then archived pass. */
+async function resolveEntry(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  args: { id: string; namespace?: string | undefined },
+): Promise<ResolvedEntry> {
+  const namespace = args.namespace;
+  if (
+    namespace !== undefined &&
+    !canTargetNamespace(identity, "read", namespace)
+  ) {
+    return unresolved("not_readable", args.id, [], namespace);
+  }
+
+  const readableTables = ALL_TABLES.filter((table) =>
+    canRead(identity.role, table),
+  );
+  if (readableTables.length === 0) {
+    return unresolved("not_readable", args.id, [], namespace ?? null);
+  }
+
+  const found = await findRow(dependencies, {
+    identity,
+    id: args.id,
+    tables: readableTables,
+    requestedNamespace: namespace,
+    archived: false,
+    checkedTables: [],
+  });
+  if (found) return resolvedHit(args.id, found, readableTables);
+
+  const archived = await resolveArchived(dependencies, identity, args.id, {
+    readableTables,
+    requestedNamespace: namespace,
+  });
+  if (archived) return archived;
+
+  return unresolved(
+    "not_found_or_unreadable",
+    args.id,
+    readableTables,
+    namespace ?? null,
+  );
 }
 
 export function registerResolveEntryTool(
@@ -103,88 +269,13 @@ export function registerResolveEntryTool(
     {
       description:
         "Resolve a memory UUID to its readable source type, namespace, and get_entry fetch path without semantic search.",
-      inputSchema: {
-        id: z.string().uuid(),
-        namespace: z.string().min(1).max(500).optional(),
-      },
-      annotations: {
-        title: "Resolve Entry",
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      inputSchema: resolveEntryInputSchema,
+      annotations: resolveEntryAnnotations,
     },
     async (args, extra) => {
       const identity = authIdentity(extra.authInfo);
-      if (!identity) return errorResult("Permission denied: cannot resolve entries");
-      const namespace = args.namespace;
-
-      if (namespace !== undefined && !canTargetNamespace(identity, "read", namespace)) {
-        return textResult(unresolved("not_readable", args.id, [], namespace));
-      }
-
-      const readableTables = ALL_TABLES.filter((table) => canRead(identity.role, table));
-      if (readableTables.length === 0) {
-        return textResult(unresolved("not_readable", args.id, [], namespace ?? null));
-      }
-
-      const found = await findRow(
-        dependencies,
-        identity,
-        args.id,
-        readableTables,
-        namespace,
-        false,
-        [],
-      );
-      if (found) {
-        // First match in table order wins; UUIDs are unique across source tables.
-        const checkedTables = uniqueTables(
-          readableTables.slice(0, readableTables.indexOf(found.table) + 1),
-        );
-        return textResult({
-          resolved: true,
-          status: "found",
-          id: args.id,
-          source_type: SOURCE_TYPE_BY_TABLE[found.table],
-          table: found.table,
-          namespace: found.namespace,
-          fetch_path: { tool: "get_entry", arguments: { table: found.table, id: args.id } },
-          checked_sources: checkedTables.map((table) => SOURCE_TYPE_BY_TABLE[table]),
-          checked_tables: checkedTables,
-        } satisfies ResolvedEntry);
-      }
-
-      // Only admin-tier identities learn that an id exists but is archived.
-      if (identity.role === "admin" || identity.role === "ob-admin") {
-        const checkedTables: ResourceTable[] = [];
-        const archived = await findRow(
-          dependencies,
-          identity,
-          args.id,
-          readableTables,
-          namespace,
-          true,
-          checkedTables,
-        );
-        if (archived) {
-          return textResult({
-            ...unresolved(
-              "archived",
-              args.id,
-              uniqueTables([...readableTables, ...checkedTables]),
-              archived.namespace,
-            ),
-            source_type: SOURCE_TYPE_BY_TABLE[archived.table],
-            table: archived.table,
-            namespace: archived.namespace,
-          } satisfies ResolvedEntry);
-        }
-      }
-
-      return textResult(
-        unresolved("not_found_or_unreadable", args.id, readableTables, namespace ?? null),
-      );
+      if (!identity) return errorResult(NOT_AUTHENTICATED);
+      return textResult(await resolveEntry(dependencies, identity, args));
     },
   );
 }


### PR DESCRIPTION
## Summary

- Brings `server/tools/resolve-entry.ts` to the repo lint standard (#780), wave 2 lane 6. Two oxlint findings cleared, no behavior change.
- `findRow` took 7 positional parameters. Its per-probe inputs now travel as a single `ProbeRequest` object, and the namespace-scoping half moved into a `scopeParameters` helper. Same clauses, same parameter positions, same SQL text.
- The registered handler had a complexity of 11. It is now registration only; the work moved to module-level `resolveEntry`, with `resolvedHit` shaping the success payload and `resolveArchived` owning the admin-tier archived second pass.
- Schema and annotations hoisted to module consts (`resolveEntryInputSchema`, `resolveEntryAnnotations`) with identical description strings and rule values, matching lane 2 (`search-brain.ts`) and lane 3 (`search-all.ts`, 011bf24). The "Permission denied: cannot resolve entries" string became a named `NOT_AUTHENTICATED` const with the identical value.
- No other existing file was touched. No new shared module: every helper is private to this file, because no second caller exists now.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED (untouched file, before any edit):

```
server/tools/resolve-entry.ts:60:23: error eslint(max-params): Function 'findRow' has too many parameters (7). Maximum allowed is 4.
server/tools/resolve-entry.ts:117:5: error eslint(complexity): async function has a complexity of 11. Maximum allowed is 10.
```

`DONE_MEANS_780_FILES=server/tools/resolve-entry.ts bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 1, `FAIL: oxlint reported findings in the file(s) listed above.`

GREEN (re-run on the COMMITTED tree at ddd4557, after the pre-commit prettier pass, working tree clean):

- `./node_modules/.bin/oxlint --deny-warnings server/tools/resolve-entry.ts` -> exit 0, no findings
- `bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 0, diff-derived, `PASS: every file this branch touched under server/ lints clean.`
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated src/tools/__tests__/resolve-entry.test.ts src/contract.test.ts server/tools` -> 180 pass, 0 fail, 750 expect() calls across 19 files, tests exited 0

Python package: not applicable, `python/openbrain-memory/` is untouched. Live smoke: not applicable, this is a source-internal refactor with no wire-visible change.

## Critical Self-Review

- Highest-risk behavior: the namespace predicate on the ID-based read. This is a security boundary, not a formatting detail — an `id` is caller-supplied and globally unique, so an unscoped probe would let any identity confirm and read a row in a namespace it has no read authority over. Both branches are preserved exactly: an explicit `namespace` is bound as `$2` only after `canTargetNamespace(identity, "read", namespace)` clears it, and otherwise `namespacePredicate(identity, "read", 2)` supplies the auth-derived clause and values. Moving that into `scopeParameters` was deliberate — it puts both branches side by side in one named function with a doc comment stating the invariant, so a future edit that drops one is visible rather than buried in a probe loop.
- Assumptions that could be wrong: that `scopeParameters` produces byte-identical SQL per iteration. It is rebuilt inside the loop exactly as before rather than hoisted, which matters because it mutates a fresh `params` array per table; hoisting it would have shared one array across probes and shifted parameter positions. I kept the per-iteration construction for that reason. Also assumed `resolveArchived` returning `null` is indistinguishable from the old inline fall-through — it is, both land on the same `not_found_or_unreadable` result.
- Missing/weak tests: no test was added. The existing `src/tools/__tests__/resolve-entry.test.ts` pins the behavior of the `src/` twin, not the `server/` file directly; the `server/` file's namespace scoping is covered indirectly by `server/tools/namespace-denial.test.ts` and `server/tools/ported-tools-scope.test.ts`, which ran green. A targeted `server/`-side test that a non-admin identity cannot resolve an id outside its namespace would be stronger than what exists, and this PR does not add one — it is a pure refactor lane and adding coverage would mix concerns, but the gap is real and named here.
- Security/permission risk: low, and reviewed specifically. The auth gate (`authIdentity` -> `errorResult`), the `canTargetNamespace` check, the `canRead` table filter, and the admin/ob-admin restriction on the archived pass are all preserved with identical ordering and identical short-circuit behavior. The archived pass still runs only for `admin`/`ob-admin`, so archived rows stay invisible to everyone else exactly as an absent row would be. The diagnostics contract is unchanged: `checked_sources`/`checked_tables` still describe what the caller was allowed to search, never metadata from an unreadable row.
- Migration/deploy risk: none. No schema, no migration, no config, no startup path touched.
- Downstream client/runtime risk: none. No MCP tool name, description, input schema, annotation, error string, or response field changed, so the wire contract is byte-identical and no client can observe this.
- Rollback/cleanup concern: none beyond reverting the single commit. One file, no shared module added, nothing else imports the new helpers.
- Fixes made before PR: caught and rejected a reuse that would have changed behavior — `read-scope.ts`'s `appendReadNamespacePredicate` emits `= ANY($n::text[])` against a caller-named column and takes an `includeLegacySharedFallback` option, which is not the same clause `namespacePredicate(identity, "read", 2)` produces here. Swapping it in would have altered SQL under a refactor label, so `namespacePredicate` stayed. Also checked `normalizeSearchArgs` (`search-request.ts`) and `respondToSearchFailure` (`tool-failure.ts`) per the reuse-first rule and rejected both: this tool has no query/limit/offset/mode args for the former, and no catch block for the latter.
- Known residual risk: the `server/` and `src/` copies of this tool remain separate implementations; this PR changed only the `server/` one, so the two now differ structurally while remaining behaviorally equivalent. That duplication predates this lane and is not introduced here.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no new MEDIUM+ review finding — it is a mechanical lint-standard refactor with no behavior change, and the one judgment call it did make (rejecting a same-named-looking helper whose emitted SQL differs) is already covered by the existing "nothing is adjusted silently" and minimal-correct-change entries rather than being a new pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no wire-visible, schema, or runtime-behavior change — the MCP contract is byte-identical, so a live smoke would exercise nothing this PR could have broken.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no path in `contracts/parity-paths.txt` is touched. This PR changes only `server/tools/resolve-entry.ts`; `python/openbrain-memory/`, `clients/ts/`, `contracts/`, `src/contract.ts`, and `src/contract-schemas.ts` are all unmodified, and the tool's declared schema values are unchanged, so the existing fixtures remain correct.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Downstream rollout is not applicable. Per `docs/downstream-rollout.md`, rollout is triggered by MCP tool/schema/protocol/client-facing changes. This PR changes none: the tool name `resolve_entry`, its description string, its input schema, its annotations, its error strings, and every field of its response are identical to `origin/main`. The change is internal function decomposition inside one server file, invisible to rtech-mcps, mcp2cli, and the rtech-hermes runtime.
