### PR TITLE
refactor(context-pack-repo-facts): bring server/tools/context-pack-repo-facts.ts to the lint standard (#780)

### DIFF
--- a/server/tools/context-pack-repo-facts.ts
+++ b/server/tools/context-pack-repo-facts.ts
@@ -22,6 +22,7 @@ import {
   type SectionFragment,
   type SectionReaderDeps,
 } from "./context-pack-sections.ts";
+import { asError, errorIdentityFields } from "./context-pack-shared.ts";
 
 /**
  * Read-side mirror of the write-side `staleness_policy` enum.
@@ -127,6 +128,206 @@ export type RepoFactsReaderArgs = {
   budget?: SectionBudget;
 };
 
+type RepoFactRowAdmission =
+  | { admitted: false; countsAsTruncated: boolean }
+  | { admitted: true; text: string; truncated: boolean };
+
+/**
+ * Decide whether one row may become an item, and with what text.
+ *
+ * The three exclusions are ordered exactly as the original loop ran them, and
+ * that order is behavior: only the LAST of them (an unusable `fact`) can mark
+ * the section truncated, so a row rejected by an earlier guard must not reach
+ * the text step and set that flag. Lifting the decision here keeps the three
+ * reasons legible without letting them reorder.
+ */
+function admitRepoFactRow(
+  meta: Record<string, unknown>,
+  repo: string,
+  maxItemChars: number,
+): RepoFactRowAdmission {
+  // Defense in depth: never let a row whose metadata.repo drifted from the
+  // bind slip through, in case a JSON edit ever bypasses the predicate.
+  if (asText(meta.repo) !== repo) {
+    return { admitted: false, countsAsTruncated: false };
+  }
+  // A repo fact without source refs cannot be cited to its exact commit.
+  // Excluding it is the point of the section: an uncitable "fact" is just an
+  // assertion, and this section's value is that every item is checkable.
+  if (!asText(meta.source_url) || !asText(meta.source_commit)) {
+    return { admitted: false, countsAsTruncated: false };
+  }
+  const bounded = boundedItemText(meta.fact, maxItemChars);
+  if (!bounded.text) {
+    return { admitted: false, countsAsTruncated: asText(meta.fact) !== null };
+  }
+  return { admitted: true, text: bounded.text, truncated: bounded.truncated };
+}
+
+/** One admitted row as its item body and its matching citation. */
+function repoFactEntry(options: {
+  row: Record<string, unknown>;
+  meta: Record<string, unknown>;
+  repo: string;
+  fact: string;
+  nowMs: number;
+}): {
+  item: Record<string, unknown>;
+  citation: Record<string, unknown>;
+} {
+  const { row, meta, repo, fact, nowMs } = options;
+  const sourceUrl = asText(meta.source_url);
+  const sourceCommit = asText(meta.source_commit);
+  const citationId = `repo_fact:${String(row.id)}`;
+  return {
+    item: {
+      id: row.id,
+      repo,
+      path: asText(meta.path),
+      subject: asText(meta.subject) ?? asText(meta.symbol),
+      fact_type: asText(meta.fact_type),
+      fact,
+      source_commit: sourceCommit,
+      source_url: sourceUrl,
+      verified_at: asText(meta.verified_at),
+      staleness_policy: asText(meta.staleness_policy),
+      staleness_disposition: stalenessDispositionFor(
+        asText(meta.staleness_policy),
+        asText(meta.verified_at),
+        nowMs,
+      ),
+      confidence: typeof meta.confidence === "number" ? meta.confidence : null,
+      citation_id: citationId,
+    },
+    citation: {
+      id: citationId,
+      kind: "repo_fact",
+      source_ref: `ob_entities/${String(row.id)}`,
+      source_url: sourceUrl,
+      source_commit: sourceCommit,
+    },
+  };
+}
+
+/** Everything the row loop produces, before the envelope is assembled. */
+type RepoFactCollection = {
+  items: Array<Record<string, unknown>>;
+  citations: Array<Record<string, unknown>>;
+  truncated: boolean;
+};
+
+/**
+ * Walk the ordered rows once, admitting each through {@link admitRepoFactRow}.
+ * `truncated` starts at the caller's row-count verdict and can only be set, so
+ * the flag means "something did not make it in whole", exactly as before.
+ */
+function collectRepoFacts(options: {
+  rows: Array<Record<string, unknown>>;
+  repo: string;
+  maxItemChars: number;
+  nowMs: number;
+  truncated: boolean;
+}): RepoFactCollection {
+  const { rows, repo, maxItemChars, nowMs } = options;
+  const items: Array<Record<string, unknown>> = [];
+  const citations: Array<Record<string, unknown>> = [];
+  let truncated = options.truncated;
+
+  for (const row of rows) {
+    const meta = metadataOf(row);
+    const admission = admitRepoFactRow(meta, repo, maxItemChars);
+    if (!admission.admitted) {
+      if (admission.countsAsTruncated) truncated = true;
+      continue;
+    }
+    if (admission.truncated) truncated = true;
+    const entry = repoFactEntry({
+      row,
+      meta,
+      repo,
+      fact: admission.text,
+      nowMs,
+    });
+    items.push(entry.item);
+    citations.push(entry.citation);
+  }
+
+  return { items, citations, truncated };
+}
+
+/** The defined empty state for a pack that carries no active repo. */
+function noActiveRepoFragment(
+  budget: Record<string, unknown>,
+): SectionFragment {
+  return {
+    section: {
+      label: "repo_facts",
+      repo: null,
+      namespace_bound: true,
+      repo_bound: false,
+      items: [],
+      item_count: 0,
+      truncated: false,
+    },
+    scopeDenials: [{ source: "repo_facts", reasons: ["no_active_repo"] }],
+    truncation: [],
+    degradedSources: [],
+    budget,
+    citations: [],
+  };
+}
+
+/** The ordered, exactly-bound rows for one repo. No cross-repo fallback. */
+async function queryRepoFactRows(
+  deps: SectionReaderDeps,
+  namespace: string,
+  repo: string,
+): Promise<Array<Record<string, unknown>>> {
+  // Exact repo bind, archived rows excluded, no legacy fallback.
+  const { rows } = await deps.query(
+    `SELECT id, namespace, metadata, updated_at
+         FROM ob_entities
+        WHERE entity_type = 'repo_fact'
+          AND archived_at IS NULL
+          AND namespace = $1
+          AND metadata->>'repo' = $2
+        ORDER BY updated_at DESC, id DESC`,
+    [namespace, repo],
+  );
+  return rows;
+}
+
+/**
+ * Log a failed repo_facts read on two lines. ERROR states what broke so it is
+ * visible at the default level; DEBUG carries every input that shaped the call.
+ */
+function logRepoFactsFailure(options: {
+  logger: Logger | undefined;
+  args: RepoFactsReaderArgs;
+  repo: string;
+  budget: Record<string, unknown>;
+  error: unknown;
+}): void {
+  const { logger, args, repo, budget, error } = options;
+  const identity = errorIdentityFields(error);
+  logger?.error(
+    { repo, namespace: args.namespace, ...identity },
+    "repo_facts_section_failed",
+  );
+  logger?.debug(
+    {
+      repo,
+      namespace: args.namespace,
+      requested_budget: args.budget,
+      resolved_budget: budget,
+      ...identity,
+      pg_code: (error as { code?: unknown })?.code ?? null,
+      stack: asError(error)?.stack ?? null,
+    },
+    "repo_facts_section_failed_detail",
+  );
+}
+
 /**
  * Assemble a repo_facts fragment bound to exactly one repo. Deterministic order:
  * most-recently-updated first, then id.
@@ -148,104 +349,28 @@ export async function loadRepoFactsSection(
   };
 
   // No active repo -> defined empty state. Never widen the bind to recover.
-  if (repo === null) {
-    return {
-      section: {
-        label: "repo_facts",
-        repo: null,
-        namespace_bound: true,
-        repo_bound: false,
-        items: [],
-        item_count: 0,
-        truncated: false,
-      },
-      scopeDenials: [{ source: "repo_facts", reasons: ["no_active_repo"] }],
-      truncation: [],
-      degradedSources: [],
-      budget,
-      citations: [],
-    };
-  }
+  if (repo === null) return noActiveRepoFragment(budget);
 
   try {
-    // Exact repo bind, archived rows excluded, no legacy fallback.
-    const { rows } = await deps.query(
-      `SELECT id, namespace, metadata, updated_at
-         FROM ob_entities
-        WHERE entity_type = 'repo_fact'
-          AND archived_at IS NULL
-          AND namespace = $1
-          AND metadata->>'repo' = $2
-        ORDER BY updated_at DESC, id DESC`,
-      [args.namespace, repo],
-    );
+    const rows = await queryRepoFactRows(deps, args.namespace, repo);
+    const overCount = rows.length > maxItems;
+    const collected = collectRepoFacts({
+      rows: overCount ? rows.slice(0, maxItems) : rows,
+      repo,
+      maxItemChars,
+      nowMs: args.nowMs,
+      truncated: overCount,
+    });
 
-    const truncation: Array<Record<string, unknown>> = [];
-    let itemsTruncated = rows.length > maxItems;
-    const capped = itemsTruncated ? rows.slice(0, maxItems) : rows;
-
-    const items: Array<Record<string, unknown>> = [];
-    const citations: Array<Record<string, unknown>> = [];
-
-    for (const row of capped) {
-      const meta = metadataOf(row);
-      const boundRepo = asText(meta.repo);
-      // Defense in depth: never let a row whose metadata.repo drifted from the
-      // bind slip through, in case a JSON edit ever bypasses the predicate.
-      if (boundRepo !== repo) continue;
-
-      const sourceUrl = asText(meta.source_url);
-      const sourceCommit = asText(meta.source_commit);
-      // A repo fact without source refs cannot be cited to its exact commit.
-      // Excluding it is the point of the section: an uncitable "fact" is just an
-      // assertion, and this section's value is that every item is checkable.
-      if (!sourceUrl || !sourceCommit) continue;
-
-      const bounded = boundedItemText(meta.fact, maxItemChars);
-      if (!bounded.text) {
-        if (asText(meta.fact)) itemsTruncated = true;
-        continue;
-      }
-      if (bounded.truncated) itemsTruncated = true;
-
-      const disposition = stalenessDispositionFor(
-        asText(meta.staleness_policy),
-        asText(meta.verified_at),
-        args.nowMs,
-      );
-      const citationId = `repo_fact:${String(row.id)}`;
-      items.push({
-        id: row.id,
-        repo,
-        path: asText(meta.path),
-        subject: asText(meta.subject) ?? asText(meta.symbol),
-        fact_type: asText(meta.fact_type),
-        fact: bounded.text,
-        source_commit: sourceCommit,
-        source_url: sourceUrl,
-        verified_at: asText(meta.verified_at),
-        staleness_policy: asText(meta.staleness_policy),
-        staleness_disposition: disposition,
-        confidence:
-          typeof meta.confidence === "number" ? meta.confidence : null,
-        citation_id: citationId,
-      });
-      citations.push({
-        id: citationId,
-        kind: "repo_fact",
-        source_ref: `ob_entities/${String(row.id)}`,
-        source_url: sourceUrl,
-        source_commit: sourceCommit,
-      });
-    }
-
-    if (itemsTruncated) {
-      truncation.push({
-        source: "repo_facts",
-        max_items: maxItems,
-        max_item_chars: maxItemChars,
-      });
-    }
+    const truncation: Array<Record<string, unknown>> = collected.truncated
+      ? [
+          {
+            source: "repo_facts",
+            max_items: maxItems,
+            max_item_chars: maxItemChars,
+          },
+        ]
+      : [];
 
     return {
       section: {
@@ -253,40 +378,18 @@ export async function loadRepoFactsSection(
         repo,
         namespace_bound: true,
         repo_bound: true,
-        items,
-        item_count: items.length,
+        items: collected.items,
+        item_count: collected.items.length,
         truncated: truncation.length > 0,
       },
       scopeDenials: [],
       truncation,
       degradedSources: [],
-      budget: { ...budget, items_included: items.length },
-      citations,
+      budget: { ...budget, items_included: collected.items.length },
+      citations: collected.citations,
     };
   } catch (error) {
-    const err = error instanceof Error ? error : undefined;
-    logger?.error(
-      {
-        repo,
-        namespace: args.namespace,
-        error_name: err?.name ?? typeof error,
-        error_message: err?.message ?? String(error),
-      },
-      "repo_facts_section_failed",
-    );
-    logger?.debug(
-      {
-        repo,
-        namespace: args.namespace,
-        requested_budget: args.budget,
-        resolved_budget: budget,
-        error_name: err?.name ?? typeof error,
-        error_message: err?.message ?? String(error),
-        pg_code: (error as { code?: unknown })?.code ?? null,
-        stack: err?.stack ?? null,
-      },
-      "repo_facts_section_failed_detail",
-    );
+    logRepoFactsFailure({ logger, args, repo, budget, error });
     return databaseUnavailableFragment("repo_facts", budget);
   }
 }


### PR DESCRIPTION
## Summary

- `loadRepoFactsSection` carried the whole section in one body and drew all three lint findings from one structural cause: complexity 29, 142 lines, and a block nested four deep at the text step. The row-admission decision, the item shape, the query, and the failure log all lived inline in the same function.
- Split into named module-level helpers, each reproducing what the original did. `admitRepoFactRow` lifts the row-admission decision into one predicate returning a discriminated result; `repoFactEntry` builds an admitted row's item body and matching citation field for field; `collectRepoFacts` does the single walk over the ordered rows; `noActiveRepoFragment`, `queryRepoFactRows`, and `logRepoFactsFailure` carry the empty state, the exactly-bound query, and the two-line failure log verbatim.
- The ORDER of the three exclusions is preserved deliberately, because that order is behavior: only the last of them (an unusable `fact`) can mark the section trimmed, so a row rejected by an earlier guard must not reach the text step and set that flag. The `truncated` accumulator likewise seeds from the caller's row-count verdict and is only ever set, never cleared, exactly as the original local flag behaved.
- Reuse over reinvention: `asError` and `errorIdentityFields` are imported from the sibling `server/tools/context-pack-shared.ts`, which already derives `error_name` / `error_message` exactly as this module did. `logDurableFailure` from that same sibling was deliberately NOT reused: it takes a required `DurableFailureLogger` and re-derives `error_message` itself, while this module's `logger` parameter is optional, so the shapes are not identical and reusing it would have moved behavior.
- No behavior change. The SQL text, the schemas, the defaults, the error strings, the log event names (`repo_facts_section_failed`, `repo_facts_section_failed_detail`), the section key order, and the fragment shape are byte-identical to `origin/main`.
- One file changed. No exported signature moved, so no caller needed touching and no other existing file is in the diff.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`./node_modules/.bin/oxlint --deny-warnings server/tools/context-pack-repo-facts.ts` returned the three findings verbatim before the change and exit 0 after. `bunx tsc --noEmit` exit 0. `bun run test:isolated` over the repo_facts pinning tests (`server/tools/context-pack.test.ts`, `src/tools/__tests__/agent-context-pack-repo-facts.test.ts`, `src/tools/__tests__/agent-context-pack-guidance-repo-facts.test.ts`) gave 60 pass / 0 fail, and over `server/tools/` gave 163 pass / 0 fail. `scripts/done-means/780-touched-files-lint-clean.sh` exit 0, re-run on the committed tree after the pre-commit prettier hook (which reported the file unchanged). Python package untouched. No runtime, schema, or transport surface moved, so no live smoke applies.

## Critical Self-Review

- Highest-risk behavior: the row-admission predicate. Three exclusions that previously fell through one inline sequence are now one function returning a discriminated result, and only the third of them may set the trimmed flag. A rewrite that let an earlier guard reach the text step would silently mark sections trimmed that are not.
- Assumptions that could be wrong: that `asText` never returns an empty string, which is what makes the original truthy check `if (asText(meta.fact))` equivalent to my explicit `!== null`. Read back against the source: `asText` returns the value only when `typeof value === "string" && value.length > 0`, so `""` is impossible and the two are the same test.
- Missing/weak tests: the existing suite covers the empty state, the exact repo bind, the source-ref exclusion, and the staleness dispositions, and it does not cover the interaction of a row-count overflow with a per-item text overflow in the same read. That gap predates this change and the accumulator seeding is the part it would exercise; I verified that path by reading the rewrite against the original rather than by a new test, since the lane's rule is that existing tests stay unmodified.
- Security/permission risk: none introduced. The namespace predicate and the exact `metadata->>'repo' = $2` bind stay in one parameterized query, now in `queryRepoFactRows`, with the same two parameters in the same order. No cross-repo fallback was added and no interpolation was introduced.
- Migration/deploy risk: none. No schema, no migration, no config.
- Downstream client/runtime risk: none. Per `docs/downstream-rollout.md` this is an internal server-side refactor with no MCP tool, schema, protocol, or client-facing surface in the diff; the module's only in-repo importer is `server/tools/context-pack-loaders.ts` and its call shape is unchanged.
- Rollback/cleanup concern: a single-file, single-commit revert. Nothing else depends on the new private helpers.
- Fixes made before PR: none needed beyond the split; the first assembly typechecked and linted clean and the pinning tests passed on the first run.
- Known residual risk: the legacy sibling `src/tools/agent-context-pack-repo-facts.ts` still holds a near-duplicate of this logic with its own logger. It is out of this lane's scope and was not touched, so the two copies can still drift.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no new MEDIUM+ review finding — the reuse-only-when-shape-identical rule and the side-effect-ordering check are already recorded in the lane contract (round 38) and were applied here rather than discovered.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or client-facing surface changed; the verification is lint, typecheck, and the isolated suite.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface moved. The fragment shape, section keys, denial reasons, and citation fields are identical to `origin/main`, so the existing fixtures already assert the correct output.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Internal refactor only. No MCP tool definition, no schema, no transport, and no Python client code is in the diff, so none of the downstream steps apply.
