### PR TITLE
refactor(server-identity): bring server/transport/server-identity.ts to the lint standard (#780)

### DIFF
--- a/server/transport/server-identity.ts
+++ b/server/transport/server-identity.ts
@@ -47,21 +47,44 @@ export const UNKNOWN_SERVER_IP = "unknown";
  * RFC1918 plus RFC3927 link-local and RFC6598 carrier-grade NAT, which are the
  * ranges this fleet actually appears on.
  */
-function isPrivateIpv4(address: string): boolean {
+/**
+ * The accepted ranges as data, first octet exact and second octet inclusive.
+ *
+ * A `secondMin`/`secondMax` spanning the whole octet is how a /8 is written, so
+ * every range is checked by one expression rather than a per-range branch.
+ */
+const PRIVATE_IPV4_RANGES: ReadonlyArray<{
+  readonly first: number;
+  readonly secondMin: number;
+  readonly secondMax: number;
+}> = [
+  { first: 10, secondMin: 0, secondMax: 255 }, // RFC1918 10/8
+  { first: 172, secondMin: 16, secondMax: 31 }, // RFC1918 172.16/12
+  { first: 192, secondMin: 168, secondMax: 168 }, // RFC1918 192.168/16
+  { first: 169, secondMin: 254, secondMax: 254 }, // RFC3927 link-local
+  { first: 100, secondMin: 64, secondMax: 127 }, // RFC6598 carrier-grade NAT
+];
+
+function parseIpv4Octets(address: string): [number, number] | undefined {
   const octets = address.split(".").map((part) => Number(part));
   if (
     octets.length !== 4 ||
     octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255)
   ) {
-    return false;
+    return undefined;
   }
   const [a, b] = octets as [number, number, number, number];
-  if (a === 10) return true;
-  if (a === 172 && b >= 16 && b <= 31) return true;
-  if (a === 192 && b === 168) return true;
-  if (a === 169 && b === 254) return true;
-  if (a === 100 && b >= 64 && b <= 127) return true;
-  return false;
+  return [a, b];
+}
+
+function isPrivateIpv4(address: string): boolean {
+  const parsed = parseIpv4Octets(address);
+  if (parsed === undefined) return false;
+  const [a, b] = parsed;
+  return PRIVATE_IPV4_RANGES.some(
+    (range) =>
+      a === range.first && b >= range.secondMin && b <= range.secondMax,
+  );
 }
 
 /**
@@ -173,25 +196,41 @@ function detectLanIpv4(
  *   3. Detected private LAN interfaces.
  *   4. `"unknown"` — only when the host genuinely has no private address.
  */
+/**
+ * The machine hostname, degraded to `"unknown"` rather than thrown.
+ *
+ * Fail open for the same reason `detectLanIpv4` does: a host that cannot name
+ * itself still has a `/health` answer to give.
+ */
+function resolveHostname(hostnameFn: () => string): string {
+  try {
+    return hostnameFn().trim() || UNKNOWN_SERVER_IP;
+  } catch {
+    return UNKNOWN_SERVER_IP;
+  }
+}
+
+/**
+ * The first configured value that names a concrete machine — precedence steps 1
+ * and 2, in order. `undefined` means configuration named nothing usable and
+ * detection is next.
+ */
+function configuredServerIp(input: ServerIdentityInput): string | undefined {
+  for (const candidate of [input.configuredServerIp, input.bindHost]) {
+    const value = normalize(candidate);
+    if (value && isConcreteHost(value)) return value;
+  }
+  return undefined;
+}
+
 export function resolveServerIdentity(
   input: ServerIdentityInput = {},
 ): ServerIdentity {
-  const hostnameFn = input.hostname ?? (() => os.hostname());
-  let hostname: string;
-  try {
-    hostname = hostnameFn().trim() || UNKNOWN_SERVER_IP;
-  } catch {
-    hostname = UNKNOWN_SERVER_IP;
-  }
+  const hostname = resolveHostname(input.hostname ?? (() => os.hostname()));
 
-  const configured = normalize(input.configuredServerIp);
-  if (configured && isConcreteHost(configured)) {
+  const configured = configuredServerIp(input);
+  if (configured !== undefined) {
     return { hostname, serverIp: configured, serverIps: [configured] };
-  }
-
-  const bindHost = normalize(input.bindHost);
-  if (bindHost && isConcreteHost(bindHost)) {
-    return { hostname, serverIp: bindHost, serverIps: [bindHost] };
   }
 
   const detected = detectLanIpv4(


### PR DESCRIPTION
## Summary

- `server/transport/server-identity.ts` carried the last two `#780` lint findings in this file: `isPrivateIpv4` at complexity 14 and `resolveServerIdentity` at 11, against a maximum of 10. Both are pure functions, so this is a structural change with no behavior moved.
- `isPrivateIpv4` had one branch per accepted range. The five ranges are now a table of first-octet plus second-octet-span records, tested by a single expression, so reading or adding a range is a data edit instead of another branch. A /8 is written as a span across the whole second octet. The accepted set is unchanged: 10/8, 172.16/12, 192.168/16 (RFC1918), 169.254/16 (RFC3927), 100.64/10 (RFC6598).
- Octet parsing and validation moved into `parseIpv4Octets`, which reports `undefined` for a malformed address at exactly the point the previous inline guard returned `false`.
- `resolveServerIdentity` gained two named module-level helpers. `resolveHostname` holds the try/catch that degrades an unreadable hostname to `unknown`, which is the same fail-open posture `detectLanIpv4` already takes. `configuredServerIp` walks `configuredServerIp` then `bindHost` in that order and returns the first that names a concrete machine.
- `docs/CONFIG_REFERENCE.md` ("Host identity in `/health`") already describes steps 1 and 2 as configuration ahead of detection, so collapsing them into one ordered walk follows the recorded design rather than inventing a new one. Precedence, the returned shape, and the single-element `server_ips` for a configured answer are identical.
- No schema, default, error string, SQL, or log event name is touched. No other file is changed, and no lint rule is disabled.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Red first, on the untouched file:

```
server/transport/server-identity.ts:50:1: error eslint(complexity): function `isPrivateIpv4` has a complexity of 14. Maximum allowed is 10.
server/transport/server-identity.ts:176:8: error eslint(complexity): function `resolveServerIdentity` has a complexity of 11. Maximum allowed is 10.
```

`DONE_MEANS_780_FILES=server/transport/server-identity.ts bash scripts/done-means/780-touched-files-lint-clean.sh` exited 1 before the change.

Green, re-run on the committed tree after the pre-commit prettier hook:

- `./node_modules/.bin/oxlint --deny-warnings server/transport/server-identity.ts` -> exit 0, no findings.
- `bunx tsc --noEmit` -> exit 0.
- `bun run test:isolated server/transport/ src/server.test.ts` -> 86 pass, 0 fail, 192 expect() calls across 5 files. The 25 tests in `server/transport/server-identity.test.ts` are unmodified and pin the precedence order, the numeric-IPv4-family case older Node runtimes report, physical-before-virtual ordering, and the `unknown` fallback.
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (file list derived from `git diff --name-only origin/main...HEAD`) -> exit 0.

Python package is untouched, so its checks are not applicable. No migration, no runtime contract change, so no live smoke applies.

## Critical Self-Review

- Highest-risk behavior: private-range membership. `isPrivateIpv4` decides which interfaces `/health` will volunteer, so a widened range would disclose a public address on an unauthenticated endpoint. The table encodes the same five ranges the branches did, and 192.168/16 and 169.254/16 are written as single-value spans so they cannot widen to a /8 by accident.
- Assumptions that could be wrong: that `configuredServerIp` and `bindHost` were the only two configuration sources and were evaluated in that order. Read directly from the replaced code and confirmed against `docs/CONFIG_REFERENCE.md` steps 1 and 2.
- Missing/weak tests: no test asserts that a public address such as 8.8.8.8 is rejected by `isPrivateIpv4` through the resolver. The existing suite proves the accepted ranges are accepted, not that a routable address is refused. The function is not exported, so this would be an addition through `resolveServerIdentity`; it is pre-existing and not introduced here.
- Security/permission risk: none added. The disclosure boundary is the range table, which is unchanged; `/health` remains unauthenticated and detection still never volunteers a routable address.
- Migration/deploy risk: none. No schema, no migration, no config key added or renamed.
- Downstream client/runtime risk: none. No exported signature changed — `resolveServerIdentity`, `readDeployedRevision`, `UNKNOWN_SERVER_IP`, `ServerIdentity`, and `ServerIdentityInput` keep their shapes, so `src/index.ts`, `server/config.ts`, `server/observability/trace-release.ts`, and `scripts/run-two-worker.ts` are unaffected. The `/health` response body is byte-identical for the same host.
- Rollback/cleanup concern: none. Single commit, single file, revertable on its own.
- Fixes made before PR: checked `src/tools/repo-facts.ts:isPrivateOrLocalHost` and `src/sharing.ts:isPrivate` for reuse before writing anything. Neither fits: the first is an SSRF allowlist that must accept loopback and localhost, which this module must reject, and it omits RFC6598; the second is about private content tags and is unrelated. Sharing either would have changed behavior in both callers, so no helper was extracted across module boundaries.
- Known residual risk: low. The change is confined to control flow inside two non-exported code paths of one file, with 25 unmodified tests over the observable output.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical lint-standard refactor under #780 with no review finding, no defect, and no new pattern for a future swarm to check.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no MCP tool, transport, schema, or client-facing surface changed; `/health` output is identical for the same host.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface is touched. The change is internal control flow in one server module, with no tool schema, response shape, or wire format affected.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Rollout does not apply: `docs/downstream-rollout.md` scopes it to MCP tool, schema, protocol, and client-facing changes. This PR changes no exported signature and no response body, so no downstream consumer can observe it.
