### PR TITLE
refactor(tier-lane): bring server/tools/tier-lane.ts to the lint standard (#780)

### DIFF
--- a/server/tools/tier-lane.ts
+++ b/server/tools/tier-lane.ts
@@ -33,6 +33,7 @@
  */
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { AuthIdentity } from "../auth/types.ts";
 import { canWrite } from "../auth/permissions.ts";
 import { canTargetNamespace } from "../auth/namespace-policy.ts";
 import {
@@ -54,6 +55,38 @@ import {
 /** Lane events scanned when the caller names no preference. */
 const DEFAULT_EVENTS_SCANNED = 100;
 
+const tierLaneInputSchema = {
+  session_key: z
+    .string()
+    .min(1)
+    .max(500)
+    .describe("Stable lane identifier to tier"),
+  namespace: z
+    .string()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Namespace of the lane (defaults to caller's clientId)"),
+  dry_run: z
+    .boolean()
+    .optional()
+    .describe("Preview without writing durable thoughts (default true)"),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe(`Max lane events to scan (default ${DEFAULT_EVENTS_SCANNED})`),
+};
+
+const tierLaneAnnotations = {
+  title: "Tier Session Lane",
+  readOnlyHint: false,
+  destructiveHint: false,
+  idempotentHint: true,
+};
+
 export function registerTierLaneTool(
   server: McpServer,
   dependencies: MemoryToolDependencies,
@@ -66,118 +99,205 @@ export function registerTierLaneTool(
         "OWN durable thoughts (same namespace). Classifies each event, skips " +
         "duplicates, and graduates facts/decisions/handoffs. Dry-run by default. " +
         "An agent may only tier a lane in a namespace it can write.",
-      inputSchema: {
-        session_key: z
-          .string()
-          .min(1)
-          .max(500)
-          .describe("Stable lane identifier to tier"),
-        namespace: z
-          .string()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe("Namespace of the lane (defaults to caller's clientId)"),
-        dry_run: z
-          .boolean()
-          .optional()
-          .describe("Preview without writing durable thoughts (default true)"),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe(`Max lane events to scan (default ${DEFAULT_EVENTS_SCANNED})`),
-      },
-      annotations: {
-        title: "Tier Session Lane",
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
+      inputSchema: tierLaneInputSchema,
+      annotations: tierLaneAnnotations,
     },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      // Graduation writes THOUGHTS, so the thoughts write permission is the
-      // authority -- not a session or lane permission.
-      if (!identity || !canWrite(identity.role, "thoughts")) {
-        return errorResult("Permission denied: cannot write to thoughts");
-      }
-
-      const requested = args.namespace ?? identity.clientId;
-      if (!canTargetNamespace(identity, "write", requested)) {
-        dependencies.logger.warn(
-          { tool: "tier_lane", role: identity.role, namespace: requested },
-          "tier_lane_denied",
-        );
-        return errorResult(
-          `Permission denied: ${identity.role} role cannot write to namespace '${requested}'`,
-        );
-      }
-
-      const namespace = physicalNamespace(requested);
-      // Mutation is OPT-IN. Reading this as `?? false` would make every
-      // exploratory call write durable memory.
-      const dryRun = args.dry_run ?? true;
-      const scanLimit = args.limit ?? DEFAULT_EVENTS_SCANNED;
-
-      try {
-        // Events are joined to their lane so each row carries the lane's own
-        // namespace and agent; the lane is what the namespace predicate binds
-        // to, because events hold no namespace of their own.
-        const { rows } = await dependencies.pool.query(
-          `SELECT e.id, e.lane_id, l.namespace, l.agent, l.session_key,
-                  e.event_type, e.content, e.importance, e.content_hash,
-                  e.created_at, e.metadata
-             FROM ob_session_events e
-             JOIN ob_session_lanes l ON e.lane_id = l.id
-            WHERE l.namespace = $1 AND l.session_key = $2
-            ORDER BY e.created_at ASC, e.id ASC
-            LIMIT $3`,
-          [namespace, args.session_key, scanLimit],
-        );
-
-        const receipt = newTierReceipt(dryRun);
-        for (const row of rows as LaneEventRow[]) {
-          await tierLaneEvent(row, receipt, {
-            pool: dependencies.pool,
-            embedFn: dependencies.embedFn,
-            namespace,
-            createdBy: identity.clientId,
-            dryRun,
-          });
-        }
-
-        dependencies.logger.info(
-          {
-            tool: "tier_lane",
-            sessionKey: args.session_key,
-            namespace,
-            dryRun,
-            ...receipt,
-          },
-          "tool_result",
-        );
-        return textResult({
-          session_key: args.session_key,
-          namespace: canonicalNamespace(namespace),
-          ...receipt,
-        });
-      } catch (error) {
-        // Only a stable class reaches the log; the raw driver message can carry
-        // lane content and namespace names.
-        dependencies.logger.error(
-          {
-            tool: "tier_lane",
-            sessionKey: args.session_key,
-            errorName: error instanceof Error ? error.name : "unknown",
-            errorCode: (error as { code?: string } | null | undefined)?.code,
-          },
-          "tier_lane_db_error",
-        );
-        return errorResult("Database error during lane tiering");
-      }
-    },
+    async (args, extra) => handleTierLane(dependencies, args, extra),
   );
+}
+
+/** Minimal shape of the handler `extra` argument this tool reads. */
+interface HandlerExtra {
+  authInfo?: Parameters<typeof authIdentity>[0];
+}
+
+/** Caller-supplied arguments after Zod validation. */
+interface TierLaneArgs {
+  readonly session_key: string;
+  readonly namespace?: string | undefined;
+  readonly dry_run?: boolean | undefined;
+  readonly limit?: number | undefined;
+}
+
+/** A tiering request that cleared identity and target-namespace checks. */
+interface TierLaneTarget {
+  readonly identity: AuthIdentity;
+  readonly namespace: string;
+}
+
+/**
+ * Check that the caller may write thoughts into the lane's namespace.
+ *
+ * Graduation writes THOUGHTS, so the thoughts write permission is the
+ * authority -- not a session or lane permission. The namespace denial is
+ * LOGGED, which is why this stays a local helper rather than the shared
+ * `authorize` in `memory-helpers.ts`: that helper emits no `tier_lane_denied`
+ * event, so calling it would drop this tool's denial log line.
+ *
+ * @returns The authorized target, or the error result that refused it.
+ */
+function authorizeTierLane(
+  dependencies: MemoryToolDependencies,
+  identity: AuthIdentity | undefined,
+  requestedNamespace: string | undefined,
+): TierLaneTarget | ReturnType<typeof errorResult> {
+  if (!identity || !canWrite(identity.role, "thoughts")) {
+    return errorResult("Permission denied: cannot write to thoughts");
+  }
+
+  const requested = requestedNamespace ?? identity.clientId;
+  if (!canTargetNamespace(identity, "write", requested)) {
+    dependencies.logger.warn(
+      { tool: "tier_lane", role: identity.role, namespace: requested },
+      "tier_lane_denied",
+    );
+    return errorResult(
+      `Permission denied: ${identity.role} role cannot write to namespace '${requested}'`,
+    );
+  }
+
+  return { identity, namespace: physicalNamespace(requested) };
+}
+
+/** @returns True when authorization returned a refusal rather than a target. */
+function isRefusal(
+  outcome: TierLaneTarget | ReturnType<typeof errorResult>,
+): outcome is ReturnType<typeof errorResult> {
+  return !("identity" in outcome);
+}
+
+/**
+ * Read one lane's events, newest last.
+ *
+ * Events are joined to their lane so each row carries the lane's own namespace
+ * and agent; the lane is what the namespace predicate binds to, because events
+ * hold no namespace of their own.
+ */
+async function readLaneEvents(
+  dependencies: MemoryToolDependencies,
+  namespace: string,
+  sessionKey: string,
+  scanLimit: number,
+): Promise<LaneEventRow[]> {
+  const { rows } = await dependencies.pool.query(
+    `SELECT e.id, e.lane_id, l.namespace, l.agent, l.session_key,
+            e.event_type, e.content, e.importance, e.content_hash,
+            e.created_at, e.metadata
+       FROM ob_session_events e
+       JOIN ob_session_lanes l ON e.lane_id = l.id
+      WHERE l.namespace = $1 AND l.session_key = $2
+      ORDER BY e.created_at ASC, e.id ASC
+      LIMIT $3`,
+    [namespace, sessionKey, scanLimit],
+  );
+  return rows as LaneEventRow[];
+}
+
+/** One graduation pass over a lane's events. */
+interface TierLaneRun {
+  readonly dependencies: MemoryToolDependencies;
+  readonly rows: readonly LaneEventRow[];
+  readonly namespace: string;
+  readonly createdBy: string;
+  readonly dryRun: boolean;
+}
+
+/**
+ * Classify and graduate each event, accumulating the receipt.
+ *
+ * Sequential by design: `tierLaneEvent` deduplicates against what the same run
+ * has already written, so concurrent passes would each miss the other's writes.
+ */
+async function tierLaneEvents(
+  run: TierLaneRun,
+): Promise<ReturnType<typeof newTierReceipt>> {
+  const receipt = newTierReceipt(run.dryRun);
+  for (const row of run.rows) {
+    await tierLaneEvent(row, receipt, {
+      pool: run.dependencies.pool,
+      embedFn: run.dependencies.embedFn,
+      namespace: run.namespace,
+      createdBy: run.createdBy,
+      dryRun: run.dryRun,
+    });
+  }
+  return receipt;
+}
+
+/**
+ * Log the driver failure without leaking its message.
+ *
+ * Only a stable class reaches the log; the raw driver message can carry lane
+ * content and namespace names.
+ */
+function logLaneTieringFailure(
+  dependencies: MemoryToolDependencies,
+  sessionKey: string,
+  error: unknown,
+): void {
+  dependencies.logger.error(
+    {
+      tool: "tier_lane",
+      sessionKey,
+      errorName: error instanceof Error ? error.name : "unknown",
+      errorCode: (error as { code?: string } | null | undefined)?.code,
+    },
+    "tier_lane_db_error",
+  );
+}
+
+async function handleTierLane(
+  dependencies: MemoryToolDependencies,
+  args: TierLaneArgs,
+  extra: HandlerExtra,
+): Promise<ReturnType<typeof textResult>> {
+  const authorized = authorizeTierLane(
+    dependencies,
+    authIdentity(extra.authInfo),
+    args.namespace,
+  );
+  if (isRefusal(authorized)) {
+    return authorized;
+  }
+
+  const { identity, namespace } = authorized;
+  // Mutation is OPT-IN. Reading this as `?? false` would make every
+  // exploratory call write durable memory.
+  const dryRun = args.dry_run ?? true;
+  const scanLimit = args.limit ?? DEFAULT_EVENTS_SCANNED;
+
+  try {
+    const rows = await readLaneEvents(
+      dependencies,
+      namespace,
+      args.session_key,
+      scanLimit,
+    );
+    const receipt = await tierLaneEvents({
+      dependencies,
+      rows,
+      namespace,
+      createdBy: identity.clientId,
+      dryRun,
+    });
+
+    dependencies.logger.info(
+      {
+        tool: "tier_lane",
+        sessionKey: args.session_key,
+        namespace,
+        dryRun,
+        ...receipt,
+      },
+      "tool_result",
+    );
+    return textResult({
+      session_key: args.session_key,
+      namespace: canonicalNamespace(namespace),
+      ...receipt,
+    });
+  } catch (error) {
+    logLaneTieringFailure(dependencies, args.session_key, error);
+    return errorResult("Database error during lane tiering");
+  }
 }


### PR DESCRIPTION
## Summary

- Clears the two oxlint findings on `server/tools/tier-lane.ts` (#780): `registerTierLaneTool` ran 113 lines against a maximum of 100, and its inline handler carried a complexity of 11 against a maximum of 10. Both came from one shape — schema, annotations, auth, SQL, the graduation loop, and two log sites all inlined into a single `registerTool` call.
- Split along the seams `tiering.ts` (#813) and `tier-mutations.ts` (#803) already established for this file family: `tierLaneInputSchema` and `tierLaneAnnotations` hoisted verbatim to module level, and `registerTierLaneTool` reduced to a thin registration delegating to a named `handleTierLane`.
- Extracted `authorizeTierLane` / `isRefusal` (the `promotion.ts` target-or-refusal shape), plus `readLaneEvents`, `tierLaneEvents`, and `logLaneTieringFailure`. The graduation pass takes a `TierLaneRun` options object rather than five positional arguments.
- **Reuse decision worth reading:** this tool deliberately keeps its own auth helper instead of the shared `authorize` in `memory-helpers.ts`. The shapes are close but not identical field for field — `authorize` emits no denial log, so calling it would silently drop the `tier_lane_denied` warn line. Every tool here that logs a denial (`promotion.ts`, `adjacent-context.ts`, `citation-recall.ts`, `promote-entry.ts`) keeps a local helper for exactly that reason. `HandlerExtra` is likewise declared locally, matching how both siblings declare their own rather than sharing one; hoisting it would mean touching another lane's file.
- No behavior change: schemas, defaults (`dry_run` stays opt-in at `true`), every error string, both log event names, receipt field ordering, and the query text are unchanged. The SQL moved out one nesting level, so its common leading indent shrank while the internal alignment stayed exact.
- One file touched. No other existing file changed, and no helper was moved out.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Red first, on the untouched file — `oxlint --deny-warnings server/tools/tier-lane.ts`:

```
server/tools/tier-lane.ts:57:8: error eslint(max-lines-per-function): The function `registerTierLaneTool` has too many lines (113). Maximum allowed is 100.
server/tools/tier-lane.ts:100:5: error eslint(complexity): async function has a complexity of 11. Maximum allowed is 10.
```

`DONE_MEANS_780_FILES=server/tools/tier-lane.ts bash scripts/done-means/780-touched-files-lint-clean.sh` reported `FAIL: oxlint reported findings`.

Green, re-run on the COMMITTED tree after the prettier pre-commit hook (which reported the file unchanged):

- `./node_modules/.bin/oxlint --deny-warnings server/tools/tier-lane.ts` → exit 0
- `bunx tsc --noEmit` → exit 0
- `bun run test:isolated src/tools/__tests__/tier-lane.test.ts server/tools/ported-tools-scope.test.ts` → 38 pass, 0 fail, 111 expect() calls
- `bun run test:isolated server/tools/` → 163 pass, 0 fail across 17 files
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived from `origin/main...HEAD`) → exit 0

Existing tests are unmodified. `src/tools/tier-lane.ts` reports 100% function and line coverage under the pinning tests.

## Critical Self-Review

- Highest-risk behavior: the auth path. Splitting it into `authorizeTierLane` moves the permission check, the namespace-denial log, and `physicalNamespace()` resolution behind one call. The ordering is preserved exactly — role/table permission first (so an unprivileged caller never learns whether a namespace exists), then `canTargetNamespace`, then `physicalNamespace` on the way out, which is where the original called it too.
- Assumptions that could be wrong: that the SQL reindent is inert. It sits in a template literal, so the bytes did change — the common leading indent shrank by 6 spaces as the code moved out a nesting level. I diffed it token for token and the internal alignment is preserved; Postgres is whitespace-insensitive here. If anything ever asserts on the literal query string this would surface, and nothing in the suite does.
- Missing/weak tests: no test asserts the `tier_lane_denied` warn line is emitted, which is the one behavior most at risk from the reuse decision above. That gap is what made me keep the local helper rather than take the shared `authorize` — the suite would not have caught the dropped log. Not filed as a new test here because the brief holds existing tests unmodified; worth a follow-up.
- Security/permission risk: none introduced. Write authority over `thoughts` and the namespace predicate are unchanged, and the namespace is still resolved from the token when the caller supplies none.
- Migration/deploy risk: none. No schema, no migration, no config.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` applies to MCP tool/schema/protocol changes; the published `tier_lane` schema, description, annotations, and response envelope are byte-identical, so there is no contract surface for a client to notice.
- Rollback/cleanup concern: single-file, single-commit, revert-clean.
- Fixes made before PR: first draft imported `AuthIdentity` from `./types.ts`, which re-exports nothing of the sort — corrected to `../auth/types.ts`, matching `promotion.ts` and `memory-helpers.ts`.
- Known residual risk: low. The refactor is structural; the read-back against the original was done line by line specifically because #806 shipped a non-equivalent predicate rewrite that the suite did not catch.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the reuse-vs-denial-logging tension is already recorded as lane-contract round 38 (reuse only when the shape matches field for field, defaults and failure shape included); this PR is an instance of that rule, not a new pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or query behavior changed — this is a structural refactor with an identical published contract.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract changed. `contracts/server/server-tier-tools.fixture.json` pins the `tier_lane` schema and annotations, which moved verbatim to module-level consts; `server/tools/ported-tools-scope.test.ts` passes unmodified, which is what proves it.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: the MCP tool name, input schema, annotations, description string, and response envelope are unchanged, so no downstream client sees a different surface. The rollout gate keys on tool/schema/protocol/client-facing changes; this PR has none.
