### PR TITLE
refactor(tiering): bring server/tools/tiering.ts to the lint standard (#780)

### DIFF
--- a/server/tools/tiering.ts
+++ b/server/tools/tiering.ts
@@ -24,7 +24,12 @@ import {
   type NamespacePredicate,
 } from "../auth/namespace-policy.ts";
 import type { ResourceTable } from "../auth/types.ts";
-import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import {
   ALL_TABLES,
   PREVIEW_WIDTH,
@@ -73,6 +78,63 @@ interface TierCandidate {
   reasoning: string;
 }
 
+const tierRecommendationsInputSchema = {
+  action: z.enum(["promote", "demote"]),
+  threshold_days: z.number().int().min(1).max(365).optional(),
+  candidates: z.number().int().min(1).max(100).optional(),
+};
+
+const tierRecommendationsAnnotations = {
+  title: "Tier Recommendations",
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+const listStaleInputSchema = {
+  table: tableEnum.optional().describe("Optional: filter to a specific table"),
+  days: z
+    .number()
+    .int()
+    .min(1)
+    .max(365)
+    .optional()
+    .describe(
+      "Entries not accessed in this many days are considered stale (default 30)",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Maximum entries to return (default 50, max 500)"),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Number of entries to skip for pagination (default 0)"),
+  tier: tierEnum
+    .optional()
+    .describe(
+      "Optional: filter to a specific tier (e.g. 'hot' to find hot entries that should decay to warm)",
+    ),
+  response_format: z
+    .enum(["envelope", "array"])
+    .optional()
+    .describe(
+      "Response format: 'envelope' (default) returns {entries, total_count, has_more}; 'array' returns raw array for backwards compatibility",
+    ),
+};
+
+const listStaleAnnotations = {
+  title: "List Stale",
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
 export function registerTieringTools(
   server: McpServer,
   dependencies: MemoryToolDependencies,
@@ -82,45 +144,65 @@ export function registerTieringTools(
     {
       description:
         "Get tier change recommendations based on access patterns. Suggests entries to promote (cold/warm -> hot) or demote (warm -> cold).",
-      inputSchema: {
-        action: z.enum(["promote", "demote"]),
-        threshold_days: z.number().int().min(1).max(365).optional(),
-        candidates: z.number().int().min(1).max(100).optional(),
-      },
-      annotations: {
-        title: "Tier Recommendations",
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      inputSchema: tierRecommendationsInputSchema,
+      annotations: tierRecommendationsAnnotations,
     },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      if (!identity) return errorResult("Permission denied: not authenticated");
-      const accessible = ALL_TABLES.filter((table) => canRead(identity.role, table));
-      if (accessible.length === 0) return errorResult("Permission denied: no readable tables");
+    async (args, extra) => handleTierRecommendations(dependencies, args, extra),
+  );
 
-      const wanted = args.candidates ?? 20;
-      const thresholdDays = args.threshold_days ?? (args.action === "demote" ? 30 : 7);
-      const candidates: TierCandidate[] = [];
+  server.registerTool(
+    "list_stale",
+    {
+      description:
+        "Find brain entries not accessed recently -- candidates for tier demotion (hot->warm->cold). " +
+        "Queries by last_accessed_at (falls back to created_at for never-accessed entries). " +
+        "Returns {entries, total_count, has_more} envelope by default, or raw array with response_format='array'. " +
+        "Resilient parsing: const entries = Array.isArray(result) ? result : result.entries ?? [];",
+      inputSchema: listStaleInputSchema,
+      annotations: listStaleAnnotations,
+    },
+    async (args, extra) => handleListStale(dependencies, args, extra),
+  );
+}
 
-      for (const table of accessible) {
-        if (candidates.length >= wanted) break;
-        const remaining = wanted - candidates.length;
-        const alias = TABLE_ALIAS[table];
-        const preview = ALIASED_PREVIEW[table];
-        const predicate = namespacePredicate(identity, "read", 3);
-        const scoped = qualifyNamespacePredicate(predicate, `${alias}.namespace`, 3);
-        const params = [thresholdDays, remaining, ...predicate.values];
+/** Minimal shape of the handler `extra` argument these tools read. */
+interface HandlerExtra {
+  authInfo?: Parameters<typeof authIdentity>[0];
+}
 
-        if (args.action === "demote") {
-          const { rows } = await dependencies.pool.query(
-            `SELECT ${alias}.id,
+/** One table's worth of recommendation scan inputs. */
+interface TierScan {
+  readonly dependencies: MemoryToolDependencies;
+  readonly table: ResourceTable;
+  readonly thresholdDays: number;
+  readonly remaining: number;
+  readonly predicate: NamespacePredicate;
+}
+
+/**
+ * Demotion arm: warm entries that have gone quiet.
+ *
+ * Kept apart from the promotion arm because the two read different sources --
+ * this one uses the stored counter for a coarse "barely touched" signal, while
+ * promotion must go to the access LOG for real recency.
+ */
+async function collectDemotionCandidates(
+  scan: TierScan,
+): Promise<TierCandidate[]> {
+  const alias = TABLE_ALIAS[scan.table];
+  const preview = ALIASED_PREVIEW[scan.table];
+  const scoped = qualifyNamespacePredicate(
+    scan.predicate,
+    `${alias}.namespace`,
+    3,
+  );
+  const { rows } = await scan.dependencies.pool.query(
+    `SELECT ${alias}.id,
                     LEFT(${preview}, ${PREVIEW_WIDTH}) AS content_preview,
                     COALESCE(${alias}.tier, 'warm') AS tier,
                     COALESCE(${alias}.access_count, 0) AS access_count,
                     ${alias}.last_accessed_at
-               FROM ${table} ${alias}
+               FROM ${scan.table} ${alias}
               WHERE ${alias}.archived_at IS NULL
                 AND COALESCE(${alias}.tier, 'warm') = 'warm'
                 AND (${alias}.last_accessed_at IS NULL
@@ -129,24 +211,28 @@ export function registerTieringTools(
                 ${scoped}
               ORDER BY COALESCE(${alias}.access_count, 0) ASC, ${alias}.created_at ASC
               FETCH FIRST $2 ROWS ONLY`,
-            params,
-          );
-          for (const row of rows) {
-            candidates.push({
-              id: row.id,
-              table,
-              content_preview: row.content_preview,
-              current_tier: row.tier,
-              suggested_tier: "cold",
-              access_count: Number(row.access_count),
-              last_accessed_at: row.last_accessed_at,
-              reasoning: `Warm entry with ${row.access_count} accesses, not accessed in ${thresholdDays}+ days`,
-            });
-          }
-        } else {
-          // Recency/frequency come from the access LOG, not a lossy counter.
-          const { rows } = await dependencies.pool.query(
-            `SELECT sub.id, sub.content_preview, sub.tier, sub.access_count,
+    [scan.thresholdDays, scan.remaining, ...scan.predicate.values],
+  );
+  return rows.map((row) => ({
+    id: row.id,
+    table: scan.table,
+    content_preview: row.content_preview,
+    current_tier: row.tier,
+    suggested_tier: "cold",
+    access_count: Number(row.access_count),
+    last_accessed_at: row.last_accessed_at,
+    reasoning: `Warm entry with ${row.access_count} accesses, not accessed in ${scan.thresholdDays}+ days`,
+  }));
+}
+
+/** Promotion arm: recency/frequency come from the access LOG, not a lossy counter. */
+async function collectPromotionCandidates(
+  scan: TierScan,
+): Promise<TierCandidate[]> {
+  const alias = TABLE_ALIAS[scan.table];
+  const preview = ALIASED_PREVIEW[scan.table];
+  const { rows } = await scan.dependencies.pool.query(
+    `SELECT sub.id, sub.content_preview, sub.tier, sub.access_count,
                     sub.last_accessed_at, sub.recent_accesses
                FROM (
                  SELECT ${alias}.id,
@@ -158,165 +244,198 @@ export function registerTieringTools(
                           WHERE eal.entry_id = ${alias}.id
                             AND eal.source_table = $3
                             AND eal.accessed_at >= NOW() - INTERVAL '1 day' * $1) AS recent_accesses
-                   FROM ${table} ${alias}
+                   FROM ${scan.table} ${alias}
                   WHERE ${alias}.archived_at IS NULL
                     AND COALESCE(${alias}.tier, 'warm') IN ('warm', 'cold')
-                    ${qualifyNamespacePredicate(predicate, `${alias}.namespace`, 4)}
+                    ${qualifyNamespacePredicate(scan.predicate, `${alias}.namespace`, 4)}
                ) sub
               WHERE sub.recent_accesses > 5
               ORDER BY sub.recent_accesses DESC
               FETCH FIRST $2 ROWS ONLY`,
-            [thresholdDays, remaining, table, ...predicate.values],
-          );
-          for (const row of rows) {
-            candidates.push({
-              id: row.id,
-              table,
-              content_preview: row.content_preview,
-              current_tier: row.tier,
-              suggested_tier: "hot",
-              access_count: Number(row.access_count),
-              recent_accesses: Number(row.recent_accesses),
-              last_accessed_at: row.last_accessed_at,
-              reasoning: `${row.tier} entry with ${row.recent_accesses} accesses in last ${thresholdDays} days`,
-            });
-          }
-        }
-      }
-
-      dependencies.logger.info(
-        { tool: "tier_recommendations", action: args.action, candidatesFound: candidates.length },
-        "tool_result",
-      );
-      return textResult({
-        action: args.action,
-        threshold_days: thresholdDays,
-        candidates_found: candidates.length,
-        candidates,
-      });
-    },
+    [scan.thresholdDays, scan.remaining, scan.table, ...scan.predicate.values],
   );
+  return rows.map((row) => ({
+    id: row.id,
+    table: scan.table,
+    content_preview: row.content_preview,
+    current_tier: row.tier,
+    suggested_tier: "hot",
+    access_count: Number(row.access_count),
+    recent_accesses: Number(row.recent_accesses),
+    last_accessed_at: row.last_accessed_at,
+    reasoning: `${row.tier} entry with ${row.recent_accesses} accesses in last ${scan.thresholdDays} days`,
+  }));
+}
 
-  server.registerTool(
-    "list_stale",
+async function handleTierRecommendations(
+  dependencies: MemoryToolDependencies,
+  args: {
+    action: "promote" | "demote";
+    threshold_days?: number;
+    candidates?: number;
+  },
+  extra: HandlerExtra,
+) {
+  const identity = authIdentity(extra.authInfo);
+  if (!identity) return errorResult("Permission denied: not authenticated");
+  const accessible = ALL_TABLES.filter((table) =>
+    canRead(identity.role, table),
+  );
+  if (accessible.length === 0)
+    return errorResult("Permission denied: no readable tables");
+
+  const wanted = args.candidates ?? 20;
+  const thresholdDays =
+    args.threshold_days ?? (args.action === "demote" ? 30 : 7);
+  const collect =
+    args.action === "demote"
+      ? collectDemotionCandidates
+      : collectPromotionCandidates;
+  const candidates: TierCandidate[] = [];
+
+  for (const table of accessible) {
+    if (candidates.length >= wanted) break;
+    const found = await collect({
+      dependencies,
+      table,
+      thresholdDays,
+      remaining: wanted - candidates.length,
+      predicate: namespacePredicate(identity, "read", 3),
+    });
+    candidates.push(...found);
+  }
+
+  dependencies.logger.info(
     {
-      description:
-        "Find brain entries not accessed recently -- candidates for tier demotion (hot->warm->cold). " +
-        "Queries by last_accessed_at (falls back to created_at for never-accessed entries). " +
-        "Returns {entries, total_count, has_more} envelope by default, or raw array with response_format='array'. " +
-        "Resilient parsing: const entries = Array.isArray(result) ? result : result.entries ?? [];",
-      inputSchema: {
-        table: tableEnum.optional().describe("Optional: filter to a specific table"),
-        days: z
-          .number()
-          .int()
-          .min(1)
-          .max(365)
-          .optional()
-          .describe(
-            "Entries not accessed in this many days are considered stale (default 30)",
-          ),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe("Maximum entries to return (default 50, max 500)"),
-        offset: z
-          .number()
-          .int()
-          .min(0)
-          .optional()
-          .describe("Number of entries to skip for pagination (default 0)"),
-        tier: tierEnum
-          .optional()
-          .describe(
-            "Optional: filter to a specific tier (e.g. 'hot' to find hot entries that should decay to warm)",
-          ),
-        response_format: z
-          .enum(["envelope", "array"])
-          .optional()
-          .describe(
-            "Response format: 'envelope' (default) returns {entries, total_count, has_more}; 'array' returns raw array for backwards compatibility",
-          ),
-      },
-      annotations: {
-        title: "List Stale",
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      tool: "tier_recommendations",
+      action: args.action,
+      candidatesFound: candidates.length,
     },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      if (!identity) return errorResult("Permission denied: no readable tables");
+    "tool_result",
+  );
+  return textResult({
+    action: args.action,
+    threshold_days: thresholdDays,
+    candidates_found: candidates.length,
+    candidates,
+  });
+}
 
-      // A named table the caller cannot read is a distinct refusal from having
-      // no readable tables at all, matching observed current-src wording.
-      let accessible: readonly ResourceTable[];
-      if (args.table) {
-        if (!canRead(identity.role, args.table)) {
-          return errorResult(`Permission denied: cannot read ${args.table}`);
-        }
-        accessible = [args.table];
-      } else {
-        accessible = ALL_TABLES.filter((table) => canRead(identity.role, table));
-      }
-      if (accessible.length === 0) {
-        return errorResult("Permission denied: no readable tables");
-      }
+/**
+ * Resolve which tables a stale scan reads, or the refusal that stops it.
+ *
+ * A named table the caller cannot read is a distinct refusal from having no
+ * readable tables at all, matching observed current-src wording.
+ */
+function resolveStaleTables(
+  role: Parameters<typeof canRead>[0],
+  named: ResourceTable | undefined,
+):
+  | { readonly tables: readonly ResourceTable[]; readonly refusal?: undefined }
+  | {
+      readonly tables?: undefined;
+      readonly refusal: ReturnType<typeof errorResult>;
+    } {
+  if (named) {
+    if (!canRead(role, named)) {
+      return {
+        refusal: errorResult(`Permission denied: cannot read ${named}`),
+      };
+    }
+    return { tables: [named] };
+  }
+  const tables = ALL_TABLES.filter((table) => canRead(role, table));
+  if (tables.length === 0) {
+    return { refusal: errorResult("Permission denied: no readable tables") };
+  }
+  return { tables };
+}
 
-      const days = args.days ?? 30;
-      const rowCap = args.limit ?? 50;
-      const offset = args.offset ?? 0;
-      const useArray = args.response_format === "array";
+interface StaleArgs {
+  table?: ResourceTable;
+  days?: number;
+  limit?: number;
+  offset?: number;
+  tier?: Tier;
+  response_format?: "envelope" | "array";
+}
 
-      // The data query binds $1..$3 before the namespace values; the count
-      // query binds only $1, so its namespace values start one slot later.
-      const dataPredicate = namespacePredicate(identity, "read", 4);
-      const countPredicate = namespacePredicate(identity, "read", 2);
+/** The stale-scan defaults, in one place so the handler reads as one path. */
+function staleWindow(args: StaleArgs): {
+  readonly days: number;
+  readonly rowCap: number;
+  readonly offset: number;
+} {
+  return {
+    days: args.days ?? 30,
+    rowCap: args.limit ?? 50,
+    offset: args.offset ?? 0,
+  };
+}
 
-      const selects = accessible.map((table) =>
-        buildStaleSelect(table, args.tier, dataPredicate, 4),
-      );
-      const sql = `${selects.join("\nUNION ALL\n")}
+async function handleListStale(
+  dependencies: MemoryToolDependencies,
+  args: StaleArgs,
+  extra: HandlerExtra,
+) {
+  const identity = authIdentity(extra.authInfo);
+  if (!identity) return errorResult("Permission denied: no readable tables");
+
+  const scope = resolveStaleTables(identity.role, args.table);
+  if (scope.refusal) return scope.refusal;
+  const accessible = scope.tables;
+
+  const { days, rowCap, offset } = staleWindow(args);
+  const useArray = args.response_format === "array";
+
+  // The data query binds $1..$3 before the namespace values; the count
+  // query binds only $1, so its namespace values start one slot later.
+  const dataPredicate = namespacePredicate(identity, "read", 4);
+  const countPredicate = namespacePredicate(identity, "read", 2);
+
+  const selects = accessible.map((table) =>
+    buildStaleSelect(table, args.tier, dataPredicate, 4),
+  );
+  const sql = `${selects.join("\nUNION ALL\n")}
         ORDER BY effective_last_access ASC
         LIMIT $2 OFFSET $3`;
 
-      const countSelects = accessible.map((table) =>
-        buildStaleCountSelect(table, args.tier, countPredicate, 2),
-      );
-      const countSql = `SELECT SUM(cnt)::int AS total_count FROM (${countSelects.join("\nUNION ALL\n")}) counts`;
+  const countSelects = accessible.map((table) =>
+    buildStaleCountSelect(table, args.tier, countPredicate, 2),
+  );
+  const countSql = `SELECT SUM(cnt)::int AS total_count FROM (${countSelects.join("\nUNION ALL\n")}) counts`;
 
-      const [dataResult, countResult] = await Promise.all([
-        dependencies.pool.query(sql, [days, rowCap, offset, ...dataPredicate.values]),
-        dependencies.pool
-          .query(countSql, [days, ...countPredicate.values])
-          .catch(() => null),
-      ]);
+  const [dataResult, countResult] = await Promise.all([
+    dependencies.pool.query(sql, [
+      days,
+      rowCap,
+      offset,
+      ...dataPredicate.values,
+    ]),
+    dependencies.pool
+      .query(countSql, [days, ...countPredicate.values])
+      .catch(() => null),
+  ]);
 
-      const totalCount = countResult?.rows[0]?.total_count ?? null;
-      const hasMore =
-        totalCount !== null ? offset + dataResult.rows.length < totalCount : false;
+  const totalCount = countResult?.rows[0]?.total_count ?? null;
+  const hasMore =
+    totalCount !== null ? offset + dataResult.rows.length < totalCount : false;
 
-      dependencies.logger.info(
-        { tool: "list_stale", tables: accessible.length, days },
-        "tool_result",
-      );
+  dependencies.logger.info(
+    { tool: "list_stale", tables: accessible.length, days },
+    "tool_result",
+  );
 
-      return textResult(
-        useArray
-          ? dataResult.rows
-          : {
-              entries: dataResult.rows,
-              total_count: totalCount,
-              offset,
-              limit: rowCap,
-              has_more: hasMore,
-            },
-      );
-    },
+  return textResult(
+    useArray
+      ? dataResult.rows
+      : {
+          entries: dataResult.rows,
+          total_count: totalCount,
+          offset,
+          limit: rowCap,
+          has_more: hasMore,
+        },
   );
 }
 


### PR DESCRIPTION
## Summary

- `registerTieringTools` held both tool registrations and both handler bodies inline: 227 lines, with the two handlers at complexity 11 and 13. Three oxlint findings, no disable comments used.
- Applies the shape `server/tools/tier-mutations.ts` already uses for the tier write tools, so the two tier files read alike: input schemas and annotations hoisted to module scope, and each `registerTool` call is a one-line delegation to a named module-level handler taking `(dependencies, args, extra)`.
- `tier_recommendations` carried two unrelated SQL arms in one `if`/`else` — demotion reads the stored `access_count`, promotion reads `entry_access_log` rows. They are now `collectDemotionCandidates` and `collectPromotionCandidates`, each taking one `TierScan` options object, selected once by `action`. `list_stale`'s table resolution moved to `resolveStaleTables` and its argument defaults to `staleWindow`.
- No behavior change. Schemas, defaults, error strings, SQL text, log event names, and response shapes are identical; the SQL template literals keep their original indentation so the emitted statements are byte-identical. No other existing file is touched, and no test was modified.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Red first, on the untouched file: `oxlint --deny-warnings server/tools/tiering.ts` reported `max-lines-per-function` (`registerTieringTools`, 227 lines) at `tiering.ts:76:8`, and `complexity` 11 at `:97:5` and 13 at `:251:5`; `DONE_MEANS_780_FILES=server/tools/tiering.ts bash scripts/done-means/780-touched-files-lint-clean.sh` exited 1.

Green, re-run on the COMMITTED tree after the pre-commit prettier hook reformatted the file:

- `./node_modules/.bin/oxlint --deny-warnings server/tools/tiering.ts` -> exit 0
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated server/tools/ src/tools/__tests__/tier-recommendations{.pg,}.test.ts src/tools/__tests__/list-stale{,.pg}.test.ts` -> 194 pass, 0 fail across 21 files
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived) -> exit 0
- `git status --short` -> clean

Python package is untouched, so its checks are not applicable. No live smoke: the change is a pure in-file restructure of two read-only tools with no schema, transport, or SQL change.

## Critical Self-Review

- Highest-risk behavior: the two `tier_recommendations` SQL statements. Their parameter numbering differs between arms — demotion qualifies its namespace predicate at `$3`, promotion at `$4` because it binds `table` as `$3` — and splitting the arms is exactly where a silent off-by-one would land. Both arms carry their original numbering and value order verbatim; `tiering.pg.test.ts` and `tier-recommendations.pg.test.ts` execute both against real Postgres, so a mismatch fails rather than returning wrong rows.
- Assumptions that could be wrong: that `candidates.length >= wanted` still short-circuits identically now that `push(...found)` replaces a per-row `push` inside the query loop. It does — the check runs once per table before the query in both versions, and `remaining` is still computed from the live length — but a reader could reasonably expect per-row accounting.
- Missing/weak tests: nothing new is tested because nothing new is claimed; this leans entirely on the existing pinning tests. Those do not assert the exact SQL string, so a whitespace-level SQL change would pass. That is why the template literals were kept byte-identical rather than re-indented to match the new nesting.
- Security/permission risk: the namespace predicate and `canRead` checks are the isolation boundary here. `resolveStaleTables` reproduces the original three-way outcome exactly, including the distinction between "cannot read `<table>`" for a named table and "no readable tables" — the wording difference is load-bearing for callers and is preserved verbatim. No predicate was made optional and no interpolation was widened.
- Migration/deploy risk: none. No schema, migration, or config change.
- Downstream client/runtime risk: none. Tool names, input schemas, annotations, descriptions, and response envelopes are unchanged, so the MCP contract is identical and `docs/downstream-rollout.md` does not apply.
- Rollback/cleanup concern: single-file, single-commit revert with no state to unwind.
- Fixes made before PR: the first pass left `handleListStale` at complexity 11 — extracting the handlers alone was not enough, because the run of `??` defaults counted against it. Extracting `staleWindow` brought it under. Caught by re-running oxlint, not assumed.
- Known residual risk: the file is 462 lines, under the 500 threshold but with less headroom than before, so the next tool added here should go in a sibling rather than inline.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical lint-standard restructure that found no new defect class — the pattern it applies is already recorded and already landed in `server/tools/tier-mutations.ts`, `search-brain.ts`, and `entities.ts`.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no schema, transport, or client-facing change — both tools are read-only and their SQL is byte-identical.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface moved. Tool names, input schemas, annotations, and response shapes are unchanged, so no fixture describes anything different.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Classified not applicable under `docs/downstream-rollout.md`: rollout applies to MCP tool, schema, protocol, or client-facing changes. This changes none of them — it moves function bodies within one server file and leaves every registered tool's name, schema, annotations, and output identical.
