### PR TITLE
refactor(session-manager): bring server/transport/session-manager.ts to the lint standard (#780)

### DIFF
--- a/server/transport/session-manager.ts
+++ b/server/transport/session-manager.ts
@@ -4,22 +4,19 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import type { Request, Response } from "express";
 import type { Logger } from "pino";
-import type { AuthIdentity } from "../auth/types.ts";
+import { SessionStore, sameIdentity } from "./session-store.ts";
+import type {
+  SessionIdentity,
+  SessionTransportConfig,
+} from "./session-store.ts";
+
+export type {
+  SessionIdentity,
+  SessionTransportConfig,
+} from "./session-store.ts";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-export interface SessionIdentity extends AuthIdentity {
-  readonly agentId?: string;
-}
-
-export interface SessionTransportConfig {
-  readonly sessionTtlMs: number;
-  readonly maxSessions: number;
-  readonly retryAfterSeconds: number;
-  readonly closeTimeoutMs: number;
-  readonly sweepIntervalMs: number;
-}
 
 export interface SessionTransportFactoryInput {
   readonly sessionIdGenerator: () => string;
@@ -34,14 +31,6 @@ export type McpServerFactory = () => Pick<McpServer, "connect">;
 
 type AuthenticatedRequest = Request & { auth?: SessionIdentity };
 
-interface SessionEntry {
-  readonly transport: StreamableHTTPServerTransport;
-  readonly identity: SessionIdentity;
-  timer: ReturnType<typeof setTimeout>;
-  lastActivity: number;
-  inFlight: number;
-}
-
 export interface SessionTransportHandlers {
   handlePost(request: Request, response: Response): Promise<void>;
   handleGet(request: Request, response: Response): Promise<void>;
@@ -49,6 +38,15 @@ export interface SessionTransportHandlers {
   sessionCount(): number;
   pendingInitializeCount(): number;
   close(): Promise<void>;
+}
+
+/** Everything the module-level handler helpers need from one manager instance. */
+interface HandlerContext {
+  readonly store: SessionStore;
+  readonly config: SessionTransportConfig;
+  readonly logger: Logger;
+  readonly serverFactory: McpServerFactory;
+  readonly transportFactory: SessionTransportFactory;
 }
 
 function defaultTransportFactory(
@@ -65,14 +63,229 @@ function requestSessionId(request: Request): string | undefined {
   return typeof raw === "string" && UUID_RE.test(raw) ? raw : undefined;
 }
 
-function sameIdentity(left: SessionIdentity | undefined, right: SessionIdentity): boolean {
-  return (
-    left?.tokenClientId === right.tokenClientId &&
-    left?.role === right.role &&
-    left?.clientId === right.clientId &&
-    left?.namespaceSource === right.namespaceSource &&
-    (left?.agentId ?? "") === (right.agentId ?? "")
+function rejectIdentity(
+  context: HandlerContext,
+  response: Response,
+  sessionId: string,
+): void {
+  context.logger.warn({ session_id: sessionId }, "session_identity_rejected");
+  response
+    .status(403)
+    .json({ error: "Request identity does not match session" });
+}
+
+function rejectAdmission(context: HandlerContext, response: Response): void {
+  const activeSessions = context.store.activeCount;
+  context.logger.warn(
+    {
+      active_sessions: activeSessions,
+      max_sessions: context.config.maxSessions,
+    },
+    "session_admission_rejected",
   );
+  response.setHeader("Retry-After", String(context.config.retryAfterSeconds));
+  response.status(429).json({
+    error: "Too many active sessions",
+    code: "session_cap_exceeded",
+    active_sessions: activeSessions,
+    max_sessions: context.config.maxSessions,
+    retry_after_seconds: context.config.retryAfterSeconds,
+  });
+}
+
+/**
+ * Serve a request against an already-live session, answering whether it was
+ * handled here. `false` means no such session, and the caller decides what that
+ * means for its own method.
+ */
+async function handleExisting(input: {
+  readonly context: HandlerContext;
+  readonly request: Request;
+  readonly response: Response;
+  readonly sessionId: string;
+  readonly includeBody: boolean;
+}): Promise<boolean> {
+  const { context, request, response, sessionId } = input;
+  const entry = context.store.get(sessionId);
+  if (!entry) return false;
+  const identity = (request as AuthenticatedRequest).auth;
+  if (!sameIdentity(identity, entry.identity)) {
+    rejectIdentity(context, response, sessionId);
+    return true;
+  }
+  context.store.armExpiry(sessionId);
+  await context.store.runWithSession(sessionId, () =>
+    entry.transport.handleRequest(
+      request,
+      response,
+      input.includeBody ? request.body : undefined,
+    ),
+  );
+  return true;
+}
+
+/** Build the transport for a new session, wiring registration and close-out. */
+function createInitializeTransport(
+  context: HandlerContext,
+  identity: SessionIdentity,
+): StreamableHTTPServerTransport {
+  const transport = context.transportFactory({
+    sessionIdGenerator: randomUUID,
+    onSessionInitialized: (initializedId) => {
+      context.store.register(initializedId, transport, identity);
+    },
+  });
+  transport.onclose = () => {
+    const initializedId = transport.sessionId;
+    if (!initializedId) return;
+    context.store.forget(initializedId);
+  };
+  return transport;
+}
+
+/**
+ * Reject an initialize request that cannot be admitted, answering whether a
+ * response was already sent.
+ */
+function rejectInitialize(input: {
+  readonly context: HandlerContext;
+  readonly response: Response;
+  readonly body: unknown;
+  readonly sessionId: string | undefined;
+  readonly identity: SessionIdentity | undefined;
+}): boolean {
+  const { context, response } = input;
+  if (input.sessionId || !isInitializeRequest(input.body)) {
+    response.status(400).json({
+      error: "Bad request: missing session or not an initialize request",
+    });
+    return true;
+  }
+  if (!context.store.admits()) {
+    rejectAdmission(context, response);
+    return true;
+  }
+  if (!input.identity) {
+    response.status(401).json({ error: "Auth info missing" });
+    return true;
+  }
+  return false;
+}
+
+/** Run the initialize handshake, retiring the transport if it throws. */
+async function runInitialize(
+  context: HandlerContext,
+  request: Request,
+  response: Response,
+  identity: SessionIdentity,
+): Promise<void> {
+  context.store.beginInitialize();
+  const transport = createInitializeTransport(context, identity);
+  try {
+    const server = context.serverFactory();
+    await server.connect(transport);
+    await transport.handleRequest(request, response, request.body);
+  } catch (error: unknown) {
+    const initializedId = transport.sessionId;
+    if (initializedId && context.store.get(initializedId)) {
+      await context.store.expire(initializedId, "initialize_error");
+    } else {
+      await context.store.closeTransport(
+        transport,
+        initializedId ?? "pending",
+        "initialize_error",
+      );
+    }
+    throw error;
+  } finally {
+    context.store.endInitialize();
+  }
+}
+
+async function handlePost(
+  context: HandlerContext,
+  request: Request,
+  response: Response,
+): Promise<void> {
+  const sessionId = requestSessionId(request);
+  if (
+    sessionId &&
+    (await handleExisting({
+      context,
+      request,
+      response,
+      sessionId,
+      includeBody: true,
+    }))
+  ) {
+    return;
+  }
+  const identity = (request as AuthenticatedRequest).auth;
+  if (
+    rejectInitialize({
+      context,
+      response,
+      body: request.body,
+      sessionId,
+      identity,
+    })
+  ) {
+    return;
+  }
+  await runInitialize(context, request, response, identity as SessionIdentity);
+}
+
+async function handleGet(
+  context: HandlerContext,
+  request: Request,
+  response: Response,
+): Promise<void> {
+  const sessionId = requestSessionId(request);
+  if (
+    sessionId &&
+    (await handleExisting({
+      context,
+      request,
+      response,
+      sessionId,
+      includeBody: false,
+    }))
+  ) {
+    return;
+  }
+  response.status(400).json({ error: "Invalid or missing session" });
+}
+
+async function handleDelete(
+  context: HandlerContext,
+  request: Request,
+  response: Response,
+): Promise<void> {
+  const sessionId = requestSessionId(request);
+  const entry = sessionId ? context.store.get(sessionId) : undefined;
+  if (!sessionId || !entry) {
+    response.status(400).json({ error: "Invalid or missing session" });
+    return;
+  }
+  const identity = (request as AuthenticatedRequest).auth;
+  if (!sameIdentity(identity, entry.identity)) {
+    rejectIdentity(context, response, sessionId);
+    return;
+  }
+  await context.store.expire(sessionId, "client_delete");
+  response.status(200).json({ status: "session closed" });
+}
+
+function startSweeper(context: HandlerContext): ReturnType<typeof setInterval> {
+  const sweepTimer = setInterval(() => {
+    const swept = context.store.sweep();
+    context.logger.debug(
+      { active_sessions: context.store.size, swept_sessions: swept },
+      "session_sweeper_result",
+    );
+  }, context.config.sweepIntervalMs);
+  sweepTimer.unref();
+  return sweepTimer;
 }
 
 export function createSessionTransportHandlers(input: {
@@ -81,239 +294,28 @@ export function createSessionTransportHandlers(input: {
   readonly serverFactory: McpServerFactory;
   readonly transportFactory?: SessionTransportFactory;
 }): SessionTransportHandlers {
-  const sessions = new Map<string, SessionEntry>();
-  const transportFactory = input.transportFactory ?? defaultTransportFactory;
-  let pendingInitializes = 0;
-
-  function armExpiry(sessionId: string): void {
-    const entry = sessions.get(sessionId);
-    if (!entry) return;
-    clearTimeout(entry.timer);
-    entry.lastActivity = Date.now();
-    entry.timer = setTimeout(() => {
-      void expireSession(sessionId, "inactivity");
-    }, input.config.sessionTtlMs);
-  }
-
-  async function closeTransport(
-    transport: StreamableHTTPServerTransport,
-    sessionId: string,
-    reason: string,
-  ): Promise<void> {
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-    try {
-      await Promise.race([
-        transport.close(),
-        new Promise<void>((_, reject) => {
-          timeout = setTimeout(
-            () => reject(new Error("session_transport_close_timeout")),
-            input.config.closeTimeoutMs,
-          );
-          timeout.unref();
-        }),
-      ]);
-      input.logger.info({ session_id: sessionId, reason }, "session_closed");
-    } catch (error: unknown) {
-      input.logger.warn(
-        {
-          session_id: sessionId,
-          reason,
-          error_category: error instanceof Error ? error.name : typeof error,
-        },
-        "session_close_failed",
-      );
-    } finally {
-      if (timeout) clearTimeout(timeout);
-    }
-  }
-
-  async function expireSession(sessionId: string, reason: string): Promise<void> {
-    const entry = sessions.get(sessionId);
-    if (!entry) return;
-    if (entry.inFlight > 0) {
-      input.logger.debug({ session_id: sessionId, reason }, "session_expiry_deferred");
-      armExpiry(sessionId);
-      return;
-    }
-    clearTimeout(entry.timer);
-    sessions.delete(sessionId);
-    await closeTransport(entry.transport, sessionId, reason);
-  }
-
-  async function runWithSession(
-    sessionId: string,
-    work: () => Promise<void>,
-  ): Promise<void> {
-    const entry = sessions.get(sessionId);
-    if (!entry) {
-      await work();
-      return;
-    }
-    entry.inFlight += 1;
-    try {
-      await work();
-    } finally {
-      const current = sessions.get(sessionId);
-      if (current) {
-        current.inFlight = Math.max(0, current.inFlight - 1);
-        armExpiry(sessionId);
-      }
-    }
-  }
-
-  function rejectIdentity(response: Response, sessionId: string): void {
-    input.logger.warn({ session_id: sessionId }, "session_identity_rejected");
-    response.status(403).json({ error: "Request identity does not match session" });
-  }
-
-  function rejectAdmission(response: Response): void {
-    const activeSessions = sessions.size + pendingInitializes;
-    input.logger.warn(
-      { active_sessions: activeSessions, max_sessions: input.config.maxSessions },
-      "session_admission_rejected",
-    );
-    response.setHeader("Retry-After", String(input.config.retryAfterSeconds));
-    response.status(429).json({
-      error: "Too many active sessions",
-      code: "session_cap_exceeded",
-      active_sessions: activeSessions,
-      max_sessions: input.config.maxSessions,
-      retry_after_seconds: input.config.retryAfterSeconds,
-    });
-  }
-
-  async function handleExisting(
-    request: Request,
-    response: Response,
-    sessionId: string,
-    includeBody: boolean,
-  ): Promise<boolean> {
-    const entry = sessions.get(sessionId);
-    if (!entry) return false;
-    const identity = (request as AuthenticatedRequest).auth;
-    if (!sameIdentity(identity, entry.identity)) {
-      rejectIdentity(response, sessionId);
-      return true;
-    }
-    armExpiry(sessionId);
-    await runWithSession(sessionId, () =>
-      entry.transport.handleRequest(
-        request,
-        response,
-        includeBody ? request.body : undefined,
-      ),
-    );
-    return true;
-  }
-
-  const sweepTimer = setInterval(() => {
-    const now = Date.now();
-    let swept = 0;
-    for (const [sessionId, entry] of sessions) {
-      if (entry.inFlight > 0) continue;
-      if (now - entry.lastActivity <= input.config.sessionTtlMs * 2) continue;
-      swept += 1;
-      void expireSession(sessionId, "sweeper");
-    }
-    input.logger.debug(
-      { active_sessions: sessions.size, swept_sessions: swept },
-      "session_sweeper_result",
-    );
-  }, input.config.sweepIntervalMs);
-  sweepTimer.unref();
+  const context: HandlerContext = {
+    store: new SessionStore(input.config, input.logger),
+    config: input.config,
+    logger: input.logger,
+    serverFactory: input.serverFactory,
+    transportFactory: input.transportFactory ?? defaultTransportFactory,
+  };
+  const sweepTimer = startSweeper(context);
 
   return {
-    async handlePost(request, response) {
-      const sessionId = requestSessionId(request);
-      if (sessionId && (await handleExisting(request, response, sessionId, true))) return;
-      if (sessionId || !isInitializeRequest(request.body)) {
-        response.status(400).json({
-          error: "Bad request: missing session or not an initialize request",
-        });
-        return;
-      }
-      if (sessions.size + pendingInitializes >= input.config.maxSessions) {
-        rejectAdmission(response);
-        return;
-      }
-      const identity = (request as AuthenticatedRequest).auth;
-      if (!identity) {
-        response.status(401).json({ error: "Auth info missing" });
-        return;
-      }
-
-      pendingInitializes += 1;
-      const transport = transportFactory({
-        sessionIdGenerator: randomUUID,
-        onSessionInitialized: (initializedId) => {
-          const timer = setTimeout(() => {
-            void expireSession(initializedId, "inactivity");
-          }, input.config.sessionTtlMs);
-          sessions.set(initializedId, {
-            transport,
-            identity,
-            timer,
-            lastActivity: Date.now(),
-            inFlight: 0,
-          });
-          input.logger.info({ session_id: initializedId }, "session_initialized");
-        },
-      });
-      transport.onclose = () => {
-        const initializedId = transport.sessionId;
-        if (!initializedId) return;
-        const entry = sessions.get(initializedId);
-        if (!entry) return;
-        clearTimeout(entry.timer);
-        sessions.delete(initializedId);
-        input.logger.info({ session_id: initializedId }, "session_transport_closed");
-      };
-
-      try {
-        const server = input.serverFactory();
-        await server.connect(transport);
-        await transport.handleRequest(request, response, request.body);
-      } catch (error: unknown) {
-        const initializedId = transport.sessionId;
-        if (initializedId && sessions.has(initializedId)) {
-          await expireSession(initializedId, "initialize_error");
-        } else {
-          await closeTransport(transport, initializedId ?? "pending", "initialize_error");
-        }
-        throw error;
-      } finally {
-        pendingInitializes = Math.max(0, pendingInitializes - 1);
-      }
-    },
-
-    async handleGet(request, response) {
-      const sessionId = requestSessionId(request);
-      if (sessionId && (await handleExisting(request, response, sessionId, false))) return;
-      response.status(400).json({ error: "Invalid or missing session" });
-    },
-
-    async handleDelete(request, response) {
-      const sessionId = requestSessionId(request);
-      const entry = sessionId ? sessions.get(sessionId) : undefined;
-      if (!sessionId || !entry) {
-        response.status(400).json({ error: "Invalid or missing session" });
-        return;
-      }
-      const identity = (request as AuthenticatedRequest).auth;
-      if (!sameIdentity(identity, entry.identity)) {
-        rejectIdentity(response, sessionId);
-        return;
-      }
-      await expireSession(sessionId, "client_delete");
-      response.status(200).json({ status: "session closed" });
-    },
-
-    sessionCount: () => sessions.size,
-    pendingInitializeCount: () => pendingInitializes,
+    handlePost: (request, response) => handlePost(context, request, response),
+    handleGet: (request, response) => handleGet(context, request, response),
+    handleDelete: (request, response) =>
+      handleDelete(context, request, response),
+    sessionCount: () => context.store.size,
+    pendingInitializeCount: () => context.store.pendingCount,
     async close() {
       clearInterval(sweepTimer);
       await Promise.all(
-        [...sessions.keys()].map((sessionId) => expireSession(sessionId, "manager_close")),
+        context.store
+          .ids()
+          .map((sessionId) => context.store.expire(sessionId, "manager_close")),
       );
     },
   };

--- a/server/transport/session-store.ts
+++ b/server/transport/session-store.ts
@@ -1,0 +1,219 @@
+/**
+ * Live MCP session bookkeeping for `session-manager.ts`.
+ *
+ * Extracted from `session-manager.ts` (#780) so the handler module is left with
+ * request/response shaping and this module owns the one thing every handler
+ * shares: the map of live sessions and the rules for keeping an entry alive,
+ * retiring it, and deciding whether a request is allowed to touch it.
+ *
+ * Nothing here reads or writes an Express request. The store is handed a
+ * transport and an identity, and it hands back state -- which is what makes the
+ * expiry and identity rules testable through the public handler surface without
+ * a socket.
+ */
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { Logger } from "pino";
+import type { AuthIdentity } from "../auth/types.ts";
+
+export interface SessionIdentity extends AuthIdentity {
+  readonly agentId?: string;
+}
+
+export interface SessionTransportConfig {
+  readonly sessionTtlMs: number;
+  readonly maxSessions: number;
+  readonly retryAfterSeconds: number;
+  readonly closeTimeoutMs: number;
+  readonly sweepIntervalMs: number;
+}
+
+interface SessionEntry {
+  readonly transport: StreamableHTTPServerTransport;
+  readonly identity: SessionIdentity;
+  timer: ReturnType<typeof setTimeout>;
+  lastActivity: number;
+  inFlight: number;
+}
+
+/**
+ * Two identities are the same session only when every auth-derived field
+ * matches. Written as a table walk rather than a chain of `&&` so adding a
+ * field is a one-line change and the comparison stays flat.
+ */
+const IDENTITY_FIELDS = [
+  (identity: SessionIdentity) => identity.tokenClientId,
+  (identity: SessionIdentity) => identity.role,
+  (identity: SessionIdentity) => identity.clientId,
+  (identity: SessionIdentity) => identity.namespaceSource,
+  (identity: SessionIdentity) => identity.agentId ?? "",
+] as const;
+
+export function sameIdentity(
+  left: SessionIdentity | undefined,
+  right: SessionIdentity,
+): boolean {
+  if (!left) return false;
+  return IDENTITY_FIELDS.every((read) => read(left) === read(right));
+}
+
+export class SessionStore {
+  private readonly sessions = new Map<string, SessionEntry>();
+  private pendingInitializes = 0;
+
+  constructor(
+    private readonly config: SessionTransportConfig,
+    private readonly logger: Logger,
+  ) {}
+
+  get size(): number {
+    return this.sessions.size;
+  }
+
+  get pendingCount(): number {
+    return this.pendingInitializes;
+  }
+
+  get activeCount(): number {
+    return this.sessions.size + this.pendingInitializes;
+  }
+
+  get(sessionId: string): SessionEntry | undefined {
+    return this.sessions.get(sessionId);
+  }
+
+  ids(): string[] {
+    return [...this.sessions.keys()];
+  }
+
+  beginInitialize(): void {
+    this.pendingInitializes += 1;
+  }
+
+  endInitialize(): void {
+    this.pendingInitializes = Math.max(0, this.pendingInitializes - 1);
+  }
+
+  admits(): boolean {
+    return this.activeCount < this.config.maxSessions;
+  }
+
+  register(
+    sessionId: string,
+    transport: StreamableHTTPServerTransport,
+    identity: SessionIdentity,
+  ): void {
+    const timer = setTimeout(() => {
+      void this.expire(sessionId, "inactivity");
+    }, this.config.sessionTtlMs);
+    this.sessions.set(sessionId, {
+      transport,
+      identity,
+      timer,
+      lastActivity: Date.now(),
+      inFlight: 0,
+    });
+    this.logger.info({ session_id: sessionId }, "session_initialized");
+  }
+
+  /** Drop an entry whose transport closed under us, without closing it again. */
+  forget(sessionId: string): void {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) return;
+    clearTimeout(entry.timer);
+    this.sessions.delete(sessionId);
+    this.logger.info({ session_id: sessionId }, "session_transport_closed");
+  }
+
+  armExpiry(sessionId: string): void {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) return;
+    clearTimeout(entry.timer);
+    entry.lastActivity = Date.now();
+    entry.timer = setTimeout(() => {
+      void this.expire(sessionId, "inactivity");
+    }, this.config.sessionTtlMs);
+  }
+
+  async expire(sessionId: string, reason: string): Promise<void> {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) return;
+    if (entry.inFlight > 0) {
+      this.logger.debug(
+        { session_id: sessionId, reason },
+        "session_expiry_deferred",
+      );
+      this.armExpiry(sessionId);
+      return;
+    }
+    clearTimeout(entry.timer);
+    this.sessions.delete(sessionId);
+    await this.closeTransport(entry.transport, sessionId, reason);
+  }
+
+  async closeTransport(
+    transport: StreamableHTTPServerTransport,
+    sessionId: string,
+    reason: string,
+  ): Promise<void> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        transport.close(),
+        new Promise<void>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("session_transport_close_timeout")),
+            this.config.closeTimeoutMs,
+          );
+          timeout.unref();
+        }),
+      ]);
+      this.logger.info({ session_id: sessionId, reason }, "session_closed");
+    } catch (error: unknown) {
+      this.logger.warn(
+        {
+          session_id: sessionId,
+          reason,
+          error_category: error instanceof Error ? error.name : typeof error,
+        },
+        "session_close_failed",
+      );
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  }
+
+  /** Run `work` with the session marked busy, so idle expiry cannot land mid-request. */
+  async runWithSession(
+    sessionId: string,
+    work: () => Promise<void>,
+  ): Promise<void> {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) {
+      await work();
+      return;
+    }
+    entry.inFlight += 1;
+    try {
+      await work();
+    } finally {
+      const current = this.sessions.get(sessionId);
+      if (current) {
+        current.inFlight = Math.max(0, current.inFlight - 1);
+        this.armExpiry(sessionId);
+      }
+    }
+  }
+
+  /** Retire every entry idle for more than twice the TTL; returns how many were swept. */
+  sweep(): number {
+    const now = Date.now();
+    let swept = 0;
+    for (const [sessionId, entry] of this.sessions) {
+      if (entry.inFlight > 0) continue;
+      if (now - entry.lastActivity <= this.config.sessionTtlMs * 2) continue;
+      swept += 1;
+      void this.expire(sessionId, "sweeper");
+    }
+    return swept;
+  }
+}


