### PR TITLE
refactor(worker-proxy): bring server/transport/worker-proxy.ts to the lint standard (#780)

### DIFF
--- a/server/transport/worker-proxy.ts
+++ b/server/transport/worker-proxy.ts
@@ -88,76 +88,123 @@ async function workerHealth(
   }
 }
 
+interface ProxyState {
+  readonly input: WorkerProxyInput;
+  readonly fetchWorker: typeof fetch;
+  readonly sessionWorkers: Map<string, WorkerTarget>;
+  nextWorker: number;
+}
+
+async function aggregateHealthResponse(
+  input: WorkerProxyInput,
+): Promise<Response> {
+  const workers = await Promise.all(
+    input.workers.map((worker) => workerHealth(input, worker)),
+  );
+  const healthy = workers.every((worker) => worker.ok);
+  const health: AggregateHealth = {
+    status: healthy ? "healthy" : "degraded",
+    hostname: input.hostname,
+    server_ip: input.serverIp,
+    server_ips: input.serverIps,
+    ...(input.revision ? { revision: input.revision } : {}),
+    workers,
+    timestamp: new Date().toISOString(),
+  };
+  input.logger.info(
+    { status: health.status, worker_count: workers.length },
+    "aggregate_health_result",
+  );
+  return Response.json(health, { status: healthy ? 200 : 503 });
+}
+
+/** Sticky by session id when present, else round-robin; advancing only on unsessioned calls. */
+function selectWorker(
+  state: ProxyState,
+  sessionId: string | null,
+): WorkerTarget | undefined {
+  const workers = state.input.workers;
+  let worker = sessionId ? state.sessionWorkers.get(sessionId) : undefined;
+  worker ??= workers[state.nextWorker % workers.length];
+  if (worker && !sessionId) state.nextWorker += 1;
+  return worker;
+}
+
+function forwardHeaders(request: Request, worker: WorkerTarget): Headers {
+  const headers = new Headers(request.headers);
+  headers.set("x-open-brain-worker", worker.name);
+  headers.delete("host");
+  return headers;
+}
+
+async function forwardToWorker(
+  state: ProxyState,
+  request: Request,
+  incomingUrl: URL,
+  worker: WorkerTarget,
+): Promise<Response> {
+  const targetUrl = new URL(
+    incomingUrl.pathname + incomingUrl.search,
+    worker.baseUrl,
+  );
+  const response = await state.fetchWorker(targetUrl, {
+    method: request.method,
+    headers: forwardHeaders(request, worker),
+    body:
+      request.method === "GET" || request.method === "HEAD"
+        ? undefined
+        : request.body,
+    redirect: "manual",
+    signal: request.signal,
+  });
+
+  const sessionId = request.headers.get("mcp-session-id");
+  const responseSessionId = response.headers.get("mcp-session-id");
+  if (responseSessionId) state.sessionWorkers.set(responseSessionId, worker);
+  if (sessionId && request.method === "DELETE" && response.ok) {
+    state.sessionWorkers.delete(sessionId);
+  }
+  state.input.logger.info(
+    {
+      method: request.method,
+      worker: worker.name,
+      status: response.status,
+      session_affinity: Boolean(sessionId || responseSessionId),
+    },
+    "worker_proxy_result",
+  );
+  return response;
+}
+
 /** Build the aggregate front as a pure fetch handler; the caller owns any socket. */
