### PR TITLE
refactor(skill-usage): bring server/tools/skill-usage.ts to the lint standard (#780)

### DIFF
--- a/server/tools/skill-usage.ts
+++ b/server/tools/skill-usage.ts
@@ -71,6 +71,84 @@ export function registerSkillUsageTools(
   registerRecordSkillUsage(server, dependencies);
   registerSkillUsageReport(server, dependencies);
 }
+/** Frozen `record_skill_usage` argument contract: the names and rule values are the API. */
+const recordSkillUsageInputSchema = {
+  skill_slug: z
+    .string()
+    .trim()
+    .min(1)
+    .max(200)
+    .describe("Slug of the skill or canon rule that was invoked"),
+  usage_kind: z
+    .enum(["skill", "canon"])
+    .optional()
+    .describe("Whether a skill or a canon rule was loaded"),
+  agent: z
+    .string()
+    .trim()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe("Agent that invoked it"),
+  repo: z
+    .string()
+    .trim()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Repository the invocation happened in"),
+  session_id: z
+    .string()
+    .trim()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe("Harness session the invocation belongs to"),
+  runtime: z
+    .string()
+    .trim()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("Emitting runtime, e.g. claude-code, codex, pi"),
+  namespace: z
+    .string()
+    .trim()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Namespace the skill entity belongs to"),
+};
+
+/** Frozen `skill_usage_report` argument contract. */
+const skillUsageReportInputSchema = {
+  days: z
+    .number()
+    .int()
+    .min(1)
+    .max(365)
+    .optional()
+    .describe(`Window in days (default ${DEFAULT_REPORT_DAYS})`),
+  usage_kind: z
+    .enum(["skill", "canon"])
+    .optional()
+    .describe("Restrict the report to one kind"),
+};
+
+type RecordSkillUsageArgs = {
+  skill_slug: string;
+  usage_kind?: "skill" | "canon" | undefined;
+  agent?: string | undefined;
+  repo?: string | undefined;
+  session_id?: string | undefined;
+  runtime?: string | undefined;
+  namespace?: string | undefined;
+};
+
+type SkillUsageReportArgs = {
+  days?: number | undefined;
+  usage_kind?: "skill" | "canon" | undefined;
+};
 
 /**
  * Build the namespace-scoped join from the usage log to its owning entity.
@@ -100,6 +178,240 @@ function skillUsageReadScope(
             AND e.archived_at IS NULL${scoped}`;
 }
 
+/**
+ * Seed (or touch) the `ob_entities` row the usage log row points at.
+ *
+ * The entity is seeded on first use rather than requiring a separate seeding
+ * pass: telemetry that silently dropped an invocation because nobody had
+ * registered the skill yet would under-count exactly the new skills whose
+ * adoption Rico most wants to see. `skill.<slug>` matches the scope-key pattern
+ * canon seeding already uses, and the upsert is the `ob_entities` shape from
+ * `repo-facts.ts`.
+ */
+async function seedSkillEntity(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  request: { skillSlug: string; usageKind: string; namespace: string },
+): Promise<string | undefined> {
+  const entityName = `${SKILL_ENTITY_TYPE}.${request.skillSlug}`;
+  const { rows } = await dependencies.pool.query(
+    `INSERT INTO ob_entities
+       (entity_type, name, namespace, metadata, created_by)
+     VALUES ($1, $2, $3, $4::jsonb, $5)
+     ON CONFLICT (namespace, entity_type, lower(name))
+     WHERE archived_at IS NULL
+     DO UPDATE SET updated_at = NOW()
+     RETURNING id`,
+    [
+      SKILL_ENTITY_TYPE,
+      entityName,
+      request.namespace,
+      JSON.stringify({
+        skill_slug: request.skillSlug,
+        usage_kind: request.usageKind,
+      }),
+      identity.clientId,
+    ],
+  );
+  return rows[0]?.id as string | undefined;
+}
+
+/** Append the one usage row and return it as stored. */
+async function appendUsageRow(
+  dependencies: MemoryToolDependencies,
+  entityId: string,
+  args: RecordSkillUsageArgs,
+  usageKind: string,
+): Promise<unknown> {
+  const { rows } = await dependencies.pool.query(
+    `INSERT INTO skill_usage_log
+       (entity_id, skill_slug, agent, repo, session_id, runtime, usage_kind)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     RETURNING id, entity_id, skill_slug, agent, repo, session_id, runtime,
+               usage_kind, invoked_at`,
+    [
+      entityId,
+      args.skill_slug,
+      args.agent ?? null,
+      args.repo ?? null,
+      args.session_id ?? null,
+      args.runtime ?? null,
+      usageKind,
+    ],
+  );
+  return rows[0];
+}
+
+/** Counts per skill x agent x repo x runtime -- the four dimensions #469 names. */
+async function queryUsageCounts(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  args: SkillUsageReportArgs,
+  days: number,
+): Promise<Record<string, unknown>[]> {
+  const values: unknown[] = [];
+  const join = skillUsageReadScope(identity, values);
+  values.push(days);
+  const windowParameter = `$${values.length}`;
+  const kindFilter = args.usage_kind
+    ? ` AND sul.usage_kind = $${values.push(args.usage_kind)}`
+    : "";
+  const { rows } = await dependencies.pool.query(
+    `SELECT sul.skill_slug,
+            sul.usage_kind,
+            sul.agent,
+            sul.repo,
+            sul.runtime,
+            COUNT(*)::int          AS invocations,
+            MAX(sul.invoked_at)    AS last_used_at
+       FROM skill_usage_log sul${join}
+      WHERE sul.invoked_at >= NOW() - (${windowParameter} || ' days')::interval${kindFilter}
+      GROUP BY sul.skill_slug, sul.usage_kind, sul.agent, sul.repo,
+               sul.runtime
+      ORDER BY invocations DESC, sul.skill_slug ASC
+      LIMIT ${REPORT_LIMIT}`,
+    values,
+  );
+  return rows;
+}
+
+/**
+ * The prior window of equal length, so the caller can see the trend as two
+ * counts rather than as a word this tool is not allowed to supply.
+ */
+async function queryPriorWindow(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  args: SkillUsageReportArgs,
+  days: number,
+): Promise<Record<string, number>> {
+  const trendValues: unknown[] = [];
+  const trendJoin = skillUsageReadScope(identity, trendValues);
+  trendValues.push(days);
+  const trendWindow = `$${trendValues.length}`;
+  const trendKindFilter = args.usage_kind
+    ? ` AND sul.usage_kind = $${trendValues.push(args.usage_kind)}`
+    : "";
+  const { rows } = await dependencies.pool.query(
+    `SELECT sul.skill_slug, COUNT(*)::int AS invocations
+       FROM skill_usage_log sul${trendJoin}
+      WHERE sul.invoked_at <  NOW() - (${trendWindow} || ' days')::interval
+        AND sul.invoked_at >= NOW() - (${trendWindow} || ' days')::interval * 2${trendKindFilter}
+      GROUP BY sul.skill_slug`,
+    trendValues,
+  );
+  const priorWindow: Record<string, number> = {};
+  for (const row of rows) {
+    priorWindow[String(row.skill_slug)] = Number(row.invocations);
+  }
+  return priorWindow;
+}
+
+/**
+ * Seeded skills with no invocation inside the window. #469 asks for this list
+ * explicitly, and it is a LIST of names with zero counts -- naming what went
+ * unused is a fact; deciding what to do about it is Rico's.
+ */
+async function queryNeverUsed(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  days: number,
+): Promise<string[]> {
+  const neverValues: unknown[] = [];
+  const neverPredicate = namespacePredicate(
+    identity,
+    "read",
+    neverValues.length + 1,
+  );
+  neverValues.push(...neverPredicate.values);
+  const neverScoped = qualifyNamespacePredicate(
+    neverPredicate,
+    "e.namespace",
+    neverValues.length,
+  );
+  neverValues.push(days);
+  const neverWindow = `$${neverValues.length}`;
+  const { rows } = await dependencies.pool.query(
+    `SELECT e.name
+       FROM ob_entities e
+      WHERE e.entity_type = '${SKILL_ENTITY_TYPE}'
+        AND e.archived_at IS NULL${neverScoped}
+        AND NOT EXISTS (
+              SELECT 1
+                FROM skill_usage_log sul
+               WHERE sul.entity_id = e.id
+                 AND sul.invoked_at >=
+                     NOW() - (${neverWindow} || ' days')::interval
+            )
+      ORDER BY e.name ASC
+      LIMIT ${REPORT_LIMIT}`,
+    neverValues,
+  );
+  return rows.map((row) => String(row.name));
+}
+
+/** Shape one usage row for the response, carrying its prior-window count. */
+function usageEntry(
+  row: Record<string, unknown>,
+  priorWindow: Record<string, number>,
+): Record<string, unknown> {
+  return {
+    skill_slug: String(row.skill_slug),
+    usage_kind: String(row.usage_kind),
+    agent: row.agent === null ? null : String(row.agent),
+    repo: row.repo === null ? null : String(row.repo),
+    runtime: row.runtime === null ? null : String(row.runtime),
+    invocations: Number(row.invocations),
+    last_used_at: row.last_used_at,
+    prior_window_invocations: priorWindow[String(row.skill_slug)] ?? 0,
+  };
+}
+
+/** Record one invocation end to end, once the identity has been authorized. */
+async function recordSkillUsage(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  args: RecordSkillUsageArgs,
+): Promise<{ error: string } | { recorded: true; usage: unknown }> {
+  const namespace = args.namespace ?? identity.clientId;
+  if (!canTargetNamespace(identity, "write", namespace)) {
+    return { error: "Permission denied: namespace write denied" };
+  }
+  const usageKind = args.usage_kind ?? "skill";
+  const entityId = await seedSkillEntity(dependencies, identity, {
+    skillSlug: args.skill_slug,
+    usageKind,
+    namespace,
+  });
+  if (!entityId) {
+    return { error: "Failed to resolve skill entity" };
+  }
+  const usage = await appendUsageRow(dependencies, entityId, args, usageKind);
+  return { recorded: true, usage };
+}
+
+/** Build the whole report, once the identity has been authorized. */
+async function buildSkillUsageReport(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity,
+  args: SkillUsageReportArgs,
+): Promise<Record<string, unknown>> {
+  const days = args.days ?? DEFAULT_REPORT_DAYS;
+  const usage = await queryUsageCounts(dependencies, identity, args, days);
+  const priorWindow = await queryPriorWindow(
+    dependencies,
+    identity,
+    args,
+    days,
+  );
+  const neverUsed = await queryNeverUsed(dependencies, identity, days);
+  return {
+    window_days: days,
+    usage: usage.map((row) => usageEntry(row, priorWindow)),
+    never_used: neverUsed,
+  };
+}
+
 function registerRecordSkillUsage(
   server: McpServer,
   dependencies: MemoryToolDependencies,
@@ -109,110 +421,16 @@ function registerRecordSkillUsage(
     {
       description:
         "Records one skill or canon invocation as a usage metric: which skill, which agent, which repo, which session, and when. Metrics only -- it never categorizes, recommends, rotates, shelves, or retires anything.",
-      inputSchema: {
-        skill_slug: z
-          .string()
-          .trim()
-          .min(1)
-          .max(200)
-          .describe("Slug of the skill or canon rule that was invoked"),
-        usage_kind: z
-          .enum(["skill", "canon"])
-          .optional()
-          .describe("Whether a skill or a canon rule was loaded"),
-        agent: z
-          .string()
-          .trim()
-          .min(1)
-          .max(200)
-          .optional()
-          .describe("Agent that invoked it"),
-        repo: z
-          .string()
-          .trim()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe("Repository the invocation happened in"),
-        session_id: z
-          .string()
-          .trim()
-          .min(1)
-          .max(200)
-          .optional()
-          .describe("Harness session the invocation belongs to"),
-        runtime: z
-          .string()
-          .trim()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe("Emitting runtime, e.g. claude-code, codex, pi"),
-        namespace: z
-          .string()
-          .trim()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe("Namespace the skill entity belongs to"),
-      },
+      inputSchema: recordSkillUsageInputSchema,
     },
     async (args, extra) => {
       const identity = authIdentity(extra.authInfo);
       if (!identity || !canWrite(identity.role, "sessions")) {
         return errorResult("Permission denied: write access required");
       }
-      const namespace = args.namespace ?? identity.clientId;
-      if (!canTargetNamespace(identity, "write", namespace)) {
-        return errorResult("Permission denied: namespace write denied");
-      }
-
-      const usageKind = args.usage_kind ?? "skill";
-      // The entity is seeded on first use rather than requiring a separate
-      // seeding pass: telemetry that silently dropped an invocation because
-      // nobody had registered the skill yet would under-count exactly the new
-      // skills whose adoption Rico most wants to see. `skill.<slug>` matches
-      // the scope-key pattern canon seeding already uses, and the upsert is the
-      // `ob_entities` shape from `repo-facts.ts`.
-      const entityName = `${SKILL_ENTITY_TYPE}.${args.skill_slug}`;
-      const { rows: entityRows } = await dependencies.pool.query(
-        `INSERT INTO ob_entities
-           (entity_type, name, namespace, metadata, created_by)
-         VALUES ($1, $2, $3, $4::jsonb, $5)
-         ON CONFLICT (namespace, entity_type, lower(name))
-         WHERE archived_at IS NULL
-         DO UPDATE SET updated_at = NOW()
-         RETURNING id`,
-        [
-          SKILL_ENTITY_TYPE,
-          entityName,
-          namespace,
-          JSON.stringify({ skill_slug: args.skill_slug, usage_kind: usageKind }),
-          identity.clientId,
-        ],
-      );
-      const entityId = entityRows[0]?.id as string | undefined;
-      if (!entityId) {
-        return errorResult("Failed to resolve skill entity");
-      }
-
-      const { rows } = await dependencies.pool.query(
-        `INSERT INTO skill_usage_log
-           (entity_id, skill_slug, agent, repo, session_id, runtime, usage_kind)
-         VALUES ($1, $2, $3, $4, $5, $6, $7)
-         RETURNING id, entity_id, skill_slug, agent, repo, session_id, runtime,
-                   usage_kind, invoked_at`,
-        [
-          entityId,
-          args.skill_slug,
-          args.agent ?? null,
-          args.repo ?? null,
-          args.session_id ?? null,
-          args.runtime ?? null,
-          usageKind,
-        ],
-      );
-      return textResult({ recorded: true, usage: rows[0] });
+      const outcome = await recordSkillUsage(dependencies, identity, args);
+      if ("error" in outcome) return errorResult(outcome.error);
+      return textResult(outcome);
     },
   );
 }
@@ -226,124 +444,16 @@ function registerSkillUsageReport(
     {
       description:
         "Reports skill and canon invocation counts per skill, agent, repo, and runtime over a window, with last-used timestamps and an explicit never-used list. Facts only -- no categorization, recommendation, rotation, shelving, or retirement.",
-      inputSchema: {
-        days: z
-          .number()
-          .int()
-          .min(1)
-          .max(365)
-          .optional()
-          .describe(`Window in days (default ${DEFAULT_REPORT_DAYS})`),
-        usage_kind: z
-          .enum(["skill", "canon"])
-          .optional()
-          .describe("Restrict the report to one kind"),
-      },
+      inputSchema: skillUsageReportInputSchema,
     },
     async (args, extra) => {
       const identity = authIdentity(extra.authInfo);
       if (!identity || !canRead(identity.role, "sessions")) {
         return errorResult("Permission denied: read access required");
       }
-      const days = args.days ?? DEFAULT_REPORT_DAYS;
-
-      const values: unknown[] = [];
-      const join = skillUsageReadScope(identity, values);
-      values.push(days);
-      const windowParameter = `$${values.length}`;
-      const kindFilter = args.usage_kind
-        ? ` AND sul.usage_kind = $${values.push(args.usage_kind)}`
-        : "";
-
-      // Counts per skill x agent x repo x runtime -- the four dimensions #469
-      // names -- plus the last-used timestamp for each combination.
-      const { rows: usage } = await dependencies.pool.query(
-        `SELECT sul.skill_slug,
-                sul.usage_kind,
-                sul.agent,
-                sul.repo,
-                sul.runtime,
-                COUNT(*)::int          AS invocations,
-                MAX(sul.invoked_at)    AS last_used_at
-           FROM skill_usage_log sul${join}
-          WHERE sul.invoked_at >= NOW() - (${windowParameter} || ' days')::interval${kindFilter}
-          GROUP BY sul.skill_slug, sul.usage_kind, sul.agent, sul.repo,
-                   sul.runtime
-          ORDER BY invocations DESC, sul.skill_slug ASC
-          LIMIT ${REPORT_LIMIT}`,
-        values,
+      return textResult(
+        await buildSkillUsageReport(dependencies, identity, args),
       );
-
-      // The prior window of equal length, so the caller can see the trend as
-      // two counts rather than as a word this tool is not allowed to supply.
-      const trendValues: unknown[] = [];
-      const trendJoin = skillUsageReadScope(identity, trendValues);
-      trendValues.push(days);
-      const trendWindow = `$${trendValues.length}`;
-      const trendKindFilter = args.usage_kind
-        ? ` AND sul.usage_kind = $${trendValues.push(args.usage_kind)}`
-        : "";
-      const { rows: priorRows } = await dependencies.pool.query(
-        `SELECT sul.skill_slug, COUNT(*)::int AS invocations
-           FROM skill_usage_log sul${trendJoin}
-          WHERE sul.invoked_at <  NOW() - (${trendWindow} || ' days')::interval
-            AND sul.invoked_at >= NOW() - (${trendWindow} || ' days')::interval * 2${trendKindFilter}
-          GROUP BY sul.skill_slug`,
-        trendValues,
-      );
-      const priorWindow: Record<string, number> = {};
-      for (const row of priorRows) {
-        priorWindow[String(row.skill_slug)] = Number(row.invocations);
-      }
-
-      // Seeded skills with no invocation inside the window. #469 asks for this
-      // list explicitly, and it is a LIST of names with zero counts -- naming
-      // what went unused is a fact; deciding what to do about it is Rico's.
-      const neverValues: unknown[] = [];
-      const neverPredicate = namespacePredicate(
-        identity,
-        "read",
-        neverValues.length + 1,
-      );
-      neverValues.push(...neverPredicate.values);
-      const neverScoped = qualifyNamespacePredicate(
-        neverPredicate,
-        "e.namespace",
-        neverValues.length,
-      );
-      neverValues.push(days);
-      const neverWindow = `$${neverValues.length}`;
-      const { rows: neverUsed } = await dependencies.pool.query(
-        `SELECT e.name
-           FROM ob_entities e
-          WHERE e.entity_type = '${SKILL_ENTITY_TYPE}'
-            AND e.archived_at IS NULL${neverScoped}
-            AND NOT EXISTS (
-                  SELECT 1
-                    FROM skill_usage_log sul
-                   WHERE sul.entity_id = e.id
-                     AND sul.invoked_at >=
-                         NOW() - (${neverWindow} || ' days')::interval
-                )
-          ORDER BY e.name ASC
-          LIMIT ${REPORT_LIMIT}`,
-        neverValues,
-      );
-
-      return textResult({
-        window_days: days,
-        usage: usage.map((row) => ({
-          skill_slug: String(row.skill_slug),
-          usage_kind: String(row.usage_kind),
-          agent: row.agent === null ? null : String(row.agent),
-          repo: row.repo === null ? null : String(row.repo),
-          runtime: row.runtime === null ? null : String(row.runtime),
-          invocations: Number(row.invocations),
-          last_used_at: row.last_used_at,
-          prior_window_invocations: priorWindow[String(row.skill_slug)] ?? 0,
-        })),
-        never_used: neverUsed.map((row) => String(row.name)),
-      });
     },
   );
 }


### PR DESCRIPTION
## Summary

- `server/tools/skill-usage.ts` carried three oxlint findings: `registerRecordSkillUsage` at 108 lines, `registerSkillUsageReport` at 118, and the record handler at a complexity of 12. Each registration function held its whole tool inline — argument schema, auth check, every query, and response shaping.
- Split along the seams the module already had, following `resolve-entry.ts`, `search-all.ts`, and `entities.ts` in main: both argument schemas hoisted to module-level constants; the record path split into `seedSkillEntity`, `appendUsageRow`, and `recordSkillUsage`; the report path split into `queryUsageCounts`, `queryPriorWindow`, `queryNeverUsed`, `usageEntry`, and `buildSkillUsageReport` — one helper per query it already ran.
- Each registered handler is now the auth check and a dispatch. Helpers carrying more than a few values take an options object, so no signature exceeds four parameters.
- No behavior moves: schemas, defaults, SQL text, parameter ordering, error strings, and response field order are identical to what they replaced. `skillUsageReadScope` — the namespace join that carries the isolation boundary — is untouched.
- One file changed. No other file was edited, and no helper was moved out of the target.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Red first, on the untouched file: `oxlint --deny-warnings server/tools/skill-usage.ts` reported the three findings above; `DONE_MEANS_780_FILES=server/tools/skill-usage.ts bash scripts/done-means/780-touched-files-lint-clean.sh` exited 1.

Green, re-run on the COMMITTED tree after the pre-commit prettier hook reformatted the staged file:

- `./node_modules/.bin/oxlint --deny-warnings server/tools/skill-usage.ts` → exit 0
- `bunx tsc --noEmit` → exit 0
- `bun run test:isolated server/tools/` → 163 pass, 0 fail across 17 files
- `bun run test:isolated server/tools/skill-usage.pg.test.ts server/contracts/declaration.test.ts` → 20 pass, 0 fail (the pinning tests for this file)
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived) → exit 0

