### PR TITLE
refactor(context-pack): bring the durable context-pack loaders and their agent-context-pack caller to the lint standard (#780)

### DIFF
--- a/docs/sme/entries/2026-08-26-an-over-complex-function-is-usually-held-together-by-mutable-locals-not-by-length.md
+++ b/docs/sme/entries/2026-08-26-an-over-complex-function-is-usually-held-together-by-mutable-locals-not-by-length.md
@@ -1,0 +1,53 @@
+---
+lane: quality
+order: 76
+---
+## [2026-08-26] An over-complex function is usually held together by mutable locals, not by length
+
+**Provenance:** PR #806, issue #780. Severity: MEDIUM. Status: open.
+**Scope:** any `complexity` / `max-lines-per-function` finding; review of a PR
+that answers one by extracting helpers.
+
+`buildAgentContextPackPayload` scored 129 on complexity across 535 lines. The
+length was the symptom. What actually held it together was three mutable
+locals — the surviving chars, whether the next admitted member still gets the
+comma-free first slot, and an accumulated markers array — read and written by
+each of nine sections in sequence.
+
+That is why the function had grown instead of being split earlier. Extracting
+any one section required passing all three in and getting two of them back, so
+every candidate helper had a worse signature than the code it replaced, and
+`max-params` was waiting on the other side. Splitting on line count alone
+produces exactly that: helpers that take five arguments and return a tuple,
+which trades one finding for another and makes the flow harder to read.
+
+Naming the shared state as ONE object first is the move that unlocks the split.
+Once the three locals became fields on a `PackAllocator` passed to each section,
+every section became a function taking one options object and returning what it
+contributed — and the file went 729 → 425 code lines across eight siblings with
+no helper exceeding four parameters.
+
+**What a reviewer should check** on a PR that answers a complexity finding:
+
+- Did the author identify the shared MUTABLE state before extracting, or just
+  cut at line boundaries? A helper list with no state object, where several
+  helpers take the same three or four scalars, is the tell that the split
+  fought the state instead of naming it.
+- Do the new helpers hand state back through return tuples or out-parameters?
+  That is the same coupling with more surface.
+- Ordering that used to be visible as one inline sequence — array spreads,
+  insertion into a map, a priority walk — is now decided by the ORDER OF A LIST
+  passed to a composer. That is a real behavior surface with no compiler check
+  behind it; confirm a test asserts the resulting order, and that the list is
+  commented with what its order means.
+- Two blocks merged into one parameterized helper need a reason they will not
+  need to diverge. Two blocks kept separate need a reason they must. In this PR
+  the two append-store sections merged (they differed only by key and reconciled
+  counts) and the two recall sections did not (they trim in opposite
+  directions) — both calls were stated and both are checkable.
+
+**Also observed:** the extraction rewrote one boolean predicate into a
+non-equivalent nested conditional, and the existing suite did not catch it. A
+refactor claimed to be behavior-free is verified by reading each extraction back
+against its original, not only by a green run — the tests cover the
+combinations someone already thought of.

--- a/docs/sme/quality.md
+++ b/docs/sme/quality.md
@@ -409,3 +409,53 @@ Namespace- or row-scoped cleanup does not isolate table-level DDL: a test that d
 Verbatim, from the source:
 
 > The fixture globally drops and narrows `maintenance_jobs_last_error_category_check` on the shared CI database. Bun runs test files in parallel by default, so another live queue test can observe the temporary old constraint and fail spuriously. Namespace-scoped row cleanup does not isolate table-level DDL.
+
+## [2026-08-26] An over-complex function is usually held together by mutable locals, not by length
+
+**Provenance:** PR #806, issue #780. Severity: MEDIUM. Status: open.
+**Scope:** any `complexity` / `max-lines-per-function` finding; review of a PR
+that answers one by extracting helpers.
+
+`buildAgentContextPackPayload` scored 129 on complexity across 535 lines. The
+length was the symptom. What actually held it together was three mutable
+locals — the surviving chars, whether the next admitted member still gets the
+comma-free first slot, and an accumulated markers array — read and written by
+each of nine sections in sequence.
+
+That is why the function had grown instead of being split earlier. Extracting
+any one section required passing all three in and getting two of them back, so
+every candidate helper had a worse signature than the code it replaced, and
+`max-params` was waiting on the other side. Splitting on line count alone
+produces exactly that: helpers that take five arguments and return a tuple,
+which trades one finding for another and makes the flow harder to read.
+
+Naming the shared state as ONE object first is the move that unlocks the split.
+Once the three locals became fields on a `PackAllocator` passed to each section,
+every section became a function taking one options object and returning what it
+contributed — and the file went 729 → 425 code lines across eight siblings with
+no helper exceeding four parameters.
+
+**What a reviewer should check** on a PR that answers a complexity finding:
+
+- Did the author identify the shared MUTABLE state before extracting, or just
+  cut at line boundaries? A helper list with no state object, where several
+  helpers take the same three or four scalars, is the tell that the split
+  fought the state instead of naming it.
+- Do the new helpers hand state back through return tuples or out-parameters?
+  That is the same coupling with more surface.
+- Ordering that used to be visible as one inline sequence — array spreads,
+  insertion into a map, a priority walk — is now decided by the ORDER OF A LIST
+  passed to a composer. That is a real behavior surface with no compiler check
+  behind it; confirm a test asserts the resulting order, and that the list is
+  commented with what its order means.
+- Two blocks merged into one parameterized helper need a reason they will not
+  need to diverge. Two blocks kept separate need a reason they must. In this PR
+  the two append-store sections merged (they differed only by key and reconciled
+  counts) and the two recall sections did not (they trim in opposite
+  directions) — both calls were stated and both are checkable.
+
+**Also observed:** the extraction rewrote one boolean predicate into a
+non-equivalent nested conditional, and the existing suite did not catch it. A
+refactor claimed to be behavior-free is verified by reading each extraction back
+against its original, not only by a green run — the tests cover the
+combinations someone already thought of.

--- a/server/tools/agent-context-pack.ts
+++ b/server/tools/agent-context-pack.ts
@@ -40,45 +40,31 @@ import {
   type WorkingSetScope,
 } from "../realtime/working-set.ts";
 import {
+  createAllocator,
+  wholePackBudgetFor,
+} from "./context-pack-allocator.ts";
+import { admitAppendSection } from "./context-pack-append-sections.ts";
+import {
   agentContextPackStrictSchema,
   agentReflexPointersStrictSchema,
   parseAgentContextPackArgs,
   parseAgentReflexPointersArgs,
-  SECTION_NAMES,
   type AgentContextPackArgs,
   type AgentReflexPointersArgs,
 } from "./context-pack-args.ts";
 import {
-  CHARS_PER_TOKEN,
-  CONTEXT_PACK_SECTION_PRIORITY,
-  durableLaneContentChars,
-  durableMemoryContentChars,
-  fitDurableLaneSection,
-  fitItemSection,
-  fitRankedItemSection,
-  reconcileCitedItemCitations,
-  reconcileDurableMemoryCitations,
-  sectionFrameCost,
-  serializedLength,
-  type DurableLaneSection,
-  type DurableMemorySection,
-} from "./context-pack-budget.ts";
+  assembleBudget,
+  assemblePackWarnings,
+  buildRecallSections,
+  buildStructuredSections,
+} from "./context-pack-assembly.ts";
+import { CONTEXT_PACK_SECTION_PRIORITY } from "./context-pack-budget.ts";
+import { POINTERS_SECTION_NAME } from "./context-pack-pointers.ts";
+import { assembleSections, sectionsReceipt } from "./context-pack-payload.ts";
 import {
-  CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
-  loadDurableLaneContext,
-} from "./context-pack-durable-lane.ts";
-import { loadDurableMemoryContext } from "./context-pack-durable-memory.ts";
-import {
-  loadGuidanceSection,
-  type GuidanceSectionName,
-} from "./context-pack-guidance.ts";
-import {
-  buildCandidateSection,
-  buildPointerSection,
-  POINTERS_SECTION_NAME,
-} from "./context-pack-pointers.ts";
-import { loadRepoFactsSection } from "./context-pack-repo-facts.ts";
-import type { SectionFragment } from "./context-pack-sections.ts";
+  selectSections,
+  type SectionSelection,
+} from "./context-pack-selection.ts";
 import { canReadNamespace } from "./read-scope.ts";
 import { recoveryWalStoreFor, workingSetStoreFor } from "./realtime-stores.ts";
 import { physicalNamespace } from "./shared-namespace.ts";
@@ -93,28 +79,69 @@ export interface AgentContextPackBuildResult {
   isError: boolean;
 }
 
