### PR TITLE
refactor(list-recent): bring server/tools/list-recent.ts to the lint standard (#780)

### DIFF
--- a/server/tools/list-recent.ts
+++ b/server/tools/list-recent.ts
@@ -23,9 +23,14 @@
  */
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { ResourceTable } from "../auth/types.ts";
+import type { AuthIdentity, ResourceTable } from "../auth/types.ts";
 import { canRead } from "../auth/permissions.ts";
-import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import { readableNamespaces } from "./read-scope.ts";
 import {
   ALL_TABLES,
@@ -55,7 +60,9 @@ function buildWhereClause(
   tier: Tier | undefined,
   namespaceParamIndex: number | undefined,
 ): string {
-  const archiveFilter = includeArchived ? "" : ` AND ${alias}.archived_at IS NULL`;
+  const archiveFilter = includeArchived
+    ? ""
+    : ` AND ${alias}.archived_at IS NULL`;
   const tierFilter = tier ? ` AND ${alias}.tier = '${tier}'` : "";
   const namespaceFilter = namespaceParamIndex
     ? ` AND ${alias}.namespace = ANY($${namespaceParamIndex}::text[])`
@@ -102,6 +109,239 @@ function buildCountSelect(
   ${buildWhereClause(alias, includeArchived, tier, namespaceParamIndex)}`;
 }
 
+const listRecentDescription =
+  "List recent brain entries chronologically. Returns {entries, total_count, has_more} envelope by default, " +
+  "or raw array with response_format='array'. " +
+  "Resilient parsing: const entries = Array.isArray(result) ? result : result.entries ?? [];";
+
+const listRecentInputSchema = {
+  table: z
+    .enum(["thoughts", "decisions", "relationships", "projects", "sessions"])
+    .optional()
+    .describe("Optional: filter to a specific table"),
+  days: z
+    .number()
+    .int()
+    .min(1)
+    .max(365)
+    .optional()
+    .describe("Number of days to look back (default 7)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Maximum entries to return (default 20, max 500)"),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Number of entries to skip for pagination (default 0)"),
+  include_archived: z
+    .boolean()
+    .optional()
+    .describe("Include archived entries (default false)"),
+  tier: z
+    .enum(["hot", "warm", "cold"])
+    .optional()
+    .describe("Optional: filter to a specific cognitive tier"),
+  response_format: z
+    .enum(["envelope", "array"])
+    .optional()
+    .describe(
+      "Response format: 'envelope' (default) returns {entries, total_count, has_more}; 'array' returns raw array for backwards compatibility",
+    ),
+};
+
+const listRecentAnnotations = {
+  title: "List Recent",
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+/** The `list_recent` arguments as published by {@link listRecentInputSchema}. */
+interface ListRecentArgs {
+  readonly table?: string;
+  readonly days?: number;
+  readonly limit?: number;
+  readonly offset?: number;
+  readonly include_archived?: boolean;
+  readonly tier?: string;
+  readonly response_format?: string;
+}
+
+/** The arguments after the documented defaults are applied. */
+interface ListRecentRequest {
+  readonly days: number;
+  readonly limit: number;
+  readonly offset: number;
+  readonly includeArchived: boolean;
+  readonly tier: Tier | undefined;
+  readonly asArray: boolean;
+}
+
+/**
+ * Apply the documented argument defaults.
+ *
+ * These defaults are part of the frozen client contract, so they live in one
+ * place rather than inline where a later edit could move one and not the other.
+ *
+ * @param args Caller-supplied arguments, already schema-validated.
+ * @returns The normalized request.
+ */
+function normalizeListRecentArgs(args: ListRecentArgs): ListRecentRequest {
+  return {
+    days: args.days ?? 7,
+    limit: args.limit ?? 20,
+    offset: args.offset ?? 0,
+    includeArchived: args.include_archived ?? false,
+    tier: args.tier as Tier | undefined,
+    asArray: args.response_format === "array",
+  };
+}
+
+/**
+ * Resolve which tables this identity may list, or the reason it may not.
+ *
+ * The role gate runs against the table the caller named so an unreadable table
+ * is denied by name, rather than silently widening to the readable set.
+ *
+ * @param identity Token-derived identity.
+ * @param requested The caller-supplied table argument, if any.
+ * @returns The readable tables, or a `denied` message to return verbatim.
+ */
+function resolveListRecentTables(
+  identity: AuthIdentity,
+  requested: ResourceTable | undefined,
+): { tables: ResourceTable[] } | { denied: string } {
+  if (requested) {
+    if (!canRead(identity.role, requested)) {
+      return { denied: `Permission denied: cannot read ${requested}` };
+    }
+    return { tables: [requested] };
+  }
+  const tables = ALL_TABLES.filter((table) => canRead(identity.role, table));
+  if (tables.length === 0) return { denied: NO_READABLE_TABLES };
+  return { tables };
+}
+
+/** The two SQL strings and the parameters each one binds. */
+interface ListRecentQueries {
+  readonly dataSql: string;
+  readonly dataParams: unknown[];
+  readonly countSql: string;
+  readonly countParams: unknown[];
+}
+
+/**
+ * Build the data and count queries for one listing.
+ *
+ * @param options Readable tables, the normalized request, and the readable
+ *   namespaces (`undefined` for a role whose reads are global by design).
+ * @returns Both queries with their bound parameters.
+ */
+function buildListRecentQueries(options: {
+  tables: readonly ResourceTable[];
+  request: ListRecentRequest;
+  readable: string[] | undefined;
+}): ListRecentQueries {
+  const { tables, request, readable } = options;
+  const { days, limit, offset, includeArchived, tier } = request;
+  // The data query binds days/limit/offset first, so namespaces land at $4.
+  // The count query binds only days, so they land at $2. Getting these two
+  // indexes crossed would silently constrain the wrong parameter.
+  const dataNamespaceIndex = readable ? 4 : undefined;
+  const countNamespaceIndex = readable ? 2 : undefined;
+
+  const dataSql = `${tables
+    .map((table) =>
+      buildTableSelect(table, includeArchived, tier, dataNamespaceIndex),
+    )
+    .join("\nUNION ALL\n")}\nORDER BY created_at DESC\nLIMIT $2 OFFSET $3`;
+
+  const countSql = `SELECT SUM(cnt)::int AS total_count FROM (${tables
+    .map((table) =>
+      buildCountSelect(table, includeArchived, tier, countNamespaceIndex),
+    )
+    .join("\nUNION ALL\n")}) counts`;
+
+  return {
+    dataSql,
+    dataParams: readable
+      ? [days, limit, offset, readable]
+      : [days, limit, offset],
+    countSql,
+    countParams: readable ? [days, readable] : [days],
+  };
+}
+
+/**
+ * Run the data query and the independently-recoverable count query together.
+ *
+ * A failed count yields `null` rather than failing the call: the rows are the
+ * answer and the count is a convenience.
+ *
+ * @param options The built queries and the pool/logger they run against.
+ * @returns The data rows and the total count, which may be `null`.
+ */
+async function runListRecentQueries(options: {
+  queries: ListRecentQueries;
+  dependencies: MemoryToolDependencies;
+}): Promise<{ rows: unknown[]; totalCount: number | null }> {
+  const { queries, dependencies } = options;
+  const [dataResult, countResult] = await Promise.all([
+    dependencies.pool.query(queries.dataSql, queries.dataParams),
+    // Independently recoverable: the entries are the answer, the count is a
+    // convenience, so a failed count yields null rather than failing the call.
+    dependencies.pool
+      .query(queries.countSql, queries.countParams)
+      .catch((error: unknown) => {
+        dependencies.logger.warn(
+          {
+            error_message:
+              error instanceof Error ? error.message : String(error),
+          },
+          "list_recent_count_failed",
+        );
+        return null;
+      }),
+  ]);
+
+  const totalCount =
+    (countResult?.rows[0] as { total_count?: number } | undefined)
+      ?.total_count ?? null;
+
+  return { rows: dataResult.rows, totalCount };
+}
+
+/**
+ * Shape the response in whichever of the two frozen formats the caller asked for.
+ *
+ * @param options The rows, the count, and the normalized request.
+ * @returns The tool result.
+ */
+function listRecentResult(options: {
+  rows: unknown[];
+  totalCount: number | null;
+  request: ListRecentRequest;
+}) {
+  const { rows, totalCount, request } = options;
+  if (request.asArray) return textResult(rows);
+  return textResult({
+    entries: rows,
+    total_count: totalCount,
+    offset: request.offset,
+    limit: request.limit,
+    // Unknowable without a count, and `false` is the honest answer there:
+    // it claims no knowledge of further pages rather than inventing one.
+    has_more:
+      totalCount !== null ? request.offset + rows.length < totalCount : false,
+  });
+}
+
 export function registerListRecentTool(
   server: McpServer,
   dependencies: MemoryToolDependencies,
@@ -109,144 +349,34 @@ export function registerListRecentTool(
   server.registerTool(
     "list_recent",
     {
-      description:
-        "List recent brain entries chronologically. Returns {entries, total_count, has_more} envelope by default, " +
-        "or raw array with response_format='array'. " +
-        "Resilient parsing: const entries = Array.isArray(result) ? result : result.entries ?? [];",
-      inputSchema: {
-        table: z
-          .enum([
-            "thoughts",
-            "decisions",
-            "relationships",
-            "projects",
-            "sessions",
-          ])
-          .optional()
-          .describe("Optional: filter to a specific table"),
-        days: z
-          .number()
-          .int()
-          .min(1)
-          .max(365)
-          .optional()
-          .describe("Number of days to look back (default 7)"),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe("Maximum entries to return (default 20, max 500)"),
-        offset: z
-          .number()
-          .int()
-          .min(0)
-          .optional()
-          .describe("Number of entries to skip for pagination (default 0)"),
-        include_archived: z
-          .boolean()
-          .optional()
-          .describe("Include archived entries (default false)"),
-        tier: z
-          .enum(["hot", "warm", "cold"])
-          .optional()
-          .describe("Optional: filter to a specific cognitive tier"),
-        response_format: z
-          .enum(["envelope", "array"])
-          .optional()
-          .describe(
-            "Response format: 'envelope' (default) returns {entries, total_count, has_more}; 'array' returns raw array for backwards compatibility",
-          ),
-      },
-      annotations: {
-        title: "List Recent",
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      description: listRecentDescription,
+      inputSchema: listRecentInputSchema,
+      annotations: listRecentAnnotations,
     },
     async (args, extra) => {
       const identity = authIdentity(extra.authInfo);
       if (!identity) return errorResult(NO_READABLE_TABLES);
 
-      const requested = args.table as ResourceTable | undefined;
-      let tables: ResourceTable[];
-      if (requested) {
-        if (!canRead(identity.role, requested)) {
-          return errorResult(`Permission denied: cannot read ${requested}`);
-        }
-        tables = [requested];
-      } else {
-        tables = ALL_TABLES.filter((table) => canRead(identity.role, table));
-      }
-      if (tables.length === 0) return errorResult(NO_READABLE_TABLES);
+      const scope = resolveListRecentTables(
+        identity,
+        args.table as ResourceTable | undefined,
+      );
+      if ("denied" in scope) return errorResult(scope.denied);
 
-      const days = args.days ?? 7;
-      const limit = args.limit ?? 20;
-      const offset = args.offset ?? 0;
-      const includeArchived = args.include_archived ?? false;
-      const tier = args.tier as Tier | undefined;
-      const asArray = args.response_format === "array";
-
+      const request = normalizeListRecentArgs(args);
       // `undefined` here means a global read, which is only reachable for a role
       // whose reads are global by design; every other role gets the predicate.
       const readable = readableNamespaces(identity);
-      // The data query binds days/limit/offset first, so namespaces land at $4.
-      // The count query binds only days, so they land at $2. Getting these two
-      // indexes crossed would silently constrain the wrong parameter.
-      const dataNamespaceIndex = readable ? 4 : undefined;
-      const countNamespaceIndex = readable ? 2 : undefined;
-
-      const dataSql = `${tables
-        .map((table) =>
-          buildTableSelect(table, includeArchived, tier, dataNamespaceIndex),
-        )
-        .join("\nUNION ALL\n")}\nORDER BY created_at DESC\nLIMIT $2 OFFSET $3`;
-
-      const countSql = `SELECT SUM(cnt)::int AS total_count FROM (${tables
-        .map((table) =>
-          buildCountSelect(table, includeArchived, tier, countNamespaceIndex),
-        )
-        .join("\nUNION ALL\n")}) counts`;
-
-      const dataParams = readable
-        ? [days, limit, offset, readable]
-        : [days, limit, offset];
-      const countParams = readable ? [days, readable] : [days];
-
-      const [dataResult, countResult] = await Promise.all([
-        dependencies.pool.query(dataSql, dataParams),
-        // Independently recoverable: the entries are the answer, the count is a
-        // convenience, so a failed count yields null rather than failing the call.
-        dependencies.pool.query(countSql, countParams).catch((error: unknown) => {
-          dependencies.logger.warn(
-            {
-              error_message:
-                error instanceof Error ? error.message : String(error),
-            },
-            "list_recent_count_failed",
-          );
-          return null;
-        }),
-      ]);
-
-      const totalCount =
-        (countResult?.rows[0] as { total_count?: number } | undefined)
-          ?.total_count ?? null;
-
-      if (asArray) return textResult(dataResult.rows);
-
-      return textResult({
-        entries: dataResult.rows,
-        total_count: totalCount,
-        offset,
-        limit,
-        // Unknowable without a count, and `false` is the honest answer there:
-        // it claims no knowledge of further pages rather than inventing one.
-        has_more:
-          totalCount !== null ? offset + dataResult.rows.length < totalCount : false,
+      const queries = buildListRecentQueries({
+        tables: scope.tables,
+        request,
+        readable,
       });
+      const { rows, totalCount } = await runListRecentQueries({
+        queries,
+        dependencies,
+      });
+      return listRecentResult({ rows, totalCount, request });
     },
   );
 }


### PR DESCRIPTION
## Summary

- `registerListRecentTool` in `server/tools/list-recent.ts` was 129 lines and its handler carried a complexity of 18, both over the repo standard. The registration wrapper and the request handling were a single function, so every branch counted against a body that was mostly a literal input schema.
- Applies the shape the already-converted tools use (`scan-namespace.ts`, `find-duplicates.ts`, `search-brain.ts`): the description, input schema, and annotations are hoisted to module-level constants, and the handler is split into named module-level helpers — `normalizeListRecentArgs` (documented defaults), `resolveListRecentTables` (the house `{tables} | {denied}` shape), `buildListRecentQueries` and `runListRecentQueries` (the data/count pair), and `listRecentResult` (the two frozen response formats). Helpers taking more than a couple of inputs take an options object rather than positional parameters.
- No behavior moves. The schema, the defaults (7 days, 20 entries, offset 0), both permission-denied strings, both SQL builders, the `list_recent_count_failed` log event, the null-count recovery, and both response shapes are identical. `readableNamespaces` from `read-scope.ts` remains the namespace source; the `$4`/`$2` parameter-index split moves into `buildListRecentQueries` with its explanatory comment intact.
- Reuse check: `normalizeSearchArgs` in `search-request.ts` was evaluated and rejected — it defaults `limit` to 10 where `list_recent` publishes 20, and carries search-mode/fts-config fields this tool has no argument for. Reusing it would have moved a frozen default.
- One file changed. No existing test modified, no other file touched, no disable comments.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Red first, on the untouched file:

```
server/tools/list-recent.ts:105:8: error eslint(max-lines-per-function): The function `registerListRecentTool` has too many lines (129). Maximum allowed is 100.
server/tools/list-recent.ts:169:5: error eslint(complexity): async function has a complexity of 18. Maximum allowed is 10.
```

`DONE_MEANS_780_FILES=server/tools/list-recent.ts bash scripts/done-means/780-touched-files-lint-clean.sh` exited 1.

Green, re-run on the committed tree after the pre-commit prettier pass:

- `./node_modules/.bin/oxlint --deny-warnings server/tools/list-recent.ts` -> exit 0
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated src/tools/__tests__/list-recent.test.ts server/tools/search-read-scope.test.ts server/tools/` -> 175 pass, 0 fail across 18 files
- `bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 0

Python package checks are not applicable: nothing under `python/openbrain-memory/` changed. A live smoke is not applicable: this is an internal restructuring with no wire-visible change, and the `list_recent` contract fixtures are untouched.

## Critical Self-Review

- Highest-risk behavior: the namespace predicate. `list_recent` binds readable namespaces at `$4` in the data query and `$2` in the count query, and the two indexes are not interchangeable — crossing them would constrain the wrong parameter and return rows from namespaces the caller may not read, silently. Both index computations moved into `buildListRecentQueries` together, so they cannot drift apart, and `server/tools/search-read-scope.test.ts` asserts the emitted SQL and bound parameters.
- Assumptions that could be wrong: that folding the original `tables.length === 0` check into `resolveListRecentTables` preserves the denial. The original ran that check after both branches; the extracted version runs it only on the unfiltered branch. The named-table branch always yields exactly one element, so the length is never 0 there — the two are equivalent, and the named-table path has its own by-name denial ahead of it.
- Missing/weak tests: no test drives the `response_format: "array"` path against a real pool at the `server/` layer; coverage for that shape comes from the `src/tools/` sibling. Not made worse here, and not in scope for a lint lane.
- Security/permission risk: both permission-denied strings are byte-identical to the originals, and the role gate still runs against the caller-named table before any query is built. Namespace scoping is unchanged and still auth-derived via `readableNamespaces`.
- Migration/deploy risk: none. No schema, no migration, no config.
- Downstream client/runtime risk: none. Per `docs/downstream-rollout.md` this is not an MCP tool/schema/protocol change — the tool name, input schema, annotations, and both response shapes are unchanged, so no client sees a difference.
- Rollback/cleanup concern: a single-file revert restores the prior behavior exactly; nothing was moved out of the file, so no other module depends on this commit.
- Fixes made before PR: read each extracted helper back against the original line by line after extraction, because the suite did not catch a non-equivalent predicate rewrite in #806. That read is what surfaced the `tables.length === 0` ordering question above.
- Known residual risk: low. The only non-mechanical judgment is the table-resolution ordering, reasoned through above; everything else is a literal move of unchanged text.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new failure pattern surfaced — this lane exercised the existing round-38 lane-contract guidance (verify helper reuse is identical field for field before reusing; read every extraction back against the original) and both rules held without amendment.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no wire-visible change; the restructuring is internal to one server tool module and the contract fixtures are untouched.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract moved. `contracts/server/server-recall-family.fixture.json` describes the `list_recent` tool surface, and the tool name, input schema, annotations, and both response shapes are byte-identical after this change, so there is nothing for a fixture to record.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All four are not applicable by the same reason: the rollout doc scopes downstream work to MCP tool/schema/protocol/client-facing changes, and this PR changes none of them. `list_recent` publishes the same name, the same input schema, the same annotations, and the same two response shapes before and after. A downstream client cannot observe this commit.