Python package checks are not applicable: nothing under `python/openbrain-memory/` is touched. Live smoke is not applicable: this is an internal refactor with no contract, schema, or wire-format change.

## Critical Self-Review

- Highest-risk behavior: the namespace-scoped join in `skillUsageReadScope`, which is what keeps one tenant's usage profile — which skills they run and how often — invisible to another. It is the one function carried across unchanged, byte for byte, and `skill-usage.pg.test.ts` asserts a second namespace's rows stay invisible.
- Assumptions that could be wrong: that splitting the report into three helpers preserves query ordering. It does — `buildSkillUsageReport` awaits them in the original sequence, and each helper builds its own parameter array exactly as the inline code did, so no parameter index is shared across queries.
- Missing/weak tests: the report path has no test asserting the response field ORDER, so a reordering would pass. I kept the order identical by construction rather than relying on a test to catch it. Adding that assertion is a test-only change and belongs to whoever owns the pinning tests, not to a lint lane.
- Security/permission risk: none introduced. Both auth checks (`canWrite(identity.role, "sessions")`, `canRead(...)`) stay in the registered handlers and run before any helper is reached; `canTargetNamespace` still gates the write path inside `recordSkillUsage`. No predicate, join, or role check changed.
- Migration/deploy risk: none. No migration, no schema change, no config.
- Downstream client/runtime risk: none. Per `docs/downstream-rollout.md` this is not a contract-changing MCP, transport, or Python-client change — tool names, descriptions, input schemas, and response shapes are unchanged, which the contract declaration tests confirm.
- Rollback/cleanup concern: single-commit, single-file, revertible with no coordination.
- Fixes made before PR: none needed beyond the refactor; the first oxlint run after the split was clean.
- Known residual risk: low. The refactor is mechanical, but "no behavior change" here rests on reading the SQL strings as identical rather than on a test that would fail if a WHERE clause drifted. The pg tests exercise both tools end to end against a real database, which is the strongest available check.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical lint refactor with no review finding behind it — no new failure pattern was discovered, so an SME entry would add noise to a knowledge base whose value depends on every entry being a real caught defect.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no contract, schema, or wire-format change reaches a live client.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface moved. Tool names, descriptions, and input schemas are unchanged — the schemas were hoisted to constants, not rewritten — so the existing fixtures still match, and `server/contracts/declaration.test.ts` passes unmodified.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All four are not applicable. `docs/downstream-rollout.md` scopes rollout to MCP tool, schema, protocol, and client-facing changes; this changes none of them. The two tools keep their names, descriptions, input schemas, and response shapes, and `server/contracts/declaration.test.ts` passes unmodified — which is the check that would fail if a client-facing surface had moved.