-export function createWorkerProxyHandler(input: WorkerProxyInput): WorkerProxyHandler {
+export function createWorkerProxyHandler(
+  input: WorkerProxyInput,
+): WorkerProxyHandler {
   if (input.workers.length === 0) {
     throw new Error("worker_proxy_requires_at_least_one_worker");
   }
-  const fetchWorker = input.fetch ?? fetch;
-  const sessionWorkers = new Map<string, WorkerTarget>();
-  let nextWorker = 0;
+  const state: ProxyState = {
+    input,
+    fetchWorker: input.fetch ?? fetch,
+    sessionWorkers: new Map<string, WorkerTarget>(),
+    nextWorker: 0,
+  };
 
   return async (request) => {
     const incomingUrl = new URL(request.url);
     if (incomingUrl.pathname === "/health") {
-      const workers = await Promise.all(
-        input.workers.map((worker) => workerHealth(input, worker)),
-      );
-      const healthy = workers.every((worker) => worker.ok);
-      const health: AggregateHealth = {
-        status: healthy ? "healthy" : "degraded",
-        hostname: input.hostname,
-        server_ip: input.serverIp,
-        server_ips: input.serverIps,
-        ...(input.revision ? { revision: input.revision } : {}),
-        workers,
-        timestamp: new Date().toISOString(),
-      };
-      input.logger.info(
-        { status: health.status, worker_count: workers.length },
-        "aggregate_health_result",
-      );
-      return Response.json(health, { status: healthy ? 200 : 503 });
+      return await aggregateHealthResponse(input);
     }
 
-    const sessionId = request.headers.get("mcp-session-id");
-    let worker = sessionId ? sessionWorkers.get(sessionId) : undefined;
-    worker ??= input.workers[nextWorker % input.workers.length];
+    const worker = selectWorker(state, request.headers.get("mcp-session-id"));
     if (!worker) {
       input.logger.error("worker_proxy_unavailable");
-      return Response.json({ error: "No Open Brain workers configured" }, { status: 503 });
+      return Response.json(
+        { error: "No Open Brain workers configured" },
+        { status: 503 },
+      );
     }
-    if (!sessionId) nextWorker += 1;
 
-    const targetUrl = new URL(incomingUrl.pathname + incomingUrl.search, worker.baseUrl);
-    const headers = new Headers(request.headers);
-    headers.set("x-open-brain-worker", worker.name);
-    headers.delete("host");
-    const response = await fetchWorker(targetUrl, {
-      method: request.method,
-      headers,
-      body:
-        request.method === "GET" || request.method === "HEAD"
-          ? undefined
-          : request.body,
-      redirect: "manual",
-      signal: request.signal,
-    });
-
-    const responseSessionId = response.headers.get("mcp-session-id");
-    if (responseSessionId) sessionWorkers.set(responseSessionId, worker);
-    if (sessionId && request.method === "DELETE" && response.ok) {
-      sessionWorkers.delete(sessionId);
-    }
-    input.logger.info(
-      {
-        method: request.method,
-        worker: worker.name,
-        status: response.status,
-        session_affinity: Boolean(sessionId || responseSessionId),
-      },
-      "worker_proxy_result",
-    );
-    return response;
+    return await forwardToWorker(state, request, incomingUrl, worker);
   };
 }


### PR DESCRIPTION
## Summary

- `server/transport/worker-proxy.ts` carried one oxlint finding: `eslint(complexity)` — the handler returned by `createWorkerProxyHandler` scored 16 against a maximum of 10. This PR splits that handler into named module-level helpers and changes nothing else.
- The extraction follows the pattern `main` already uses in `server/tools/search-all.ts`, `search-brain.ts`, `brain-answer.ts` and their siblings: handlers split into module-level named functions taking an options-style first parameter rather than a pile of closure captures.
- New private helpers, all in the same file: `aggregateHealthResponse()` (the `/health` branch verbatim), `selectWorker()` (sticky-by-`mcp-session-id` lookup with round-robin fallback), `forwardHeaders()` (outbound `Headers` construction), `forwardToWorker()` (forwarding plus session-affinity bookkeeping). Closure state moved into a private `ProxyState` object so no helper exceeds four parameters.
- No exported signature changed. `createWorkerProxyHandler` and every exported interface are identical, so `server/transport/index.ts` and its callers are untouched.
- Transport behavior is held fixed: forwarded `method`, `headers`, `body`, `redirect: "manual"` and `signal` are byte-for-byte the same; the worker `Response` is still returned untouched so status codes pass through unchanged; the `aggregate_health_result`, `worker_proxy_result` and `worker_proxy_unavailable` log event names and field sets are identical; the 503 error string and the `worker_proxy_requires_at_least_one_worker` throw are unchanged.
- Round-robin equivalence was checked by hand rather than assumed: the original incremented `nextWorker` *after* the `!worker` early return, so it did not advance when no worker resolved. `selectWorker()` guards with `if (worker && !sessionId)` and preserves that exactly.
- No lint disable comments were added, and no other existing file was modified.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts, all re-run on the committed tree after the pre-commit prettier hook reformatted the staged file:

- `./node_modules/.bin/oxlint --deny-warnings server/transport/worker-proxy.ts` -> exit 0 (red beforehand: `server/transport/worker-proxy.ts:100:10: error eslint(complexity): async function has a complexity of 16. Maximum allowed is 10.`)
- `bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 0, `PASS: every file this branch touched under server/ lints clean.` (red beforehand with the `DONE_MEANS_780_FILES` override -> exit 1)
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated server/transport/` -> 67 pass, 0 fail, 4 files
- `bun run test:isolated server/application/sdk-protocol.pg.test.ts` -> 12 pass, 0 fail (the one caller-side test that exercises this module)

No test file was modified. Python package is untouched by this change, and no migration or live service change is involved.

## Critical Self-Review

- Highest-risk behavior: the round-robin counter. Moving `nextWorker` out of a closure and into `ProxyState` while also moving the increment into `selectWorker()` is the one place where a plausible-looking rewrite could silently change worker distribution or double-advance the rotation. Read back line by line against the original and guarded to match the original's post-early-return placement.
- Assumptions that could be wrong: that `input.workers` being non-empty (enforced by the existing throw) means the modulo index always resolves. A sparse array would still yield `undefined`; the `!worker` 503 branch is retained unchanged for exactly that case rather than removed as dead.
- Missing/weak tests: `server/transport/worker-proxy.test.ts` covers the health aggregate, session affinity and forwarding, but there is no test asserting that the rotation counter does *not* advance on the 503 no-worker path. That gap predates this PR and is why the equivalence was verified by reading rather than trusted to the suite — the same class of gap let a non-equivalent predicate rewrite through in #806.
- Security/permission risk: none new. `headers.delete("host")` and the `x-open-brain-worker` header are set in `forwardHeaders()` in the same order as before, so no inbound header reaches a worker that did not reach it previously, and no auth header handling changed.
- Migration/deploy risk: none. No schema, no config, no startup path touched.
- Downstream client/runtime risk: none. This is a private-to-the-file restructure behind an unchanged export; no MCP tool, schema, protocol or client-facing surface is involved, so `docs/downstream-rollout.md` classifies as not applicable.
- Rollback/cleanup concern: single-file, single-commit, revertible with no coordination.
- Fixes made before PR: none needed beyond the refactor; the first oxlint run after the extraction was clean.
- Known residual risk: the untested no-worker rotation path noted above. It is unreachable with the current construction guard.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical lint-standard extraction with no new defect pattern; the equivalence-checking discipline it relied on is already recorded as the #806 lesson in the lane contract, so a duplicate entry would add noise rather than signal.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, schema or client-facing surface changed — the module's exports and wire behavior are identical.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, tool schema or fixture is touched; the change is internal function structure within one transport module.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, protocol or client-facing signature changed. `createWorkerProxyHandler` and the exported `WorkerTarget` / `WorkerHealthResult` / `AggregateHealth` / `WorkerProxyInput` / `WorkerProxyHandler` types are byte-identical to `origin/main`, so nothing downstream can observe this change.
