### PR TITLE
refactor(update-entry): bring server/tools/update-entry.ts to the lint standard (#780)

### DIFF
--- a/server/tools/update-entry.ts
+++ b/server/tools/update-entry.ts
@@ -8,11 +8,17 @@
  * on state that no longer holds.
  */
 import { z } from "zod";
+import type { PoolClient } from "pg";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { toSql } from "pgvector/pg";
 import { namespacePredicate } from "../auth/namespace-policy.ts";
-import type { ResourceTable } from "../auth/types.ts";
-import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
+import type { AuthIdentity, ResourceTable } from "../auth/types.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import { authorize, contentHash } from "./memory-helpers.ts";
 import { tableEnum } from "./curation-helpers.ts";
 import {
@@ -38,7 +44,14 @@ const VALID_FIELDS: Readonly<Record<ResourceTable, readonly string[]>> = {
     "metadata",
   ],
   projects: ["name", "description", "tags"],
-  sessions: ["summary", "project", "key_decisions", "next_steps", "blockers", "tags"],
+  sessions: [
+    "summary",
+    "project",
+    "key_decisions",
+    "next_steps",
+    "blockers",
+    "tags",
+  ],
 };
 
 /**
@@ -57,8 +70,49 @@ const CONTENT_FIELDS: Readonly<Record<ResourceTable, readonly string[]>> = {
   sessions: ["summary", "project", "key_decisions", "next_steps", "blockers"],
 };
 
+/** Frozen `update_entry` argument contract: the field names are the API. */
+const updateEntryInputSchema = {
+  table: tableEnum,
+  id: z.string().uuid(),
+  content: z.string().optional(),
+  title: z.string().optional(),
+  rationale: z.string().optional(),
+  alternatives: z.array(z.string()).optional(),
+  summary: z.string().optional(),
+  project: z.string().optional(),
+  key_decisions: z.array(z.string()).optional(),
+  next_steps: z.array(z.string()).optional(),
+  blockers: z.array(z.string()).optional(),
+  person_name: z.string().optional(),
+  context: z.string().optional(),
+  name: z.string().optional(),
+  description: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  relationship_type: z.string().optional(),
+  warmth: z.number().int().min(1).max(5).optional(),
+  last_contact: z.string().optional(),
+  email: z.string().optional(),
+  phone: z.string().optional(),
+  notes: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+};
+
+/** Tool annotations; `update_entry` mutates an existing row in place. */
+const updateEntryAnnotations = {
+  title: "Update Entry",
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: false,
+};
+
+const UPDATE_ENTRY_DESCRIPTION =
+  "Update a brain entry's mutable fields. Re-embeds content when semantic fields change.";
+
 /** Build the embeddable text for a merged post-update row. */
-function buildEmbeddableText(table: ResourceTable, merged: Record<string, unknown>): string {
+function buildEmbeddableText(
+  table: ResourceTable,
+  merged: Record<string, unknown>,
+): string {
   switch (table) {
     case "thoughts":
       return String(merged.content ?? "");
@@ -76,9 +130,273 @@ function buildEmbeddableText(table: ResourceTable, merged: Record<string, unknow
 }
 
 /** Build the source-hash input, which sessions compute differently. */
-function buildHashInput(table: ResourceTable, merged: Record<string, unknown>): string {
+function buildHashInput(
+  table: ResourceTable,
+  merged: Record<string, unknown>,
+): string {
   if (table === "sessions") return sessionSourceHashInput(merged);
   return buildEmbeddableText(table, merged);
+}
+
+/** Narrow the validated args to the mutable fields this table actually accepts. */
+function collectProvidedFields(
+  table: ResourceTable,
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  const providedFields: Record<string, unknown> = {};
+  for (const field of VALID_FIELDS[table]) {
+    if (args[field] !== undefined) providedFields[field] = args[field];
+  }
+  return providedFields;
+}
+
+/** The locked pre-update row, or the error envelope that ended the transaction. */
+type LockedRow =
+  | { ok: true; row: Record<string, unknown> }
+  | { ok: false; response: ReturnType<typeof errorResult> };
+
+/**
+ * Lock the target row under the caller's write namespace predicate.
+ *
+ * The `FOR UPDATE` lock is what makes the archived guard below meaningful: it
+ * holds the row against a concurrent archive between this SELECT and the UPDATE.
+ */
+async function lockExistingRow(
+  client: PoolClient,
+  identity: AuthIdentity,
+  request: { table: ResourceTable; id: string },
+): Promise<LockedRow> {
+  const { table, id } = request;
+  const selectColumns = [...VALID_FIELDS[table], "archived_at"].join(", ");
+  const selectPredicate = namespacePredicate(identity, "write", 2);
+  const { rows: existingRows } = await client.query(
+    `SELECT id, namespace, ${selectColumns} FROM ${table}
+            WHERE id = $1${selectPredicate.clause} FOR UPDATE`,
+    [id, ...selectPredicate.values],
+  );
+  if (existingRows.length === 0) {
+    await client.query("ROLLBACK");
+    return { ok: false, response: errorResult("Not found") };
+  }
+  const existingRow = existingRows[0];
+  if (existingRow.archived_at != null) {
+    await client.query("ROLLBACK");
+    return {
+      ok: false,
+      response: errorResult("Entry is archived -- restore it first"),
+    };
+  }
+  return { ok: true, row: existingRow };
+}
+
+/** Merge the provided semantic fields over the locked row's stored values. */
+function mergeContentFields(
+  table: ResourceTable,
+  providedFields: Record<string, unknown>,
+  existingRow: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = {};
+  for (const field of CONTENT_FIELDS[table]) {
+    merged[field] =
+      providedFields[field] !== undefined
+        ? providedFields[field]
+        : existingRow[field];
+  }
+  return merged;
+}
+
+/** A computed re-embedding, or the error envelope that ended the transaction. */
+type Reembedding =
+  | { ok: true; embedding: number[] | null; hash: string | null }
+  | { ok: false; response: ReturnType<typeof errorResult> };
+
+/**
+ * Recompute the content hash and embedding for a semantic change.
+ *
+ * The collision check runs inside the same transaction as the caller's row
+ * lock, so an identical concurrent write cannot land between the check and the
+ * UPDATE and leave two rows sharing a content hash in one namespace.
+ */
+async function computeReembedding(
+  client: PoolClient,
+  dependencies: MemoryToolDependencies,
+  request: {
+    table: ResourceTable;
+    id: string;
+    providedFields: Record<string, unknown>;
+    existingRow: Record<string, unknown>;
+  },
+): Promise<Reembedding> {
+  const { table, id, providedFields, existingRow } = request;
+  const merged = mergeContentFields(table, providedFields, existingRow);
+  const hash = contentHash(buildHashInput(table, merged));
+  const { rows: collisions } = await client.query(
+    `SELECT id FROM ${table} WHERE content_hash = $1 AND id != $2 AND namespace = $3`,
+    [hash, id, existingRow.namespace],
+  );
+  if (collisions.length > 0) {
+    await client.query("ROLLBACK");
+    return {
+      ok: false,
+      response: errorResult("Duplicate content exists in another entry"),
+    };
+  }
+  const embedding = await dependencies.embedFn(
+    buildEmbeddableText(table, merged),
+  );
+  return { ok: true, embedding, hash };
+}
+
+/** A dynamic `SET` list and its positional parameters, in matching order. */
+interface UpdateAssignments {
+  setClauses: string[];
+  params: unknown[];
+}
+
+/** Append the caller's mutable field assignments, jsonb-encoding where needed. */
+function appendFieldAssignments(
+  assignments: UpdateAssignments,
+  table: ResourceTable,
+  providedFields: Record<string, unknown>,
+): void {
+  const { setClauses, params } = assignments;
+  for (const [field, value] of Object.entries(providedFields)) {
+    // decisions.alternatives is jsonb: a raw JS array would serialize as a
+    // Postgres array literal, which is not valid JSON.
+    if (table === "decisions" && field === "alternatives") {
+      params.push(JSON.stringify(value ?? []));
+      setClauses.push(`${field} = $${params.length}::jsonb`);
+    } else {
+      params.push(value);
+      setClauses.push(`${field} = $${params.length}`);
+    }
+  }
+}
+
+/** Append the four embedding columns, all null when the embed call returned null. */
+function appendEmbeddingAssignments(
+  assignments: UpdateAssignments,
+  dependencies: MemoryToolDependencies,
+  computed: { embedding: number[] | null; hash: string | null },
+): void {
+  const { setClauses, params } = assignments;
+  const { embedding, hash } = computed;
+  params.push(embedding ? toSql(embedding) : null);
+  setClauses.push(`embedding = $${params.length}`);
+  params.push(hash);
+  setClauses.push(`content_hash = $${params.length}`);
+  params.push(embedding ? new Date().toISOString() : null);
+  setClauses.push(`embedded_at = $${params.length}`);
+  params.push(embedding ? (dependencies.embeddingModel ?? null) : null);
+  setClauses.push(`embedding_model = $${params.length}`);
+}
+
+/** Build the whole `SET` list for this update, embedding columns included. */
+function buildAssignments(
+  dependencies: MemoryToolDependencies,
+  request: {
+    table: ResourceTable;
+    providedFields: Record<string, unknown>;
+    reembedding: { embedding: number[] | null; hash: string | null } | null;
+  },
+): UpdateAssignments {
+  const assignments: UpdateAssignments = { setClauses: [], params: [] };
+  appendFieldAssignments(assignments, request.table, request.providedFields);
+  if (request.reembedding !== null) {
+    appendEmbeddingAssignments(assignments, dependencies, request.reembedding);
+  }
+  assignments.setClauses.push("updated_at = NOW()");
+  return assignments;
+}
+
+/** Run the UPDATE under the caller's write predicate and commit. Returns the new id. */
+async function applyUpdate(
+  client: PoolClient,
+  identity: AuthIdentity,
+  request: { table: ResourceTable; id: string; assignments: UpdateAssignments },
+): Promise<string | null> {
+  const { table, id, assignments } = request;
+  const params = [...assignments.params, id];
+  const idParam = params.length;
+  const updatePredicate = namespacePredicate(identity, "write", idParam + 1);
+  const { rows: updatedRows } = await client.query(
+    `UPDATE ${table} SET ${assignments.setClauses.join(", ")}
+            WHERE id = $${idParam}${updatePredicate.clause} RETURNING id`,
+    [...params, ...updatePredicate.values],
+  );
+  await client.query("COMMIT");
+  if (updatedRows.length === 0) return null;
+  return updatedRows[0].id as string;
+}
+
+/** The tool result envelope every branch of the handler returns. */
+type ToolResponse =
+  ReturnType<typeof textResult> | ReturnType<typeof errorResult>;
+
+/**
+ * Run one authorized update inside the caller's open transaction.
+ *
+ * Every early return rolls back before answering, so a denied guard never
+ * leaves the row locked for the rest of the pool's lifetime.
+ */
+async function runUpdate(
+  client: PoolClient,
+  dependencies: MemoryToolDependencies,
+  request: {
+    identity: AuthIdentity;
+    table: ResourceTable;
+    id: string;
+    providedFields: Record<string, unknown>;
+  },
+): Promise<ToolResponse> {
+  const { identity, table, id, providedFields } = request;
+  const locked = await lockExistingRow(client, identity, { table, id });
+  if (!locked.ok) return locked.response;
+
+  const needsReembed = CONTENT_FIELDS[table].some(
+    (field) => providedFields[field] !== undefined,
+  );
+  let reembedding: { embedding: number[] | null; hash: string | null } | null =
+    null;
+  if (needsReembed) {
+    const computed = await computeReembedding(client, dependencies, {
+      table,
+      id,
+      providedFields,
+      existingRow: locked.row,
+    });
+    if (!computed.ok) return computed.response;
+    reembedding = { embedding: computed.embedding, hash: computed.hash };
+  }
+
+  const assignments = buildAssignments(dependencies, {
+    table,
+    providedFields,
+    reembedding,
+  });
+  const updatedId = await applyUpdate(client, identity, {
+    table,
+    id,
+    assignments,
+  });
+  if (updatedId === null) return errorResult("Update failed");
+
+  dependencies.logger.info(
+    {
+      tool: "update_entry",
+      table,
+      id: updatedId,
+      fields: Object.keys(providedFields),
+      reembedded: needsReembed,
+    },
+    "tool_result",
+  );
+  return textResult({
+    id: updatedId,
+    table,
+    updated: true,
+    embedded: needsReembed && reembedding?.embedding != null,
+  });
 }
 
 export function registerUpdateEntryTool(
@@ -88,39 +406,9 @@ export function registerUpdateEntryTool(
   server.registerTool(
     "update_entry",
     {
-      description:
-        "Update a brain entry's mutable fields. Re-embeds content when semantic fields change.",
-      inputSchema: {
-        table: tableEnum,
-        id: z.string().uuid(),
-        content: z.string().optional(),
-        title: z.string().optional(),
-        rationale: z.string().optional(),
-        alternatives: z.array(z.string()).optional(),
-        summary: z.string().optional(),
-        project: z.string().optional(),
-        key_decisions: z.array(z.string()).optional(),
-        next_steps: z.array(z.string()).optional(),
-        blockers: z.array(z.string()).optional(),
-        person_name: z.string().optional(),
-        context: z.string().optional(),
-        name: z.string().optional(),
-        description: z.string().optional(),
-        tags: z.array(z.string()).optional(),
-        relationship_type: z.string().optional(),
-        warmth: z.number().int().min(1).max(5).optional(),
-        last_contact: z.string().optional(),
-        email: z.string().optional(),
-        phone: z.string().optional(),
-        notes: z.string().optional(),
-        metadata: z.record(z.string(), z.unknown()).optional(),
-      },
-      annotations: {
-        title: "Update Entry",
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: false,
-      },
+      description: UPDATE_ENTRY_DESCRIPTION,
+      inputSchema: updateEntryInputSchema,
+      annotations: updateEntryAnnotations,
     },
     async (args, extra) => {
       const auth = authorize(
@@ -132,11 +420,10 @@ export function registerUpdateEntryTool(
       if (!auth.ok) return auth.response;
       const table = args.table;
 
-      const argsRecord = args as Record<string, unknown>;
-      const providedFields: Record<string, unknown> = {};
-      for (const field of VALID_FIELDS[table]) {
-        if (argsRecord[field] !== undefined) providedFields[field] = argsRecord[field];
-      }
+      const providedFields = collectProvidedFields(
+        table,
+        args as Record<string, unknown>,
+      );
       if (Object.keys(providedFields).length === 0) {
         return errorResult(`No valid fields to update for table ${table}`);
       }
@@ -144,100 +431,11 @@ export function registerUpdateEntryTool(
       const client = await dependencies.pool.connect();
       try {
         await client.query("BEGIN");
-
-        const selectColumns = [...VALID_FIELDS[table], "archived_at"].join(", ");
-        const selectPredicate = namespacePredicate(auth.identity, "write", 2);
-        const { rows: existingRows } = await client.query(
-          `SELECT id, namespace, ${selectColumns} FROM ${table}
-            WHERE id = $1${selectPredicate.clause} FOR UPDATE`,
-          [args.id, ...selectPredicate.values],
-        );
-        if (existingRows.length === 0) {
-          await client.query("ROLLBACK");
-          return errorResult("Not found");
-        }
-        const existingRow = existingRows[0];
-        if (existingRow.archived_at != null) {
-          await client.query("ROLLBACK");
-          return errorResult("Entry is archived -- restore it first");
-        }
-
-        const contentFieldNames = CONTENT_FIELDS[table];
-        const needsReembed = contentFieldNames.some(
-          (field) => providedFields[field] !== undefined,
-        );
-        let embedding: number[] | null = null;
-        let hash: string | null = null;
-
-        if (needsReembed) {
-          const merged: Record<string, unknown> = {};
-          for (const field of contentFieldNames) {
-            merged[field] =
-              providedFields[field] !== undefined ? providedFields[field] : existingRow[field];
-          }
-          hash = contentHash(buildHashInput(table, merged));
-          const { rows: collisions } = await client.query(
-            `SELECT id FROM ${table} WHERE content_hash = $1 AND id != $2 AND namespace = $3`,
-            [hash, args.id, existingRow.namespace],
-          );
-          if (collisions.length > 0) {
-            await client.query("ROLLBACK");
-            return errorResult("Duplicate content exists in another entry");
-          }
-          embedding = await dependencies.embedFn(buildEmbeddableText(table, merged));
-        }
-
-        const setClauses: string[] = [];
-        const params: unknown[] = [];
-        for (const [field, value] of Object.entries(providedFields)) {
-          // decisions.alternatives is jsonb: a raw JS array would serialize as a
-          // Postgres array literal, which is not valid JSON.
-          if (table === "decisions" && field === "alternatives") {
-            params.push(JSON.stringify(value ?? []));
-            setClauses.push(`${field} = $${params.length}::jsonb`);
-          } else {
-            params.push(value);
-            setClauses.push(`${field} = $${params.length}`);
-          }
-        }
-        if (needsReembed) {
-          params.push(embedding ? toSql(embedding) : null);
-          setClauses.push(`embedding = $${params.length}`);
-          params.push(hash);
-          setClauses.push(`content_hash = $${params.length}`);
-          params.push(embedding ? new Date().toISOString() : null);
-          setClauses.push(`embedded_at = $${params.length}`);
-          params.push(embedding ? (dependencies.embeddingModel ?? null) : null);
-          setClauses.push(`embedding_model = $${params.length}`);
-        }
-        setClauses.push("updated_at = NOW()");
-
-        params.push(args.id);
-        const idParam = params.length;
-        const updatePredicate = namespacePredicate(auth.identity, "write", idParam + 1);
-        const { rows: updatedRows } = await client.query(
-          `UPDATE ${table} SET ${setClauses.join(", ")}
-            WHERE id = $${idParam}${updatePredicate.clause} RETURNING id`,
-          [...params, ...updatePredicate.values],
-        );
-        await client.query("COMMIT");
-
-        if (updatedRows.length === 0) return errorResult("Update failed");
-        dependencies.logger.info(
-          {
-            tool: "update_entry",
-            table,
-            id: updatedRows[0].id,
-            fields: Object.keys(providedFields),
-            reembedded: needsReembed,
-          },
-          "tool_result",
-        );
-        return textResult({
-          id: updatedRows[0].id,
+        return await runUpdate(client, dependencies, {
+          identity: auth.identity,
           table,
-          updated: true,
-          embedded: needsReembed && embedding !== null,
+          id: args.id,
+          providedFields,
         });
       } catch (error) {
         await client.query("ROLLBACK").catch(() => {});


### PR DESCRIPTION
## Summary

- `server/tools/update-entry.ts` carried its whole update inside one inline registration closure: `registerUpdateEntryTool` at 157 lines wrapping a 114-line handler at complexity 23. The transaction body, the dynamic `SET` construction, and the re-embedding decision all shared one scope.
- Split along the seams `server/tools/resolve-entry.ts` and `server/tools/entities.ts` already use on `main`: the argument contract and annotations are hoisted to module-level consts (`updateEntryInputSchema`, `updateEntryAnnotations`, `UPDATE_ENTRY_DESCRIPTION`), and each phase of the transaction is a named module-level helper taking an options object instead of a positional list — `lockExistingRow`, `computeReembedding`, `mergeContentFields`, `appendFieldAssignments`, `appendEmbeddingAssignments`, `buildAssignments`, `applyUpdate`, `runUpdate`, `collectProvidedFields`.
- No behavior moves. Schema fields, annotations, error strings, SQL text, positional parameter ordering, the `tool_result` log event and its keys, and the response payload are identical. Helpers were cut so every early return still rolls back before answering, preserving the `FOR UPDATE` lock discipline the file header describes.
- No existing file outside the target was touched, and no lint disable comment was added.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Red first, on the untouched file: `oxlint --deny-warnings server/tools/update-entry.ts` reported `max-lines-per-function` (registerUpdateEntryTool, 157 lines), `complexity` (async function, 23), and `max-lines-per-function` (async function, 114); the done-means with `DONE_MEANS_780_FILES` set exited 1.

Green, re-run on the COMMITTED tree after the pre-commit prettier hook reformatted the staged file:

- `./node_modules/.bin/oxlint --deny-warnings server/tools/update-entry.ts` -> exit 0
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived from `origin/main...HEAD`) -> exit 0, 1 file linted
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated src/tools/__tests__/update-entry.test.ts server/tools/` -> 177 pass, 0 fail, tests exited 0

## Critical Self-Review

- Highest-risk behavior: the positional parameter ordering of the dynamic `UPDATE`. The original appended field params, then embedding params, then pushed `args.id` last and read `params.length` as the id placeholder. `buildAssignments` now returns the params array and `applyUpdate` appends the id, which preserves that exact order; the namespace predicate is still offset from `idParam + 1`.
- Assumptions that could be wrong: that no caller outside `server/tools/index.ts` imports anything from this module. Verified with `rg -l` — the only importer is `server/tools/index.ts:32`, and `registerUpdateEntryTool` keeps its exported signature unchanged. `src/tools/update-entry.ts` is a separate legacy twin exporting `registerUpdateEntry`; it was not touched.
- Missing/weak tests: there is no server-side test that drives `update_entry` through the server registry. The pinning coverage that exists (`src/tools/__tests__/update-entry.test.ts`, 14 tests including content-hash and re-embed assertions) exercises the `src/` twin, so it constrains the shared canonical text/hash builders but not this registration path directly. Adding server-side coverage is real work with its own behavior surface and belongs in its own change, not in a lint-only refactor.
- Security/permission risk: none intended. This file is one of the ID-based mutating tools `_plans/issues/93` covers, so the namespace predicate on both statements is the design being protected: the `authorize` call, the write-scoped `namespacePredicate` on the `SELECT ... FOR UPDATE` and on the `UPDATE`, and the namespace-scoped content-hash collision check are unchanged and still inside the same transaction. Neither statement can now be reached without its predicate.
- Migration/deploy risk: none. No schema, migration, or config change.
- Downstream client/runtime risk: none. Per `docs/downstream-rollout.md` this is not an MCP tool/schema/protocol/client-facing change — the tool name, description, input schema, annotations, and result payload are byte-identical, so no rtech-mcps, mcp2cli, or Hermes step applies.
- Rollback/cleanup concern: single-file, single-commit, revertable on its own with no dependent change.
- Fixes made before PR: re-ran oxlint, tsc, the done-means, and both test paths against the committed tree after the prettier hook reformatted the file, rather than trusting the pre-commit run.
- Known residual risk: the refactor is verified by the existing suite plus typecheck, not by a test that exercises this exact registration; the SQL strings and parameter order were compared against the pre-change file by reading the diff.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a lint-standard refactor under #780 with no behavior change and no review finding, so it produces no new pattern the next swarm should check for.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime behavior, schema, or contract changes, so a live smoke would exercise nothing this PR alters.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface moves — the `update_entry` tool name, input schema, annotations, error strings, and result payload are unchanged, so no fixture has anything new to pin.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Every downstream item is not applicable: this change is internal to one server module and alters no client-facing contract. Reviewed against the classification rules in `docs/downstream-rollout.md`.