-export async function buildAgentContextPackPayload(
+/**
+ * Authorize the call, resolving the namespace it reads.
+ *
+ * Returns the content-free denial payload instead when either gate refuses.
+ */
+function authorizePack(
   args: AgentContextPackArgs,
   auth: AuthIdentity | undefined,
-  dependencies: MemoryToolDependencies,
-): Promise<AgentContextPackBuildResult> {
+):
+  { denial: AgentContextPackBuildResult } | { auth: AuthIdentity; ns: string } {
   if (!auth || !canRead(auth.role, "sessions")) {
     return {
-      payload: { error: "Permission denied: cannot read agent context pack" },
-      isError: true,
+      denial: {
+        payload: { error: "Permission denied: cannot read agent context pack" },
+        isError: true,
+      },
     };
   }
-
   const ns = args.namespace ?? auth.clientId;
   // Gate BEFORE any query runs, so an unauthorized namespace argument is a
   // denial rather than an empty result set — the two are indistinguishable to a
   // caller, and only one of them is honest.
   if (!canReadNamespace(auth, ns)) {
     return {
-      payload: { error: `Permission denied: cannot read namespace '${ns}'` },
-      isError: true,
+      denial: {
+        payload: {
+          error: `Permission denied: cannot read namespace '${ns}'`,
+        },
+        isError: true,
+      },
     };
   }
+  return { auth, ns };
+}
+
+/** The two append-store fragments, built before any allocation is charged. */
+function loadAppendStores(options: {
+  selection: SectionSelection;
+  scope: WorkingSetScope;
+  dependencies: MemoryToolDependencies;
+}): {
+  workingSet: WorkingSetContextPackFragment | null;
+  recovery: RecoveryWalContextPackFragment | null;
+} {
+  const { selection, scope, dependencies } = options;
+  return {
+    workingSet: selection.workingSet
+      ? workingSetStoreFor(dependencies).buildContextPackFragment(scope)
+      : null,
+    recovery: selection.recovery
+      ? recoveryWalStoreFor(dependencies).buildContextPackFragment(scope)
+      : null,
+  };
+}
+
+export async function buildAgentContextPackPayload(
+  args: AgentContextPackArgs,
+  auth: AuthIdentity | undefined,
+  dependencies: MemoryToolDependencies,
+): Promise<AgentContextPackBuildResult> {
+  const authorized = authorizePack(args, auth);
+  if ("denial" in authorized) return authorized.denial;
+  const { auth: identity, ns } = authorized;
 
   const scope: WorkingSetScope = {
     namespace: ns,
@@ -126,62 +153,7 @@ export async function buildAgentContextPackPayload(
     session_key: args.session_key,
   };
   const normalizedScope = normalizeWorkingSetScope(scope);
-
-  // Section selection. Absent `requested_sections` means working_set AND
-  // durable_memory; every other section is opt-in, because each one costs a
-  // query and a caller that wanted the whole brain would have said so.
-  //
-  // WHY durable_memory IS IN THE DEFAULT (#744, operator decision 2026-08-25).
-  // It used to be opt-in with the rest, on the reasoning above. That reasoning
-  // holds for sections a caller might not want; it does not hold for the
-  // durable corpus, because a caller who asks for "context" and silently gets
-  // none has no way to tell. Measured against the local service with the
-  // installed client:
-  //
-  //   bare recall                  -> served [working_set],                citations 0
-  //   durable_memory asked for     -> served [working_set,durable_memory], citations 10
-  //
-  // The corpus is reachable and the query works. Only the default was wrong.
-  // The Python client never sets requested_sections at all
-  // (python/openbrain-memory/src/openbrain_memory/runtime.py
-  // context_pack_arguments), so EVERY bare recall took the working-set-only
-  // branch and reported success -- which is what an agent that "remembers
-  // nothing" actually looks like from the inside.
-  //
-  // The asymmetry was the tell: working_set treated an absent
-  // requested_sections as INCLUDED and durable_memory as EXCLUDED, one line
-  // apart, with nothing in the contract asking for that split.
-  // docs/agent-context-pack-contract.md names durable_lane_context as opt-in
-  // explicitly and says nothing equivalent for durable_memory.
-  //
-  // Cost is one hybrid recall per default-shaped call. That is the price of a
-  // default that means what a caller reading it would assume.
-  const includeWorkingSet =
-    !args.requested_sections || args.requested_sections.includes("working_set");
-  const includeRecovery =
-    args.include_unreviewed_recovery === true &&
-    (!args.requested_sections || args.requested_sections.includes("recovery"));
-  const includeDurableLaneContext =
-    args.requested_sections?.includes("durable_lane_context") === true;
-  const includeDurableMemorySection =
-    !args.requested_sections ||
-    args.requested_sections.includes("durable_memory");
-  const includeProfileGuidance =
-    args.requested_sections?.includes("profile_guidance") === true;
-  const includeProcessGuidance =
-    args.requested_sections?.includes("process_guidance") === true;
-  const includeRepoFacts =
-    args.requested_sections?.includes("repo_facts") === true;
-  const includePointers = args.requested_sections?.includes("pointers") === true;
-  const includeCandidateMemory =
-    args.requested_sections?.includes("candidate_memory") === true;
-
-  // INVARIANT 1. pointers derives from the durable_memory recall, so requesting
-  // EITHER runs that single recall — its net-new pool and emitted identities are
-  // then available even when the durable_memory SECTION body is not requested
-  // for output. candidate_memory does NOT drive recall: it has no predicate, so
-  // a candidate-only request must issue zero recall queries.
-  const includeDurableMemory = includeDurableMemorySection || includePointers;
+  const selection = selectSections(args);
 
   // The auth-derived physical namespace is the single isolation predicate every
   // structured-section read binds to. Authorization already passed above, so
@@ -191,527 +163,58 @@ export async function buildAgentContextPackPayload(
   // never bleed across the boundary.
   const readNamespace = physicalNamespace(ns);
 
-  // Whole-pack char budget. Absent max_tokens => no whole-pack bound, and every
-  // section keeps its independent per-section behavior.
-  const wholePackBudget =
-    args.budget?.max_tokens !== undefined
-      ? Math.max(
-          0,
-          args.budget.max_tokens * CHARS_PER_TOKEN -
-            CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
-        )
-      : null;
-  // The declared limit must always admit the irreducible two-character `{}` that
-  // JSON.stringify emits even when every section is omitted. At tiny budgets the
-  // budget clamps to 0, so the REPORTED limit is raised to that floor; section
-  // MEMBERS still get zero of it (see remainingChars), so no body is admitted.
-  const wholePackSerializedLimit =
-    wholePackBudget !== null ? Math.max(2, wholePackBudget) : null;
-  // Reserve the enclosing `{}` once, so the running budget bounds the serialized
-  // `sections` object rather than merely the summed bodies.
-  let remainingChars =
-    wholePackBudget !== null
-      ? Math.max(0, wholePackBudget - 2)
-      : Number.POSITIVE_INFINITY;
-  // Object framing is position-sensitive: the first admitted member costs
-  // `"key":<body>`, each subsequent one adds a comma. This flips only when a
-  // section is ACTUALLY admitted, so a starved candidate never consumes the
-  // comma-free first slot and mis-charge the next section.
-  let firstSectionAdmitted = true;
-  const wholePackTruncation: Array<Record<string, unknown>> = [];
-
-  const workingSet: WorkingSetContextPackFragment | null = includeWorkingSet
-    ? workingSetStoreFor(dependencies).buildContextPackFragment(scope)
-    : null;
-  const recovery: RecoveryWalContextPackFragment | null = includeRecovery
-    ? recoveryWalStoreFor(dependencies).buildContextPackFragment(scope)
-    : null;
-
-  // ---- working_set (priority 1) -------------------------------------------
-  let workingSetSection: Record<string, unknown> | null =
-    (workingSet?.working_set as Record<string, unknown> | undefined) ?? null;
-  if (workingSetSection) {
-    const frame = sectionFrameCost("working_set", firstSectionAdmitted);
-    const serving = Math.max(0, remainingChars - frame);
-    const fitted = fitItemSection(
-      workingSetSection as unknown as {
-        items: Array<{ id: string }>;
-        item_count: number;
-      },
-      ["item_count"],
-      serving,
-    );
-    if (fitted.starved && serializedLength(fitted.section) > serving) {
-      // Even the empty envelope does not fit: omit the section to hold the hard
-      // budget. Not admitted, so the first-member slot stays available.
-      workingSetSection = null;
-    } else {
-      workingSetSection = fitted.section as unknown as Record<string, unknown>;
-      remainingChars = Math.max(
-        0,
-        remainingChars - serializedLength(fitted.section) - frame,
-      );
-      firstSectionAdmitted = false;
-    }
-    if (fitted.truncated) {
-      wholePackTruncation.push({
-        source: "working_set",
-        reason: "whole_pack_budget",
-        max_chars: wholePackBudget,
-        ...(fitted.starved ? { starved: true } : {}),
-      });
-    }
-  }
-
-  // ---- recovery (priority 2) ----------------------------------------------
-  let recoverySection: Record<string, unknown> | null =
-    (recovery?.recovery as Record<string, unknown> | undefined) ?? null;
-  if (recoverySection) {
-    const frame = sectionFrameCost("recovery", firstSectionAdmitted);
-    const serving = Math.max(0, remainingChars - frame);
-    // Both counts reconcile: `pending_count` is what the caller acts on, so a
-    // trimmed section reporting the pre-trim pending count would overstate what
-    // it actually handed over.
-    const fitted = fitItemSection(
-      recoverySection as unknown as {
-        items: Array<{ id: string }>;
-        item_count: number;
-        pending_count: number;
-      },
-      ["item_count", "pending_count"],
-      serving,
-    );
-    if (fitted.starved && serializedLength(fitted.section) > serving) {
-      recoverySection = null;
-    } else {
-      recoverySection = fitted.section as unknown as Record<string, unknown>;
-      remainingChars = Math.max(
-        0,
-        remainingChars - serializedLength(fitted.section) - frame,
-      );
-      firstSectionAdmitted = false;
-    }
-    if (fitted.truncated) {
-      wholePackTruncation.push({
-        source: "recovery",
-        reason: "whole_pack_budget",
-        max_chars: wholePackBudget,
-        ...(fitted.starved ? { starved: true } : {}),
-      });
-    }
-  }
-
-  // ---- durable_lane_context (priority 3) ----------------------------------
-  // The loader trims raw content chars, but the serialized section also carries
-  // lane metadata, per-event wrappers, and citation ids. To keep the SERIALIZED
-  // section within budget, seed the loader with a content limit and then re-fit
-  // the result, dropping oldest events and finally trimming the checkpoint.
-  const durableLaneFrame = sectionFrameCost(
-    "durable_lane_context",
-    firstSectionAdmitted,
+  const allocator = createAllocator(
+    wholePackBudgetFor(args.budget?.max_tokens),
   );
-  const durableLaneServingChars =
-    wholePackBudget === null
-      ? Number.POSITIVE_INFINITY
-      : Math.max(0, remainingChars - durableLaneFrame);
-  const durableLaneContentLimit =
-    wholePackBudget === null
-      ? undefined
-      : Number.isFinite(durableLaneServingChars)
-        ? Math.floor(durableLaneServingChars)
-        : undefined;
-  const durableLaneContext = includeDurableLaneContext
-    ? await loadDurableLaneContext(
-        args,
-        ns,
-        dependencies,
-        durableLaneContentLimit,
-      )
-    : null;
-  let durableLaneSection = durableLaneContext?.section ?? null;
-  let durableCitations = durableLaneSection
-    ? (durableLaneContext?.citations ?? [])
-    : [];
-  // True only when a LOADED section is dropped by the re-fit, so the reconciled
-  // budget can report zero content emitted rather than the loader's pre-fit
-  // selection.
-  let durableLaneStarvedOut = false;
-  if (durableLaneSection && wholePackBudget !== null) {
-    const fitted = fitDurableLaneSection(
-      durableLaneSection,
-      durableCitations,
-      durableLaneServingChars,
-    );
-    if (
-      fitted.truncated &&
-      serializedLength(fitted.section) > durableLaneServingChars
-    ) {
-      // Even the trimmed section overflows: omit it AND drop its citations, so
-      // the pack stays in budget and no citation references an unemitted section.
-      durableLaneSection = null;
-      durableCitations = [];
-      durableLaneStarvedOut = true;
-      wholePackTruncation.push({
-        source: "durable_lane_context",
-        reason: "whole_pack_budget",
-        max_chars: wholePackBudget,
-        starved: true,
-      });
-    } else {
-      durableLaneSection = fitted.section;
-      durableCitations = fitted.citations;
-      remainingChars = Math.max(
-        0,
-        remainingChars -
-          serializedLength(durableLaneSection) -
-          durableLaneFrame,
-      );
-      firstSectionAdmitted = false;
-      if (fitted.truncated) {
-        wholePackTruncation.push({
-          source: "durable_lane_context",
-          reason: "whole_pack_budget",
-          max_chars: wholePackBudget,
-        });
-      }
-    }
-  } else if (durableLaneSection) {
-    remainingChars = Math.max(
-      0,
-      remainingChars - serializedLength(durableLaneSection) - durableLaneFrame,
-    );
-    firstSectionAdmitted = false;
-  }
+  const stores = loadAppendStores({ selection, scope, dependencies });
 
-  // Reconcile content_chars_used to what actually survived. A starved-out
-  // section reports zero, so the budget never claims usage for content the
-  // caller did not receive.
-  const durableLaneBudget =
-    wholePackBudget !== null && durableLaneContext?.budget
-      ? durableLaneSection
-        ? {
-            ...durableLaneContext.budget,
-            content_chars_used: durableLaneContentChars(
-              durableLaneSection as DurableLaneSection,
-            ),
-          }
-        : durableLaneStarvedOut
-          ? { ...durableLaneContext.budget, content_chars_used: 0 }
-          : durableLaneContext.budget
-      : durableLaneContext?.budget;
+  // ---- working_set (priority 1), recovery (priority 2) --------------------
+  const workingSetSection = admitAppendSection({
+    allocator,
+    key: "working_set",
+    section:
+      (stores.workingSet?.working_set as Record<string, unknown> | undefined) ??
+      null,
+    reconciledCounts: ["item_count"],
+  });
+  // Both counts reconcile: `pending_count` is what the caller acts on, so a
+  // trimmed section reporting the pre-trim pending count would overstate what
+  // it actually handed over.
+  const recoverySection = admitAppendSection({
+    allocator,
+    key: "recovery",
+    section:
+      (stores.recovery?.recovery as Record<string, unknown> | undefined) ??
+      null,
+    reconciledCounts: ["item_count", "pending_count"],
+  });
 
-  // ---- durable_memory (priority 4) ----------------------------------------
-  const durableMemoryFrame = sectionFrameCost(
-    "durable_memory",
-    firstSectionAdmitted,
-  );
-  const durableMemoryServingChars =
-    wholePackBudget === null
-      ? Number.POSITIVE_INFINITY
-      : Math.max(0, remainingChars - durableMemoryFrame);
-  const durableMemoryContentLimit =
-    wholePackBudget === null
-      ? undefined
-      : Number.isFinite(durableMemoryServingChars)
-        ? Math.floor(durableMemoryServingChars)
-        : undefined;
-  const durableMemoryContext = includeDurableMemory
-    ? await loadDurableMemoryContext(
-        args,
-        auth,
-        ns,
-        dependencies,
-        durableMemoryContentLimit,
-      )
-    : null;
-  // The SECTION is only fitted/emitted/charged when explicitly requested. When
-  // the recall ran ONLY to feed pointers, the body is suppressed here while its
-  // pool and identities still flow to the builders below.
-  let durableMemorySection = includeDurableMemorySection
-    ? (durableMemoryContext?.section ?? null)
-    : null;
-  let durableMemoryCitations = durableMemorySection
-    ? (durableMemoryContext?.citations ?? [])
-    : [];
-  let durableMemoryStarvedOut = false;
-  if (durableMemorySection && wholePackBudget !== null) {
-    // Relevance-ordered: drop the LOWEST-ranked tail, preserving the best recall.
-    const fitted = fitRankedItemSection(
-      durableMemorySection as {
-        items: Array<{ citation_id?: unknown }>;
-        item_count: number;
-      },
-      ["item_count"],
-      durableMemoryServingChars,
-    );
-    if (
-      fitted.starved &&
-      serializedLength(fitted.section) > durableMemoryServingChars
-    ) {
-      durableMemorySection = null;
-      durableMemoryCitations = [];
-      durableMemoryStarvedOut = true;
-      wholePackTruncation.push({
-        source: "durable_memory",
-        reason: "whole_pack_budget",
-        max_chars: wholePackBudget,
-        starved: true,
-      });
-    } else {
-      durableMemorySection = fitted.section;
-      durableMemoryCitations = reconcileDurableMemoryCitations(
-        durableMemoryCitations,
-        (durableMemorySection as DurableMemorySection).items ?? [],
-      );
-      remainingChars = Math.max(
-        0,
-        remainingChars -
-          serializedLength(durableMemorySection) -
-          durableMemoryFrame,
-      );
-      firstSectionAdmitted = false;
-      if (fitted.truncated) {
-        wholePackTruncation.push({
-          source: "durable_memory",
-          reason: "whole_pack_budget",
-          max_chars: wholePackBudget,
-        });
-      }
-    }
-  } else if (durableMemorySection) {
-    remainingChars = Math.max(
-      0,
-      remainingChars -
-        serializedLength(durableMemorySection) -
-        durableMemoryFrame,
-    );
-    firstSectionAdmitted = false;
-  }
+  const recall = await buildRecallSections({
+    allocator,
+    selection,
+    args,
+    auth: identity,
+    ns,
+    dependencies,
+  });
 
-  const durableMemoryBudget =
-    wholePackBudget !== null && durableMemoryContext?.budget
-      ? durableMemorySection
-        ? {
-            ...durableMemoryContext.budget,
-            content_chars_used: durableMemoryContentChars(
-              durableMemorySection as DurableMemorySection,
-            ),
-          }
-        : durableMemoryStarvedOut
-          ? { ...durableMemoryContext.budget, content_chars_used: 0 }
-          : durableMemoryContext.budget
-      : durableMemoryContext?.budget;
+  const structured = await buildStructuredSections({
+    allocator,
+    selection,
+    args,
+    readNamespace,
+    dependencies,
+    memoryContext: recall.memoryContext,
+    memorySection: recall.memorySection,
+  });
 
-  // ---- structured sections (priorities 5-9) -------------------------------
-  // guidance, repo_facts, pointers, candidate_memory are all self-contained
-  // fragments admitted through ONE fitter, so they share a single whole-pack
-  // budget, citation, and truncation reconciliation. Each binds `readNamespace`,
-  // derives selection only from explicit typed metadata (never inferred from raw
-  // conversation), returns a defined empty state, and degrades content-free.
-  const structuredSectionQuery = async (
-    sql: string,
-    params?: unknown[],
-  ): Promise<{ rows: Array<Record<string, unknown>> }> => {
-    const result = await dependencies.pool.query(sql, params);
-    return { rows: result.rows as Array<Record<string, unknown>> };
-  };
-
-  const structuredScopeDenials: Array<Record<string, unknown>> = [];
-  const structuredDegradedSources: Array<Record<string, unknown>> = [];
-  const structuredTruncation: Array<Record<string, unknown>> = [];
-  const structuredCitations: Array<Record<string, unknown>> = [];
-  const structuredSections: Array<{
-    key: string;
-    section: Record<string, unknown>;
-  }> = [];
-
-  /**
-   * Fit one assembled fragment into the surviving budget, reconcile its
-   * citations to the surviving items, and record its warnings.
-   *
-   * Trim direction is `"tail"` here, unlike working_set/recovery. Those append
-   * stores are oldest-first so the front sheds; these loaders emit
-   * newest/current first (`ORDER BY ... DESC`), so the head must survive.
-   * Front-dropping would keep stale older guidance and shed the newest rules.
-   */
-  const admitStructuredSection = (
-    key: string,
-    fragment: SectionFragment,
-  ): void => {
-    // Content-free denials and degraded sources ALWAYS propagate: they carry no
-    // body, only a reason, and the caller needs them even when the section is
-    // omitted (e.g. no_active_repo, database_unavailable).
-    structuredScopeDenials.push(...fragment.scopeDenials);
-    structuredDegradedSources.push(...fragment.degradedSources);
-
-    const body = fragment.section;
-    // Hard internal error path: no body to fit; the degraded marker above is the
-    // whole story.
-    if (!body) return;
-
-    const citations = fragment.citations;
-
-    if (wholePackBudget === null) {
-      structuredSections.push({ key, section: body });
-      structuredTruncation.push(...fragment.truncation);
-      structuredCitations.push(...citations);
-      firstSectionAdmitted = false;
-      return;
-    }
-
-    const frame = sectionFrameCost(key, firstSectionAdmitted);
-    const serving = Math.max(0, remainingChars - frame);
-    const fitted = fitItemSection(
-      body as { items: Array<{ id: string }>; item_count: number },
-      ["item_count"],
-      serving,
-      "tail",
-    );
-    // A downstream reader trusts the section body, not just the warnings
-    // channel, so a trimmed body must say so on its OWN `truncated` flag. When
-    // the trim empties it but the envelope still fits, stamp
-    // `empty_reason='whole_pack_budget'` so the empty state reads as
-    // budget-starved rather than as a genuine no-data result. Reconciled BEFORE
-    // the overflow checks so the extra keys count against the budget.
-    if (fitted.truncated) {
-      const survivedBody = fitted.section as Record<string, unknown>;
-      survivedBody.truncated = true;
-      if ((survivedBody.item_count as number) === 0) {
-        survivedBody.empty_reason = "whole_pack_budget";
-      }
-    }
-    if (fitted.starved && serializedLength(fitted.section) > serving) {
-      structuredTruncation.push({
-        source: key,
-        reason: "whole_pack_budget",
-        max_chars: wholePackBudget,
-        starved: true,
-      });
-      return;
-    }
-
-    const survived = fitted.section as Record<string, unknown>;
-    structuredSections.push({ key, section: survived });
-    remainingChars = Math.max(
-      0,
-      remainingChars - serializedLength(survived) - frame,
-    );
-    firstSectionAdmitted = false;
-    // INVARIANT 3: citations reconciled to exactly the surviving items.
-    structuredCitations.push(
-      ...reconcileCitedItemCitations(citations, survived),
-    );
-    // A section's own truncation notices only make sense when its body was
-    // emitted; a fully-starved section is covered by the starved marker above.
-    structuredTruncation.push(...fragment.truncation);
-    if (fitted.truncated) {
-      structuredTruncation.push({
-        source: key,
-        reason: "whole_pack_budget",
-        max_chars: wholePackBudget,
-      });
-    }
-  };
-
-  const guidanceRequests: Array<{
-    include: boolean;
-    section: GuidanceSectionName;
-  }> = [
-    { include: includeProfileGuidance, section: "profile_guidance" },
-    { include: includeProcessGuidance, section: "process_guidance" },
-  ];
-  for (const request of guidanceRequests) {
-    if (!request.include) continue;
-    const fragment = await loadGuidanceSection(
-      { section: request.section, namespace: readNamespace },
-      { query: structuredSectionQuery },
-      dependencies.logger,
-    );
-    admitStructuredSection(request.section, fragment);
-  }
-
-  if (includeRepoFacts) {
-    // `nowMs` is captured ONCE so staleness dispositions are deterministic
-    // across one pack build. `repo` absent -> the loader's no-active-repo empty
-    // state; it never falls back to another repository.
-    const repoFactsFragment = await loadRepoFactsSection(
-      { namespace: readNamespace, repo: args.repo ?? null, nowMs: Date.now() },
-      { query: structuredSectionQuery },
-      dependencies.logger,
-    );
-    admitStructuredSection("repo_facts", repoFactsFragment);
-  }
-
-  const durablePool = durableMemoryContext?.pointerCandidatePool ?? [];
-  // Pointer eligibility is decided against the identities ACTUALLY RETAINED in
-  // the FINAL fitted durable_memory output — not the loader's pre-fit set. When
-  // the section is suppressed (pointers-only) this is empty, so every authorized
-  // row is pointer-eligible; when the re-fit trimmed durable rows, those rows
-  // are absent here and stay pointer-eligible instead of being silently lost.
-  const retainedDurableIdentities: string[] = [];
-  if (durableMemorySection) {
-    const retainedItems =
-      (durableMemorySection as { items?: Array<{ citation_id?: unknown }> })
-        .items ?? [];
-    for (const item of retainedItems) {
-      if (typeof item.citation_id === "string") {
-        retainedDurableIdentities.push(item.citation_id);
-      }
-    }
-  }
-
-  // When the durable_memory section is suppressed for output but its recall ran,
-  // its content-free warnings attach to the FIRST admitted #329 section, so a
-  // failed shared recall surfaces exactly once instead of being swallowed.
-  let sharedRecallWarningsPending =
-    includeDurableMemory && !includeDurableMemorySection;
-  const foldSharedRecallWarnings = (fragment: SectionFragment): void => {
-    if (!sharedRecallWarningsPending) return;
-    sharedRecallWarningsPending = false;
-    fragment.scopeDenials.push(...(durableMemoryContext?.scopeDenials ?? []));
-    fragment.degradedSources.push(
-      ...(durableMemoryContext?.degradedSources ?? []),
-    );
-  };
-
-  if (includePointers) {
-    const pointerFragment = buildPointerSection({
-      pool: durablePool,
-      durableIdentities: retainedDurableIdentities,
-    });
-    foldSharedRecallWarnings(pointerFragment);
-    admitStructuredSection(POINTERS_SECTION_NAME, pointerFragment);
-  }
-
-  if (includeCandidateMemory) {
-    // Takes no pool and drives no recall (see INVARIANT 1).
-    const candidateFragment = buildCandidateSection();
-    foldSharedRecallWarnings(candidateFragment);
-    admitStructuredSection("candidate_memory", candidateFragment);
-  }
-
-  const sections: Record<string, unknown> = {};
-  if (workingSetSection) sections.working_set = workingSetSection;
-  if (recoverySection) sections.recovery = recoverySection;
-  if (durableLaneSection) sections.durable_lane_context = durableLaneSection;
-  if (durableMemorySection) sections.durable_memory = durableMemorySection;
-  for (const { key, section } of structuredSections) sections[key] = section;
-
-  // #535 receipt: name what was asked for against what came back, so a section
-  // that was requested and did NOT arrive is visible in the answer itself.
-  //
-  // An unknown top-level KEY is already rejected by name at parse time, and an
-  // unknown VALUE inside `requested_sections` is already rejected by the enum
-  // with the accepted set listed. What neither catches is a section that was
-  // spelled correctly, accepted, and then dropped downstream — budget eviction
-  // being the live case. That still reads as a success-shaped short answer, so
-  // the receipt states the difference rather than leaving the caller to diff
-  // `sections` against their own request from memory.
-  //
-  // `requested: null` means the caller sent no `requested_sections` and took the
-  // documented working_set-only default — distinct from an explicit empty array.
-  const servedSections = Object.keys(sections);
-  const requestedSections = args.requested_sections ?? null;
+  const sections = assembleSections({
+    workingSet: workingSetSection,
+    recovery: recoverySection,
+    durableLane: recall.laneSection as Record<string, unknown> | null,
+    durableMemory: recall.memorySection as Record<string, unknown> | null,
+    structured: structured.sections,
+  });
 
   return {
     payload: {
@@ -719,94 +222,30 @@ export async function buildAgentContextPackPayload(
       status: "ok",
       scope: { namespace_source: "authorization", ...normalizedScope },
       sections,
-      sections_receipt: {
-        requested: requestedSections,
-        served: servedSections,
-        requested_not_served:
-          requestedSections === null
-            ? []
-            : requestedSections.filter(
-                (name) => !servedSections.includes(name),
-              ),
-        // What a BARE call (no requested_sections) did not consult.
-        //
-        // `requested_not_served` is empty for a bare call and always will be:
-        // nothing was requested, so by its own definition nothing was withheld.
-        // That is truthful and useless. The caller receives an `ok` envelope
-        // listing only `working_set` and has no way to distinguish "the durable
-        // corpus was searched and had nothing" from "the durable corpus was
-        // never consulted at all" -- and every default-shaped recall takes the
-        // second path.
-        //
-        // This field states the omission plainly instead. It changes no
-        // selection behaviour: which sections a bare call serves is a contract
-        // decision (docs/agent-context-pack-contract.md), not a receipt
-        // concern. It only stops the receipt from implying completeness it
-        // never had.
-        not_consulted_by_default:
-          requestedSections === null
-            ? SECTION_NAMES.filter(
-                (name: string) => !servedSections.includes(name),
-              )
-            : [],
-      },
-      warnings: {
-        scope_denials: [
-          ...(workingSet ? workingSet.warnings.scope_denials : []),
-          ...(recovery ? recovery.warnings.scope_denials : []),
-          ...(durableLaneContext?.scopeDenials ?? []),
-          // Emitted here ONLY when the section was requested for output; when
-          // the recall ran solely for pointers/candidates these are folded into
-          // those fragments instead, so they surface exactly once.
-          ...(includeDurableMemorySection
-            ? (durableMemoryContext?.scopeDenials ?? [])
-            : []),
-          ...structuredScopeDenials,
-        ],
-        degraded_sources: [
-          ...(durableLaneContext?.degradedSources ?? []),
-          ...(includeDurableMemorySection
-            ? (durableMemoryContext?.degradedSources ?? [])
-            : []),
-          ...structuredDegradedSources,
-        ],
-        truncation: [
-          ...(durableLaneSection ? (durableLaneContext?.truncation ?? []) : []),
-          ...(durableMemorySection
-            ? (durableMemoryContext?.truncation ?? [])
-            : []),
-          ...wholePackTruncation,
-          ...structuredTruncation,
-        ],
-      },
-      budget: {
-        requested: args.budget ?? null,
-        ...(wholePackBudget !== null
-          ? {
-              whole_pack: {
-                content_char_limit: wholePackSerializedLimit,
-                content_chars_used:
-                  wholePackBudget - Math.max(0, remainingChars),
-                allocation_order: [...CONTEXT_PACK_SECTION_PRIORITY],
-              },
-            }
-          : {}),
-        ...(workingSet ? workingSet.budget : {}),
-        ...(recovery ? recovery.budget : {}),
-        ...(durableLaneSection || durableLaneContext
-          ? { durable_lane_context: durableLaneBudget }
-          : {}),
-        // Reported only when the section was requested for output. A recall that
-        // ran solely to feed pointers reports no durable_memory budget block,
-        // because that section is absent.
-        ...(includeDurableMemorySection && durableMemoryContext
-          ? { durable_memory: durableMemoryBudget }
-          : {}),
-      },
+      sections_receipt: sectionsReceipt(
+        args.requested_sections ?? null,
+        Object.keys(sections),
+      ),
+      warnings: assemblePackWarnings({
+        selection,
+        workingSet: stores.workingSet,
+        recovery: stores.recovery,
+        recall,
+        allocator,
+        structured,
+      }),
+      budget: assembleBudget({
+        args,
+        allocator,
+        selection,
+        workingSet: stores.workingSet,
+        recovery: stores.recovery,
+        recall,
+      }),
       citations: [
-        ...durableCitations,
-        ...durableMemoryCitations,
-        ...structuredCitations,
+        ...recall.laneCitations,
+        ...recall.memoryCitations,
+        ...structured.citations,
       ],
       query: args.query ?? null,
     },

--- a/server/tools/context-pack-allocator.ts
+++ b/server/tools/context-pack-allocator.ts
@@ -1,0 +1,151 @@
+/**
+ * Whole-pack char allocation state for `agent_context_pack`.
+ *
+ * INVARIANT 2 lives here. Allocation walks a fixed priority order and each
+ * section sees only what its predecessors left. The three values that make that
+ * work — the surviving chars, whether the next admitted member still gets the
+ * comma-free first slot, and the accumulated `whole_pack_budget` markers — used
+ * to be three mutable locals inside one 535-line builder, which is why no
+ * section could be lifted out of it. Passing them as ONE object is what lets
+ * each section become its own function while the arithmetic stays identical.
+ */
+import {
+  CHARS_PER_TOKEN,
+  sectionFrameCost,
+  serializedLength,
+} from "./context-pack-budget.ts";
+import { CONTEXT_PACK_ENVELOPE_CHAR_RESERVE } from "./context-pack-shared.ts";
+
+/** The running whole-pack allocation, mutated in section-priority order. */
+export interface PackAllocator {
+  /**
+   * The declared whole-pack char allowance, or null when `max_tokens` was not
+   * requested and every section keeps its independent per-section behavior.
+   */
+  readonly wholePackBudget: number | null;
+  /** Chars still available to section MEMBERS. Infinite when unbounded. */
+  remainingChars: number;
+  /**
+   * Object framing is position-sensitive: the first admitted member costs
+   * `"key":<body>`, each subsequent one adds a comma. Flips only when a section
+   * is ACTUALLY admitted, so a starved candidate never consumes the comma-free
+   * first slot and mis-charges the next section.
+   */
+  firstSectionAdmitted: boolean;
+  /** `whole_pack_budget` markers, in the order the sections were walked. */
+  readonly truncation: Array<Record<string, unknown>>;
+}
+
+/**
+ * Derive the whole-pack allowance from the requested token budget.
+ *
+ * Absent `max_tokens` => no whole-pack bound.
+ */
+export function wholePackBudgetFor(
+  maxTokens: number | undefined,
+): number | null {
+  return maxTokens !== undefined
+    ? Math.max(
+        0,
+        maxTokens * CHARS_PER_TOKEN - CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
+      )
+    : null;
+}
+
+/**
+ * The REPORTED allowance.
+ *
+ * It must always admit the irreducible two-character `{}` that JSON.stringify
+ * emits even when every section is omitted. At tiny budgets the allowance
+ * clamps to 0, so the reported number is raised to that floor; section MEMBERS
+ * still get zero of it, so no body is admitted.
+ */
+export function wholePackSerializedLimitFor(
+  wholePackBudget: number | null,
+): number | null {
+  return wholePackBudget !== null ? Math.max(2, wholePackBudget) : null;
+}
+
+/**
+ * Open an allocator, reserving the enclosing `{}` once so the running total
+ * bounds the serialized `sections` object rather than merely the summed bodies.
+ */
+export function createAllocator(wholePackBudget: number | null): PackAllocator {
+  return {
+    wholePackBudget,
+    remainingChars:
+      wholePackBudget !== null
+        ? Math.max(0, wholePackBudget - 2)
+        : Number.POSITIVE_INFINITY,
+    firstSectionAdmitted: true,
+    truncation: [],
+  };
+}
+
+/** Chars this section may serve once its own framing is paid for. */
+export function servingChars(allocator: PackAllocator, frame: number): number {
+  return Math.max(0, allocator.remainingChars - frame);
+}
+
+/** Charge an admitted body plus its framing against the running total. */
+export function chargeAdmitted(
+  allocator: PackAllocator,
+  body: unknown,
+  frame: number,
+): void {
+  allocator.remainingChars = Math.max(
+    0,
+    allocator.remainingChars - serializedLength(body) - frame,
+  );
+  allocator.firstSectionAdmitted = false;
+}
+
+/** Record one `whole_pack_budget` marker for a trimmed or starved section. */
+export function noteBudgetTruncation(
+  allocator: PackAllocator,
+  source: string,
+  starved = false,
+): void {
+  allocator.truncation.push({
+    source,
+    reason: "whole_pack_budget",
+    max_chars: allocator.wholePackBudget,
+    ...(starved ? { starved: true } : {}),
+  });
+}
+
+/**
+ * The content allowance handed to a loader that trims raw content chars before
+ * the serialized section is re-fitted.
+ */
+export interface SectionServing {
+  frame: number;
+  serving: number;
+  contentLimit: number | undefined;
+}
+
+export function sectionServing(
+  allocator: PackAllocator,
+  key: string,
+): SectionServing {
+  const frame = sectionFrameCost(key, allocator.firstSectionAdmitted);
+  const serving =
+    allocator.wholePackBudget === null
+      ? Number.POSITIVE_INFINITY
+      : servingChars(allocator, frame);
+  return {
+    frame,
+    serving,
+    contentLimit:
+      allocator.wholePackBudget === null || !Number.isFinite(serving)
+        ? undefined
+        : Math.floor(serving),
+  };
+}
+
+/** Chars the pack actually spent, for the reported `content_chars_used`. */
+export function charsUsed(allocator: PackAllocator): number {
+  return allocator.wholePackBudget === null
+    ? 0
+    : allocator.wholePackBudget - Math.max(0, allocator.remainingChars);
+}

--- a/server/tools/context-pack-append-sections.ts
+++ b/server/tools/context-pack-append-sections.ts
@@ -1,0 +1,73 @@
+/**
+ * Admission of the two append-store sections of `agent_context_pack`:
+ * `working_set` (priority 1) and `recovery` (priority 2).
+ *
+ * They were two near-identical inline blocks in the pack builder, differing
+ * only in their key and in which counts must reconcile after a trim. Two copies
+ * of one admission rule is how the two sections drift apart under a later edit,
+ * so they share one function and name their differences as arguments.
+ *
+ * Trim direction is the fitter's default (front): these stores are oldest-first,
+ * so the front sheds and the newest entries survive.
+ */
+import {
+  chargeAdmitted,
+  noteBudgetTruncation,
+  servingChars,
+  type PackAllocator,
+} from "./context-pack-allocator.ts";
+import {
+  fitItemSection,
+  sectionFrameCost,
+  serializedLength,
+} from "./context-pack-budget.ts";
+
+/**
+ * The shape the fitter reconciles: the items it trims, plus whichever counts
+ * this section must keep in step with them (`recovery` also carries
+ * `pending_count`).
+ */
+type CountedItemSection = {
+  items: Array<{ id: string }>;
+  item_count: number;
+  [count: string]: unknown;
+};
+
+/**
+ * Fit one append-store section into the surviving allowance.
+ *
+ * Returns the section to emit, or null when even its empty envelope does not
+ * fit — in which case it is OMITTED to hold the hard allowance, is not
+ * admitted, and so leaves the first-member slot available to the next section.
+ */
+export function admitAppendSection(options: {
+  allocator: PackAllocator;
+  key: string;
+  section: Record<string, unknown> | null;
+  /** Counts that must reconcile to what actually survived the trim. */
+  reconciledCounts: Array<keyof CountedItemSection>;
+}): Record<string, unknown> | null {
+  const { allocator, key, section, reconciledCounts } = options;
+  if (!section) return null;
+
+  const frame = sectionFrameCost(key, allocator.firstSectionAdmitted);
+  const serving = servingChars(allocator, frame);
+  const fitted = fitItemSection(
+    section as unknown as CountedItemSection,
+    reconciledCounts,
+    serving,
+  );
+
+  const starvedOut =
+    fitted.starved && serializedLength(fitted.section) > serving;
+  let admitted: Record<string, unknown> | null = null;
+  if (!starvedOut) {
+    admitted = fitted.section as unknown as Record<string, unknown>;
+    chargeAdmitted(allocator, fitted.section, frame);
+  }
+
+  if (fitted.truncated) {
+    noteBudgetTruncation(allocator, key, fitted.starved);
+  }
+  return admitted;
+}

--- a/server/tools/context-pack-assembly.ts
+++ b/server/tools/context-pack-assembly.ts
@@ -1,0 +1,334 @@
+/**
+ * The middle of the `agent_context_pack` build: the two recall sections, the
+ * structured sections, and the two envelope blocks composed from what they all
+ * produced.
+ *
+ * This is where the pack's SHAPE is decided — which sections are loaded, in
+ * what order they are charged against the running allocation, and which of them
+ * contributes to each warnings channel. The entry point keeps only the scope,
+ * the authorization, and the finished envelope.
+ */
+import type { AuthIdentity } from "../auth/types.ts";
+import type { RecoveryWalContextPackFragment } from "../realtime/recovery-wal.ts";
+import type { WorkingSetContextPackFragment } from "../realtime/working-set.ts";
+import {
+  sectionServing,
+  type PackAllocator,
+} from "./context-pack-allocator.ts";
+import type { AgentContextPackArgs } from "./context-pack-args.ts";
+import type {
+  DurableLaneSection,
+  DurableMemorySection,
+} from "./context-pack-budget.ts";
+import {
+  admitGuidanceSections,
+  admitPointerSections,
+  admitRepoFactsSection,
+  loadLaneContext,
+  loadMemoryContext,
+  retainedDurableIdentities,
+  structuredSectionQueryFor,
+  type DurableLaneContext,
+  type DurableMemoryContext,
+} from "./context-pack-loaders.ts";
+import {
+  assembleWarnings,
+  wholePackReport,
+  type WarningSource,
+} from "./context-pack-payload.ts";
+import {
+  admitDurableLaneSection,
+  admitDurableMemorySection,
+  durableLaneContentChars,
+  durableMemoryContentChars,
+  reconcileSectionBudget,
+} from "./context-pack-recall-sections.ts";
+import type { SectionSelection } from "./context-pack-selection.ts";
+import {
+  createStructuredAccumulator,
+  type StructuredSectionAccumulator,
+} from "./context-pack-structured-sections.ts";
+import type { MemoryToolDependencies } from "./types.ts";
+
+/** One recall section's loaded context, fitted section, and reconciled block. */
+interface RecallSection<TSection> {
+  context: unknown;
+  section: TSection | null;
+  citations: Array<Record<string, unknown>>;
+  budget: Record<string, unknown> | undefined;
+}
+
+/** Everything the two recall sections contribute to the finished pack. */
+export interface RecallSectionsResult {
+  laneContext: DurableLaneContext | null;
+  laneSection: DurableLaneSection | null;
+  laneCitations: Array<Record<string, unknown>>;
+  laneBudget: Record<string, unknown> | undefined;
+  memoryContext: DurableMemoryContext | null;
+  memorySection: DurableMemorySection | null;
+  memoryCitations: Array<Record<string, unknown>>;
+  memoryBudget: Record<string, unknown> | undefined;
+}
+
+/**
+ * Load and admit `durable_lane_context` (priority 3).
+ *
+ * The loader trims raw content chars, but the serialized section also carries
+ * lane metadata, per-event wrappers, and citation ids. To keep the SERIALIZED
+ * section within the allowance, the loader is seeded with a content allowance
+ * and the result is then re-fitted.
+ */
+async function buildLaneSection(options: {
+  allocator: PackAllocator;
+  include: boolean;
+  args: AgentContextPackArgs;
+  ns: string;
+  dependencies: MemoryToolDependencies;
+}): Promise<
+  RecallSection<DurableLaneSection> & { context: DurableLaneContext | null }
+> {
+  const { allocator, include, args, ns, dependencies } = options;
+  const serving = sectionServing(allocator, "durable_lane_context");
+  const context = await loadLaneContext({
+    include,
+    args,
+    namespace: ns,
+    dependencies,
+    contentLimit: serving.contentLimit,
+  });
+  const loadedSection = context?.section ?? null;
+  const admitted = admitDurableLaneSection({
+    allocator,
+    section: loadedSection,
+    citations: loadedSection ? (context?.citations ?? []) : [],
+    frame: serving.frame,
+    serving: serving.serving,
+  });
+  return {
+    context,
+    section: admitted.section,
+    citations: admitted.citations,
+    budget: reconcileSectionBudget({
+      allocator,
+      loaded: context?.budget,
+      section: admitted.section,
+      starvedOut: admitted.starvedOut,
+      contentChars: durableLaneContentChars,
+    }),
+  };
+}
+
+/**
+ * Run the shared recall and admit `durable_memory` (priority 4).
+ *
+ * The SECTION is only fitted/emitted/charged when explicitly requested. When
+ * the recall ran ONLY to feed pointers, the body is suppressed here while its
+ * pool and identities still flow to the pointer builders.
+ */
+async function buildMemorySection(options: {
+  allocator: PackAllocator;
+  selection: SectionSelection;
+  args: AgentContextPackArgs;
+  auth: AuthIdentity;
+  ns: string;
+  dependencies: MemoryToolDependencies;
+}): Promise<
+  RecallSection<DurableMemorySection> & { context: DurableMemoryContext | null }
+> {
+  const { allocator, selection, args, auth, ns, dependencies } = options;
+  const serving = sectionServing(allocator, "durable_memory");
+  const context = await loadMemoryContext({
+    include: selection.durableMemory,
+    args,
+    auth,
+    namespace: ns,
+    dependencies,
+    contentLimit: serving.contentLimit,
+  });
+  const requested = selection.durableMemorySection
+    ? ((context?.section ?? null) as DurableMemorySection | null)
+    : null;
+  const admitted = admitDurableMemorySection({
+    allocator,
+    section: requested,
+    citations: requested ? (context?.citations ?? []) : [],
+    frame: serving.frame,
+    serving: serving.serving,
+  });
+  return {
+    context,
+    section: admitted.section,
+    citations: admitted.citations,
+    budget: reconcileSectionBudget({
+      allocator,
+      loaded: context?.budget,
+      section: admitted.section,
+      starvedOut: admitted.starvedOut,
+      contentChars: durableMemoryContentChars,
+    }),
+  };
+}
+
+/** Admit the two recall sections in priority order. */
+export async function buildRecallSections(options: {
+  allocator: PackAllocator;
+  selection: SectionSelection;
+  args: AgentContextPackArgs;
+  auth: AuthIdentity;
+  ns: string;
+  dependencies: MemoryToolDependencies;
+}): Promise<RecallSectionsResult> {
+  const lane = await buildLaneSection({
+    allocator: options.allocator,
+    include: options.selection.durableLaneContext,
+    args: options.args,
+    ns: options.ns,
+    dependencies: options.dependencies,
+  });
+  const memory = await buildMemorySection(options);
+  return {
+    laneContext: lane.context,
+    laneSection: lane.section,
+    laneCitations: lane.citations,
+    laneBudget: lane.budget,
+    memoryContext: memory.context,
+    memorySection: memory.section,
+    memoryCitations: memory.citations,
+    memoryBudget: memory.budget,
+  };
+}
+
+/**
+ * Load and admit the self-contained structured sections (priorities 5-9), in
+ * their fixed order.
+ */
+export async function buildStructuredSections(options: {
+  allocator: PackAllocator;
+  selection: SectionSelection;
+  args: AgentContextPackArgs;
+  readNamespace: string;
+  dependencies: MemoryToolDependencies;
+  memoryContext: DurableMemoryContext | null;
+  memorySection: DurableMemorySection | null;
+}): Promise<StructuredSectionAccumulator> {
+  const { allocator, selection, args, readNamespace, dependencies } = options;
+  const accumulator = createStructuredAccumulator();
+  const query = structuredSectionQueryFor(dependencies);
+
+  await admitGuidanceSections({
+    accumulator,
+    allocator,
+    selection,
+    readNamespace,
+    query,
+    dependencies,
+  });
+
+  if (selection.repoFacts) {
+    await admitRepoFactsSection({
+      accumulator,
+      allocator,
+      args,
+      readNamespace,
+      query,
+      dependencies,
+    });
+  }
+
+  admitPointerSections({
+    accumulator,
+    allocator,
+    selection,
+    memoryContext: options.memoryContext,
+    durableIdentities: retainedDurableIdentities(options.memorySection),
+  });
+
+  return accumulator;
+}
+
+/** The reported allocation block, one member per section that reports one. */
+export function assembleBudget(options: {
+  args: AgentContextPackArgs;
+  allocator: PackAllocator;
+  selection: SectionSelection;
+  workingSet: WorkingSetContextPackFragment | null;
+  recovery: RecoveryWalContextPackFragment | null;
+  recall: RecallSectionsResult;
+}): Record<string, unknown> {
+  const { args, allocator, selection, workingSet, recovery, recall } = options;
+  return {
+    requested: args.budget ?? null,
+    ...wholePackReport(allocator),
+    ...(workingSet ? workingSet.budget : {}),
+    ...(recovery ? recovery.budget : {}),
+    ...(recall.laneSection || recall.laneContext
+      ? { durable_lane_context: recall.laneBudget }
+      : {}),
+    // Reported only when the section was requested for output. A recall that
+    // ran solely to feed pointers reports no durable_memory block, because that
+    // section is absent.
+    ...(selection.durableMemorySection && recall.memoryContext
+      ? { durable_memory: recall.memoryBudget }
+      : {}),
+  };
+}
+
+/** The lane section's contribution to the three warnings channels. */
+function laneWarnings(recall: RecallSectionsResult): WarningSource {
+  return {
+    scopeDenials: recall.laneContext?.scopeDenials ?? [],
+    degradedSources: recall.laneContext?.degradedSources ?? [],
+    truncation: recall.laneSection
+      ? (recall.laneContext?.truncation ?? [])
+      : [],
+  };
+}
+
+/**
+ * The durable_memory section's contribution.
+ *
+ * Its denials and degraded sources are emitted here ONLY when the section was
+ * requested for output; when the recall ran solely for pointers/candidates
+ * they are folded into those fragments instead, so they surface exactly once.
+ */
+function memoryWarnings(
+  recall: RecallSectionsResult,
+  selection: SectionSelection,
+): WarningSource {
+  return {
+    scopeDenials: selection.durableMemorySection
+      ? (recall.memoryContext?.scopeDenials ?? [])
+      : [],
+    degradedSources: selection.durableMemorySection
+      ? (recall.memoryContext?.degradedSources ?? [])
+      : [],
+    truncation: recall.memorySection
+      ? (recall.memoryContext?.truncation ?? [])
+      : [],
+  };
+}
+
+/** Compose the three warnings channels from every contributing section. */
+export function assemblePackWarnings(options: {
+  selection: SectionSelection;
+  workingSet: WorkingSetContextPackFragment | null;
+  recovery: RecoveryWalContextPackFragment | null;
+  recall: RecallSectionsResult;
+  allocator: PackAllocator;
+  structured: StructuredSectionAccumulator;
+}): Record<string, unknown> {
+  const { selection, workingSet, recovery, recall, allocator, structured } =
+    options;
+  return assembleWarnings([
+    { scopeDenials: workingSet ? workingSet.warnings.scope_denials : [] },
+    { scopeDenials: recovery ? recovery.warnings.scope_denials : [] },
+    laneWarnings(recall),
+    memoryWarnings(recall, selection),
+    { truncation: allocator.truncation },
+    {
+      scopeDenials: structured.scopeDenials,
+      degradedSources: structured.degradedSources,
+      truncation: structured.truncation,
+    },
+  ]);
+}

--- a/server/tools/context-pack-durable-lane.ts
+++ b/server/tools/context-pack-durable-lane.ts
@@ -9,53 +9,24 @@
  * query that finds the "closest" lane.
  */
 import type { PoolClient, QueryConfig } from "pg";
-import type { Logger } from "pino";
 import type { AgentContextPackArgs } from "./context-pack-args.ts";
 import type { MemoryToolDependencies } from "./types.ts";
+import {
+  UNBOUNDED,
+  type DurableFailureLogger,
+  asError,
+  boundedText,
+  errorIdentityFields,
+  logDurableFailure,
+  pgDiagnosticFields,
+  resolveContentChars,
+} from "./context-pack-shared.ts";
 
-/**
- * Characters reserved for the envelope (schema/scope/warnings/budget/citations)
- * before section bodies get any of a caller's token budget.
- */
-export const CONTEXT_PACK_ENVELOPE_CHAR_RESERVE = 1_200;
-
-/**
- * What the pack reports for a bound nobody imposed.
- *
- * These budget fields are typed `number` and mean "the bound that actually
- * applied to this read". When no bound applied, the honest typed value is the
- * effective one — every row, every character — not `null`. Nulling it would
- * force every consumer to handle an absence that never happens, and would say
- * "unknown" where the truth is "everything".
- */
-export const UNBOUNDED = Number.MAX_SAFE_INTEGER;
-
-/**
- * Recall means TOTAL recall.
- *
- * This path once carried four ceilings — 12,000 content chars, 6,000 context
- * chars, 8 events, 1,000 chars per event — and none was ever asked for. The
- * effect was visible in every session-start block: exactly eight handoff lines,
- * each severed mid-word, while the lane held thousands of whole events.
- *
- * A caller that genuinely needs a bounded pack still gets one by passing
- * `budget.max_tokens` explicitly, and the whole-pack fitter honours it. Absent
- * that request, the lane comes back whole. Do not reintroduce a default.
- */
-function resolveDurableLaneContentChars(
-  args: AgentContextPackArgs,
-  contentCharLimit: number | undefined,
-): number {
-  // An explicit whole-pack allocation is the caller's own request; honour it.
-  if (contentCharLimit !== undefined) return Math.max(0, contentCharLimit);
-  if (args.budget?.max_tokens !== undefined) {
-    return Math.max(
-      0,
-      args.budget.max_tokens * 4 - CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
-    );
-  }
-  return UNBOUNDED;
-}
+export {
+  CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
+  UNBOUNDED,
+  boundedText,
+} from "./context-pack-shared.ts";
 
 export type DurableLaneContextFragment = {
   section?: Record<string, unknown>;
@@ -139,13 +110,14 @@ async function acquirePoolClient(
 
 type TimedQueryConfig = QueryConfig<unknown[]> & { query_timeout: number };
 
-async function queryWithinLatencyBudget(
-  client: PoolClient,
-  startedAt: number,
-  maxLatencyMs: number,
-  text: string,
-  values?: unknown[],
-): Promise<{ rows: Array<Record<string, unknown>> }> {
+async function queryWithinLatencyBudget(options: {
+  client: PoolClient;
+  startedAt: number;
+  maxLatencyMs: number;
+  text: string;
+  values?: unknown[];
+}): Promise<{ rows: Array<Record<string, unknown>> }> {
+  const { client, startedAt, maxLatencyMs, text, values } = options;
   const config: TimedQueryConfig = {
     text,
     values,
@@ -201,13 +173,13 @@ async function openDurableLaneReader(
   };
   const query = async (sql: string, params?: unknown[]) => {
     try {
-      return await queryWithinLatencyBudget(
+      return await queryWithinLatencyBudget({
         client,
         startedAt,
         maxLatencyMs,
-        sql,
-        params,
-      );
+        text: sql,
+        values: params,
+      });
     } catch (error) {
       markUnsafe(error);
       throw error;
@@ -240,39 +212,31 @@ async function openDurableLaneReader(
   };
 }
 
-/**
- * Bound a text value to `maxChars`, reporting whether anything was dropped.
- * Shared with the durable-memory loader so both recall paths bound content
- * identically.
- */
-export function boundedText(
-  value: unknown,
-  maxChars: number,
-): { text: string | null; truncated: boolean } {
-  if (typeof value !== "string" || value.length === 0 || maxChars <= 0) {
-    return {
-      text: null,
-      truncated: typeof value === "string" && value.length > 0,
-    };
-  }
-  if (value.length <= maxChars) return { text: value, truncated: false };
-  return { text: value.slice(0, maxChars), truncated: true };
+/** The content-free fragment returned when no lane matches all seven coordinates. */
+function laneScopeDenial(maxContentChars: number): DurableLaneContextFragment {
+  return {
+    scopeDenials: [
+      { source: "durable_lane_context", reasons: ["exact_scope"] },
+    ],
+    truncation: [],
+    degradedSources: [],
+    budget: {
+      content_char_limit: maxContentChars,
+      content_chars_used: 0,
+      max_events: UNBOUNDED,
+    },
+    citations: [],
+  };
 }
 
-export async function loadDurableLaneContext(
+/** All seven scope coordinates, in the order every query in this file binds them. */
+function laneScopeParams(
   args: AgentContextPackArgs,
   namespace: string,
-  dependencies: MemoryToolDependencies,
-  contentCharLimit?: number,
-): Promise<DurableLaneContextFragment> {
-  const maxContentChars = resolveDurableLaneContentChars(
-    args,
-    contentCharLimit,
-  );
-  // All seven coordinates, bound as parameters. `thread_id` uses
-  // IS NOT DISTINCT FROM so a null thread matches ONLY unthreaded lanes rather
-  // than every thread in the channel.
-  const scopeParams = [
+): unknown[] {
+  // `thread_id` uses IS NOT DISTINCT FROM so a null thread matches ONLY
+  // unthreaded lanes rather than every thread in the channel.
+  return [
     namespace,
     args.session_key,
     args.agent,
@@ -281,15 +245,9 @@ export async function loadDurableLaneContext(
     args.channel_id,
     args.thread_id ?? null,
   ];
+}
 
-  let reader: DurableLaneReader | undefined;
-  try {
-    reader = await openDurableLaneReader(
-      dependencies,
-      args.budget?.max_latency_ms,
-    );
-    const { rows: laneRows } = await reader.query(
-      `SELECT id, session_key, status, agent, source, channel_id, thread_id,
+const LANE_SELECT_SQL = `SELECT id, session_key, status, agent, source, channel_id, thread_id,
               project, topic, current_context_md, updated_at
          FROM ob_session_lanes
         WHERE namespace = $1
@@ -298,49 +256,13 @@ export async function loadDurableLaneContext(
           AND source = $4
           AND metadata->>'server_id' = $5
           AND channel_id = $6
-          AND thread_id IS NOT DISTINCT FROM $7::text`,
-      scopeParams,
-    );
-    const lane = laneRows[0] as Record<string, unknown> | undefined;
-    if (!lane) {
-      await reader.commit();
-      return {
-        scopeDenials: [
-          { source: "durable_lane_context", reasons: ["exact_scope"] },
-        ],
-        truncation: [],
-        degradedSources: [],
-        budget: {
-          content_char_limit: maxContentChars,
-          content_chars_used: 0,
-          max_events: UNBOUNDED,
-        },
-        citations: [],
-      };
-    }
+          AND thread_id IS NOT DISTINCT FROM $7::text`;
 
-    // With no bound, the checkpoint arrives whole. Under an explicit budget it
-    // takes at most HALF, leaving the rest for what actually happened: a bounded
-    // read that returns a full checkpoint and zero events is the same
-    // silent-nothing failure in a different costume. Removing the old fixed
-    // 6,000-char ceiling exposed exactly that — a 3,000-token request produced a
-    // 9,000-char checkpoint and no events at all.
-    const contextShare =
-      maxContentChars === UNBOUNDED
-        ? UNBOUNDED
-        : Math.max(0, Math.floor(maxContentChars / 2));
-    const context = boundedText(lane.current_context_md, contextShare);
-    let remainingChars = Math.max(
-      0,
-      maxContentChars - (context.text?.length ?? 0),
-    );
-
-    // Every event in the lane, newest-first. No row ceiling: the caller asked for
-    // this lane's durable context, and a partial answer that reports itself as
-    // complete is the silent-zero failure `docs/GOTCHAS.md` names. The join
-    // re-binds all seven coordinates so a lane_id alone can never widen scope.
-    const { rows: eventRows } = await reader.query(
-      `SELECT e.id, e.event_type, e.content, e.source, e.importance,
+// Every event in the lane, newest-first. No row ceiling: the caller asked for
+// this lane's durable context, and a partial answer that reports itself as
+// complete is the silent-zero failure `docs/GOTCHAS.md` names. The join
+// re-binds all seven coordinates so a lane_id alone can never widen scope.
+const LANE_EVENTS_SQL = `SELECT e.id, e.event_type, e.content, e.source, e.importance,
               e.artifact_path, e.transcript_ref, e.occurred_at, e.created_at
          FROM ob_session_events e
          JOIN ob_session_lanes l ON l.id = e.lane_id
@@ -352,114 +274,218 @@ export async function loadDurableLaneContext(
           AND l.metadata->>'server_id' = $6
           AND l.channel_id = $7
           AND l.thread_id IS NOT DISTINCT FROM $8::text
-        ORDER BY e.created_at DESC, e.id DESC`,
-      [lane.id, ...scopeParams],
-    );
+        ORDER BY e.created_at DESC, e.id DESC`;
 
-    const events: Array<Record<string, unknown>> = [];
-    const citations: Array<Record<string, unknown>> = [
-      {
-        id: `session_lane:${String(lane.id)}`,
-        kind: "session_lane",
-        source_ref: `ob_session_lanes/${String(lane.id)}`,
-      },
-    ];
-    let eventsTruncated = false;
-    for (const row of eventRows) {
-      const eventContent = boundedText(row.content, remainingChars);
-      if (!eventContent.text) {
-        if (typeof row.content === "string" && row.content.length > 0) {
-          eventsTruncated = true;
-        }
-        break;
-      }
-      const citationId = `session_event:${String(row.id)}`;
-      events.push({
-        id: row.id,
-        event_type: row.event_type,
-        content: eventContent.text,
-        source: row.source,
-        importance: row.importance,
-        artifact_path: row.artifact_path,
-        transcript_ref: row.transcript_ref,
-        occurred_at: row.occurred_at,
-        created_at: row.created_at,
-        citation_id: citationId,
-      });
-      citations.push({
-        id: citationId,
-        kind: "session_event",
-        source_ref: `ob_session_events/${String(row.id)}`,
-        transcript_ref: row.transcript_ref ?? null,
-        artifact_path: row.artifact_path ?? null,
-      });
-      remainingChars -= eventContent.text.length;
-      if (eventContent.truncated) eventsTruncated = true;
-    }
-    // Fetched newest-first (so a budget keeps the NEWEST events), emitted
-    // oldest-first so the caller reads the lane in chronological order.
-    events.reverse();
+type LaneEventCollection = {
+  events: Array<Record<string, unknown>>;
+  citations: Array<Record<string, unknown>>;
+  remainingChars: number;
+  eventsTruncated: boolean;
+};
 
-    const truncation: Array<Record<string, unknown>> = [];
-    // Only reachable when the caller itself asked for a bounded pack.
-    if (context.truncated) {
-      truncation.push({
-        source: "durable_lane_context.current_context_md",
-        max_chars: maxContentChars,
-      });
-    }
-    if (eventsTruncated) {
-      truncation.push({
-        source: "durable_lane_context.events",
-        max_events: UNBOUNDED,
-        max_event_chars: UNBOUNDED,
-        content_char_limit: maxContentChars,
-      });
-    }
+/**
+ * Whether an event row held a body that the char allocation could not admit.
+ * That is a genuine drop and must be reported; an empty body is not.
+ */
+function droppedNonEmptyContent(content: unknown): boolean {
+  return typeof content === "string" && content.length > 0;
+}
 
+/**
+ * Shape the lane's events into the emitted collection.
+ *
+ * Rows arrive newest-first (so a constrained read keeps the NEWEST events) and
+ * are emitted oldest-first, so the caller reads the lane in chronological
+ * order.
+ */
+function collectLaneEvents(
+  eventRows: Array<Record<string, unknown>>,
+  laneId: unknown,
+  startingChars: number,
+): LaneEventCollection {
+  const events: Array<Record<string, unknown>> = [];
+  const citations: Array<Record<string, unknown>> = [
+    {
+      id: `session_lane:${String(laneId)}`,
+      kind: "session_lane",
+      source_ref: `ob_session_lanes/${String(laneId)}`,
+    },
+  ];
+  let remainingChars = startingChars;
+  let eventsTruncated = false;
+
+  for (const row of eventRows) {
+    const eventContent = boundedText(row.content, remainingChars);
+    if (!eventContent.text) {
+      if (droppedNonEmptyContent(row.content)) eventsTruncated = true;
+      break;
+    }
+    const citationId = `session_event:${String(row.id)}`;
+    events.push({
+      id: row.id,
+      event_type: row.event_type,
+      content: eventContent.text,
+      source: row.source,
+      importance: row.importance,
+      artifact_path: row.artifact_path,
+      transcript_ref: row.transcript_ref,
+      occurred_at: row.occurred_at,
+      created_at: row.created_at,
+      citation_id: citationId,
+    });
+    citations.push({
+      id: citationId,
+      kind: "session_event",
+      source_ref: `ob_session_events/${String(row.id)}`,
+      transcript_ref: row.transcript_ref ?? null,
+      artifact_path: row.artifact_path ?? null,
+    });
+    remainingChars -= eventContent.text.length;
+    if (eventContent.truncated) eventsTruncated = true;
+  }
+  events.reverse();
+
+  return { events, citations, remainingChars, eventsTruncated };
+}
+
+/** What was dropped, if anything. Only reachable when the caller asked for a bounded pack. */
+function laneTruncationEntries(options: {
+  contextTruncated: boolean;
+  eventsTruncated: boolean;
+  maxContentChars: number;
+}): Array<Record<string, unknown>> {
+  const { contextTruncated, eventsTruncated, maxContentChars } = options;
+  const truncation: Array<Record<string, unknown>> = [];
+  if (contextTruncated) {
+    truncation.push({
+      source: "durable_lane_context.current_context_md",
+      max_chars: maxContentChars,
+    });
+  }
+  if (eventsTruncated) {
+    truncation.push({
+      source: "durable_lane_context.events",
+      max_events: UNBOUNDED,
+      max_event_chars: UNBOUNDED,
+      content_char_limit: maxContentChars,
+    });
+  }
+  return truncation;
+}
+
+/**
+ * The share of the allocation the checkpoint may take.
+ *
+ * With nothing imposed the checkpoint arrives whole. Under an explicit request
+ * it takes at most HALF, leaving the rest for what actually happened: a
+ * constrained read that returns a full checkpoint and zero events is the same
+ * silent-nothing failure in a different costume. Removing the old fixed
+ * 6,000-char ceiling exposed exactly that — a 3,000-token request produced a
+ * 9,000-char checkpoint and no events at all.
+ */
+function laneContextShare(maxContentChars: number): number {
+  if (maxContentChars === UNBOUNDED) return UNBOUNDED;
+  return Math.max(0, Math.floor(maxContentChars / 2));
+}
+
+/** Read the lane and its events, and assemble the populated fragment. */
+async function readLaneFragment(options: {
+  args: AgentContextPackArgs;
+  reader: DurableLaneReader;
+  scopeParams: unknown[];
+  maxContentChars: number;
+}): Promise<DurableLaneContextFragment> {
+  const { args, reader, scopeParams, maxContentChars } = options;
+
+  const { rows: laneRows } = await reader.query(LANE_SELECT_SQL, scopeParams);
+  const lane = laneRows[0] as Record<string, unknown> | undefined;
+  if (!lane) {
     await reader.commit();
-    return {
-      section: {
-        label: "durable_lane_context",
-        exact_scope_required: true,
-        lane: {
-          id: lane.id,
-          session_key: lane.session_key,
-          status: lane.status,
-          agent: lane.agent,
-          platform: lane.source,
-          server_id: args.server_id,
-          channel_id: lane.channel_id,
-          thread_id: lane.thread_id,
-          project: lane.project,
-          topic: lane.topic,
-          current_context_md: context.text,
-          updated_at: lane.updated_at,
-          citation_id: `session_lane:${String(lane.id)}`,
-        },
-        events,
-        event_count: events.length,
-        truncated: truncation.length > 0,
+    return laneScopeDenial(maxContentChars);
+  }
+
+  const context = boundedText(
+    lane.current_context_md,
+    laneContextShare(maxContentChars),
+  );
+  const startingChars = Math.max(
+    0,
+    maxContentChars - (context.text?.length ?? 0),
+  );
+
+  const { rows: eventRows } = await reader.query(LANE_EVENTS_SQL, [
+    lane.id,
+    ...scopeParams,
+  ]);
+  const collected = collectLaneEvents(eventRows, lane.id, startingChars);
+
+  const truncation = laneTruncationEntries({
+    contextTruncated: context.truncated,
+    eventsTruncated: collected.eventsTruncated,
+    maxContentChars,
+  });
+
+  await reader.commit();
+  return {
+    section: {
+      label: "durable_lane_context",
+      exact_scope_required: true,
+      lane: {
+        id: lane.id,
+        session_key: lane.session_key,
+        status: lane.status,
+        agent: lane.agent,
+        platform: lane.source,
+        server_id: args.server_id,
+        channel_id: lane.channel_id,
+        thread_id: lane.thread_id,
+        project: lane.project,
+        topic: lane.topic,
+        current_context_md: context.text,
+        updated_at: lane.updated_at,
+        citation_id: `session_lane:${String(lane.id)}`,
       },
-      scopeDenials: [],
-      truncation,
-      degradedSources: [],
-      budget: {
-        content_char_limit: maxContentChars,
-        content_chars_used: maxContentChars - remainingChars,
-        max_context_chars: UNBOUNDED,
-        max_events: UNBOUNDED,
-        max_event_chars: UNBOUNDED,
-      },
-      citations,
-    };
+      events: collected.events,
+      event_count: collected.events.length,
+      truncated: truncation.length > 0,
+    },
+    scopeDenials: [],
+    truncation,
+    degradedSources: [],
+    budget: {
+      content_char_limit: maxContentChars,
+      content_chars_used: maxContentChars - collected.remainingChars,
+      max_context_chars: UNBOUNDED,
+      max_events: UNBOUNDED,
+      max_event_chars: UNBOUNDED,
+    },
+    citations: collected.citations,
+  };
+}
+
+export async function loadDurableLaneContext(
+  args: AgentContextPackArgs,
+  namespace: string,
+  dependencies: MemoryToolDependencies,
+  contentCharLimit?: number,
+): Promise<DurableLaneContextFragment> {
+  const maxContentChars = resolveContentChars(args, contentCharLimit);
+  const scopeParams = laneScopeParams(args, namespace);
+
+  let reader: DurableLaneReader | undefined;
+  try {
+    reader = await openDurableLaneReader(
+      dependencies,
+      args.budget?.max_latency_ms,
+    );
+    return await readLaneFragment({
+      args,
+      reader,
+      scopeParams,
+      maxContentChars,
+    });
   } catch (error) {
     await reader?.rollback();
-    // This catch was once bare: the read failed, the envelope said
-    // "database_unavailable", and the actual reason went in the bin. ERROR names
-    // what broke at the default level; DEBUG carries the whole autopsy, because
-    // a "database_unavailable" envelope on its own tells a later reader nothing
-    // and by then the inputs that produced it are gone.
     logDurableLaneFailure(dependencies.logger, args, maxContentChars, error);
     return {
       scopeDenials: [],
@@ -480,31 +506,24 @@ export async function loadDurableLaneContext(
 }
 
 /**
- * Two lines on purpose. ERROR states what broke, briefly, so it is visible at
- * the default level. DEBUG carries every input that shaped the call plus the
- * driver's own fields — sifting a large log is a later reader's problem; having
- * no log at all is a later reader's disaster.
- *
- * The raw pg fields are named individually rather than spread, so no driver
- * string carrying query fragments reaches the log wholesale.
+ * Log a failed lane read. See {@link logDurableFailure} for why it is two lines
+ * and why the driver's fields are named individually rather than spread.
  */
 function logDurableLaneFailure(
-  logger: Logger,
+  logger: DurableFailureLogger,
   args: AgentContextPackArgs,
   maxContentChars: number,
   error: unknown,
 ): void {
-  const err = error instanceof Error ? error : undefined;
-  logger.error(
-    {
+  logDurableFailure({
+    logger,
+    event: "durable_lane_context_read_failed",
+    error,
+    errorFields: {
       namespace: args.namespace,
       session_key: args.session_key,
-      error_message: err?.message ?? String(error),
     },
-    "durable_lane_context_read_failed",
-  );
-  logger.debug(
-    {
+    detailFields: {
       namespace: args.namespace,
       agent: args.agent,
       platform: args.platform,
@@ -515,16 +534,16 @@ function logDurableLaneFailure(
       repo: args.repo ?? null,
       requested_max_tokens: args.budget?.max_tokens ?? null,
       content_char_limit: maxContentChars,
-      error_name: err?.name ?? typeof error,
-      error_message: err?.message ?? String(error),
-      pg_code: (error as { code?: unknown })?.code ?? null,
-      pg_detail: (error as { detail?: unknown })?.detail ?? null,
-      pg_hint: (error as { hint?: unknown })?.hint ?? null,
-      pg_constraint: (error as { constraint?: unknown })?.constraint ?? null,
-      pg_routine: (error as { routine?: unknown })?.routine ?? null,
-      stack: err?.stack ?? null,
-      cause: err?.cause ? String(err.cause) : null,
+      ...errorIdentityFields(error),
+      ...pgDiagnosticFields(error, [
+        "code",
+        "detail",
+        "hint",
+        "constraint",
+        "routine",
+      ]),
+      stack: asError(error)?.stack ?? null,
+      cause: asError(error)?.cause ? String(asError(error)?.cause) : null,
     },
-    "durable_lane_context_read_failed_detail",
-  );
+  });
 }

--- a/server/tools/context-pack-durable-memory.ts
+++ b/server/tools/context-pack-durable-memory.ts
@@ -518,19 +518,9 @@ function prepareRecall(
 }
 
 export async function loadDurableMemoryContext(
-  args: AgentContextPackArgs,
-  auth: AuthIdentity,
-  namespace: string,
-  dependencies: MemoryToolDependencies,
-  contentCharLimit?: number,
+  request: DurableMemoryContextRequest,
 ): Promise<DurableMemoryContextFragment> {
-  const request: DurableMemoryContextRequest = {
-    args,
-    auth,
-    namespace,
-    dependencies,
-    contentCharLimit,
-  };
+  const { args, contentCharLimit } = request;
   const maxContentChars = resolveContentChars(
     args,
     contentCharLimit,

--- a/server/tools/context-pack-durable-memory.ts
+++ b/server/tools/context-pack-durable-memory.ts
@@ -17,7 +17,6 @@
  * and could return a DIFFERENT ranking, so pointers would dedupe against rows
  * durable_memory never saw.
  */
-import type { Logger } from "pino";
 import type { AuthIdentity, ResourceTable } from "../auth/types.ts";
 import { canRead } from "../auth/permissions.ts";
 import type { AgentContextPackArgs } from "./context-pack-args.ts";
@@ -26,9 +25,14 @@ import { ALL_TABLES } from "./search-constants.ts";
 import { executeSearch, type SearchRow } from "./search-engine.ts";
 import type { MemoryToolDependencies } from "./types.ts";
 import {
-  CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
+  type DurableFailureLogger,
+  asError,
   boundedText,
-} from "./context-pack-durable-lane.ts";
+  errorIdentityFields,
+  logDurableFailure,
+  pgDiagnosticFields,
+  resolveContentChars,
+} from "./context-pack-shared.ts";
 import {
   suppressReferencedRecords,
   type PriorContextReference,
@@ -78,38 +82,6 @@ export const DURABLE_MEMORY_BURST_ITEMS = 10;
  * pointer/dedupe contract, never a frozen top-N identity.
  */
 const DURABLE_MEMORY_POINTER_OVERFETCH = 20;
-
-/**
- * Resolve the durable-memory content char budget.
- *
- * An explicit whole-pack allocation wins; then an explicit `max_tokens`; and
- * absent BOTH, recall means total recall. This mirrors the durable-lane resolver
- * instead of applying an undeclared 4,000-token default — that default silently
- * imposed a ~14,800-char ceiling on a pack whose own contract says an absent
- * budget returns everything, so a large recall was truncated exactly where the
- * contract promised it would not be.
- */
-function resolveDurableMemoryContentChars(
-  args: AgentContextPackArgs,
-  contentCharLimit: number | undefined,
-): number {
-  if (contentCharLimit !== undefined) {
-    return Math.max(
-      0,
-      Math.min(DURABLE_MEMORY_MAX_CONTENT_CHARS, contentCharLimit),
-    );
-  }
-  if (args.budget?.max_tokens !== undefined) {
-    return Math.max(
-      0,
-      Math.min(
-        DURABLE_MEMORY_MAX_CONTENT_CHARS,
-        args.budget.max_tokens * 4 - CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
-      ),
-    );
-  }
-  return DURABLE_MEMORY_MAX_CONTENT_CHARS;
-}
 
 export type DurableMemoryContextFragment = {
   section?: Record<string, unknown>;
@@ -207,92 +179,82 @@ export function recordStructuralSourceRef(row: SearchRow): {
  * the citations are built from the same refs, so every emitted item is
  * independently resolvable back to its record.
  */
-export async function loadDurableMemoryContext(
-  args: AgentContextPackArgs,
-  auth: AuthIdentity,
-  namespace: string,
-  dependencies: MemoryToolDependencies,
-  contentCharLimit?: number,
-): Promise<DurableMemoryContextFragment> {
-  const maxContentChars = resolveDurableMemoryContentChars(
-    args,
-    contentCharLimit,
-  );
-  const query = args.query?.trim() ?? "";
+/** Everything the durable-memory recall path needs, in one object. */
+export type DurableMemoryContextRequest = {
+  args: AgentContextPackArgs;
+  auth: AuthIdentity;
+  namespace: string;
+  dependencies: MemoryToolDependencies;
+  contentCharLimit?: number;
+};
 
-  // Where in the ranked recall this reply's burst starts. A caller walking the
-  // corpus replays the same request carrying the handle the previous reply
-  // returned; absent one, the walk starts at the top of the ranking.
-  const burstOffset = Math.max(0, Math.trunc(args.continue_from?.offset ?? 0));
-
-  const emptyBudget = () => ({
+/** The allocation block every empty/degraded/denied fragment reports. */
+function emptyBudget(maxContentChars: number): Record<string, unknown> {
+  return {
     content_char_limit: maxContentChars,
     content_chars_used: 0,
     burst_items: DURABLE_MEMORY_BURST_ITEMS,
     max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
-  });
+  };
+}
 
-  const emptyFragment = (
-    section: Record<string, unknown>,
-    extra: Partial<DurableMemoryContextFragment> = {},
-  ): DurableMemoryContextFragment => ({
-    section,
+/** A fragment carrying a defined-but-empty section and nothing else. */
+function emptyFragment(options: {
+  section: Record<string, unknown>;
+  maxContentChars: number;
+  extra?: Partial<DurableMemoryContextFragment>;
+}): DurableMemoryContextFragment {
+  return {
+    section: options.section,
     scopeDenials: [],
     truncation: [],
     degradedSources: [],
-    budget: emptyBudget(),
+    budget: emptyBudget(options.maxContentChars),
     citations: [],
     pointerCandidatePool: [],
-    ...extra,
-  });
+    ...options.extra,
+  };
+}
 
-  // Recall requires a query. A defined empty section lets the caller tell
-  // "requested but no query" apart from "not requested".
-  if (query.length === 0) {
-    return emptyFragment({
-      label: "durable_memory",
-      namespace_scoped: true,
-      query: null,
-      empty_reason: "no_query",
-      items: [],
-      item_count: 0,
-      truncated: false,
-    });
-  }
+/** The common shape of every empty durable_memory section. */
+function emptySection(
+  query: string | null,
+  emptyReason: string,
+): Record<string, unknown> {
+  return {
+    label: "durable_memory",
+    namespace_scoped: true,
+    query,
+    empty_reason: emptyReason,
+    items: [],
+    item_count: 0,
+    truncated: false,
+  };
+}
 
-  const accessibleTables: ResourceTable[] = ALL_TABLES.filter((table) =>
-    canRead(auth.role, table),
-  );
-  if (accessibleTables.length === 0) {
-    return emptyFragment(
-      {
-        label: "durable_memory",
-        namespace_scoped: true,
-        query,
-        empty_reason: "no_readable_tables",
-        items: [],
-        item_count: 0,
-        truncated: false,
-      },
-      {
-        scopeDenials: [
-          { source: "durable_memory", reasons: ["no_readable_tables"] },
-        ],
-      },
-    );
-  }
-
-  // The auth-derived namespace predicate is the isolation boundary. An explicit
-  // namespace argument was already authorized by the caller before any query
-  // ran; otherwise fall back to the caller's own readable namespaces.
-  const namespaceFilter = args.namespace
-    ? namespaceFilterFor(auth, namespace)
-    : namespaceFilterFor(auth);
-
-  let rows: SearchRow[];
+/**
+ * Run the one retrieval call, or return the truthful empty envelope for a
+ * failure.
+ *
+ * Recall was explicitly requested and failed. A defined empty envelope (not an
+ * omitted section) lets the caller tell "requested, recall failed" apart from
+ * "not requested". The envelope and the warning stay content-free — no
+ * dependency or error detail leaks into either — but the reason is NOT thrown
+ * away: this catch used to swallow the error entirely, so a failed recall was
+ * indistinguishable from an empty one.
+ */
+async function recallRows(options: {
+  request: DurableMemoryContextRequest;
+  query: string;
+  accessibleTables: ResourceTable[];
+  namespaceFilter: string | string[] | undefined;
+  maxContentChars: number;
+}): Promise<{ rows: SearchRow[] } | { failure: DurableMemoryContextFragment }> {
+  const { request, query, accessibleTables, namespaceFilter, maxContentChars } =
+    options;
   try {
-    rows = await executeSearch(
-      dependencies,
+    const rows = await executeSearch(
+      request.dependencies,
       accessibleTables,
       query,
       // Everything the query matches, plus the pointer over-fetch. Retrieval is
@@ -310,76 +272,47 @@ export async function loadDurableMemoryContext(
       0,
       namespaceFilter,
     );
+    return { rows };
   } catch (error) {
-    // Recall was explicitly requested and failed. Return a truthful empty
-    // envelope (not an omitted section) so the caller can tell "requested,
-    // recall failed" apart from "not requested". The envelope and the warning
-    // stay content-free — no dependency or error detail leaks into either.
-    //
-    // But the reason is NOT thrown away. This catch used to swallow the error
-    // entirely, so a failed recall was indistinguishable from an empty one and
-    // the only evidence left was `empty_reason: "recall_failed"` with nothing to
-    // act on.
-    logRecallFailure(
-      dependencies.logger,
-      auth,
-      args,
+    logRecallFailure({
+      logger: request.dependencies.logger,
+      auth: request.auth,
+      args: request.args,
       query,
       accessibleTables,
       namespaceFilter,
       error,
-    );
-    return emptyFragment(
-      {
-        label: "durable_memory",
-        namespace_scoped: true,
-        query,
-        empty_reason: "recall_failed",
-        items: [],
-        item_count: 0,
-        truncated: false,
-      },
-      {
-        degradedSources: [
-          { source: "durable_memory", reason: "recall_failed" },
-        ],
-      },
-    );
+    });
+    return {
+      failure: emptyFragment({
+        section: emptySection(query, "recall_failed"),
+        maxContentChars,
+        extra: {
+          degradedSources: [
+            { source: "durable_memory", reason: "recall_failed" },
+          ],
+        },
+      }),
+    };
   }
+}
 
-  // Prior-context suppression (#333) runs BEFORE the char budget selects and
-  // bounds bodies, so the surviving relevance order, item selection, citations,
-  // and budget accounting all reconcile against net-new results only. Budgeting
-  // first would spend the allocation on records about to be dropped.
-  const priorContext = (args.prior_context ??
-    []) as ReadonlyArray<PriorContextReference>;
-  const suppression = suppressReferencedRecords(
-    rows,
-    (row) => ({
-      citation_id: recordCitationId(row),
-      source_ref: recordSourceRef(row),
-    }),
-    priorContext,
-  );
-  const netNewRows = suppression.kept;
+type BurstItems = {
+  items: Array<Record<string, unknown>>;
+  citations: Array<Record<string, unknown>>;
+  remainingChars: number;
+  itemsTruncated: boolean;
+};
 
-  let remainingChars = maxContentChars;
+/** Shape one burst of ranked net-new rows into emitted items and citations. */
+function buildBurstItems(
+  burstRows: readonly SearchRow[],
+  startingChars: number,
+): BurstItems {
   const items: Array<Record<string, unknown>> = [];
   const citations: Array<Record<string, unknown>> = [];
+  let remainingChars = startingChars;
   let itemsTruncated = false;
-  const pointerCandidatePool: SearchRow[] = [...netNewRows];
-
-  // The burst window: the slice of the ranked net-new recall THIS reply
-  // delivers (#563). Rows before it were delivered by an earlier burst in the
-  // walk; rows after it are delivered by a later one and stay pointer-eligible
-  // meanwhile. Every row is in exactly one burst, so a full walk reconstructs
-  // the complete recalled set — this re-shapes delivery, it does not discard.
-  const burstRows = netNewRows.slice(
-    burstOffset,
-    burstOffset + DURABLE_MEMORY_BURST_ITEMS,
-  );
-  const burstEnd = burstOffset + burstRows.length;
-  const moreAfterBurst = netNewRows.length > burstEnd;
 
   for (const row of burstRows) {
     const bounded = boundedText(
@@ -387,20 +320,21 @@ export async function loadDurableMemoryContext(
       Math.min(DURABLE_MEMORY_MAX_ITEM_CHARS, remainingChars),
     );
     if (!bounded.text) {
+      // A non-empty body the char allocation could not admit IS a genuine
+      // durable drop. The row keeps a valid identity and stays
+      // pointer-eligible.
       if (
         typeof row.content_preview === "string" &&
         row.content_preview.length > 0
       ) {
-        // A non-empty body the char budget could not admit IS a genuine durable
-        // truncation. The row keeps a valid identity and stays pointer-eligible.
         itemsTruncated = true;
       }
       continue;
     }
     const citationId = recordCitationId(row);
-    // Build the bounded source_ref ONCE and attach the SAME object to both the
-    // item and its citation, so an item is independently resolvable without a
-    // citation lookup and the two can never drift through a partial trim.
+    // Build the source_ref ONCE and attach the SAME object to both the item and
+    // its citation, so an item is independently resolvable without a citation
+    // lookup and the two can never drift through a partial trim.
     const sourceRef = recordSourceRef(row);
     items.push({
       id: row.id,
@@ -413,59 +347,243 @@ export async function loadDurableMemoryContext(
       citation_id: citationId,
       source_ref: sourceRef,
     });
-    citations.push({ id: citationId, kind: "brain_record", source_ref: sourceRef });
+    citations.push({
+      id: citationId,
+      kind: "brain_record",
+      source_ref: sourceRef,
+    });
     remainingChars -= bounded.text.length;
     if (bounded.truncated) itemsTruncated = true;
   }
 
-  // When net-new records survived suppression but NONE produced an emittable
-  // body, durable_memory reports zero items with a truncated empty state: the
-  // diverted rows still resurface as pointers, but the durable section says
-  // truthfully that it emitted no content for a net-new match.
-  // Scoped to the burst window: a later burst that is legitimately empty
-  // because the walk has run past the end of the recall must not be reported as
-  // unemittable content.
-  if (
-    items.length === 0 &&
-    burstRows.length > 0 &&
-    suppression.suppression.net_new > 0
-  ) {
-    itemsTruncated = true;
-  }
+  return { items, citations, remainingChars, itemsTruncated };
+}
 
-  const truncation: Array<Record<string, unknown>> = [];
-  if (itemsTruncated) {
-    truncation.push({
+/**
+ * The burst window: the slice of the ranked net-new recall THIS reply delivers
+ * (#563).
+ *
+ * Rows before it were delivered by an earlier burst in the walk; rows after it
+ * are delivered by a later one and stay pointer-eligible meanwhile. Every row
+ * is in exactly one burst, so a full walk reconstructs the complete recalled
+ * set — this re-shapes delivery, it does not discard. A caller walking the
+ * corpus replays the same request carrying the handle the previous reply
+ * returned; absent one, the walk starts at the top of the ranking.
+ */
+function burstWindow(
+  netNewRows: readonly SearchRow[],
+  requestedOffset: number | undefined,
+): {
+  burstOffset: number;
+  burstRows: SearchRow[];
+  burstEnd: number;
+  moreAfterBurst: boolean;
+} {
+  const burstOffset = Math.max(0, Math.trunc(requestedOffset ?? 0));
+  const burstRows = netNewRows.slice(
+    burstOffset,
+    burstOffset + DURABLE_MEMORY_BURST_ITEMS,
+  );
+  const burstEnd = burstOffset + burstRows.length;
+  return {
+    burstOffset,
+    burstRows,
+    burstEnd,
+    moreAfterBurst: netNewRows.length > burstEnd,
+  };
+}
+
+/**
+ * What this burst could not emit, if anything.
+ *
+ * When net-new records survived suppression but NONE produced an emittable
+ * body, durable_memory reports zero items with a truncated empty state: the
+ * diverted rows still resurface as pointers, but the durable section says
+ * truthfully that it emitted no content for a net-new match. Scoped to the
+ * burst window: a later burst that is legitimately empty because the walk has
+ * run past the end of the recall must not be reported as unemittable content.
+ */
+function memoryTruncationEntries(options: {
+  burst: BurstItems;
+  burstRowCount: number;
+  netNew: number;
+  maxContentChars: number;
+}): Array<Record<string, unknown>> {
+  const { burst, burstRowCount, netNew, maxContentChars } = options;
+  const unemittableNetNew =
+    burst.items.length === 0 && burstRowCount > 0 && netNew > 0;
+  if (!burst.itemsTruncated && !unemittableNetNew) return [];
+  return [
+    {
       source: "durable_memory.items",
       burst_items: DURABLE_MEMORY_BURST_ITEMS,
       max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
       content_char_limit: maxContentChars,
-    });
+    },
+  ];
+}
+
+/**
+ * Which of the four genuine zero-item causes applies, or `undefined` when items
+ * were emitted.
+ *
+ * The order is the only one that reads correctly.
+ *   - walk_complete: the caller walked past the end of the recall, so this
+ *     reply is empty for the one benign reason — everything was already
+ *     delivered. Checked FIRST because it is a property of the WALK, not of the
+ *     records; reporting it as no_matches would tell a caller who now holds the
+ *     whole corpus that nothing matched.
+ *   - content_unavailable: net-new records survived but none had an emittable
+ *     body (null/empty preview, or the allocation admitted none). Checked
+ *     before no_matches so a net-new-but-unemittable section can never be
+ *     mislabeled.
+ *   - all_suppressed: recall returned rows and suppression removed every one.
+ *   - no_matches: recall genuinely found nothing.
+ */
+function resolveEmptyReason(options: {
+  itemCount: number;
+  burstRowCount: number;
+  burstOffset: number;
+  netNew: number;
+  suppressed: number;
+  recalledRowCount: number;
+}): string | undefined {
+  const {
+    itemCount,
+    burstRowCount,
+    burstOffset,
+    netNew,
+    suppressed,
+    recalledRowCount,
+  } = options;
+  if (itemCount > 0) return undefined;
+  if (burstRowCount === 0 && burstOffset > 0) return "walk_complete";
+  if (netNew > 0) return "content_unavailable";
+  if (recalledRowCount > 0 && suppressed === recalledRowCount) {
+    return "all_suppressed";
+  }
+  return "no_matches";
+}
+
+/**
+ * Validate the request and resolve the namespace predicate, or return the
+ * defined-empty fragment that answers it.
+ */
+function prepareRecall(
+  request: DurableMemoryContextRequest,
+  query: string,
+  maxContentChars: number,
+):
+  | {
+      accessibleTables: ResourceTable[];
+      namespaceFilter: string | string[] | undefined;
+    }
+  | { fragment: DurableMemoryContextFragment } {
+  // Recall requires a query. A defined empty section lets the caller tell
+  // "requested but no query" apart from "not requested".
+  if (query.length === 0) {
+    return {
+      fragment: emptyFragment({
+        section: emptySection(null, "no_query"),
+        maxContentChars,
+      }),
+    };
   }
 
-  // Three genuine zero-item causes, distinguished in the only order that reads
-  // correctly. `net_new` is checked FIRST so a net-new-but-unemittable section
-  // can never be mislabeled `no_matches`:
-  //   - content_unavailable: net-new records survived but none had an emittable
-  //     body (null/empty preview, or the budget admitted none).
-  //   - all_suppressed: recall returned rows and suppression removed every one.
-  //   - no_matches: recall genuinely found nothing.
-  // `walk_complete` is the fourth genuine zero-item cause, introduced with the
-  // burst shape (#563): the caller walked past the end of the recall, so this
-  // reply is empty for the one benign reason — everything was already
-  // delivered. Checked FIRST because it is a property of the WALK, not of the
-  // records; reporting it as no_matches would tell a caller who now holds the
-  // whole corpus that nothing matched.
-  const emptyReason =
-    items.length === 0
-      ? burstRows.length === 0 && burstOffset > 0
-        ? "walk_complete"
-        : suppression.suppression.net_new > 0
-          ? "content_unavailable"
-          : rows.length > 0 && suppression.suppression.suppressed === rows.length
-            ? "all_suppressed"
-            : "no_matches"
-      : undefined;
+  const accessibleTables: ResourceTable[] = ALL_TABLES.filter((table) =>
+    canRead(request.auth.role, table),
+  );
+  if (accessibleTables.length === 0) {
+    return {
+      fragment: emptyFragment({
+        section: emptySection(query, "no_readable_tables"),
+        maxContentChars,
+        extra: {
+          scopeDenials: [
+            { source: "durable_memory", reasons: ["no_readable_tables"] },
+          ],
+        },
+      }),
+    };
+  }
+
+  // The auth-derived namespace predicate is the isolation boundary. An explicit
+  // namespace argument was already authorized by the caller before any query
+  // ran; otherwise fall back to the caller's own readable namespaces.
+  const namespaceFilter = request.args.namespace
+    ? namespaceFilterFor(request.auth, request.namespace)
+    : namespaceFilterFor(request.auth);
+
+  return { accessibleTables, namespaceFilter };
+}
+
+export async function loadDurableMemoryContext(
+  args: AgentContextPackArgs,
+  auth: AuthIdentity,
+  namespace: string,
+  dependencies: MemoryToolDependencies,
+  contentCharLimit?: number,
+): Promise<DurableMemoryContextFragment> {
+  const request: DurableMemoryContextRequest = {
+    args,
+    auth,
+    namespace,
+    dependencies,
+    contentCharLimit,
+  };
+  const maxContentChars = resolveContentChars(
+    args,
+    contentCharLimit,
+    DURABLE_MEMORY_MAX_CONTENT_CHARS,
+  );
+  const query = args.query?.trim() ?? "";
+
+  const prepared = prepareRecall(request, query, maxContentChars);
+  if ("fragment" in prepared) return prepared.fragment;
+
+  const recalled = await recallRows({
+    request,
+    query,
+    accessibleTables: prepared.accessibleTables,
+    namespaceFilter: prepared.namespaceFilter,
+    maxContentChars,
+  });
+  if ("failure" in recalled) return recalled.failure;
+  const rows = recalled.rows;
+
+  // Prior-context suppression (#333) runs BEFORE the char allocation selects and
+  // shapes bodies, so the surviving relevance order, item selection, citations,
+  // and accounting all reconcile against net-new results only. Allocating first
+  // would spend it on records about to be dropped.
+  const priorContext = (args.prior_context ??
+    []) as ReadonlyArray<PriorContextReference>;
+  const suppression = suppressReferencedRecords(
+    rows,
+    (row) => ({
+      citation_id: recordCitationId(row),
+      source_ref: recordSourceRef(row),
+    }),
+    priorContext,
+  );
+  const netNewRows = suppression.kept;
+
+  const window = burstWindow(netNewRows, args.continue_from?.offset);
+  const burst = buildBurstItems(window.burstRows, maxContentChars);
+  const truncation = memoryTruncationEntries({
+    burst,
+    burstRowCount: window.burstRows.length,
+    netNew: suppression.suppression.net_new,
+    maxContentChars,
+  });
+
+  const emptyReason = resolveEmptyReason({
+    itemCount: burst.items.length,
+    burstRowCount: window.burstRows.length,
+    burstOffset: window.burstOffset,
+    netNew: suppression.suppression.net_new,
+    suppressed: suppression.suppression.suppressed,
+    recalledRowCount: rows.length,
+  });
 
   return {
     section: {
@@ -473,8 +591,8 @@ export async function loadDurableMemoryContext(
       namespace_scoped: true,
       query,
       ...(emptyReason ? { empty_reason: emptyReason } : {}),
-      items,
-      item_count: items.length,
+      items: burst.items,
+      item_count: burst.items.length,
       truncated: truncation.length > 0,
       // How to ask for the next burst of this walk (#563). Present ONLY while
       // records remain undelivered, so a caller walks until it disappears and a
@@ -483,10 +601,15 @@ export async function loadDurableMemoryContext(
       // separate `complete` flag is emitted: one fact, one field, and no way
       // for the two to disagree. The burst size and the delivery position live
       // in `budget` (below) rather than being restated here — a tight
-      // whole-pack budget must spend its bytes on records, not on an envelope
-      // describing itself.
-      ...(moreAfterBurst
-        ? { next: { offset: burstEnd, delivered_through: burstEnd } }
+      // whole-pack allocation must spend its bytes on records, not on an
+      // envelope describing itself.
+      ...(window.moreAfterBurst
+        ? {
+            next: {
+              offset: window.burstEnd,
+              delivered_through: window.burstEnd,
+            },
+          }
         : {}),
       // Content-free suppression counters (#333): counts only, never an id, a
       // reference, or a body.
@@ -494,7 +617,7 @@ export async function loadDurableMemoryContext(
         recalled: suppression.suppression.recalled,
         suppressed: suppression.suppression.suppressed,
         net_new: suppression.suppression.net_new,
-        emitted: items.length,
+        emitted: burst.items.length,
       },
     },
     scopeDenials: [],
@@ -502,19 +625,20 @@ export async function loadDurableMemoryContext(
     degradedSources: [],
     budget: {
       content_char_limit: maxContentChars,
-      content_chars_used: maxContentChars - remainingChars,
+      content_chars_used: maxContentChars - burst.remainingChars,
       burst_items: DURABLE_MEMORY_BURST_ITEMS,
-      burst_offset: burstOffset,
+      burst_offset: window.burstOffset,
       recalled_net_new: netNewRows.length,
       max_item_chars: DURABLE_MEMORY_MAX_ITEM_CHARS,
     },
-    citations,
-    pointerCandidatePool,
+    citations: burst.citations,
+    pointerCandidatePool: [...netNewRows],
   };
 }
 
 /**
- * Fail loudly in the log, stay content-free in the envelope.
+ * Fail loudly in the log, stay content-free in the envelope. See
+ * {@link logDurableFailure} for the two-line shape.
  *
  * The raw recall `query` is deliberately NOT logged. It is arbitrary caller
  * content — a private name, incident text, anything someone searched for — that
@@ -522,26 +646,33 @@ export async function loadDurableMemoryContext(
  * credential. `query_chars` keeps the one diagnostic that matters (an empty or
  * pathological query) without writing the body.
  */
-function logRecallFailure(
-  logger: Logger,
-  auth: AuthIdentity,
-  args: AgentContextPackArgs,
-  query: string,
-  accessibleTables: readonly ResourceTable[],
-  namespaceFilter: string | string[] | undefined,
-  error: unknown,
-): void {
-  const err = error instanceof Error ? error : undefined;
-  logger.error(
-    {
+function logRecallFailure(options: {
+  logger: DurableFailureLogger;
+  auth: AuthIdentity;
+  args: AgentContextPackArgs;
+  query: string;
+  accessibleTables: readonly ResourceTable[];
+  namespaceFilter: string | string[] | undefined;
+  error: unknown;
+}): void {
+  const {
+    logger,
+    auth,
+    args,
+    query,
+    accessibleTables,
+    namespaceFilter,
+    error,
+  } = options;
+  logDurableFailure({
+    logger,
+    event: "durable_memory_recall_failed",
+    error,
+    errorFields: {
       client_id: auth.clientId,
-      error_name: err?.name ?? typeof error,
-      error_message: err?.message ?? String(error),
+      ...errorIdentityFields(error),
     },
-    "durable_memory_recall_failed",
-  );
-  logger.debug(
-    {
+    detailFields: {
       client_id: auth.clientId,
       role: auth.role,
       agent: args.agent,
@@ -554,13 +685,9 @@ function logRecallFailure(
       namespace_filter: namespaceFilter,
       requested_max_tokens: args.budget?.max_tokens ?? null,
       pointer_overfetch: DURABLE_MEMORY_POINTER_OVERFETCH,
-      error_name: err?.name ?? typeof error,
-      error_message: err?.message ?? String(error),
-      pg_code: (error as { code?: unknown })?.code ?? null,
-      pg_detail: (error as { detail?: unknown })?.detail ?? null,
-      pg_hint: (error as { hint?: unknown })?.hint ?? null,
-      stack: err?.stack ?? null,
+      ...errorIdentityFields(error),
+      ...pgDiagnosticFields(error, ["code", "detail", "hint"]),
+      stack: asError(error)?.stack ?? null,
     },
-    "durable_memory_recall_failed_detail",
-  );
+  });
 }

--- a/server/tools/context-pack-loaders.ts
+++ b/server/tools/context-pack-loaders.ts
@@ -1,0 +1,217 @@
+/**
+ * The retrieval calls the pack builder makes, and the small reconciliations
+ * that belong with them.
+ *
+ * Each loader here is the ONE place its section is fetched. Keeping them
+ * together with `structuredSectionQuery` is what stops a second query path
+ * appearing for a section that already has one.
+ */
+import type { AuthIdentity } from "../auth/types.ts";
+import type { AgentContextPackArgs } from "./context-pack-args.ts";
+import { loadDurableLaneContext } from "./context-pack-durable-lane.ts";
+import { loadDurableMemoryContext } from "./context-pack-durable-memory.ts";
+import {
+  loadGuidanceSection,
+  type GuidanceSectionName,
+} from "./context-pack-guidance.ts";
+import {
+  buildCandidateSection,
+  buildPointerSection,
+  POINTERS_SECTION_NAME,
+} from "./context-pack-pointers.ts";
+import { loadRepoFactsSection } from "./context-pack-repo-facts.ts";
+import type { SectionFragment } from "./context-pack-sections.ts";
+import {
+  admitStructuredSection,
+  type StructuredSectionAccumulator,
+} from "./context-pack-structured-sections.ts";
+import type { PackAllocator } from "./context-pack-allocator.ts";
+import type { SectionSelection } from "./context-pack-selection.ts";
+import type { MemoryToolDependencies } from "./types.ts";
+
+export type StructuredSectionQuery = (
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: Array<Record<string, unknown>> }>;
+
+export function structuredSectionQueryFor(
+  dependencies: MemoryToolDependencies,
+): StructuredSectionQuery {
+  return async (sql, params) => {
+    const result = await dependencies.pool.query(sql, params);
+    return { rows: result.rows as Array<Record<string, unknown>> };
+  };
+}
+
+export type DurableLaneContext = Awaited<
+  ReturnType<typeof loadDurableLaneContext>
+>;
+export type DurableMemoryContext = Awaited<
+  ReturnType<typeof loadDurableMemoryContext>
+>;
+
+/** Load `durable_lane_context`, seeded with its content allowance. */
+export function loadLaneContext(options: {
+  include: boolean;
+  args: AgentContextPackArgs;
+  namespace: string;
+  dependencies: MemoryToolDependencies;
+  contentLimit: number | undefined;
+}): Promise<DurableLaneContext> | null {
+  return options.include
+    ? loadDurableLaneContext(
+        options.args,
+        options.namespace,
+        options.dependencies,
+        options.contentLimit,
+      )
+    : null;
+}
+
+/** Run the single shared hybrid recall behind durable_memory and pointers. */
+export function loadMemoryContext(options: {
+  include: boolean;
+  args: AgentContextPackArgs;
+  auth: AuthIdentity;
+  namespace: string;
+  dependencies: MemoryToolDependencies;
+  contentLimit: number | undefined;
+}): Promise<DurableMemoryContext> | null {
+  return options.include
+    ? loadDurableMemoryContext({
+        args: options.args,
+        auth: options.auth,
+        namespace: options.namespace,
+        dependencies: options.dependencies,
+        contentCharLimit: options.contentLimit,
+      })
+    : null;
+}
+
+/** Admit the two guidance sections, in their fixed order. */
+export async function admitGuidanceSections(options: {
+  accumulator: StructuredSectionAccumulator;
+  allocator: PackAllocator;
+  selection: SectionSelection;
+  readNamespace: string;
+  query: StructuredSectionQuery;
+  dependencies: MemoryToolDependencies;
+}): Promise<void> {
+  const requests: Array<{ include: boolean; section: GuidanceSectionName }> = [
+    { include: options.selection.profileGuidance, section: "profile_guidance" },
+    { include: options.selection.processGuidance, section: "process_guidance" },
+  ];
+  for (const request of requests) {
+    if (!request.include) continue;
+    const fragment = await loadGuidanceSection(
+      { section: request.section, namespace: options.readNamespace },
+      { query: options.query },
+      options.dependencies.logger,
+    );
+    admitStructuredSection({
+      accumulator: options.accumulator,
+      allocator: options.allocator,
+      key: request.section,
+      fragment,
+    });
+  }
+}
+
+/** Admit `repo_facts` when requested. */
+export async function admitRepoFactsSection(options: {
+  accumulator: StructuredSectionAccumulator;
+  allocator: PackAllocator;
+  args: AgentContextPackArgs;
+  readNamespace: string;
+  query: StructuredSectionQuery;
+  dependencies: MemoryToolDependencies;
+}): Promise<void> {
+  // `nowMs` is captured ONCE so staleness dispositions are deterministic across
+  // one pack build. `repo` absent -> the loader's no-active-repo empty state; it
+  // never falls back to another repository.
+  const fragment = await loadRepoFactsSection(
+    {
+      namespace: options.readNamespace,
+      repo: options.args.repo ?? null,
+      nowMs: Date.now(),
+    },
+    { query: options.query },
+    options.dependencies.logger,
+  );
+  admitStructuredSection({
+    accumulator: options.accumulator,
+    allocator: options.allocator,
+    key: "repo_facts",
+    fragment,
+  });
+}
+
+/**
+ * The identities ACTUALLY RETAINED in the FINAL fitted durable_memory output.
+ *
+ * Pointer eligibility is decided against these, not the loader's pre-fit set.
+ * When the section is suppressed (pointers-only) this is empty, so every
+ * authorized row is pointer-eligible; when the re-fit trimmed durable rows,
+ * those rows are absent here and stay pointer-eligible instead of being
+ * silently lost.
+ */
+export function retainedDurableIdentities(
+  section: { items?: Array<{ citation_id?: unknown }> } | null,
+): string[] {
+  const retained: string[] = [];
+  for (const item of section?.items ?? []) {
+    if (typeof item.citation_id === "string") retained.push(item.citation_id);
+  }
+  return retained;
+}
+
+/**
+ * Admit `pointers` and `candidate_memory` (#329).
+ *
+ * When the durable_memory section is suppressed for output but its recall ran,
+ * its content-free warnings attach to the FIRST admitted #329 section, so a
+ * failed shared recall surfaces exactly once instead of being swallowed.
+ */
+export function admitPointerSections(options: {
+  accumulator: StructuredSectionAccumulator;
+  allocator: PackAllocator;
+  selection: SectionSelection;
+  memoryContext: DurableMemoryContext | null;
+  durableIdentities: string[];
+}): void {
+  const { accumulator, allocator, selection, memoryContext } = options;
+  let warningsPending =
+    selection.durableMemory && !selection.durableMemorySection;
+  const foldSharedRecallWarnings = (fragment: SectionFragment): void => {
+    if (!warningsPending) return;
+    warningsPending = false;
+    fragment.scopeDenials.push(...(memoryContext?.scopeDenials ?? []));
+    fragment.degradedSources.push(...(memoryContext?.degradedSources ?? []));
+  };
+
+  if (selection.pointers) {
+    const fragment = buildPointerSection({
+      pool: memoryContext?.pointerCandidatePool ?? [],
+      durableIdentities: options.durableIdentities,
+    });
+    foldSharedRecallWarnings(fragment);
+    admitStructuredSection({
+      accumulator,
+      allocator,
+      key: POINTERS_SECTION_NAME,
+      fragment,
+    });
+  }
+
+  if (selection.candidateMemory) {
+    // Takes no pool and drives no recall (see INVARIANT 1).
+    const fragment = buildCandidateSection();
+    foldSharedRecallWarnings(fragment);
+    admitStructuredSection({
+      accumulator,
+      allocator,
+      key: "candidate_memory",
+      fragment,
+    });
+  }
+}

--- a/server/tools/context-pack-payload.ts
+++ b/server/tools/context-pack-payload.ts
@@ -1,0 +1,137 @@
+/**
+ * Envelope assembly for `agent_context_pack`: the sections map, the #535
+ * sections receipt, the warnings channel, the reported allocation, and the
+ * citation list.
+ *
+ * Split out of the pack builder so the ORDER of the sections map and the
+ * composition of each warnings channel are readable in one place. Every field
+ * here is contract surface (docs/agent-context-pack-contract.md); nothing in
+ * this module decides WHAT was retrieved, only how the finished pieces are
+ * named in the answer.
+ */
+import { SECTION_NAMES } from "./context-pack-args.ts";
+import {
+  charsUsed,
+  wholePackSerializedLimitFor,
+  type PackAllocator,
+} from "./context-pack-allocator.ts";
+import { CONTEXT_PACK_SECTION_PRIORITY } from "./context-pack-budget.ts";
+
+type Warnings = Array<Record<string, unknown>>;
+/** Any section's warning list, whatever its own element type is named. */
+type WarningInput = ReadonlyArray<unknown>;
+
+/** One section's contribution to the three warnings channels. */
+export interface WarningSource {
+  scopeDenials?: WarningInput;
+  degradedSources?: WarningInput;
+  truncation?: WarningInput;
+}
+
+/**
+ * Build the sections map in allocation-priority order.
+ *
+ * Insertion order IS the emitted key order, so this is the one place section
+ * ordering is decided.
+ */
+export function assembleSections(options: {
+  workingSet: Record<string, unknown> | null;
+  recovery: Record<string, unknown> | null;
+  durableLane: Record<string, unknown> | null;
+  durableMemory: Record<string, unknown> | null;
+  structured: Array<{ key: string; section: Record<string, unknown> }>;
+}): Record<string, unknown> {
+  const sections: Record<string, unknown> = {};
+  if (options.workingSet) sections.working_set = options.workingSet;
+  if (options.recovery) sections.recovery = options.recovery;
+  if (options.durableLane) sections.durable_lane_context = options.durableLane;
+  if (options.durableMemory) sections.durable_memory = options.durableMemory;
+  for (const { key, section } of options.structured) sections[key] = section;
+  return sections;
+}
+
+/**
+ * #535 receipt: name what was asked for against what came back, so a section
+ * that was requested and did NOT arrive is visible in the answer itself.
+ *
+ * An unknown top-level KEY is already rejected by name at parse time, and an
+ * unknown VALUE inside `requested_sections` is already rejected by the enum
+ * with the accepted set listed. What neither catches is a section that was
+ * spelled correctly, accepted, and then dropped downstream -- allowance
+ * eviction being the live case. That still reads as a success-shaped short
+ * answer, so the receipt states the difference rather than leaving the caller
+ * to diff `sections` against their own request from memory.
+ *
+ * `requested: null` means the caller sent no `requested_sections` and took the
+ * documented working_set-only default -- distinct from an explicit empty array.
+ */
+export function sectionsReceipt(
+  requestedSections: string[] | null,
+  servedSections: string[],
+): Record<string, unknown> {
+  return {
+    requested: requestedSections,
+    served: servedSections,
+    requested_not_served:
+      requestedSections === null
+        ? []
+        : requestedSections.filter((name) => !servedSections.includes(name)),
+    // What a BARE call (no requested_sections) did not consult.
+    //
+    // `requested_not_served` is empty for a bare call and always will be:
+    // nothing was requested, so by its own definition nothing was withheld.
+    // That is truthful and useless. The caller receives an `ok` envelope
+    // listing only `working_set` and has no way to distinguish "the durable
+    // corpus was searched and had nothing" from "the durable corpus was never
+    // consulted at all" -- and every default-shaped recall takes the second
+    // path.
+    //
+    // This field states the omission plainly instead. It changes no selection
+    // behaviour: which sections a bare call serves is a contract decision
+    // (docs/agent-context-pack-contract.md), not a receipt concern. It only
+    // stops the receipt from implying completeness it never had.
+    not_consulted_by_default:
+      requestedSections === null
+        ? SECTION_NAMES.filter((name: string) => !servedSections.includes(name))
+        : [],
+  };
+}
+
+function asWarnings(input: WarningInput | undefined): Warnings {
+  return (input ?? []) as Warnings;
+}
+
+/** Concatenate the three warnings channels in source order. */
+export function assembleWarnings(
+  sources: ReadonlyArray<WarningSource>,
+): Record<string, unknown> {
+  const scopeDenials: Warnings = [];
+  const degradedSources: Warnings = [];
+  const truncation: Warnings = [];
+  for (const source of sources) {
+    scopeDenials.push(...asWarnings(source.scopeDenials));
+    degradedSources.push(...asWarnings(source.degradedSources));
+    truncation.push(...asWarnings(source.truncation));
+  }
+  return {
+    scope_denials: scopeDenials,
+    degraded_sources: degradedSources,
+    truncation,
+  };
+}
+
+/** The reported whole-pack allocation block, present only when one applies. */
+export function wholePackReport(
+  allocator: PackAllocator,
+): Record<string, unknown> {
+  if (allocator.wholePackBudget === null) return {};
+  return {
+    whole_pack: {
+      content_char_limit: wholePackSerializedLimitFor(
+        allocator.wholePackBudget,
+      ),
+      content_chars_used: charsUsed(allocator),
+      allocation_order: [...CONTEXT_PACK_SECTION_PRIORITY],
+    },
+  };
+}

--- a/server/tools/context-pack-recall-sections.ts
+++ b/server/tools/context-pack-recall-sections.ts
@@ -1,0 +1,133 @@
+/**
+ * Admission of the two recall-backed sections of `agent_context_pack`:
+ * `durable_lane_context` (priority 3) and `durable_memory` (priority 4).
+ *
+ * Both are loaded with a content allowance, then RE-FITTED, because the loader
+ * trims raw content chars while the serialized section also carries metadata,
+ * per-item wrappers, and citation ids. Both drop their citations when they are
+ * starved out, so no citation ever references an unemitted section, and both
+ * reconcile the reported `content_chars_used` to what actually survived.
+ *
+ * They are separate functions rather than one parameterized helper because they
+ * differ where it matters: the lane path trims oldest-first and finally trims
+ * the checkpoint, while durable_memory is relevance-ordered and sheds the
+ * LOWEST-ranked tail so the best recall survives.
+ */
+import {
+  chargeAdmitted,
+  noteBudgetTruncation,
+  type PackAllocator,
+} from "./context-pack-allocator.ts";
+import {
+  durableLaneContentChars,
+  durableMemoryContentChars,
+  fitDurableLaneSection,
+  fitRankedItemSection,
+  reconcileDurableMemoryCitations,
+  serializedLength,
+  type DurableLaneSection,
+  type DurableMemorySection,
+} from "./context-pack-budget.ts";
+
+/** What one recall section contributes to the pack after re-fitting. */
+export interface RecallAdmission<TSection> {
+  section: TSection | null;
+  citations: Array<Record<string, unknown>>;
+  /**
+   * True only when a LOADED section was dropped by the re-fit, so the
+   * reconciled allocation can report zero content emitted rather than the
+   * loader's pre-fit selection.
+   */
+  starvedOut: boolean;
+}
+
+/**
+ * Reconcile a loader's reported allocation to what actually survived.
+ *
+ * A starved-out section reports zero, so the reported block never claims usage
+ * for content the caller did not receive.
+ */
+export function reconcileSectionBudget<TSection>(options: {
+  allocator: PackAllocator;
+  loaded: Record<string, unknown> | undefined;
+  section: TSection | null;
+  starvedOut: boolean;
+  contentChars: (section: TSection) => number;
+}): Record<string, unknown> | undefined {
+  const { allocator, loaded, section, starvedOut, contentChars } = options;
+  if (allocator.wholePackBudget === null || !loaded) return loaded;
+  if (section) {
+    return { ...loaded, content_chars_used: contentChars(section) };
+  }
+  return starvedOut ? { ...loaded, content_chars_used: 0 } : loaded;
+}
+
+/** Fit `durable_lane_context` into the surviving allowance. */
+export function admitDurableLaneSection(options: {
+  allocator: PackAllocator;
+  section: DurableLaneSection | null;
+  citations: Array<Record<string, unknown>>;
+  frame: number;
+  serving: number;
+}): RecallAdmission<DurableLaneSection> {
+  const { allocator, section, citations, frame, serving } = options;
+  if (!section) return { section: null, citations: [], starvedOut: false };
+
+  if (allocator.wholePackBudget === null) {
+    chargeAdmitted(allocator, section, frame);
+    return { section, citations, starvedOut: false };
+  }
+
+  const fitted = fitDurableLaneSection(section, citations, serving);
+  if (fitted.truncated && serializedLength(fitted.section) > serving) {
+    // Even the trimmed section overflows: omit it AND drop its citations.
+    noteBudgetTruncation(allocator, "durable_lane_context", true);
+    return { section: null, citations: [], starvedOut: true };
+  }
+
+  chargeAdmitted(allocator, fitted.section, frame);
+  if (fitted.truncated) noteBudgetTruncation(allocator, "durable_lane_context");
+  return {
+    section: fitted.section,
+    citations: fitted.citations,
+    starvedOut: false,
+  };
+}
+
+/** Fit `durable_memory` into the surviving allowance. */
+export function admitDurableMemorySection(options: {
+  allocator: PackAllocator;
+  section: DurableMemorySection | null;
+  citations: Array<Record<string, unknown>>;
+  frame: number;
+  serving: number;
+}): RecallAdmission<DurableMemorySection> {
+  const { allocator, section, citations, frame, serving } = options;
+  if (!section) return { section: null, citations: [], starvedOut: false };
+
+  if (allocator.wholePackBudget === null) {
+    chargeAdmitted(allocator, section, frame);
+    return { section, citations, starvedOut: false };
+  }
+
+  const fitted = fitRankedItemSection(
+    section as { items: Array<{ citation_id?: unknown }>; item_count: number },
+    ["item_count"],
+    serving,
+  );
+  if (fitted.starved && serializedLength(fitted.section) > serving) {
+    noteBudgetTruncation(allocator, "durable_memory", true);
+    return { section: null, citations: [], starvedOut: true };
+  }
+
+  const survived = fitted.section as DurableMemorySection;
+  chargeAdmitted(allocator, survived, frame);
+  if (fitted.truncated) noteBudgetTruncation(allocator, "durable_memory");
+  return {
+    section: survived,
+    citations: reconcileDurableMemoryCitations(citations, survived.items ?? []),
+    starvedOut: false,
+  };
+}
+
+export { durableLaneContentChars, durableMemoryContentChars };

--- a/server/tools/context-pack-selection.ts
+++ b/server/tools/context-pack-selection.ts
@@ -1,0 +1,85 @@
+/**
+ * Section selection for `agent_context_pack`.
+ *
+ * Absent `requested_sections` means working_set AND durable_memory; every other
+ * section is opt-in, because each one costs a query and a caller that wanted
+ * the whole brain would have said so.
+ *
+ * WHY durable_memory IS IN THE DEFAULT (#744, operator decision 2026-08-25).
+ * It used to be opt-in with the rest, on the reasoning above. That reasoning
+ * holds for sections a caller might not want; it does not hold for the durable
+ * corpus, because a caller who asks for "context" and silently gets none has no
+ * way to tell. Measured against the local service with the installed client:
+ *
+ *   bare recall                  -> served [working_set],                citations 0
+ *   durable_memory asked for     -> served [working_set,durable_memory], citations 10
+ *
+ * The corpus is reachable and the query works. Only the default was wrong.
+ * The Python client never sets requested_sections at all
+ * (python/openbrain-memory/src/openbrain_memory/runtime.py
+ * context_pack_arguments), so EVERY bare recall took the working-set-only
+ * branch and reported success -- which is what an agent that "remembers
+ * nothing" actually looks like from the inside.
+ *
+ * The asymmetry was the tell: working_set treated an absent requested_sections
+ * as INCLUDED and durable_memory as EXCLUDED, one line apart, with nothing in
+ * the contract asking for that split. docs/agent-context-pack-contract.md names
+ * durable_lane_context as opt-in explicitly and says nothing equivalent for
+ * durable_memory.
+ *
+ * Cost is one hybrid recall per default-shaped call. That is the price of a
+ * default that means what a caller reading it would assume.
+ */
+import type { AgentContextPackArgs } from "./context-pack-args.ts";
+
+/** One declared section name, as `requested_sections` spells it. */
+type SectionName = NonNullable<
+  AgentContextPackArgs["requested_sections"]
+>[number];
+
+/** Which sections this call will build. */
+export interface SectionSelection {
+  workingSet: boolean;
+  recovery: boolean;
+  durableLaneContext: boolean;
+  /** Whether the durable_memory SECTION BODY is emitted. */
+  durableMemorySection: boolean;
+  /** Whether the shared recall RUNS (see INVARIANT 1). */
+  durableMemory: boolean;
+  profileGuidance: boolean;
+  processGuidance: boolean;
+  repoFacts: boolean;
+  pointers: boolean;
+  candidateMemory: boolean;
+}
+
+export function selectSections(args: AgentContextPackArgs): SectionSelection {
+  const requested = args.requested_sections;
+  const optIn = (name: SectionName): boolean =>
+    requested?.includes(name) === true;
+
+  const durableMemorySection =
+    !requested || requested.includes("durable_memory");
+  const pointers = optIn("pointers");
+
+  return {
+    workingSet: !requested || requested.includes("working_set"),
+    recovery:
+      args.include_unreviewed_recovery === true &&
+      (!requested || requested.includes("recovery")),
+    durableLaneContext: optIn("durable_lane_context"),
+    durableMemorySection,
+    // INVARIANT 1. pointers derives from the durable_memory recall, so
+    // requesting EITHER runs that single recall -- its net-new pool and emitted
+    // identities are then available even when the durable_memory SECTION BODY
+    // is not requested for output. candidate_memory does NOT drive recall: it
+    // has no predicate, so a candidate-only request must issue zero recall
+    // queries.
+    durableMemory: durableMemorySection || pointers,
+    profileGuidance: optIn("profile_guidance"),
+    processGuidance: optIn("process_guidance"),
+    repoFacts: optIn("repo_facts"),
+    pointers,
+    candidateMemory: optIn("candidate_memory"),
+  };
+}

--- a/server/tools/context-pack-shared.ts
+++ b/server/tools/context-pack-shared.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared internals for the two durable context-pack loaders.
+ *
+ * Owner lane: this module is owned alongside
+ * `context-pack-durable-memory.ts` and `context-pack-durable-lane.ts` (#780,
+ * one owner for a shared helper). It exists because those two files carried
+ * structural twins — a char-allocation resolver and a failure logger that
+ * differed only in their event names and their extra fields — and two private
+ * copies of one rule is how the two recall paths drift apart.
+ *
+ * Nothing here changes behavior. Each helper reproduces exactly what the two
+ * call sites already did, including the order in which the driver's own fields
+ * are read.
+ */
+import type { AgentContextPackArgs } from "./context-pack-args.ts";
+
+/**
+ * Characters reserved for the envelope (schema/scope/warnings/allocation/
+ * citations) before section bodies get any of a caller's token allocation.
+ */
+export const CONTEXT_PACK_ENVELOPE_CHAR_RESERVE = 1_200;
+
+/**
+ * What the pack reports for a bond nobody imposed.
+ *
+ * These allocation fields are typed `number` and mean "the value that actually
+ * applied to this read". When nothing applied, the honest typed value is the
+ * effective one — every row, every character — not `null`. Nulling it would
+ * force every consumer to handle an absence that never happens, and would say
+ * "unknown" where the truth is "everything".
+ */
+export const UNBOUNDED = Number.MAX_SAFE_INTEGER;
+
+/**
+ * Resolve how many content characters a durable section may spend.
+ *
+ * Recall means TOTAL recall. Both recall paths once carried fixed ceilings that
+ * nobody asked for, and the effect was visible in every session-start block:
+ * whole records severed mid-word while the store held them complete. An
+ * explicit whole-pack allocation is the caller's own request and wins; then an
+ * explicit `budget.max_tokens`; and absent BOTH, everything comes back whole.
+ * Do not reintroduce a default.
+ *
+ * `ceiling` is the caller's own maximum, applied to both explicit branches. The
+ * lane path has none, so it passes {@link UNBOUNDED} and `Math.min` is inert
+ * there — the same arithmetic either way.
+ */
+export function resolveContentChars(
+  args: AgentContextPackArgs,
+  contentCharLimit: number | undefined,
+  ceiling: number = UNBOUNDED,
+): number {
+  if (contentCharLimit !== undefined) {
+    return Math.max(0, Math.min(ceiling, contentCharLimit));
+  }
+  if (args.budget?.max_tokens !== undefined) {
+    return Math.max(
+      0,
+      Math.min(
+        ceiling,
+        args.budget.max_tokens * 4 - CONTEXT_PACK_ENVELOPE_CHAR_RESERVE,
+      ),
+    );
+  }
+  return ceiling;
+}
+
+/**
+ * Trim a text value to `maxChars`, reporting whether anything was dropped.
+ * Shared by both recall paths so they shape content identically.
+ */
+export function boundedText(
+  value: unknown,
+  maxChars: number,
+): { text: string | null; truncated: boolean } {
+  if (typeof value !== "string" || value.length === 0 || maxChars <= 0) {
+    return {
+      text: null,
+      truncated: typeof value === "string" && value.length > 0,
+    };
+  }
+  if (value.length <= maxChars) return { text: value, truncated: false };
+  return { text: value.slice(0, maxChars), truncated: true };
+}
+
+/** The subset of the logger both durable loaders need. */
+export interface DurableFailureLogger {
+  error: (fields: Record<string, unknown>, message: string) => void;
+  debug: (fields: Record<string, unknown>, message: string) => void;
+}
+
+/**
+ * The thrown value as an `Error`, or `undefined` when something else was
+ * thrown. Both loaders fall back to `String(error)` in that case.
+ */
+export function asError(error: unknown): Error | undefined {
+  return error instanceof Error ? error : undefined;
+}
+
+/** `error_name` / `error_message` exactly as both loaders derive them. */
+export function errorIdentityFields(error: unknown): Record<string, unknown> {
+  const err = asError(error);
+  return {
+    error_name: err?.name ?? typeof error,
+    error_message: err?.message ?? String(error),
+  };
+}
+
+/**
+ * The driver's own diagnostic fields, named individually rather than spread, so
+ * no driver string carrying query fragments reaches the log wholesale.
+ *
+ * `fields` names which ones to read. The two call sites ask for different sets
+ * and each keeps the exact set it already logged — adding a field to one of
+ * them here would change what that log emits.
+ */
+export function pgDiagnosticFields(
+  error: unknown,
+  fields: readonly string[],
+): Record<string, unknown> {
+  const source = error as Record<string, unknown> | null | undefined;
+  const out: Record<string, unknown> = {};
+  for (const field of fields) {
+    out[`pg_${field}`] = source?.[field] ?? null;
+  }
+  return out;
+}
+
+/**
+ * Log a durable-recall failure on two lines, then let the caller return its own
+ * content-free envelope.
+ *
+ * Two lines on purpose. ERROR states what broke, briefly, so it is visible at
+ * the default level. DEBUG carries every input that shaped the call plus the
+ * driver's own fields — sifting a large log is a later reader's problem; having
+ * no log at all is a later reader's disaster. This catch was once bare in both
+ * loaders: the read failed, the envelope named a generic reason, and the actual
+ * cause went in the bin.
+ */
+export function logDurableFailure(options: {
+  logger: DurableFailureLogger;
+  event: string;
+  error: unknown;
+  errorFields: Record<string, unknown>;
+  detailFields: Record<string, unknown>;
+}): void {
+  const { logger, event, error, errorFields, detailFields } = options;
+  const err = asError(error);
+  logger.error(
+    { ...errorFields, error_message: err?.message ?? String(error) },
+    event,
+  );
+  logger.debug(detailFields, `${event}_detail`);
+}

--- a/server/tools/context-pack-structured-sections.ts
+++ b/server/tools/context-pack-structured-sections.ts
@@ -1,0 +1,137 @@
+/**
+ * Admission of the self-contained structured sections of `agent_context_pack`
+ * (priorities 5-9): `profile_guidance`, `process_guidance`, `repo_facts`,
+ * `pointers`, and `candidate_memory`.
+ *
+ * All four loaders return a {@link SectionFragment}, so they are admitted
+ * through ONE fitter and share a single whole-pack, citation, and truncation
+ * reconciliation. Each binds the read namespace, derives selection only from
+ * explicit typed metadata (never inferred from raw conversation), returns a
+ * defined empty state, and degrades content-free.
+ */
+import {
+  chargeAdmitted,
+  servingChars,
+  type PackAllocator,
+} from "./context-pack-allocator.ts";
+import {
+  fitItemSection,
+  reconcileCitedItemCitations,
+  sectionFrameCost,
+  serializedLength,
+} from "./context-pack-budget.ts";
+import type { SectionFragment } from "./context-pack-sections.ts";
+
+/** Everything the structured sections contribute to the finished pack. */
+export interface StructuredSectionAccumulator {
+  scopeDenials: Array<Record<string, unknown>>;
+  degradedSources: Array<Record<string, unknown>>;
+  truncation: Array<Record<string, unknown>>;
+  citations: Array<Record<string, unknown>>;
+  sections: Array<{ key: string; section: Record<string, unknown> }>;
+}
+
+export function createStructuredAccumulator(): StructuredSectionAccumulator {
+  return {
+    scopeDenials: [],
+    degradedSources: [],
+    truncation: [],
+    citations: [],
+    sections: [],
+  };
+}
+
+/**
+ * Stamp a trimmed body so it says so on its OWN `truncated` flag.
+ *
+ * A downstream reader trusts the section body, not just the warnings channel.
+ * When the trim empties it but the envelope still fits, `empty_reason` reads as
+ * allowance-starved rather than as a genuine no-data result. Stamped BEFORE the
+ * overflow checks so the extra keys count against the allowance.
+ */
+function stampTrimmedBody(body: Record<string, unknown>): void {
+  body.truncated = true;
+  if ((body.item_count as number) === 0) {
+    body.empty_reason = "whole_pack_budget";
+  }
+}
+
+function pushOverflowMarker(
+  accumulator: StructuredSectionAccumulator,
+  allocator: PackAllocator,
+  key: string,
+  starved: boolean,
+): void {
+  accumulator.truncation.push({
+    source: key,
+    reason: "whole_pack_budget",
+    max_chars: allocator.wholePackBudget,
+    ...(starved ? { starved: true } : {}),
+  });
+}
+
+/**
+ * Fit one assembled fragment into the surviving allowance, reconcile its
+ * citations to the surviving items, and record its warnings.
+ *
+ * Trim direction is `"tail"` here, unlike working_set/recovery. Those append
+ * stores are oldest-first so the front sheds; these loaders emit
+ * newest/current first (`ORDER BY ... DESC`), so the head must survive.
+ * Front-dropping would keep stale older guidance and shed the newest rules.
+ */
+export function admitStructuredSection(options: {
+  accumulator: StructuredSectionAccumulator;
+  allocator: PackAllocator;
+  key: string;
+  fragment: SectionFragment;
+}): void {
+  const { accumulator, allocator, key, fragment } = options;
+  // Content-free denials and degraded sources ALWAYS propagate: they carry no
+  // body, only a reason, and the caller needs them even when the section is
+  // omitted (e.g. no_active_repo, database_unavailable).
+  accumulator.scopeDenials.push(...fragment.scopeDenials);
+  accumulator.degradedSources.push(...fragment.degradedSources);
+
+  const body = fragment.section;
+  // Hard internal error path: no body to fit; the degraded marker above is the
+  // whole story.
+  if (!body) return;
+
+  if (allocator.wholePackBudget === null) {
+    accumulator.sections.push({ key, section: body });
+    accumulator.truncation.push(...fragment.truncation);
+    accumulator.citations.push(...fragment.citations);
+    allocator.firstSectionAdmitted = false;
+    return;
+  }
+
+  const frame = sectionFrameCost(key, allocator.firstSectionAdmitted);
+  const serving = servingChars(allocator, frame);
+  const fitted = fitItemSection(
+    body as { items: Array<{ id: string }>; item_count: number },
+    ["item_count"],
+    serving,
+    "tail",
+  );
+  if (fitted.truncated) {
+    stampTrimmedBody(fitted.section as Record<string, unknown>);
+  }
+  if (fitted.starved && serializedLength(fitted.section) > serving) {
+    pushOverflowMarker(accumulator, allocator, key, true);
+    return;
+  }
+
+  const survived = fitted.section as Record<string, unknown>;
+  accumulator.sections.push({ key, section: survived });
+  chargeAdmitted(allocator, survived, frame);
+  // INVARIANT 3: citations reconciled to exactly the surviving items.
+  accumulator.citations.push(
+    ...reconcileCitedItemCitations(fragment.citations, survived),
+  );
+  // A section's own truncation notices only make sense when its body was
+  // emitted; a fully-starved section is covered by the starved marker above.
+  accumulator.truncation.push(...fragment.truncation);
+  if (fitted.truncated) {
+    pushOverflowMarker(accumulator, allocator, key, false);
+  }
+}


### PR DESCRIPTION
## Summary

- Thirteen oxlint findings across the durable context-pack recall stack and its
  one caller. **All thirteen are retired here** — the residual this PR
  previously declared red is closed by the second commit.
- **First commit (`150df0b`)** — the two durable loaders. The audit named the
  real cause, and it is not size. The two files carried **structural twins**: a
  content-char resolver and a two-line failure logger that differed only in
  their event names and their extra fields. Two private copies of one rule is
  how two recall paths drift apart, so the fix is one shared sibling rather
  than two smaller private copies. New `server/tools/context-pack-shared.ts`
  holds `resolveContentChars`, `logDurableFailure` with
  `errorIdentityFields`/`pgDiagnosticFields`, and `boundedText` +
  `CONTEXT_PACK_ENVELOPE_CHAR_RESERVE` + `UNBOUNDED`.
  `context-pack-durable-lane.ts` re-exports the moved symbols, so every
  existing importer keeps working unchanged.
- **Second commit (`abfc101`)** — the caller,
  `server/tools/agent-context-pack.ts`: 729 code lines, with
  `buildAgentContextPackPayload` scoring **129 on complexity across 535 lines**.
  Again the cause was not size. Three mutable locals — the surviving chars,
  whether the next admitted member still gets the comma-free first slot, and the
  accumulated `whole_pack_budget` markers — were threaded through every section
  in sequence, so **no section could be lifted out of the function without
  carrying that state with it**. That is the whole reason the function grew to
  535 lines: every attempt to extract a section would have needed three
  in/out parameters.
- Naming that state as ONE object (`PackAllocator`) is what makes the split
  possible. Each section then becomes its own function that takes the allocator,
  charges itself against it, and returns what it contributed:

  | Module | Code lines | Holds |
  |---|---|---|
  | `context-pack-allocator.ts` | 146 | The allocation state and its arithmetic (INVARIANT 2). |
  | `context-pack-selection.ts` | 84 | Which sections this call builds, including the #744 default reasoning that was a 30-line comment mid-function. |
  | `context-pack-append-sections.ts` | 73 | `working_set` + `recovery`, previously two near-identical inline blocks. |
  | `context-pack-recall-sections.ts` | 133 | `durable_lane_context` + `durable_memory` admission. |
  | `context-pack-structured-sections.ts` | 137 | The shared fitter for the four fragment-shaped sections. |
  | `context-pack-loaders.ts` | 217 | The retrieval calls, one place per section. |
  | `context-pack-payload.ts` | 137 | Sections map, #535 receipt, warnings, reported allocation. |
  | `context-pack-assembly.ts` | 330 | The middle of the build, composing the above. |

  `agent-context-pack.ts` itself goes 729 → 425 code lines, and
  `buildAgentContextPackPayload` from complexity 129 to under 10.
- The two append-store sections became **one** function rather than two smaller
  copies, because they differed only in their key and in which counts must
  reconcile after a trim — exactly the twin pattern the first commit fixed. The
  two recall sections stayed **separate**, because they differ where it matters:
  the lane path sheds oldest-first and finally trims the checkpoint, while
  `durable_memory` is relevance-ordered and sheds the lowest-ranked tail so the
  best recall survives. Merging those two would have been a real behavior risk.
- **`loadDurableMemoryContext` now takes an options object**, retiring the
  `max-params` finding this PR previously left honestly red. The
  `DurableMemoryContextRequest` type already existed and was already the exact
  object the function built internally on its first line; the five-parameter
  form only survived because its one caller was the file above. No other caller
  exists under `server/`, so the old form is gone rather than kept alongside.
- No behavior moves in either commit: schemas, defaults, error strings, SQL
  text, log event names, section ordering, and payload shape are identical. The
  warnings channels are concatenated in the same source order they were written
  in, and the allocation arithmetic is the same expressions with the locals
  renamed to fields. The empty-reason precedence is preserved exactly
  (`walk_complete` → `content_unavailable` → `all_suppressed` → `no_matches`).
  No disable comment is used anywhere.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

All checks re-run on the **committed** tree, after the pre-commit prettier hook
reformatted the staged files:

- `bash scripts/done-means/780-touched-files-lint-clean.sh` → exit 0, covering
  all 12 files this branch touches.
- `oxlint --deny-warnings` clean on every touched file.
- `bunx tsc --noEmit` clean.
- `bun run test:isolated server/tools src/tools/__tests__/agent-context-pack*.test.ts
  src/tools/__tests__/agent-reflex-pointers.test.ts` → **218 pass, 0 fail, 1150
  expect() calls across 22 files**. Existing tests are unmodified.

Red-first receipts: `oxlint --deny-warnings` on both loaders at `origin/main`
reported all ten findings; on `server/tools/agent-context-pack.ts` at the
branch tip before the second commit it reported exactly three — `max-lines`
(729), and `complexity` (129) plus `max-lines-per-function` (535) on
`buildAgentContextPackPayload`. The done-means exited 1 at that point on the
`max-params` residual.

No Python, migration, or client-facing surface is touched, so those checks are
not applicable.

## Critical Self-Review

- Highest-risk behavior: the **warnings channel ordering**. The entry point used
  to build `scope_denials`, `degraded_sources`, and `truncation` as three inline
  array spreads, and a reader can see the order at a glance. They are now
  composed by `assembleWarnings` from a list of per-section contributions, so
  the order is the order of that list. It is asserted by the existing pack
  tests, which check exact warning arrays, but a future edit that reorders that
  list would reorder emitted warnings silently. The list is written in section
  priority order and commented for that reason.
- Assumptions that could be wrong: that `Math.min` on the allocation and the
  first-member framing flip are order-identical once the locals became fields on
  a shared object. Each section reads `firstSectionAdmitted` before it fits and
  writes it only when it is actually admitted, which is the original rule; a
  starved section still leaves the comma-free slot for the next one. Also that
  the durable_memory section suppressed for pointers-only still folds its
  content-free warnings into the first admitted #329 fragment — moved verbatim
  into `admitPointerSections`, and covered by the pointers/candidates suites.
- Missing/weak tests: no test asserts the exact key set of the durable failure
  log lines (carried over from the first commit), and none asserts the *order*
  of the warnings arrays independently of their contents. The existing suites
  cover the envelope. Neither is added here because writing them is
  behavior-adjacent work a lint lane should not smuggle in.
- Security/permission risk: none introduced. The two authorization gates are
  moved into `authorizePack` in the same order, still **before any query runs**,
  and still returning the identical content-free error strings. `physicalNamespace(ns)`
  is still the single isolation predicate every structured-section read binds
  to, resolved at the same point in the flow. The namespace argument is still
  authorized before it reaches any loader.
- Migration/deploy risk: none. No schema, no SQL text change, no config.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or
  Python client surface is touched. `src/tools/agent-context-pack*.ts` are
  separate legacy copies, not shims, and are untouched — including their own
  five-parameter `loadDurableMemoryContext`, which is a different function in a
  different file.
- Rollback/cleanup concern: a plain revert of both commits restores the two
  original files and deletes the nine new siblings; nothing outside this branch
  imports any of them.
- Fixes made before PR: corrected the extracted `recovery` selection predicate,
  which the first draft of `selectSections` rewrote into a nested conditional
  that was not equivalent to the original
  `include_unreviewed_recovery === true && (!requested || requested.includes("recovery"))`.
  Caught by reading the extraction back against the original rather than by a
  test — the existing suites did not cover that combination, which is itself
  worth noting.
- Known residual risk: **none outstanding — the done-means is GREEN.** The
  `max-params` finding this PR previously carried as a declared residual is
  closed by the second commit, and the three findings in the caller that blocked
  it are closed with it. All 12 files on this branch lint clean under
  `--deny-warnings`. The residual risk that remains is the ordinary one for a
  refactor of this size: the behavior guarantee rests on the existing 218-test
  suite plus reading each extraction against its original, not on new tests.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because: entry added for the reviewable pattern this lane surfaced — that an over-complex function is often held together by two or three mutable locals threaded through it, and naming that state as one object is the move that makes extraction possible, whereas splitting on line count alone does not.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or client-facing surface changes; the change is internal to server-side loader and assembly modules.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, schema, or emitted-envelope field changed — section ordering, keys, and values are identical, so no fixture can move.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Classified not applicable per `docs/downstream-rollout.md`: no MCP tool,
  schema, protocol, or client-facing change. Every edited file is an internal
  server-side module; the only cross-file surfaces are
  `context-pack-durable-lane.ts` re-exporting three symbols it previously
  declared, and `loadDurableMemoryContext` changing shape with its single
  in-repo caller updated in the same commit.