### PR DESCRIPTION
## Summary

- `server/transport/session-manager.ts` carried three oxlint findings: `sameIdentity` at complexity 12, the `createSessionTransportHandlers` closure at 229 lines, and `handlePost` at complexity 11. One cause behind all three -- every piece of session bookkeeping lived as a closure inside the factory, so the factory grew with each addition and no handler could be read without reading the whole body.
- New sibling `server/transport/session-store.ts` owns the live-session map, expiry arming, transport close-out, in-flight accounting, admission, and the sweep pass. `sameIdentity` moved here and now walks a field table instead of a five-clause boolean chain, which is what took it under complexity 10.
- `session-manager.ts` keeps request/response shaping only. `handlePost` split into `rejectInitialize` (the 400/429/401 decisions, in their original order) and `runInitialize` (the handshake and its failure path); `handleExisting` takes an options object rather than four positional arguments.
- No behavior moves: status codes, header names, JSON payload key order, log event names and their fields, and check ordering are identical. `SessionIdentity` and `SessionTransportConfig` are re-exported from the manager, so no caller import changes.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`./node_modules/.bin/oxlint --deny-warnings server/transport/session-manager.ts server/transport/session-store.ts` -> exit 0 (was 3 findings). `bunx tsc --noEmit` -> exit 0. `bun run test:isolated server/transport/` -> 67 pass, 0 fail across 4 files. `bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 0. All re-run on the committed tree after the pre-commit prettier pass. Python package untouched; no migration, no schema, no MCP tool surface.

## Critical Self-Review

- Highest-risk behavior: session identity binding. `sameIdentity` changed shape, and a false positive there would let one caller's request drive another caller's session. The rewrite adds an explicit `if (!left) return false`, which the old optional-chaining form reached the same way -- `undefined === value` is false for every field, and `tokenClientId` is required on the identity type. Pinned by the 403 assertions in `session-manager.test.ts`.
- Assumptions that could be wrong: that pending-initialize accounting still spans exactly the same window. `beginInitialize` is called at the same point the old `pendingInitializes += 1` was, and `endInitialize` sits in the same `finally`, so admission sees the same values -- but this is accounting a test only observes through `pendingInitializeCount()`, not directly around the throw path.
- Missing/weak tests: no test drives the sweeper's `sweep()` return value directly; it is observed only through the `session_sweeper_result` debug log. Unchanged from before this PR -- the extraction removed no coverage, and adding it is outside a lint sweep.
- Security/permission risk: the identity comparison is the namespace-isolation boundary for a live session. Kept semantically identical and left in one place; a single exported `sameIdentity` is easier to test than the previous module-private function.
- Migration/deploy risk: none. No SQL, no schema, no config key, no environment variable.
- Downstream client/runtime risk: none. `server/transport/index.ts` re-exports the same names, `http-app.ts` imports the same `SessionTransportHandlers` type, and the wire contract (status codes, `Retry-After`, `mcp-session-id`, the 429 body's `session_cap_exceeded` code) is byte-identical.
- Rollback/cleanup concern: revert is a single-commit revert; the new file is additive and has no other importer.
- Fixes made before PR: none needed beyond the refactor itself -- oxlint, tsc, and the pinning tests were green on the first full pass and re-verified after prettier reformatted the staged files.
- Known residual risk: `src/transport.ts` still carries its own inline identity comparison for the legacy Bun transport. Deliberately not touched -- a different file with its own lane, and unifying the two would be a behavior-affecting change rather than a lint fix.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical lint-standard refactor under #780 with no new failure pattern, and the extract-state-to-a-sibling shape is already recorded by the earlier #780 PRs it copies.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, schema, or tool-surface change; the transport's request handling is exercised by the injected-dependency tests in `server/transport/session-manager.test.ts`.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract changed. This is an internal restructuring of one `server/` module; MCP tool schemas and fixtures are untouched.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, protocol, or client-facing surface changed. The only exported symbols that moved are re-exported from their original module, so every existing import path resolves unchanged.
