### PR TITLE
refactor(find-duplicates): bring server/tools/find-duplicates.ts to the lint standard (#780)

### DIFF
--- a/server/tools/find-duplicates.ts
+++ b/server/tools/find-duplicates.ts
@@ -51,6 +51,7 @@
  * here rather than assumed: reporting them is what requires the unbounded join.
  */
 import { z } from "zod";
+import type { PoolClient } from "pg";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../auth/permissions.ts";
 import { canTargetNamespace } from "../auth/namespace-policy.ts";
@@ -125,9 +126,258 @@ function scanNamespaces(
   requested: string | undefined,
 ): readonly string[] | undefined {
   if (requested !== undefined) {
-    return canTargetNamespace(identity, "read", requested) ? [requested] : undefined;
+    return canTargetNamespace(identity, "read", requested)
+      ? [requested]
+      : undefined;
   }
   return [identity.clientId];
+}
+
+const findDuplicatesInputSchema = {
+  table: tableEnum
+    .optional()
+    .describe("Optional: limit to a specific table (default: all)"),
+  namespace: z
+    .string()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe(
+      "Namespace to scan for duplicate pairs (defaults to the caller's own namespace)",
+    ),
+  threshold: z
+    .number()
+    .min(0)
+    .max(1)
+    .optional()
+    .describe(
+      `Cosine distance threshold for duplicates (default ${DUPLICATE_THRESHOLD}, lower = stricter)`,
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe(`Max duplicate pairs to return (default ${DEFAULT_PAIRS})`),
+};
+
+const findDuplicatesAnnotations = {
+  title: "Find Duplicates",
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+interface FindDuplicatesArgs {
+  readonly table?: string;
+  readonly namespace?: string;
+  readonly threshold?: number;
+  readonly limit?: number;
+}
+
+/** One reported pair, in the frozen observed wire shape. */
+interface DuplicatePair {
+  entry_a: { id: string; preview: string };
+  entry_b: { id: string; preview: string };
+  table: string;
+  distance: number;
+}
+
+/** The resolved, permission-checked scope of one duplicate scan. */
+interface DuplicateScanScope {
+  readonly namespaces: readonly string[];
+  readonly tables: readonly ResourceTable[];
+  readonly threshold: number;
+  readonly wanted: number;
+}
+
+/**
+ * Resolve the scope of one scan, or the reason the caller may not have it.
+ *
+ * Every denial message is returned verbatim so the two servers answer a refused
+ * call identically. The namespace resolution is the #485 fix: `scanNamespaces`
+ * is total, so a resolved scope can never carry an unscoped join.
+ *
+ * @returns The resolved scope, or a `denied` message to return as-is.
+ */
+function resolveDuplicateScanScope(
+  identity: AuthIdentity,
+  args: FindDuplicatesArgs,
+): { scope: DuplicateScanScope } | { denied: string } {
+  const namespaces = scanNamespaces(identity, args.namespace);
+  if (namespaces === undefined) {
+    return {
+      denied: `Permission denied: cannot read namespace '${String(args.namespace)}'`,
+    };
+  }
+
+  const requestedTables = args.table
+    ? [args.table as ResourceTable]
+    : ALL_TABLES;
+  const tables = requestedTables.filter((table) =>
+    canRead(identity.role, table),
+  );
+  if (tables.length === 0) {
+    return { denied: "Permission denied: no readable tables" };
+  }
+
+  return {
+    scope: {
+      namespaces,
+      tables,
+      threshold: args.threshold ?? DUPLICATE_THRESHOLD,
+      wanted: args.limit ?? DEFAULT_PAIRS,
+    },
+  };
+}
+
+/**
+ * Query one table's nearest duplicate pairs within the resolved namespaces.
+ *
+ * BOTH sides of the self-join are bound to the same resolved namespace list.
+ * Binding only one side still admits a cross-namespace pair, which is both an
+ * isolation leak and the unbounded shape #485 measured.
+ *
+ * @param remaining Pairs still wanted, passed straight to `LIMIT`.
+ * @returns The raw rows, nearest pair first.
+ */
+async function queryDuplicatePairs(options: {
+  client: PoolClient;
+  table: ResourceTable;
+  scope: DuplicateScanScope;
+  remaining: number;
+}): Promise<Record<string, unknown>[]> {
+  const { client, table, scope, remaining } = options;
+  const { rows } = await client.query(
+    `SELECT
+       a.id AS id_a,
+       LEFT(${previewForAlias(table, "a")}, ${PREVIEW_WIDTH}) AS preview_a,
+       b.id AS id_b,
+       LEFT(${previewForAlias(table, "b")}, ${PREVIEW_WIDTH}) AS preview_b,
+       a.embedding <=> b.embedding AS distance
+     FROM ${table} a
+     JOIN ${table} b ON a.id < b.id
+       AND b.archived_at IS NULL
+       AND b.embedding IS NOT NULL
+       AND b.namespace = ANY($3::text[])
+     WHERE a.archived_at IS NULL
+       AND a.embedding IS NOT NULL
+       AND a.namespace = ANY($3::text[])
+       AND a.embedding <=> b.embedding < $1
+     ORDER BY distance ASC
+     LIMIT $2`,
+    [scope.threshold, remaining, scope.namespaces],
+  );
+  return rows;
+}
+
+/**
+ * Scan every accessible table inside one bounded READ ONLY transaction.
+ *
+ * One connection covers the whole scan. Taking a fresh pooled connection per
+ * table would re-arm the timeout each time but would also let a slow table hold
+ * a connection the next table then waits for.
+ *
+ * @returns The pairs found, nearest first within each table, in table order.
+ */
+async function scanTablesForDuplicates(
+  client: PoolClient,
+  scope: DuplicateScanScope,
+): Promise<DuplicatePair[]> {
+  const duplicates: DuplicatePair[] = [];
+  await client.query("BEGIN READ ONLY");
+  await client.query("SELECT set_config('statement_timeout', $1, true)", [
+    `${SELF_JOIN_STATEMENT_TIMEOUT_MS}ms`,
+  ]);
+
+  for (const table of scope.tables) {
+    if (duplicates.length >= scope.wanted) break;
+    const rows = await queryDuplicatePairs({
+      client,
+      table,
+      scope,
+      remaining: scope.wanted - duplicates.length,
+    });
+
+    for (const row of rows) {
+      duplicates.push({
+        entry_a: { id: row.id_a as string, preview: row.preview_a as string },
+        entry_b: { id: row.id_b as string, preview: row.preview_b as string },
+        table,
+        distance: Number(row.distance),
+      });
+    }
+  }
+  await client.query("COMMIT");
+  return duplicates;
+}
+
+/**
+ * Log a failed scan and map it to the refusal the caller can act on.
+ *
+ * `57014` is a statement cancelled by the timeout above. It is reported as its
+ * own refusal rather than a generic failure, because the caller CAN act on it:
+ * narrowing the table or tightening the threshold makes the same call succeed.
+ *
+ * @returns The tool error response.
+ */
+function respondToScanFailure(
+  dependencies: MemoryToolDependencies,
+  error: unknown,
+): ReturnType<typeof errorResult> {
+  const code = (error as { code?: string } | null | undefined)?.code;
+  dependencies.logger.error(
+    {
+      tool: "find_duplicates",
+      errorName: error instanceof Error ? error.name : "unknown",
+      errorCode: code,
+    },
+    "find_duplicates_error",
+  );
+  return errorResult(
+    code === "57014"
+      ? "Duplicate scan exceeded its time bound; narrow it with table or a stricter threshold"
+      : "Database error during duplicate scan",
+  );
+}
+
+async function handleFindDuplicates(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity | null | undefined,
+  args: FindDuplicatesArgs,
+) {
+  if (!identity) return errorResult("Permission denied: not authenticated");
+
+  const resolved = resolveDuplicateScanScope(identity, args);
+  if ("denied" in resolved) return errorResult(resolved.denied);
+  const { scope } = resolved;
+
+  let duplicates: DuplicatePair[];
+  const client = await dependencies.pool.connect();
+  try {
+    duplicates = await scanTablesForDuplicates(client, scope);
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    return respondToScanFailure(dependencies, error);
+  } finally {
+    client.release();
+  }
+
+  dependencies.logger.info(
+    {
+      tool: "find_duplicates",
+      tablesScanned: scope.tables.length,
+      duplicatesFound: duplicates.length,
+    },
+    "tool_result",
+  );
+  return textResult({
+    threshold: scope.threshold,
+    namespaces: scope.namespaces,
+    duplicates_found: duplicates.length,
+    duplicates,
+  });
 }
 
 export function registerFindDuplicatesTool(
@@ -141,157 +391,10 @@ export function registerFindDuplicatesTool(
         "Discover potential duplicate entries using vector similarity. Read-only -- does NOT archive anything. " +
         "The pairwise scan is always bounded to one namespace: it defaults to the caller's own and can be pointed " +
         "at any namespace the caller may read.",
-      inputSchema: {
-        table: tableEnum
-          .optional()
-          .describe("Optional: limit to a specific table (default: all)"),
-        namespace: z
-          .string()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe(
-            "Namespace to scan for duplicate pairs (defaults to the caller's own namespace)",
-          ),
-        threshold: z
-          .number()
-          .min(0)
-          .max(1)
-          .optional()
-          .describe(
-            `Cosine distance threshold for duplicates (default ${DUPLICATE_THRESHOLD}, lower = stricter)`,
-          ),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe(`Max duplicate pairs to return (default ${DEFAULT_PAIRS})`),
-      },
-      annotations: {
-        title: "Find Duplicates",
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      inputSchema: findDuplicatesInputSchema,
+      annotations: findDuplicatesAnnotations,
     },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      if (!identity) return errorResult("Permission denied: not authenticated");
-
-      const namespaces = scanNamespaces(identity, args.namespace);
-      if (namespaces === undefined) {
-        return errorResult(
-          `Permission denied: cannot read namespace '${String(args.namespace)}'`,
-        );
-      }
-
-      const requestedTables = args.table ? [args.table as ResourceTable] : ALL_TABLES;
-      const accessible = requestedTables.filter((table) =>
-        canRead(identity.role, table),
-      );
-      if (accessible.length === 0) {
-        return errorResult("Permission denied: no readable tables");
-      }
-
-      const threshold = args.threshold ?? DUPLICATE_THRESHOLD;
-      const wanted = args.limit ?? DEFAULT_PAIRS;
-      const duplicates: Array<{
-        entry_a: { id: string; preview: string };
-        entry_b: { id: string; preview: string };
-        table: string;
-        distance: number;
-      }> = [];
-
-      // One connection for the whole scan, inside one READ ONLY transaction
-      // carrying the statement timeout. Taking a fresh pooled connection per
-      // table would re-arm the bound each time but would also let a slow table
-      // hold a connection the next table then waits for.
-      const client = await dependencies.pool.connect();
-      try {
-        await client.query("BEGIN READ ONLY");
-        await client.query("SELECT set_config('statement_timeout', $1, true)", [
-          `${SELF_JOIN_STATEMENT_TIMEOUT_MS}ms`,
-        ]);
-
-        for (const table of accessible) {
-          if (duplicates.length >= wanted) break;
-          const remaining = wanted - duplicates.length;
-
-          // BOTH sides of the self-join are bound to the same resolved
-          // namespace list. Binding only one side still admits a cross-namespace
-          // pair, which is both an isolation leak and the unbounded shape #485
-          // measured.
-          const { rows } = await client.query(
-            `SELECT
-               a.id AS id_a,
-               LEFT(${previewForAlias(table, "a")}, ${PREVIEW_WIDTH}) AS preview_a,
-               b.id AS id_b,
-               LEFT(${previewForAlias(table, "b")}, ${PREVIEW_WIDTH}) AS preview_b,
-               a.embedding <=> b.embedding AS distance
-             FROM ${table} a
-             JOIN ${table} b ON a.id < b.id
-               AND b.archived_at IS NULL
-               AND b.embedding IS NOT NULL
-               AND b.namespace = ANY($3::text[])
-             WHERE a.archived_at IS NULL
-               AND a.embedding IS NOT NULL
-               AND a.namespace = ANY($3::text[])
-               AND a.embedding <=> b.embedding < $1
-             ORDER BY distance ASC
-             LIMIT $2`,
-            [threshold, remaining, namespaces],
-          );
-
-          for (const row of rows) {
-            duplicates.push({
-              entry_a: { id: row.id_a, preview: row.preview_a },
-              entry_b: { id: row.id_b, preview: row.preview_b },
-              table,
-              distance: Number(row.distance),
-            });
-          }
-        }
-        await client.query("COMMIT");
-      } catch (error) {
-        await client.query("ROLLBACK").catch(() => undefined);
-        // `57014` is a statement cancelled by the timeout above. It is reported
-        // as its own refusal rather than a generic failure, because the caller
-        // CAN act on it -- narrowing the table or tightening the threshold makes
-        // the same call succeed.
-        const code = (error as { code?: string } | null | undefined)?.code;
-        dependencies.logger.error(
-          {
-            tool: "find_duplicates",
-            errorName: error instanceof Error ? error.name : "unknown",
-            errorCode: code,
-          },
-          "find_duplicates_error",
-        );
-        return errorResult(
-          code === "57014"
-            ? "Duplicate scan exceeded its time bound; narrow it with table or a stricter threshold"
-            : "Database error during duplicate scan",
-        );
-      } finally {
-        client.release();
-      }
-
-      dependencies.logger.info(
-        {
-          tool: "find_duplicates",
-          tablesScanned: accessible.length,
-          duplicatesFound: duplicates.length,
-        },
-        "tool_result",
-      );
-      return textResult({
-        threshold,
-        namespaces,
-        duplicates_found: duplicates.length,
-        duplicates,
-      });
-    },
+    async (args, extra) =>
+      handleFindDuplicates(dependencies, authIdentity(extra.authInfo), args),
   );
 }


### PR DESCRIPTION
## Summary

- `server/tools/find-duplicates.ts` carried the whole tool inside `registerFindDuplicatesTool`: a 145-line function whose async handler had a complexity of 14. Both oxlint findings share one cause -- schema, permission resolution, SQL, transaction management, error mapping, and response shaping all lived in a single closure.
- Split along the seams the ported siblings already use (`scan-namespace.ts`, `search-all.ts`, `entities.ts`): the input schema and annotations become module constants (`findDuplicatesInputSchema`, `findDuplicatesAnnotations`), and the handler becomes named module-level helpers -- `resolveDuplicateScanScope` (permission plus namespace resolution, returning either a scope or the verbatim denial string), `queryDuplicatePairs` (one table's self-join), `scanTablesForDuplicates` (the `READ ONLY` transaction across tables), `respondToScanFailure` (error logging and mapping), and `handleFindDuplicates` as the thin composer. `registerFindDuplicatesTool` is registration only.
- No behavior change. Schemas, defaults, denial strings, the self-join SQL text, the `57014` special case, log event names and their fields, and response key ordering are identical to the previous inline versions. The issue #485 invariant is unchanged and now easier to read at a glance: `scanNamespaces` is total, so a resolved scope can never carry an unscoped self-join, and both sides of the join stay bound to the same resolved namespace list inside `queryDuplicatePairs`.
- `queryDuplicatePairs` and `scanTablesForDuplicates` take an options object rather than positional parameters, matching `collectTable` in `scan-namespace.ts`.
- Reuse check: `rg` over `server/tools/` found no existing helper matching these shapes. `tool-failure.ts` was the closest candidate for the failure path and does not fit -- it logs `{namespace, mode, tier, error_message}` and returns the driver's own message, whereas `find_duplicates` logs `{tool, errorName, errorCode}` and returns one of two fixed strings, so adopting it would change both the log envelope and the caller-facing text. Nothing was reused and nothing new was shared out; no file other than the target was touched.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts, all re-run on the COMMITTED tree after the pre-commit prettier hook reformatted the file:

- Red first, before any edit: `./node_modules/.bin/oxlint --deny-warnings server/tools/find-duplicates.ts` reported `find-duplicates.ts:133:8: error eslint(max-lines-per-function): The function registerFindDuplicatesTool has too many lines (145). Maximum allowed is 100.` and `find-duplicates.ts:179:5: error eslint(complexity): async function has a complexity of 14. Maximum allowed is 10.`; `DONE_MEANS_780_FILES=server/tools/find-duplicates.ts bash scripts/done-means/780-touched-files-lint-clean.sh` exited 1.
- Green: `./node_modules/.bin/oxlint --deny-warnings server/tools/find-duplicates.ts` -> exit 0, no findings.
- Green: `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived against `origin/main`) -> exit 0, `PASS: every file this branch touched under server/ lints clean.`
- `bunx tsc --noEmit` -> exit 0, no output.
- `bun run test:isolated src/tools/__tests__/find-duplicates.test.ts server/tools/` -> 173 pass, 0 fail across 18 files. The pinning tests for this tool are `src/tools/__tests__/find-duplicates.test.ts` and `server/tools/ported-tools-scope.test.ts`, found by `rg` on the tool name; both are unmodified.
- Python package: not applicable. `python/openbrain-memory/` is untouched; the `find_duplicates` wrapper there calls the tool over the wire and this change alters no request or response shape.
- Live smoke: not applicable. This is a same-process refactor of an already-ported server tool with no schema, wire, or SQL change.

## Critical Self-Review

- Highest-risk behavior: the `READ ONLY` transaction lifecycle. The scan's `BEGIN`, `set_config('statement_timeout', ...)`, and `COMMIT` moved inside `scanTablesForDuplicates` while `connect()`, `ROLLBACK`, and `release()` stayed in `handleFindDuplicates`. If the split had put `release()` on the wrong side, a failed scan would leak a pooled connection -- exactly the failure issue #485 measured, where 42 backends stayed `state='active'` after their run ended. The `finally { client.release(); }` still wraps every path including the catch, and `ROLLBACK` still runs before the failure response is built, so an exception anywhere inside the transaction is rolled back and released in the same order as before.
- Assumptions that could be wrong: that the `duplicates.length >= scope.wanted` early break and the `remaining` computation preserve the exact per-table result ordering. This is the one loop with cross-table state, so a reordering would be silent -- the response would still be well-formed with the correct count. The loop body is unchanged apart from the extracted query call, the accumulator is still appended to in table order, and `remaining` is still `wanted - duplicates.length` evaluated per iteration.
- Missing/weak tests: no test exercises the `57014` timeout branch of `respondToScanFailure` or the multi-table early break, so both rest on reading the diff rather than on a red-to-green transition. I did not add tests, because the lane's contract is a no-behavior-change refactor and a new test would be asserting behavior this PR does not change; a test for the timeout branch belongs with whoever next changes that behavior.
- Security/permission risk: the namespace isolation boundary passes through `resolveDuplicateScanScope`. The risk is that extracting it introduced a path returning a scope without a namespace check. It does not: `scanNamespaces` is unmoved, is still the only producer of `DuplicateScanScope.namespaces`, and `undefined` from it is the only way to reach the denial. The `canRead` table filter and the not-authenticated check run in the same order relative to each other as before. `server/tools/ported-tools-scope.test.ts` covers the read-scope contract and passes.
- Migration/deploy risk: none. No migration, no schema change, no config change, no new dependency. `PoolClient` is a type-only import from `pg`, which is already a direct dependency.
- Downstream client/runtime risk: none. Per `docs/downstream-rollout.md` this is not an MCP tool, schema, protocol, or client-facing change -- the registered tool name, description, input schema, annotations, and response keys are unchanged, so no downstream client can observe the difference.
- Rollback/cleanup concern: one commit touching one file, revertable on its own with no dependency on other #780 lanes.
- Fixes made before PR: none needed beyond the refactor -- oxlint, `tsc`, and the tests were green on the first assembled version and again after the prettier hook rewrote the committed file.
- Known residual risk: the SQL is a template literal that moved between functions. I verified the interpolated pieces are the same expressions (`previewForAlias(table, "a"/"b")` and `PREVIEW_WIDTH`, both still static allowlisted fragments, with `table` still gated by `tableEnum`) and that the parameter list is still `[threshold, remaining, namespaces]` in that order against the same `$1`/`$2`/`$3` placeholders. A whitespace-only difference inside the literal would not be caught by any test, and is harmless.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no new review finding -- it is a mechanical structural split of one file against a pattern `docs/sme/quality.md` and the merged #780 lanes already establish, and adding an entry restating that pattern would dilute the lane files rather than sharpen them.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no wire, schema, or SQL semantics changed, so a live check would exercise identical behavior to `main`.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: `contracts/server/server-duplicate-discovery.fixture.json`, listed in `contracts/server/parity-manifest.json`, describes the tool's wire contract, which this PR does not touch. The change is internal to the server file's function layout, so the existing fixture is still the correct assertion and updating it would be a no-op.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Every downstream item is not applicable for the same reason: `docs/downstream-rollout.md` gates on MCP tool, schema, protocol, or client-facing changes, and this PR changes none of them. The `find_duplicates` registration passes the same name, description, `inputSchema`, and `annotations` to `server.registerTool`; they were moved to module constants, not edited.
