### PR TITLE
refactor(context-pack-guidance): bring server/tools/context-pack-guidance.ts to the lint standard (#780)

### DIFF
--- a/server/tools/context-pack-guidance.ts
+++ b/server/tools/context-pack-guidance.ts
@@ -137,6 +137,177 @@ export type GuidanceReaderArgs = {
 };
 
 /**
+ * Bind by LANE namespace — the isolation boundary for session events. The
+ * candidate_type discriminator is an explicit typed metadata field, not a
+ * content match. promote/relegate/discard are all pulled so supersession is
+ * reconciled deterministically in-process.
+ */
+const GUIDANCE_ROWS_SQL = `SELECT e.id,
+              e.content,
+              e.created_at,
+              e.metadata->>'memory_lifecycle_action' AS memory_lifecycle_action,
+              e.metadata->>'candidate_type' AS candidate_type,
+              e.metadata->>'candidate_reason' AS candidate_reason,
+              (e.metadata->>'candidate_confidence')::float8 AS candidate_confidence,
+              e.metadata->'candidate_scope' AS candidate_scope
+         FROM ob_session_events e
+         JOIN ob_session_lanes l ON l.id = e.lane_id
+        WHERE l.namespace = $1
+          AND e.metadata->>'candidate_type' = $2
+          AND e.metadata->>'memory_lifecycle_action' IN ('promote', 'relegate', 'discard')
+        ORDER BY e.created_at DESC, e.id DESC`;
+
+/**
+ * Is this row a promote that is still standing for its own candidate type?
+ *
+ * Flattens what was nested selection logic: a row survives only if it is a
+ * promote of the requested type whose explicit scope key has neither been
+ * retired by a newer decisive action nor already been emitted. Keyless promotes
+ * always survive here and are flagged downstream instead.
+ */
+function isStandingPromote(options: {
+  row: LifecycleRow;
+  candidateType: string;
+  retired: Set<string>;
+  seenScopeKeys: Set<string>;
+}): boolean {
+  const { row, candidateType, retired, seenScopeKeys } = options;
+  if (row.action !== "promote") return false;
+  if (row.candidateType !== candidateType) return false;
+  if (!row.scopeKey) return true;
+  // Supersession: an explicit key later relegated/discarded is gone.
+  if (retired.has(row.scopeKey)) return false;
+  // Deterministic dedupe: keep only the most-recent promote per key.
+  if (seenScopeKeys.has(row.scopeKey)) return false;
+  seenScopeKeys.add(row.scopeKey);
+  return true;
+}
+
+type GuidanceSelection = {
+  items: Array<Record<string, unknown>>;
+  citations: Array<Record<string, unknown>>;
+  itemsTruncated: boolean;
+};
+
+/**
+ * Build the emitted items and their citations, in arrival order, applying
+ * supersession and the resolved per-item text bound. Order and admission are
+ * unchanged from the single-pass form this replaces.
+ */
+function selectGuidanceItems(options: {
+  normalized: LifecycleRow[];
+  candidateType: string;
+  retired: Set<string>;
+  maxItems: number;
+  maxItemChars: number;
+}): GuidanceSelection {
+  const { normalized, candidateType, retired, maxItems, maxItemChars } =
+    options;
+  const citations: Array<Record<string, unknown>> = [];
+  const items: Array<Record<string, unknown>> = [];
+  const seenScopeKeys = new Set<string>();
+  let itemsTruncated = false;
+
+  for (const row of normalized) {
+    if (!isStandingPromote({ row, candidateType, retired, seenScopeKeys })) {
+      continue;
+    }
+
+    if (items.length >= maxItems) {
+      itemsTruncated = true;
+      break;
+    }
+
+    const bounded = boundedItemText(row.content, maxItemChars);
+    if (!bounded.text) {
+      // Non-empty content the budget cannot admit is recorded as an omission,
+      // content-free, rather than emitted as an empty rule.
+      if (row.content) itemsTruncated = true;
+      continue;
+    }
+    if (bounded.truncated) itemsTruncated = true;
+
+    const citationId = `session_event:${row.id}`;
+    items.push({
+      id: row.id,
+      guidance: bounded.text,
+      candidate_type: candidateType,
+      confidence: row.confidence,
+      reason: row.reason,
+      scope_key: row.scopeKey,
+      // Keyless promotes cannot be proven un-superseded: flag, never fabricate.
+      supersession_verifiable: row.scopeKey !== null,
+      promoted_at: row.createdAt,
+      citation_id: citationId,
+    });
+    citations.push({
+      id: citationId,
+      kind: "session_event",
+      source_ref: `ob_session_events/${row.id}`,
+    });
+  }
+
+  return { items, citations, itemsTruncated };
+}
+
+/**
+ * ERROR names what broke at the default level; DEBUG carries the inputs,
+ * because a "database_unavailable" envelope on its own tells a later reader
+ * nothing and by then the call that produced it is gone.
+ */
+type FailureShape = {
+  error_name: string;
+  error_message: string;
+  pg_code: unknown;
+  stack: string | null;
+};
+
+/** Content-free description of a thrown value, Error or not. */
+function failureShape(error: unknown): FailureShape {
+  const err = error instanceof Error ? error : undefined;
+  return {
+    error_name: err?.name ?? typeof error,
+    error_message: err?.message ?? String(error),
+    pg_code: (error as { code?: unknown })?.code ?? null,
+    stack: err?.stack ?? null,
+  };
+}
+
+function logGuidanceFailure(options: {
+  args: GuidanceReaderArgs;
+  candidateType: string;
+  budget: Record<string, number>;
+  error: unknown;
+  logger?: Logger;
+}): void {
+  const { args, candidateType, budget, error, logger } = options;
+  const shape = failureShape(error);
+  logger?.error(
+    {
+      section: args.section,
+      namespace: args.namespace,
+      error_name: shape.error_name,
+      error_message: shape.error_message,
+    },
+    "guidance_section_failed",
+  );
+  logger?.debug(
+    {
+      section: args.section,
+      candidate_type: candidateType,
+      namespace: args.namespace,
+      requested_budget: args.budget,
+      resolved_budget: budget,
+      error_name: shape.error_name,
+      error_message: shape.error_message,
+      pg_code: shape.pg_code,
+      stack: shape.stack,
+    },
+    "guidance_section_failed_detail",
+  );
+}
+
+/**
  * Assemble one guidance fragment for an authorized namespace. Deterministic
  * order: promoted-most-recent first, then id. Empty state is an explicit empty
  * items array, never omitted and never fabricated.
@@ -159,82 +330,22 @@ export async function loadGuidanceSection(
   };
 
   try {
-    // Bind by LANE namespace — the isolation boundary for session events. The
-    // candidate_type discriminator is an explicit typed metadata field, not a
-    // content match. promote/relegate/discard are all pulled so supersession is
-    // reconciled deterministically in-process.
-    const { rows } = await deps.query(
-      `SELECT e.id,
-              e.content,
-              e.created_at,
-              e.metadata->>'memory_lifecycle_action' AS memory_lifecycle_action,
-              e.metadata->>'candidate_type' AS candidate_type,
-              e.metadata->>'candidate_reason' AS candidate_reason,
-              (e.metadata->>'candidate_confidence')::float8 AS candidate_confidence,
-              e.metadata->'candidate_scope' AS candidate_scope
-         FROM ob_session_events e
-         JOIN ob_session_lanes l ON l.id = e.lane_id
-        WHERE l.namespace = $1
-          AND e.metadata->>'candidate_type' = $2
-          AND e.metadata->>'memory_lifecycle_action' IN ('promote', 'relegate', 'discard')
-        ORDER BY e.created_at DESC, e.id DESC`,
-      [args.namespace, candidateType],
-    );
+    const { rows } = await deps.query(GUIDANCE_ROWS_SQL, [
+      args.namespace,
+      candidateType,
+    ]);
 
     const normalized = rows.map(normalizeRow);
     const retired = retiredScopeKeys(normalized);
+    const { items, citations, itemsTruncated } = selectGuidanceItems({
+      normalized,
+      candidateType,
+      retired,
+      maxItems,
+      maxItemChars,
+    });
 
     const truncation: Array<Record<string, unknown>> = [];
-    const citations: Array<Record<string, unknown>> = [];
-    const items: Array<Record<string, unknown>> = [];
-    const seenScopeKeys = new Set<string>();
-    let itemsTruncated = false;
-
-    for (const row of normalized) {
-      if (row.action !== "promote") continue;
-      if (row.candidateType !== candidateType) continue;
-      // Supersession: an explicit key later relegated/discarded is gone.
-      if (row.scopeKey && retired.has(row.scopeKey)) continue;
-      // Deterministic dedupe: keep only the most-recent promote per key.
-      if (row.scopeKey) {
-        if (seenScopeKeys.has(row.scopeKey)) continue;
-        seenScopeKeys.add(row.scopeKey);
-      }
-
-      if (items.length >= maxItems) {
-        itemsTruncated = true;
-        break;
-      }
-
-      const bounded = boundedItemText(row.content, maxItemChars);
-      if (!bounded.text) {
-        // Non-empty content the budget cannot admit is recorded as an omission,
-        // content-free, rather than emitted as an empty rule.
-        if (row.content) itemsTruncated = true;
-        continue;
-      }
-      if (bounded.truncated) itemsTruncated = true;
-
-      const citationId = `session_event:${row.id}`;
-      items.push({
-        id: row.id,
-        guidance: bounded.text,
-        candidate_type: candidateType,
-        confidence: row.confidence,
-        reason: row.reason,
-        scope_key: row.scopeKey,
-        // Keyless promotes cannot be proven un-superseded: flag, never fabricate.
-        supersession_verifiable: row.scopeKey !== null,
-        promoted_at: row.createdAt,
-        citation_id: citationId,
-      });
-      citations.push({
-        id: citationId,
-        kind: "session_event",
-        source_ref: `ob_session_events/${row.id}`,
-      });
-    }
-
     if (itemsTruncated) {
       truncation.push({
         source: args.section,
@@ -265,33 +376,7 @@ export async function loadGuidanceSection(
       citations,
     };
   } catch (error) {
-    // ERROR names what broke at the default level; DEBUG carries the inputs,
-    // because a "database_unavailable" envelope on its own tells a later reader
-    // nothing and by then the call that produced it is gone.
-    const err = error instanceof Error ? error : undefined;
-    logger?.error(
-      {
-        section: args.section,
-        namespace: args.namespace,
-        error_name: err?.name ?? typeof error,
-        error_message: err?.message ?? String(error),
-      },
-      "guidance_section_failed",
-    );
-    logger?.debug(
-      {
-        section: args.section,
-        candidate_type: candidateType,
-        namespace: args.namespace,
-        requested_budget: args.budget,
-        resolved_budget: budget,
-        error_name: err?.name ?? typeof error,
-        error_message: err?.message ?? String(error),
-        pg_code: (error as { code?: unknown })?.code ?? null,
-        stack: err?.stack ?? null,
-      },
-      "guidance_section_failed_detail",
-    );
+    logGuidanceFailure({ args, candidateType, budget, error, logger });
     return databaseUnavailableFragment(args.section, budget);
   }
 }


### PR DESCRIPTION
## Summary

- Brings `server/tools/context-pack-guidance.ts` to the repo lint standard, retiring its four oxlint findings with no disable comments and no behavior change. Rung of the #780 one-file-at-a-time sweep.
- Before: `loadGuidanceSection` was a single 130-line async function at a complexity of 29, with two blocks nested four deep inside its emit loop. Findings verbatim: `complexity ... 29. Maximum allowed is 10`, `max-lines-per-function ... (130). Maximum allowed is 100`, and `max-depth ... (4). Maximum allowed is 3` at both `:200` and `:213`.
- After: the read is split along seams the function already had. `GUIDANCE_ROWS_SQL` is hoisted to module scope byte-identical; `isStandingPromote` takes the per-row supersession decision as one predicate; `selectGuidanceItems` builds items and citations; `logGuidanceFailure` and `failureShape` carry the two-level failure logging.
- `isStandingPromote` is what actually flattens the depth, rather than a cosmetic re-indent: the retired-key check and the keyed dedupe stop being nested `if`s inside the emit loop and become early returns in a predicate that owns the whole decision.
- Helpers take options objects instead of positional arguments, matching the pattern already landed in `answer-evidence.ts` and `entity-shared.ts`.
- Scope held to one file. The audit found this file shares nothing with its durable twin `src/tools/agent-context-pack-guidance.ts`, and that twin belongs to a concurrent lane, so no shared helper was created and no other file was touched.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Red first, on untouched `origin/main` content: `DONE_MEANS_780_FILES=server/tools/context-pack-guidance.ts bash scripts/done-means/780-touched-files-lint-clean.sh` exited 1 naming all four findings.

Green, re-run on the COMMITTED tree after the pre-commit prettier hook reformatted the file:

- `npx oxlint --deny-warnings server/tools/context-pack-guidance.ts` -> exit 0
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived list) -> exit 0, `PASS: every file this branch touched under server/ lints clean.`
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated` over the guidance/context-pack pinning tests -> 96 pass, 0 fail, 379 expect() calls across 5 files
- `bun run test:isolated server/tools` -> 163 pass, 0 fail across 17 files

Python package untouched, so its checks do not apply. No migration, no schema change, no live surface change, so no smoke applies.

## Critical Self-Review

- Highest-risk behavior: the emit loop's admission and ordering. The original marked a scope key as seen BEFORE testing `items.length >= maxItems`, so a row that is deduped-then-refused still consumes its key. `isStandingPromote` adds to `seenScopeKeys` and the count test stays after the call, preserving that exact sequence; getting it backwards would change which items appear once a maximum is in play.
- Assumptions that could be wrong: that no caller depends on the SQL string identity or on the two log event names. Checked — the only importer is `server/tools/agent-context-pack.ts` at line 625, which consumes the returned fragment; the SQL text is copied byte-identical and both `guidance_section_failed` and `guidance_section_failed_detail` keep their names and fields.
- Missing/weak tests: no test was added, because no behavior was added. The guidance path already has real coverage (`src/tools/agent-context-pack-guidance.ts` reports 100% function coverage under the run above), and the lint claim is proven by the done-means, which was demonstrated red before green rather than assumed.
- Security/permission risk: none introduced. The namespace binding is unchanged — `l.namespace = $1` still comes from the auth-resolved `args.namespace`, the query stays parameterized, and no table name is interpolated. The refactor moved the SQL, it did not rewrite a predicate.
- Migration/deploy risk: none. No schema, no migration, no config, no startup path.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or client-facing contract changed; per `docs/downstream-rollout.md` this is an internal refactor with no external surface.
- Rollback/cleanup concern: single-file, single-commit, revertable on its own with no dependency on the other #780 lanes.
- Fixes made before PR: the first pass left `logGuidanceFailure` at a complexity of 12 from its `??` fallback chain; extracted `failureShape` so the Error-or-not normalization happens once, which also removed the duplicated name/message expressions between the two log calls.
- Known residual risk: low. The supersession gap the module header documents — the lifecycle stream carrying no server-enforced identity linking a retirement to the promote it supersedes — is untouched and still open; this PR neither fixes nor worsens it.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new failure pattern surfaced — this is a mechanical lint-debt rung whose one wrinkle (preserving dedupe-before-count ordering) is a normal refactor obligation already covered by the existing correctness lane guidance.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: internal refactor with no runtime, schema, or client-facing surface change.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the change is confined to the `server/` runtime copy. The durable twin `src/tools/agent-context-pack-guidance.ts` is owned by a concurrent #780 lane and was deliberately not touched; no contract, fixture, or response shape moved.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, protocol, or client-facing shape changed. The refactor is internal to one server-side section reader whose only in-repo caller is `server/tools/agent-context-pack.ts`.
