### PR TITLE
refactor(conversation-facts-contract): bring server/tools/conversation-facts-contract.ts to the lint standard (#780)

### DIFF
--- a/server/tools/conversation-facts-contract.ts
+++ b/server/tools/conversation-facts-contract.ts
@@ -24,8 +24,13 @@ import { z } from "zod";
  * contract ingests statements a caller decided are durable, not the traffic
  * they were derived from.
  */
-export const CONVERSATION_FACT_EVENT_TYPES = ["fact", "decision", "receipt"] as const;
-export type ConversationFactEventType = (typeof CONVERSATION_FACT_EVENT_TYPES)[number];
+export const CONVERSATION_FACT_EVENT_TYPES = [
+  "fact",
+  "decision",
+  "receipt",
+] as const;
+export type ConversationFactEventType =
+  (typeof CONVERSATION_FACT_EVENT_TYPES)[number];
 
 /**
  * Keys whose PRESENCE anywhere in a request means a raw conversation body was
@@ -177,7 +182,9 @@ export function findRawTranscriptKey(value: unknown): string | null {
     return null;
   }
   if (value && typeof value === "object") {
-    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    for (const [key, child] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
       if (RAW_TRANSCRIPT_KEYS.has(key.toLowerCase())) return key;
       const hit = findRawTranscriptKey(child);
       if (hit) return hit;
@@ -194,10 +201,7 @@ export function findRawTranscriptKey(value: unknown): string | null {
  * indistinguishable from having stored it, and only one of those is true.
  */
 export type UnitDisposition =
-  | "stored"
-  | "duplicate"
-  | "duplicate_evidence_merged"
-  | "evidence_not_stored";
+  "stored" | "duplicate" | "duplicate_evidence_merged" | "evidence_not_stored";
 
 /**
  * Structural evidence entries retained per duplicated durable row.
@@ -226,6 +230,70 @@ function evidenceKey(
   locator: string | undefined,
 ): string {
   return JSON.stringify([eventType ?? null, locator ?? null]);
+}
+
+/** @returns The value at `key` when it is a string, else `undefined`. */
+function stringField(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+/** @returns The row's `metadata` object, or an empty one when it is absent. */
+function rowMetadata(row: Record<string, unknown>): Record<string, unknown> {
+  return row.metadata && typeof row.metadata === "object"
+    ? (row.metadata as Record<string, unknown>)
+    : {};
+}
+
+/**
+ * The structural evidence already merged onto a stored row.
+ *
+ * Read separately from the primary write's own `(event_type, source_locator)`,
+ * because only this list grows and only its length is compared against
+ * `RETAINED_EVIDENCE_ENTRIES`.
+ *
+ * @returns The stored `metadata.additional_evidence` entries, or an empty list.
+ */
+function additionalEvidence(
+  metadata: Record<string, unknown>,
+): Array<Record<string, unknown>> {
+  return Array.isArray(metadata.additional_evidence)
+    ? (metadata.additional_evidence as Array<Record<string, unknown>>)
+    : [];
+}
+
+/**
+ * Every evidence identity the stored row already asserts.
+ *
+ * That is the primary write's own event type and locator, plus each entry
+ * merged onto it since. A candidate whose key is in here adds no new provenance
+ * and is a plain duplicate.
+ *
+ * @returns The set of `evidenceKey` values already present on the row.
+ */
+function knownEvidenceKeys(
+  row: Record<string, unknown>,
+  metadata: Record<string, unknown>,
+  existingEvidence: ReadonlyArray<Record<string, unknown>>,
+): Set<string> {
+  const known = new Set<string>([
+    evidenceKey(
+      stringField(row, "event_type"),
+      stringField(metadata, "source_locator"),
+    ),
+  ]);
+  for (const entry of existingEvidence) {
+    known.add(
+      evidenceKey(
+        stringField(entry, "event_type"),
+        stringField(entry, "source_locator"),
+      ),
+    );
+  }
+  return known;
 }
 
 /**
@@ -267,10 +335,7 @@ export async function mergeDuplicateEvidence(
   }
 
   const eventId = String(row.id);
-  const metadata =
-    row.metadata && typeof row.metadata === "object"
-      ? (row.metadata as Record<string, unknown>)
-      : {};
+  const metadata = rowMetadata(row);
   const candidate = {
     event_type: fact.event_type,
     ...(fact.source_locator !== undefined
@@ -278,25 +343,8 @@ export async function mergeDuplicateEvidence(
       : {}),
   };
 
-  // What the row already asserts: the primary write's own event type and
-  // locator, plus anything merged onto it since.
-  const existingEvidence = Array.isArray(metadata.additional_evidence)
-    ? (metadata.additional_evidence as Array<Record<string, unknown>>)
-    : [];
-  const known = new Set<string>([
-    evidenceKey(
-      typeof row.event_type === "string" ? row.event_type : undefined,
-      typeof metadata.source_locator === "string" ? metadata.source_locator : undefined,
-    ),
-  ]);
-  for (const entry of existingEvidence) {
-    known.add(
-      evidenceKey(
-        typeof entry.event_type === "string" ? entry.event_type : undefined,
-        typeof entry.source_locator === "string" ? entry.source_locator : undefined,
-      ),
-    );
-  }
+  const existingEvidence = additionalEvidence(metadata);
+  const known = knownEvidenceKeys(row, metadata, existingEvidence);
 
   if (known.has(evidenceKey(candidate.event_type, candidate.source_locator))) {
     return { eventId, kind: "duplicate" };
@@ -345,6 +393,24 @@ const SAFE_DB_ERROR_CLASSES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * The recognized SQLSTATE classes, keyed by the two-character CLASS.
+ *
+ * A finite table rather than a chain of branches: the mapping is data, and one
+ * unrecognized class is an absent key rather than a fallthrough to reason about.
+ * Every value here is also a member of `SAFE_DB_ERROR_CLASSES`.
+ */
+const SQLSTATE_CLASS_LABELS: Readonly<Record<string, string>> = {
+  "08": "connection_error",
+  "22": "data_exception",
+  "23": "integrity_constraint_violation",
+  "40": "transaction_rollback",
+  "42": "syntax_or_access_error",
+  "53": "insufficient_resources",
+  "57": "operator_intervention",
+  "58": "system_error",
+};
+
+/**
  * Map a SQLSTATE to a content-free class label.
  *
  * Only the two-character CLASS is used, never the full code, so no per-row
@@ -352,26 +418,7 @@ const SAFE_DB_ERROR_CLASSES: ReadonlySet<string> = new Set([
  */
 function sqlstateClass(code: unknown): string | null {
   if (typeof code !== "string" || code.length < 2) return null;
-  switch (code.slice(0, 2)) {
-    case "08":
-      return "connection_error";
-    case "53":
-      return "insufficient_resources";
-    case "57":
-      return "operator_intervention";
-    case "58":
-      return "system_error";
-    case "23":
-      return "integrity_constraint_violation";
-    case "40":
-      return "transaction_rollback";
-    case "22":
-      return "data_exception";
-    case "42":
-      return "syntax_or_access_error";
-    default:
-      return null;
-  }
+  return SQLSTATE_CLASS_LABELS[code.slice(0, 2)] ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Two functions in `server/tools/conversation-facts-contract.ts` were over the repo complexity standard: `mergeDuplicateEvidence` at 13 and `sqlstateClass` at 11. Both are now under it with no behavior change -- schemas, defaults, error strings, SQL, dispositions, and the retained-entries comparison are byte-identical in effect.
- `sqlstateClass` was an eight-arm switch over the two-character SQLSTATE class. The mapping is data, so it is now a frozen lookup table with the same eight classes and the same eight labels; an unrecognized class is an absent key rather than a fallthrough arm and still yields `null`. Complexity 11 -> 2.
- `mergeDuplicateEvidence` carried its branching inline as repeated `typeof x === "string" ? x : undefined` guards plus two shape reads. Those are now four named module-level helpers -- `stringField`, `rowMetadata`, `additionalEvidence`, `knownEvidenceKeys` -- leaving the merge body as the sequence of decisions its doc comment describes. The `FOR UPDATE` lock and all four dispositions are untouched. Complexity 13 -> under 10.
- No shared helper was moved or created outside the target file, and no exported signature changed. `src/source-sync.ts` already holds a table-shaped SQLSTATE classifier and was deliberately NOT reused: its labels differ (`connection_exception` vs `connection_error`, `syntax_or_access_rule_violation` vs `syntax_or_access_error`), so sharing it would change the strings this contract publishes to callers.
- One file touched, one importer (`server/tools/ingest-conversation-facts.ts`), unchanged. No test file was modified.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Red first, on the untouched file: `oxlint --deny-warnings server/tools/conversation-facts-contract.ts` reported `mergeDuplicateEvidence has a complexity of 13. Maximum allowed is 10.` and `sqlstateClass has a complexity of 11. Maximum allowed is 10.`, and the done-means check exited 1.

Green, re-run on the COMMITTED tree after the pre-commit prettier hook reformatted the file: oxlint exit 0; `bunx tsc --noEmit` exit 0; `bun run test:isolated src/tools/__tests__/ingest-conversation-facts.test.ts src/tools/__tests__/ingest-conversation-facts.pg.test.ts server/tools/` -> 188 pass, 0 fail, 713 expect() calls across 19 files; `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived, 1 file) exit 0.

## Critical Self-Review

- Highest-risk behavior: the duplicate-evidence merge deciding `duplicate` vs `duplicate_evidence_merged` vs `evidence_not_stored`. A wrong key set would silently drop a new citation or re-append a known one. The extracted `knownEvidenceKeys` reproduces the original seeding (row `event_type` + `metadata.source_locator`) and the same loop over `additional_evidence`, and `stringField` is exactly the `typeof === "string"` guard it replaces, so a non-string field still reads as `undefined`.
- Assumptions that could be wrong: that the SQLSTATE switch had no duplicate or shadowed arm whose ordering mattered. Checked -- the eight cases are distinct two-character keys, so switch order was never observable and a table is equivalent. Also that `Record<string, unknown>` index access cannot collide with a prototype key; the classes read are `event_type`/`source_locator`/`metadata` off row objects the driver builds, unchanged from before.
- Missing/weak tests: no test exercises `mergeDuplicateEvidence` or `safeErrorClass` directly by name; coverage is through the `ingest-conversation-facts` suites. This PR adds none, because the lane forbids modifying existing tests and the refactor is behavior-preserving -- but the direct unit coverage gap is real and predates this change.
- Security/permission risk: none introduced. This file holds no auth; the content-free error labels are the security-relevant surface and the label set is unchanged, so no raw driver message or SQLSTATE byte can reach a caller that could not before.
- Migration/deploy risk: none. No schema, migration, or SQL text changed.
- Downstream client/runtime risk: none. No MCP tool, schema, wire contract, or exported signature changed, so `docs/downstream-rollout.md` does not apply.
- Rollback/cleanup concern: none. Single-file, single-commit, revertable on its own.
- Fixes made before PR: re-ran oxlint, tsc, the test selection, and the done-means check against the committed tree after prettier reformatted the staged file, rather than trusting the pre-hook results.
- Known residual risk: low. The refactor is mechanical and the pinning suites pass, but they cover these two functions indirectly rather than by name.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical lint-standard refactor with no behavior change and no review finding; it teaches no new pattern a future swarm should check for.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or tool-contract surface changed.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract fixture input moved -- the schemas, tool names, and receipt shapes in this file are untouched, so `contracts/server/parity-manifest.json` needs no refresh.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable throughout: this change is internal to one server-side module. No MCP tool, schema, protocol, or client-facing signature moved, so no downstream consumer can observe it.
