### PR TITLE
refactor(get-entry): bring server/tools/get-entry.ts to the lint standard (#780)

### DIFF
--- a/server/tools/get-entry.ts
+++ b/server/tools/get-entry.ts
@@ -24,9 +24,17 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../auth/permissions.ts";
-import { namespacePredicate } from "../auth/namespace-policy.ts";
+import {
+  namespacePredicate,
+  type NamespacePredicate,
+} from "../auth/namespace-policy.ts";
 import type { ResourceTable } from "../auth/types.ts";
-import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import { SOURCE_LABELS, tableEnum } from "./curation-helpers.ts";
 
 /** Observed current-src default preview width for the compact envelope. */
@@ -73,7 +81,152 @@ const COMPACT_CONTENT: Readonly<Record<ResourceTable, string>> = {
 };
 
 /** Tables whose rows carry no `updated_at`, observed from the live schema. */
-const WITHOUT_UPDATED_AT = new Set<ResourceTable>(["relationships", "projects"]);
+const WITHOUT_UPDATED_AT = new Set<ResourceTable>([
+  "relationships",
+  "projects",
+]);
+
+/** Frozen `get_entry` argument contract: the names and rule values are the API. */
+const getEntryInputSchema = {
+  table: tableEnum.describe(
+    "Which table the entry is in (from search result source_type + 's')",
+  ),
+  id: z.string().uuid().describe("Entry UUID from search results"),
+  render: z
+    .enum(["full", "compact"])
+    .optional()
+    .describe(
+      "Response shape: full returns the complete row (default); compact returns a bounded preview envelope.",
+    ),
+  max_chars: z
+    .number()
+    .int()
+    .min(80)
+    .max(2000)
+    .optional()
+    .describe(
+      "Maximum compact content_preview length in characters (default 500, max 2000). Ignored for full render.",
+    ),
+};
+
+/** Tool annotations; `get_entry` reads and never mutates. */
+const getEntryAnnotations = {
+  title: "Get Entry",
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
+const GET_ENTRY_DESCRIPTION =
+  "Fetch a readable entry by table and ID. Defaults to full content; use render=compact for a bounded exact-UUID preview.";
+
+/**
+ * Found-but-unreadable and genuinely-absent collapse to ONE error string, so a
+ * caller cannot use this tool to probe which UUIDs exist in a namespace it has
+ * no read authority over.
+ */
+const NOT_FOUND = "Entry not found or archived";
+
+/** One resolved read: the table, the id, and the caller's read predicate. */
+interface EntryRead {
+  table: ResourceTable;
+  id: string;
+  predicate: NamespacePredicate;
+}
+
+/** Compact-render request: a resolved read plus the observed preview width. */
+interface CompactRead extends EntryRead {
+  maxChars: number;
+}
+
+/**
+ * Shape the compact envelope from one fetched row.
+ *
+ * Kept apart from the query so the payload's field order -- which clients parse
+ * -- is readable in one place rather than interleaved with SQL construction.
+ */
+function compactEnvelope(
+  row: Record<string, unknown>,
+  request: CompactRead,
+): Record<string, unknown> {
+  const namespace = typeof row.namespace === "string" ? row.namespace : null;
+  const sourceType = SOURCE_LABELS[request.table];
+  return {
+    id: row.id,
+    table: request.table,
+    source_type: sourceType,
+    namespace,
+    render: "compact",
+    max_chars: request.maxChars,
+    content_preview: row.content_preview,
+    content_length: Number(row.content_length ?? 0),
+    content_truncated: Boolean(row.content_truncated),
+    created_by: row.created_by,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    tier: row.tier,
+    tags: row.tags,
+    source_ref: { source: "brain", type: sourceType, id: row.id, namespace },
+    full_available: true,
+    fetch_path: {
+      tool: "get_entry",
+      arguments: { table: request.table, id: row.id, render: "full" },
+    },
+  };
+}
+
+/**
+ * Fetch one row as the bounded compact preview envelope.
+ *
+ * The namespace predicate is applied to the SELECT itself, inside the same
+ * statement that resolves the id, so an id alone can never reach a row the
+ * identity has no read authority over.
+ */
+async function fetchCompact(
+  dependencies: MemoryToolDependencies,
+  request: CompactRead,
+): Promise<Record<string, unknown> | null> {
+  const { table, id, predicate, maxChars } = request;
+  const parameters: unknown[] = [id, ...predicate.values];
+  parameters.push(maxChars);
+  const maxCharsParameter = `$${parameters.length}`;
+  const updatedAt = WITHOUT_UPDATED_AT.has(table)
+    ? "NULL::timestamptz"
+    : "updated_at";
+  const contentExpression = `regexp_replace(COALESCE((${COMPACT_CONTENT[table]})::text, ''), '[[:space:]]+', ' ', 'g')`;
+
+  const { rows } = await dependencies.pool.query(
+    `SELECT entry.id, entry.namespace, entry.created_by, entry.created_at,
+            entry.updated_at, entry.tier, entry.tags,
+            LEFT(entry.content_text, ${maxCharsParameter}) AS content_preview,
+            length(entry.content_text) AS content_length,
+            length(entry.content_text) > ${maxCharsParameter} AS content_truncated
+       FROM (
+         SELECT id, namespace, created_by, created_at, ${updatedAt} AS updated_at,
+                tier, tags, ${contentExpression} AS content_text
+           FROM ${table}
+          WHERE id = $1 AND archived_at IS NULL${predicate.clause}
+       ) entry`,
+    parameters,
+  );
+  if (rows.length === 0) return null;
+  return compactEnvelope(rows[0] as Record<string, unknown>, request);
+}
+
+/** Fetch one row as the table's own full projection, under the read predicate. */
+async function fetchFull(
+  dependencies: MemoryToolDependencies,
+  request: EntryRead,
+): Promise<unknown | null> {
+  const { table, id, predicate } = request;
+  const { rows } = await dependencies.pool.query(
+    `SELECT ${TABLE_COLUMNS[table]} FROM ${table}
+      WHERE id = $1 AND archived_at IS NULL${predicate.clause}`,
+    [id, ...predicate.values],
+  );
+  if (rows.length === 0) return null;
+  return rows[0];
+}
 
 export function registerGetEntryTool(
   server: McpServer,
@@ -82,35 +235,9 @@ export function registerGetEntryTool(
   server.registerTool(
     "get_entry",
     {
-      description:
-        "Fetch a readable entry by table and ID. Defaults to full content; use render=compact for a bounded exact-UUID preview.",
-      inputSchema: {
-        table: tableEnum.describe(
-          "Which table the entry is in (from search result source_type + 's')",
-        ),
-        id: z.string().uuid().describe("Entry UUID from search results"),
-        render: z
-          .enum(["full", "compact"])
-          .optional()
-          .describe(
-            "Response shape: full returns the complete row (default); compact returns a bounded preview envelope.",
-          ),
-        max_chars: z
-          .number()
-          .int()
-          .min(80)
-          .max(2000)
-          .optional()
-          .describe(
-            "Maximum compact content_preview length in characters (default 500, max 2000). Ignored for full render.",
-          ),
-      },
-      annotations: {
-        title: "Get Entry",
-        readOnlyHint: true,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      description: GET_ENTRY_DESCRIPTION,
+      inputSchema: getEntryInputSchema,
+      annotations: getEntryAnnotations,
     },
     async (args, extra) => {
       const identity = authIdentity(extra.authInfo);
@@ -119,72 +246,32 @@ export function registerGetEntryTool(
         return errorResult(`Permission denied: cannot read ${table}`);
       }
 
-      // Found-but-unreadable and genuinely-absent collapse to ONE error string,
-      // so a caller cannot use this tool to probe which UUIDs exist in a
-      // namespace it has no read authority over.
-      const notFound = errorResult("Entry not found or archived");
-      const predicate = namespacePredicate(identity, "read", 2);
+      const read: EntryRead = {
+        table,
+        id: args.id,
+        predicate: namespacePredicate(identity, "read", 2),
+      };
 
       if ((args.render ?? "full") === "compact") {
-        const maxChars = args.max_chars ?? DEFAULT_COMPACT_MAX_CHARS;
-        const parameters: unknown[] = [args.id, ...predicate.values];
-        parameters.push(maxChars);
-        const maxCharsParameter = `$${parameters.length}`;
-        const updatedAt = WITHOUT_UPDATED_AT.has(table)
-          ? "NULL::timestamptz"
-          : "updated_at";
-        const contentExpression =
-          `regexp_replace(COALESCE((${COMPACT_CONTENT[table]})::text, ''), '[[:space:]]+', ' ', 'g')`;
-
-        const { rows } = await dependencies.pool.query(
-          `SELECT entry.id, entry.namespace, entry.created_by, entry.created_at,
-                  entry.updated_at, entry.tier, entry.tags,
-                  LEFT(entry.content_text, ${maxCharsParameter}) AS content_preview,
-                  length(entry.content_text) AS content_length,
-                  length(entry.content_text) > ${maxCharsParameter} AS content_truncated
-             FROM (
-               SELECT id, namespace, created_by, created_at, ${updatedAt} AS updated_at,
-                      tier, tags, ${contentExpression} AS content_text
-                 FROM ${table}
-                WHERE id = $1 AND archived_at IS NULL${predicate.clause}
-             ) entry`,
-          parameters,
-        );
-        if (rows.length === 0) return notFound;
-
-        const row = rows[0] as Record<string, unknown>;
-        const namespace = typeof row.namespace === "string" ? row.namespace : null;
-        const sourceType = SOURCE_LABELS[table];
-        dependencies.logger.info({ tool: "get_entry", render: "compact" }, "tool_result");
-        return textResult({
-          id: row.id,
-          table,
-          source_type: sourceType,
-          namespace,
-          render: "compact",
-          max_chars: maxChars,
-          content_preview: row.content_preview,
-          content_length: Number(row.content_length ?? 0),
-          content_truncated: Boolean(row.content_truncated),
-          created_by: row.created_by,
-          created_at: row.created_at,
-          updated_at: row.updated_at,
-          tier: row.tier,
-          tags: row.tags,
-          source_ref: { source: "brain", type: sourceType, id: row.id, namespace },
-          full_available: true,
-          fetch_path: { tool: "get_entry", arguments: { table, id: row.id, render: "full" } },
+        const envelope = await fetchCompact(dependencies, {
+          ...read,
+          maxChars: args.max_chars ?? DEFAULT_COMPACT_MAX_CHARS,
         });
+        if (envelope === null) return errorResult(NOT_FOUND);
+        dependencies.logger.info(
+          { tool: "get_entry", render: "compact" },
+          "tool_result",
+        );
+        return textResult(envelope);
       }
 
-      const { rows } = await dependencies.pool.query(
-        `SELECT ${TABLE_COLUMNS[table]} FROM ${table}
-          WHERE id = $1 AND archived_at IS NULL${predicate.clause}`,
-        [args.id, ...predicate.values],
+      const row = await fetchFull(dependencies, read);
+      if (row === null) return errorResult(NOT_FOUND);
+      dependencies.logger.info(
+        { tool: "get_entry", render: "full" },
+        "tool_result",
       );
-      if (rows.length === 0) return notFound;
-      dependencies.logger.info({ tool: "get_entry", render: "full" }, "tool_result");
-      return textResult(rows[0]);
+      return textResult(row);
     },
   );
 }


### PR DESCRIPTION
## Summary

- `server/tools/get-entry.ts` carried two lint findings: `registerGetEntryTool` at 105 lines and its inline handler at complexity 11, both because the argument contract, the annotations, and both render arms lived inside the single `registerTool` call.
- Split along the seams `main` already established in `server/tools/resolve-entry.ts` and the other ported tools: the frozen argument schema (`getEntryInputSchema`), the annotations (`getEntryAnnotations`), the tool description, and the shared not-found string are now module constants.
- Each render arm is a named module-level function taking one options object — `fetchCompact(dependencies, CompactRead)` and `fetchFull(dependencies, EntryRead)` — and `compactEnvelope` shapes the compact payload on its own so the field order clients parse reads in one place instead of interleaved with SQL construction.
- The read predicate rides in the options object as the exported `NamespacePredicate` type from `server/auth/namespace-policy.ts`, keeping the namespace scope bound to the same SELECT that resolves the id, which is the isolation property the file's own header comment names.
- No behavior change: schema field names and rule values, both defaults, both error strings, both SQL statements, the `tool_result` log event and its `render` field, and the compact payload's field order are all unchanged. Only `server/tools/get-entry.ts` is touched.
- Reuse was checked before writing anything: `read-scope.ts`, `shared-namespace.ts`, `memory-helpers.ts`, `tool-failure.ts`, `search-request.ts`, and `entity-shared.ts` carry nothing matching these two table-specific projections field for field, so the extraction stayed inside the owning file and no helper was moved out.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`./node_modules/.bin/oxlint --deny-warnings server/tools/get-entry.ts` reported both findings verbatim before the change (`max-lines-per-function` 105 at :78, `complexity` 11 at :115) and exits 0 after. `bunx tsc --noEmit` is clean. `bun run test:isolated server/tools/` is 163 pass / 0 fail across 17 files, re-run on the committed tree after the pre-commit prettier hook reformatted the file. `bash scripts/done-means/780-touched-files-lint-clean.sh` exits 1 before and 0 after. Python is untouched; this is an internal TypeScript refactor with no wire-visible change, so no smoke applies.

## Critical Self-Review

- Highest-risk behavior: the compact render's payload shape and the namespace predicate binding. Both are what a client parses and what keeps an ID-based read inside the caller's authority, and both are reproduced field for field and parameter for parameter.
- Assumptions that could be wrong: that no existing shared helper already expresses these projections. Checked with `rg` across `server/tools/` before writing; the two column maps are table-specific to this tool and the compact envelope's `fetch_path` / `source_ref` fields have no sibling with the same shape.
- Missing/weak tests: no new test was added, deliberately — this change asserts equivalence, and the existing `server/tools/gap-closure-read-scope.test.ts` already exercises both render arms against the auth-derived predicate, which is the property most worth protecting here.
- Security/permission risk: the `canRead` gate and the `namespacePredicate(identity, "read", 2)` call are unmoved relative to each other, and the predicate reaches the SELECT through the options object rather than a closure. Found-but-unreadable and genuinely-absent still collapse to one error string, so the tool still cannot be used to probe which UUIDs exist elsewhere.
- Migration/deploy risk: none. No schema, no migration, no config.
- Downstream client/runtime risk: none. `get_entry`'s tool name, description, argument names and rule values, and both response shapes are byte-identical, so `contracts/server/` fixtures and the Python client see no difference.
- Rollback/cleanup concern: single-file, single-commit; reverting the commit restores the prior file exactly.
- Fixes made before PR: the first draft typed the predicate as an inline `{ clause: string; values: unknown[] }`, which `tsc` rejected because `NamespacePredicate.values` is `readonly`. Switched to importing the exported type rather than widening the local shape, so the readonly guarantee survives the extraction.
- Known residual risk: the SQL template literals shifted their leading indentation by one nesting level when the arms moved to module scope. The statements' internal alignment is unchanged and the whitespace is not semantically meaningful to Postgres, but the emitted query text differs by leading spaces from the prior version.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new failure pattern surfaced — the one `tsc` catch was a readonly-type mismatch already covered by the repo's existing typecheck gate, not a reviewer-missable class.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: internal refactor with no wire-visible or database-visible change.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface moved — the tool name, description, argument schema, and both response shapes are unchanged, so `contracts/server/server-entry-read.fixture.json` and the gap map still describe this tool accurately.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Rollout classification is not-applicable across the board: `docs/downstream-rollout.md` scopes rollout to MCP tool, schema, protocol, or client-facing changes, and none of those moved here. The change is confined to how one already-registered tool's handler is organized inside `server/tools/get-entry.ts`.
