### PR TITLE
refactor(citation-recall): bring server/tools/citation-recall.ts to the lint standard (#780)

### DIFF
--- a/server/tools/citation-recall.ts
+++ b/server/tools/citation-recall.ts
@@ -74,10 +74,16 @@ const SAFE_DB_ERROR_NAMES = new Set(["Error", "PostgresError"]);
 function safeErrorLabel(error: unknown): string {
   if (!error || typeof error !== "object") return "unknown";
   const candidate = error as { code?: unknown; name?: unknown };
-  if (typeof candidate.code === "string" && SAFE_DB_ERROR_CODES.has(candidate.code)) {
+  if (
+    typeof candidate.code === "string" &&
+    SAFE_DB_ERROR_CODES.has(candidate.code)
+  ) {
     return candidate.code;
   }
-  if (typeof candidate.name === "string" && SAFE_DB_ERROR_NAMES.has(candidate.name)) {
+  if (
+    typeof candidate.name === "string" &&
+    SAFE_DB_ERROR_NAMES.has(candidate.name)
+  ) {
     return candidate.name;
   }
   return "unknown";
@@ -104,6 +110,275 @@ function transcriptProjection(row: CitationEventRow, maxChars: number) {
   };
 }
 
+const CITATION_RECALL_DESCRIPTION =
+  "Return citation evidence for one readable session event. Stored citations include a host-neutral conversation ref, speaker, date, optional transcript, and bounded neighboring exchanges; legacy events explicitly report source_not_stored.";
+
+/** Frozen `citation_recall` argument contract: the names and rule values are the API. */
+const citationRecallInputSchema = {
+  event_id: z.string().uuid().describe("Session event UUID to cite"),
+  namespace: z
+    .string()
+    .max(500)
+    .optional()
+    .describe("Namespace for isolation (defaults to agent's clientId)"),
+  context_limit: z
+    .number()
+    .int()
+    .min(0)
+    .max(10)
+    .optional()
+    .describe(
+      `Neighboring transcript exchanges to return on each side (default ${DEFAULT_CONTEXT_EXCHANGES})`,
+    ),
+  max_transcript_chars: z
+    .number()
+    .int()
+    .min(100)
+    .max(50_000)
+    .optional()
+    .describe(
+      `Maximum characters for each returned transcript exchange (default ${DEFAULT_TRANSCRIPT_CHARS})`,
+    ),
+};
+
+/** Tool annotations; `citation_recall` reads and never mutates. */
+const citationRecallAnnotations = {
+  title: "Citation Recall",
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+/** One authorized recall: namespace already cleared, defaults already applied. */
+interface CitationRequest {
+  namespace: string;
+  eventId: string;
+  contextLimit: number;
+  maxChars: number;
+}
+
+/**
+ * Fetch the cited event under lane-derived namespace scope.
+ *
+ * The lane join IS the isolation predicate: `l.namespace = $1` is what stops an
+ * event UUID from another lane resolving here.
+ *
+ * @returns The event, or `undefined` when no readable row carries that id.
+ */
+async function fetchCitedEvent(
+  dependencies: MemoryToolDependencies,
+  request: CitationRequest,
+): Promise<CitationEventRow | undefined> {
+  const { rows } = await dependencies.pool.query<CitationEventRow>(
+    `SELECT ${TARGET_EVENT_COLUMNS}, e.lane_id, l.session_key
+             FROM ob_session_events e
+             JOIN ob_session_lanes l ON l.id = e.lane_id
+            WHERE l.namespace = $1 AND e.id = $2`,
+    [request.namespace, request.eventId],
+  );
+  return rows[0];
+}
+
+/** Both neighbor queries, each carrying one extra row purely as a "more exists" probe. */
+interface NeighborRows {
+  before: CitationEventRow[];
+  after: CitationEventRow[];
+}
+
+/**
+ * Read the exchanges either side of the cited event within its transcript.
+ *
+ * One extra row is fetched on each side purely to learn whether MORE exists; it
+ * is dropped before projection and only sets `expandable`.
+ */
+async function fetchNeighbors(
+  dependencies: MemoryToolDependencies,
+  event: CitationEventRow,
+  contextLimit: number,
+): Promise<NeighborRows> {
+  const contextValues = [
+    event.lane_id,
+    event.transcript_ref,
+    event.id,
+    contextLimit + 1,
+  ];
+  const ascending =
+    "COALESCE(candidate.occurred_at, candidate.created_at), candidate.created_at, candidate.id";
+  const descending =
+    "COALESCE(candidate.occurred_at, candidate.created_at) DESC, " +
+    "candidate.created_at DESC, candidate.id DESC";
+  // Ordering by the row tuple rather than the timestamp alone keeps
+  // same-instant events in one stable order, so `before` and `after`
+  // cannot both claim the same neighbor.
+  const contextSource = `FROM ob_session_events candidate
+             JOIN ob_session_events target ON target.id = $3::uuid
+            WHERE candidate.lane_id = $1
+              AND candidate.transcript_ref = $2
+              AND candidate.transcript IS NOT NULL`;
+
+  const [beforeResult, afterResult] = await Promise.all([
+    dependencies.pool.query<CitationEventRow>(
+      `SELECT ${CANDIDATE_EVENT_COLUMNS}
+             ${contextSource}
+              AND (${ascending}) < (
+                COALESCE(target.occurred_at, target.created_at), target.created_at, target.id
+              )
+            ORDER BY ${descending}
+            LIMIT $4`,
+      contextValues,
+    ),
+    dependencies.pool.query<CitationEventRow>(
+      `SELECT ${CANDIDATE_EVENT_COLUMNS}
+             ${contextSource}
+              AND (${ascending}) > (
+                COALESCE(target.occurred_at, target.created_at), target.created_at, target.id
+              )
+            ORDER BY ${ascending} ASC
+            LIMIT $4`,
+      contextValues,
+    ),
+  ]);
+
+  return { before: beforeResult.rows, after: afterResult.rows };
+}
+
+/**
+ * The answer for an event captured before transcripts were stored.
+ *
+ * A legacy event predates transcript storage. Saying so explicitly is the
+ * contract: an empty citation would read as "no source exists".
+ */
+function sourceNotStoredResult(
+  dependencies: MemoryToolDependencies,
+  event: CitationEventRow,
+) {
+  dependencies.logger.info(
+    {
+      tool: "citation_recall",
+      eventId: event.id,
+      citation: "source_not_stored",
+    },
+    "tool_result",
+  );
+  return textResult({
+    event_id: event.id,
+    fact: event.content,
+    citation: {
+      status: "source_not_stored",
+      conversation_ref: null,
+      date: null,
+      speaker: null,
+      transcript: null,
+    },
+    context: { before: [], after: [], expandable: false },
+  });
+}
+
+/** Everything that can leave more behind than one call returned. */
+interface ExpandableInputs {
+  transcriptTruncated: boolean;
+  projected: { transcript_truncated: boolean }[];
+  neighbors: NeighborRows;
+  contextLimit: number;
+}
+
+/**
+ * @returns `true` when anything was held back for any reason, so one flag tells
+ * a caller whether a wider call would return more.
+ */
+function isExpandable(inputs: ExpandableInputs): boolean {
+  const { neighbors, contextLimit } = inputs;
+  return (
+    inputs.transcriptTruncated ||
+    inputs.projected.some((row) => row.transcript_truncated) ||
+    neighbors.before.length > contextLimit ||
+    neighbors.after.length > contextLimit
+  );
+}
+
+/** Shape the stored-citation payload from the event and its projected neighbors. */
+function storedCitationResult(
+  dependencies: MemoryToolDependencies,
+  event: CitationEventRow,
+  neighbors: NeighborRows,
+  request: CitationRequest,
+) {
+  const { contextLimit, maxChars } = request;
+  const before = neighbors.before
+    .slice(0, contextLimit)
+    .reverse()
+    .map((row) => transcriptProjection(row, maxChars));
+  const after = neighbors.after
+    .slice(0, contextLimit)
+    .map((row) => transcriptProjection(row, maxChars));
+  const transcriptTruncated = (event.transcript?.length ?? 0) > maxChars;
+
+  dependencies.logger.info(
+    {
+      tool: "citation_recall",
+      eventId: event.id,
+      contextBefore: before.length,
+      contextAfter: after.length,
+    },
+    "tool_result",
+  );
+  return textResult({
+    event_id: event.id,
+    fact: event.content,
+    citation: {
+      status: "stored",
+      conversation_ref: event.transcript_ref,
+      speaker: event.source ?? event.created_by,
+      date: iso(event.occurred_at) ?? iso(event.created_at),
+      transcript: event.transcript?.slice(0, maxChars) ?? null,
+      transcript_length: event.transcript?.length ?? 0,
+      transcript_truncated: transcriptTruncated,
+    },
+    context: {
+      before,
+      after,
+      expandable: isExpandable({
+        transcriptTruncated,
+        projected: [...before, ...after],
+        neighbors,
+        contextLimit,
+      }),
+    },
+  });
+}
+
+/** Resolve one authorized recall end to end: event, then neighbors, then payload. */
+async function recallCitation(
+  dependencies: MemoryToolDependencies,
+  request: CitationRequest,
+) {
+  try {
+    const event = await fetchCitedEvent(dependencies, request);
+    if (!event) return errorResult("Citation event not found");
+
+    if (!event.transcript_ref) {
+      return sourceNotStoredResult(dependencies, event);
+    }
+
+    const neighbors = await fetchNeighbors(
+      dependencies,
+      event,
+      request.contextLimit,
+    );
+    return storedCitationResult(dependencies, event, neighbors, request);
+  } catch (error) {
+    dependencies.logger.error(
+      {
+        tool: "citation_recall",
+        eventId: request.eventId,
+        errorLabel: safeErrorLabel(error),
+      },
+      "citation_recall_db_error",
+    );
+    return errorResult("Database error during citation recall");
+  }
+}
+
 export function registerCitationRecallTool(
   server: McpServer,
   dependencies: MemoryToolDependencies,
@@ -111,40 +386,9 @@ export function registerCitationRecallTool(
   server.registerTool(
     "citation_recall",
     {
-      description:
-        "Return citation evidence for one readable session event. Stored citations include a host-neutral conversation ref, speaker, date, optional transcript, and bounded neighboring exchanges; legacy events explicitly report source_not_stored.",
-      inputSchema: {
-        event_id: z.string().uuid().describe("Session event UUID to cite"),
-        namespace: z
-          .string()
-          .max(500)
-          .optional()
-          .describe("Namespace for isolation (defaults to agent's clientId)"),
-        context_limit: z
-          .number()
-          .int()
-          .min(0)
-          .max(10)
-          .optional()
-          .describe(
-            `Neighboring transcript exchanges to return on each side (default ${DEFAULT_CONTEXT_EXCHANGES})`,
-          ),
-        max_transcript_chars: z
-          .number()
-          .int()
-          .min(100)
-          .max(50_000)
-          .optional()
-          .describe(
-            `Maximum characters for each returned transcript exchange (default ${DEFAULT_TRANSCRIPT_CHARS})`,
-          ),
-      },
-      annotations: {
-        title: "Citation Recall",
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      description: CITATION_RECALL_DESCRIPTION,
+      inputSchema: citationRecallInputSchema,
+      annotations: citationRecallAnnotations,
     },
     async (args, extra) => {
       const identity = authIdentity(extra.authInfo);
@@ -163,142 +407,12 @@ export function registerCitationRecallTool(
         );
       }
 
-      const contextLimit = args.context_limit ?? DEFAULT_CONTEXT_EXCHANGES;
-      const maxChars = args.max_transcript_chars ?? DEFAULT_TRANSCRIPT_CHARS;
-
-      try {
-        // The lane join IS the isolation predicate: `l.namespace = $1` is what
-        // stops an event UUID from another lane resolving here.
-        const { rows } = await dependencies.pool.query<CitationEventRow>(
-          `SELECT ${TARGET_EVENT_COLUMNS}, e.lane_id, l.session_key
-             FROM ob_session_events e
-             JOIN ob_session_lanes l ON l.id = e.lane_id
-            WHERE l.namespace = $1 AND e.id = $2`,
-          [namespace, args.event_id],
-        );
-        const event = rows[0];
-        if (!event) return errorResult("Citation event not found");
-
-        // A legacy event predates transcript storage. Saying so explicitly is
-        // the contract: an empty citation would read as "no source exists".
-        if (!event.transcript_ref) {
-          dependencies.logger.info(
-            { tool: "citation_recall", eventId: event.id, citation: "source_not_stored" },
-            "tool_result",
-          );
-          return textResult({
-            event_id: event.id,
-            fact: event.content,
-            citation: {
-              status: "source_not_stored",
-              conversation_ref: null,
-              date: null,
-              speaker: null,
-              transcript: null,
-            },
-            context: { before: [], after: [], expandable: false },
-          });
-        }
-
-        // One extra row is fetched on each side purely to learn whether MORE
-        // exists; it is dropped before projection and only sets `expandable`.
-        const contextValues = [
-          event.lane_id,
-          event.transcript_ref,
-          event.id,
-          contextLimit + 1,
-        ];
-        const ascending =
-          "COALESCE(candidate.occurred_at, candidate.created_at), candidate.created_at, candidate.id";
-        const descending =
-          "COALESCE(candidate.occurred_at, candidate.created_at) DESC, " +
-          "candidate.created_at DESC, candidate.id DESC";
-        // Ordering by the row tuple rather than the timestamp alone keeps
-        // same-instant events in one stable order, so `before` and `after`
-        // cannot both claim the same neighbor.
-        const contextSource = `FROM ob_session_events candidate
-             JOIN ob_session_events target ON target.id = $3::uuid
-            WHERE candidate.lane_id = $1
-              AND candidate.transcript_ref = $2
-              AND candidate.transcript IS NOT NULL`;
-
-        const [beforeResult, afterResult] = await Promise.all([
-          dependencies.pool.query<CitationEventRow>(
-            `SELECT ${CANDIDATE_EVENT_COLUMNS}
-             ${contextSource}
-              AND (${ascending}) < (
-                COALESCE(target.occurred_at, target.created_at), target.created_at, target.id
-              )
-            ORDER BY ${descending}
-            LIMIT $4`,
-            contextValues,
-          ),
-          dependencies.pool.query<CitationEventRow>(
-            `SELECT ${CANDIDATE_EVENT_COLUMNS}
-             ${contextSource}
-              AND (${ascending}) > (
-                COALESCE(target.occurred_at, target.created_at), target.created_at, target.id
-              )
-            ORDER BY ${ascending} ASC
-            LIMIT $4`,
-            contextValues,
-          ),
-        ]);
-
-        const before = beforeResult.rows
-          .slice(0, contextLimit)
-          .reverse()
-          .map((row) => transcriptProjection(row, maxChars));
-        const after = afterResult.rows
-          .slice(0, contextLimit)
-          .map((row) => transcriptProjection(row, maxChars));
-        const transcriptTruncated = (event.transcript?.length ?? 0) > maxChars;
-
-        dependencies.logger.info(
-          {
-            tool: "citation_recall",
-            eventId: event.id,
-            contextBefore: before.length,
-            contextAfter: after.length,
-          },
-          "tool_result",
-        );
-        return textResult({
-          event_id: event.id,
-          fact: event.content,
-          citation: {
-            status: "stored",
-            conversation_ref: event.transcript_ref,
-            speaker: event.source ?? event.created_by,
-            date: iso(event.occurred_at) ?? iso(event.created_at),
-            transcript: event.transcript?.slice(0, maxChars) ?? null,
-            transcript_length: event.transcript?.length ?? 0,
-            transcript_truncated: transcriptTruncated,
-          },
-          context: {
-            before,
-            after,
-            // `expandable` is TRUE when anything was held back for any reason,
-            // so one flag tells a caller whether a wider call would return more.
-            expandable:
-              transcriptTruncated ||
-              before.some((row) => row.transcript_truncated) ||
-              after.some((row) => row.transcript_truncated) ||
-              beforeResult.rows.length > contextLimit ||
-              afterResult.rows.length > contextLimit,
-          },
-        });
-      } catch (error) {
-        dependencies.logger.error(
-          {
-            tool: "citation_recall",
-            eventId: args.event_id,
-            errorLabel: safeErrorLabel(error),
-          },
-          "citation_recall_db_error",
-        );
-        return errorResult("Database error during citation recall");
-      }
+      return await recallCitation(dependencies, {
+        namespace,
+        eventId: args.event_id,
+        contextLimit: args.context_limit ?? DEFAULT_CONTEXT_EXCHANGES,
+        maxChars: args.max_transcript_chars ?? DEFAULT_TRANSCRIPT_CHARS,
+      });
     },
   );
 }


### PR DESCRIPTION
## Summary

- `server/tools/citation-recall.ts` carried the whole tool inside its registration function: schema, annotations, both SQL reads, two payload shapes, and the error path inline. oxlint reported three findings — `registerCitationRecallTool` at 179 lines, and its handler at complexity 24 and 135 lines.
- Split along the seams the code already had, following the pattern `server/tools/resolve-entry.ts` landed in #804: the description, input schema, and annotations are hoisted to module level (they are the frozen wire contract, so naming them separates the API from the code serving it); `recallCitation` owns one authorized request end to end and keeps the single try/catch; `fetchCitedEvent` and `fetchNeighbors` hold the two reads; `sourceNotStoredResult` and `storedCitationResult` shape the two payloads; `isExpandable` takes the held-back decision that carried the remaining complexity.
- `registerCitationRecallTool` is now only auth, namespace resolution, and defaults. A four-field `CitationRequest` options object carries the request instead of a parameter list.
- No behavior change: identical schemas, defaults, SQL text, error strings, log event names, and response field ordering. The lane join is still the isolation predicate and the comment explaining it moved with the query.
- No lint-disable comments were added. No other existing file was modified; no helper was moved out.

**Reported, not fixed:** `src/tools/citation-recall.ts` is a near-duplicate twin of this file — the SQL, the projection helper, `iso`, the default values, and the error-label allowlist are the same logic in both trees, differing only in the auth and dependency imports (`../permissions.ts` + `ToolDeps` vs `../auth/permissions.ts` + `MemoryToolDependencies`). Unifying them means moving a shared sibling across the `src/`/`server/` boundary and changing an exported signature, which is behavior-adjacent and belongs to its own lane. This lane did not edit `src/`.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Run on the committed tree, after the pre-commit prettier hook reformatted the staged file:

- `./node_modules/.bin/oxlint --deny-warnings server/tools/citation-recall.ts` -> exit 0 (was 3 findings)
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated server/contracts/declaration.test.ts server/tools/` -> 174 pass, 0 fail, 18 files
- `bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 0 (diff-derived, 1 file)

Python package is untouched; this is a TypeScript-only refactor with no wire-contract change, so no live smoke applies.

## Critical Self-Review

- Highest-risk behavior: the `expandable` flag. Its predicate moved into `isExpandable`, and the two `.some()` calls over `before` and `after` became one `.some()` over the concatenation. That is the same result for every input — a disjunction over two arrays equals the disjunction over their concatenation — but it is the one place where the shape of the expression changed rather than just its location.
- Assumptions that could be wrong: that `server/contracts/declaration.test.ts` and `server/tools/ported-tools-scope.test.ts` are the real pinning tests for this tool. I found them by `rg -l "citation_recall|citation-recall" server/ --type ts`; if coverage of this tool lives only in `src/tools/__tests__/citation-recall.test.ts`, then the server twin's response shape is pinned less tightly than the file count suggests.
- Missing/weak tests: no test was added. This is a no-behavior-change refactor and existing tests were deliberately left unmodified, so the safety argument rests on those tests plus the field-by-field diff, not on new coverage. The extracted helpers have no direct unit tests of their own.
- Security/permission risk: low, and deliberately preserved. The auth gate (`canRead(identity.role, "sessions")`) and the namespace gate (`canTargetNamespace`) both stayed in the registration function ahead of the call into `recallCitation`, so an unauthorized request still cannot reach a query. The lane-join predicate `l.namespace = $1` moved verbatim into `fetchCitedEvent` and is still the only thing stopping an event UUID from another lane resolving.
- Migration/deploy risk: none. No schema, no migration, no config.
- Downstream client/runtime risk: none intended. The tool name, description, input schema, annotations, and response JSON are byte-identical, so no rtech-mcps, mcp2cli, or Hermes surface sees a change. Per `docs/downstream-rollout.md` this is not a contract-changing edit.
- Rollback/cleanup concern: none. Single file, single commit, revertable on its own.
- Known residual risk: the `src/` twin stays duplicated, so a future fix to this tool's SQL or projection must be applied in two places until that is unified. That is called out above as a finding rather than silently left.
- Fixes made before PR: the first pass left `storedCitationResult` at complexity 13; rather than shrink it cosmetically I extracted the `expandable` decision into `isExpandable`, which is the thing that actually carried the branches.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no new review finding — it applied an existing repo pattern (`resolve-entry.ts`) to a second file, and the duplication it surfaced is reported in this PR for its own lane rather than being a missed-review pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no wire contract, schema, or runtime surface changed; the tool's registered shape is identical.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: nothing in the declared contract moved. `server/contracts/declaration.test.ts` passes unmodified, which is the check that the registered tool shape still matches the declaration.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: `docs/downstream-rollout.md` scopes rollout to MCP tool, schema, protocol, and client-facing changes. This edit changes none of them — the tool name, description, input schema, annotations, and response payload are unchanged, verified field by field against the pre-refactor file.
