### PR TITLE
refactor(people): bring server/tools/people.ts to the lint standard (#780)

### DIFF
--- a/server/tools/people.ts
+++ b/server/tools/people.ts
@@ -18,7 +18,8 @@ import {
   canTargetNamespace,
   namespacePredicate,
 } from "../auth/namespace-policy.ts";
-import { contentHash } from "./memory-helpers.ts";
+import type { NamespacePredicate } from "../auth/namespace-policy.ts";
+import { contentHash, embeddingFields } from "./memory-helpers.ts";
 import {
   authIdentity,
   errorResult,
@@ -30,76 +31,84 @@ import {
 const PERSON_COLUMNS = `id, person_name, context, relationship_type, warmth,
   last_contact, email, phone, notes, tags, metadata, created_at`;
 
-export function registerPeopleTools(
-  server: McpServer,
-  dependencies: MemoryToolDependencies,
-): void {
-  server.registerTool(
-    "upsert_person",
-    {
-      description:
-        "Create or update a person/contact in the brain. Matches on person_name (case-sensitive). If the person exists, updates provided fields; if not, creates a new record. A case-insensitive unique index is recommended.",
-      inputSchema: {
-        name: z.string().min(1).describe("Person's full name (used as unique key)"),
-        context: z.string().optional().describe("How you know them, where they work, etc."),
-        relationship_type: z
-          .string()
-          .optional()
-          .describe("Relationship category: friend, family, colleague, acquaintance, etc."),
-        warmth: z
-          .number()
-          .int()
-          .min(1)
-          .max(5)
-          .optional()
-          .describe("Closeness rating 1-5 (1=distant, 5=very close)"),
-        last_contact: z
-          .string()
-          .optional()
-          .describe("Date of last contact (ISO 8601 date, e.g. 2026-03-19)"),
-        email: z.string().optional().describe("Email address"),
-        phone: z.string().optional().describe("Phone number"),
-        notes: z.string().optional().describe("Freeform notes about the person"),
-        tags: z.array(z.string()).optional().describe("Tags for categorization"),
-        metadata: z
-          .record(z.string(), z.unknown())
-          .optional()
-          .describe("Additional structured data (e.g. apple_id, imessage, social handles)"),
-        namespace: z
-          .string()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe("Namespace to store in (defaults to caller's clientId)"),
-      },
-      annotations: {
-        title: "Upsert Person",
-        readOnlyHint: false,
-        destructiveHint: false,
-        idempotentHint: true,
-      },
-    },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      if (!identity || !canWrite(identity.role, "relationships")) {
-        return errorResult("Permission denied: cannot write to relationships");
-      }
-      const namespace = args.namespace ?? identity.clientId;
-      if (!canTargetNamespace(identity, "write", namespace)) {
-        return errorResult("Permission denied: namespace write denied");
-      }
+/**
+ * `upsert_person` input, hoisted so the write's uniqueness key -- the name that
+ * `ON CONFLICT` matches on -- is readable next to the SQL that relies on it.
+ */
+const UPSERT_PERSON_INPUT = {
+  name: z.string().min(1).describe("Person's full name (used as unique key)"),
+  context: z
+    .string()
+    .optional()
+    .describe("How you know them, where they work, etc."),
+  relationship_type: z
+    .string()
+    .optional()
+    .describe(
+      "Relationship category: friend, family, colleague, acquaintance, etc.",
+    ),
+  warmth: z
+    .number()
+    .int()
+    .min(1)
+    .max(5)
+    .optional()
+    .describe("Closeness rating 1-5 (1=distant, 5=very close)"),
+  last_contact: z
+    .string()
+    .optional()
+    .describe("Date of last contact (ISO 8601 date, e.g. 2026-03-19)"),
+  email: z.string().optional().describe("Email address"),
+  phone: z.string().optional().describe("Phone number"),
+  notes: z.string().optional().describe("Freeform notes about the person"),
+  tags: z.array(z.string()).optional().describe("Tags for categorization"),
+  metadata: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe(
+      "Additional structured data (e.g. apple_id, imessage, social handles)",
+    ),
+  namespace: z
+    .string()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Namespace to store in (defaults to caller's clientId)"),
+};
 
-      const embeddableText = [args.name, args.context ?? "", args.notes ?? ""]
-        .filter(Boolean)
-        .join("\n");
-      const embedding = await dependencies.embedFn(embeddableText);
+/** `find_person` input, hoisted alongside the upsert schema for the same reason. */
+const FIND_PERSON_INPUT = {
+  query: z.string().min(1).describe("Person name or semantic search query"),
+  mode: z
+    .enum(["name", "semantic"])
+    .optional()
+    .describe(
+      "Search mode: 'name' for ILIKE partial match (default), 'semantic' for embedding-based contextual search",
+    ),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(250)
+    .optional()
+    .describe("Maximum results to return (default 5)"),
+  offset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Number of results to skip for pagination (default 0)"),
+};
 
-      // `tags`/`metadata` use a NULL-check rather than COALESCE on the update
-      // side so that an explicitly-passed empty array or object REPLACES the
-      // stored value, while omitting the field leaves it untouched. COALESCE
-      // alone cannot tell those two cases apart.
-      const { rows } = await dependencies.pool.query(
-        `INSERT INTO relationships (
+/**
+ * `INSERT ... ON CONFLICT` for a contact row.
+ *
+ * `tags`/`metadata` use a NULL-check rather than COALESCE on the update side so
+ * that an explicitly-passed empty array or object REPLACES the stored value,
+ * while omitting the field leaves it untouched. COALESCE alone cannot tell
+ * those two cases apart.
+ */
+const UPSERT_PERSON_SQL = `INSERT INTO relationships (
            person_name, context, relationship_type, warmth, last_contact,
            email, phone, notes, tags, metadata,
            created_by, namespace, embedding, content_hash, embedded_at, embedding_model
@@ -122,25 +131,160 @@ export function registerPeopleTools(
            content_hash = EXCLUDED.content_hash,
            embedded_at = EXCLUDED.embedded_at,
            embedding_model = EXCLUDED.embedding_model
-         RETURNING id, (xmax = 0) AS inserted`,
-        [
-          args.name,
-          args.context ?? null,
-          args.relationship_type ?? null,
-          args.warmth ?? null,
-          args.last_contact ?? null,
-          args.email ?? null,
-          args.phone ?? null,
-          args.notes ?? null,
-          args.tags ?? null,
-          args.metadata ? JSON.stringify(args.metadata) : null,
-          identity.clientId,
+         RETURNING id, (xmax = 0) AS inserted`;
+
+/** Caller-supplied `upsert_person` arguments, as Zod hands them to the handler. */
+type UpsertPersonArgs = {
+  name: string;
+  context?: string | undefined;
+  relationship_type?: string | undefined;
+  warmth?: number | undefined;
+  last_contact?: string | undefined;
+  email?: string | undefined;
+  phone?: string | undefined;
+  notes?: string | undefined;
+  tags?: string[] | undefined;
+  metadata?: Record<string, unknown> | undefined;
+  namespace?: string | undefined;
+};
+
+/**
+ * The text a contact is embedded from.
+ *
+ * Name, context, and notes only: the remaining columns are structured
+ * identifiers rather than prose, and embedding them dilutes the vector.
+ */
+function personEmbedText(args: UpsertPersonArgs): string {
+  return [args.name, args.context ?? "", args.notes ?? ""]
+    .filter(Boolean)
+    .join("\n");
+}
+
+/** Positional parameters for {@link UPSERT_PERSON_SQL}, in declaration order. */
+function upsertPersonValues(options: {
+  args: UpsertPersonArgs;
+  clientId: string;
+  namespace: string;
+  embeddableText: string;
+  embedding: Awaited<ReturnType<typeof embeddingFields>>;
+}): unknown[] {
+  const { args, embedding } = options;
+  return [
+    args.name,
+    args.context ?? null,
+    args.relationship_type ?? null,
+    args.warmth ?? null,
+    args.last_contact ?? null,
+    args.email ?? null,
+    args.phone ?? null,
+    args.notes ?? null,
+    args.tags ?? null,
+    args.metadata ? JSON.stringify(args.metadata) : null,
+    options.clientId,
+    options.namespace,
+    embedding.embedding,
+    contentHash(options.embeddableText),
+    embedding.embeddedAt,
+    embedding.model,
+  ];
+}
+
+/** Rows `find_person` reads, in either search mode. */
+type PersonRow = Record<string, unknown>;
+
+/** Semantic mode: nearest contacts by embedding distance. */
+async function findPeopleSemantic(options: {
+  dependencies: MemoryToolDependencies;
+  query: string;
+  rowCount: number;
+  offset: number;
+  predicate: NamespacePredicate;
+}): Promise<PersonRow[] | null> {
+  const { dependencies, predicate } = options;
+  const embedding = await dependencies.embedFn(options.query);
+  if (!embedding) return null;
+  const result = await dependencies.pool.query(
+    `SELECT ${PERSON_COLUMNS},
+                  embedding <=> $1::halfvec(768) AS distance
+             FROM relationships
+            WHERE embedding IS NOT NULL AND archived_at IS NULL${predicate.clause}
+            ORDER BY distance ASC
+            LIMIT $2 OFFSET $3`,
+    [toSql(embedding), options.rowCount, options.offset, ...predicate.values],
+  );
+  return result.rows;
+}
+
+/** Name mode: ILIKE partial match, warmest and most recently contacted first. */
+async function findPeopleByName(options: {
+  dependencies: MemoryToolDependencies;
+  query: string;
+  rowCount: number;
+  offset: number;
+  predicate: NamespacePredicate;
+}): Promise<PersonRow[]> {
+  const { predicate } = options;
+  // `%` and `_` are ILIKE wildcards, so a caller searching for a literal
+  // one must not have it treated as a pattern.
+  const escaped = options.query.replaceAll("%", "\\%").replaceAll("_", "\\_");
+  const result = await options.dependencies.pool.query(
+    `SELECT ${PERSON_COLUMNS}
+             FROM relationships
+            WHERE person_name ILIKE $1 AND archived_at IS NULL${predicate.clause}
+            ORDER BY warmth DESC NULLS LAST, last_contact DESC NULLS LAST
+            LIMIT $2 OFFSET $3`,
+    [`%${escaped}%`, options.rowCount, options.offset, ...predicate.values],
+  );
+  return result.rows;
+}
+
+export function registerPeopleTools(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
+  registerUpsertPerson(server, dependencies);
+  registerFindPerson(server, dependencies);
+}
+
+function registerUpsertPerson(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
+  server.registerTool(
+    "upsert_person",
+    {
+      description:
+        "Create or update a person/contact in the brain. Matches on person_name (case-sensitive). If the person exists, updates provided fields; if not, creates a new record. A case-insensitive unique index is recommended.",
+      inputSchema: UPSERT_PERSON_INPUT,
+      annotations: {
+        title: "Upsert Person",
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    async (args, extra) => {
+      const identity = authIdentity(extra.authInfo);
+      if (!identity || !canWrite(identity.role, "relationships")) {
+        return errorResult("Permission denied: cannot write to relationships");
+      }
+      const namespace = args.namespace ?? identity.clientId;
+      if (!canTargetNamespace(identity, "write", namespace)) {
+        return errorResult("Permission denied: namespace write denied");
+      }
+
+      const embeddableText = personEmbedText(args);
+      const embedding = await embeddingFields(dependencies, embeddableText);
+
+      const { rows } = await dependencies.pool.query(
+        UPSERT_PERSON_SQL,
+        upsertPersonValues({
+          args,
+          clientId: identity.clientId,
           namespace,
-          embedding ? toSql(embedding) : null,
-          contentHash(embeddableText),
-          embedding ? new Date().toISOString() : null,
-          embedding ? (dependencies.embeddingModel ?? null) : null,
-        ],
+          embeddableText,
+          embedding,
+        }),
       );
 
       const row = rows[0];
@@ -154,38 +298,22 @@ export function registerPeopleTools(
         person_name: args.name,
         namespace,
         action,
-        embedded: embedding !== null,
+        embedded: embedding.embedded,
       });
     },
   );
+}
 
+function registerFindPerson(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
   server.registerTool(
     "find_person",
     {
       description:
         "Find a person in the brain by name (ILIKE partial match) or semantic search (embedding distance)",
-      inputSchema: {
-        query: z.string().min(1).describe("Person name or semantic search query"),
-        mode: z
-          .enum(["name", "semantic"])
-          .optional()
-          .describe(
-            "Search mode: 'name' for ILIKE partial match (default), 'semantic' for embedding-based contextual search",
-          ),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(250)
-          .optional()
-          .describe("Maximum results to return (default 5)"),
-        offset: z
-          .number()
-          .int()
-          .min(0)
-          .optional()
-          .describe("Number of results to skip for pagination (default 0)"),
-      },
+      inputSchema: FIND_PERSON_INPUT,
       annotations: {
         title: "Find Person",
         readOnlyHint: true,
@@ -199,46 +327,33 @@ export function registerPeopleTools(
         return errorResult("Permission denied: cannot read relationships");
       }
 
-      const rowCap = args.limit ?? 5;
-      const offset = args.offset ?? 0;
-      const predicate = namespacePredicate(identity, "read", 4);
+      const request = {
+        dependencies,
+        query: args.query,
+        rowCount: args.limit ?? 5,
+        offset: args.offset ?? 0,
+        predicate: namespacePredicate(identity, "read", 4),
+      };
 
-      let rows: Array<Record<string, unknown>>;
-      if (args.mode === "semantic") {
-        const embedding = await dependencies.embedFn(args.query);
-        if (!embedding) return errorResult("Failed to generate query embedding");
-        const result = await dependencies.pool.query(
-          `SELECT ${PERSON_COLUMNS},
-                  embedding <=> $1::halfvec(768) AS distance
-             FROM relationships
-            WHERE embedding IS NOT NULL AND archived_at IS NULL${predicate.clause}
-            ORDER BY distance ASC
-            LIMIT $2 OFFSET $3`,
-          [toSql(embedding), rowCap, offset, ...predicate.values],
-        );
-        rows = result.rows;
-      } else {
-        // `%` and `_` are ILIKE wildcards, so a caller searching for a literal
-        // one must not have it treated as a pattern.
-        const escaped = args.query.replaceAll("%", "\\%").replaceAll("_", "\\_");
-        const result = await dependencies.pool.query(
-          `SELECT ${PERSON_COLUMNS}
-             FROM relationships
-            WHERE person_name ILIKE $1 AND archived_at IS NULL${predicate.clause}
-            ORDER BY warmth DESC NULLS LAST, last_contact DESC NULLS LAST
-            LIMIT $2 OFFSET $3`,
-          [`%${escaped}%`, rowCap, offset, ...predicate.values],
-        );
-        rows = result.rows;
-      }
+      const rows =
+        args.mode === "semantic"
+          ? await findPeopleSemantic(request)
+          : await findPeopleByName(request);
+      if (rows === null)
+        return errorResult("Failed to generate query embedding");
 
       dependencies.logger.info(
-        { tool: "find_person", mode: args.mode ?? "name", returned: rows.length },
+        {
+          tool: "find_person",
+          mode: args.mode ?? "name",
+          returned: rows.length,
+        },
         "tool_result",
       );
       // Not an error, and deliberately the same text a foreign-namespace hit
       // produces, so absence and inaccessibility are indistinguishable.
-      if (rows.length === 0) return textResult(`No people found matching: ${args.query}`);
+      if (rows.length === 0)
+        return textResult(`No people found matching: ${args.query}`);
       return textResult(rows);
     },
   );


### PR DESCRIPTION
## Summary

- `registerPeopleTools` held both tool registrations inline at 198 lines, and `find_person`'s handler hit a complexity of 21 by branching the two search modes, their two SQL statements, and the shared not-found handling inside one closure. Both are #780 findings on `server/tools/people.ts`.
- Split along the seam the file already had: `registerUpsertPerson` and `registerFindPerson` are now module-level, matching how `entities.ts` and `promotion.ts` register a family of tools. `find_person`'s two modes became `findPeopleSemantic` and `findPeopleByName`, each taking one options object, so the mode choice is a single expression in the handler rather than a branch that also owns the queries.
- Both input schemas and the upsert statement are hoisted to module constants, which puts the `ON CONFLICT` uniqueness key next to the schema field it matches on.
- Reuse: the inline embedding block computed the pgvector literal, the timestamp, the model, and the embedded flag exactly as `embeddingFields` in `memory-helpers.ts` already does, field for field, so the tool now calls it. `authorize` from the same module was deliberately **not** reused — its denial text differs from this tool's (`<role> role cannot write to namespace '<ns>'` versus `namespace write denied`), and matching the observed strings matters more here than sharing the gate.
- No behavior change and no new helper file. `server/tools/people.ts` is the only file touched; `registerPeopleTools`' exported signature is unchanged, so `server/tools/index.ts` and `server/tools/entities-graph.pg.test.ts` are unaffected. No tests were modified.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Red first, on the untouched file:

```
server/tools/people.ts:33:8: error eslint(max-lines-per-function): The function `registerPeopleTools` has too many lines (198). Maximum allowed is 100.
server/tools/people.ts:82:5: error eslint(complexity): async function has a complexity of 21. Maximum allowed is 10.
```

`DONE_MEANS_780_FILES=server/tools/people.ts bash scripts/done-means/780-touched-files-lint-clean.sh` exited 1.

Green, re-run on the committed tree after the pre-commit prettier hook reformatted it:

- `./node_modules/.bin/oxlint --deny-warnings server/tools/people.ts` -> exit 0, no findings
- `bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 0, PASS
- `bunx tsc --noEmit` -> exit 0, zero errors
- `bun run test:isolated server/tools/ src/tools/__tests__/find-person.test.ts src/tools/__tests__/upsert-person.test.ts src/tools/__tests__/protocol.test.ts` -> 196 pass, 0 fail across 20 files, tests exited 0

Equivalence check beyond the suite: all three SQL template literals (the upsert, the semantic select, the name select) were extracted from `origin/main:server/tools/people.ts` and from the committed file and compared byte for byte — identical in every case, before and after prettier ran.

Python package is untouched, so its checks are not applicable. No migration, no schema change, and no wire-visible change, so a live smoke has nothing new to exercise.

## Critical Self-Review

- Highest-risk behavior: `find_person`'s two search modes. The original assigned into a mutable `rows` from an if/else; the refactor returns from two functions and uses `rows === null` as the embedding-failure signal. `findPeopleByName` never returns null, so the only path to `Failed to generate query embedding` is still the semantic branch with a falsy embedding — same condition, same string, same position relative to the logging call.
- Assumptions that could be wrong: that `embeddingFields` is field-for-field identical to the inline block it replaces. Checked directly rather than assumed — it computes `embedding ? toSql(embedding) : null`, `embedding ? new Date().toISOString() : null`, `embedding ? (dependencies.embeddingModel ?? null) : null`, and `embedding !== null`, which is exactly what the four inline expressions were, including the `?? null` on the model.
- Missing/weak tests: the suite covers `upsert_person` create/update and `find_person` in both modes, but there is no test that pins the semantic-mode embedding-failure string. That path was verified by reading rather than by a failing test, and it is unchanged rather than newly written.
- Security/permission risk: the namespace predicate is the isolation boundary here and it moved into the two query helpers as a passed-in `NamespacePredicate`, still built by `namespacePredicate(identity, "read", 4)` in the handler with the same placeholder offset of 4. The parameter arrays still spread `predicate.values` in the same trailing position, so no placeholder shifted. The write path's `canWrite` then `canTargetNamespace` order is untouched, which preserves the property that an unprivileged caller cannot learn whether a namespace exists.
- Migration/deploy risk: none. No SQL, schema, or migration changed.
- Downstream client/runtime risk: none. Tool names, descriptions, input schemas, annotations, result shapes, error strings, and log event names are all unchanged, so nothing MCP-visible moved and `docs/downstream-rollout.md` classifies this as not applicable.
- Rollback/cleanup concern: single-file, single-commit, no new files and no moved helpers, so a revert is complete on its own.
- Fixes made before PR: none needed beyond the refactor — the first oxlint and tsc run after the rewrite were both clean.
- Known residual risk: the deliberate not-reuse of `authorize` leaves this tool with its own auth gate. That is correct today because the denial strings differ, but it means a future change to the shared gate will not reach this file.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no new MEDIUM+ finding — the not-reuse decision is already covered by the lane contract's round-38 rule on field-for-field identity, which is what drove it.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: nothing wire-visible or persisted changed, so a live check would exercise identical behavior.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: `contracts/server/server-people.fixture.json` freezes `find_person`'s not-found text and `upsert_person`'s created/updated envelope, and both are unchanged by this refactor, so the existing fixture already covers it and needs no edit.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All four are not applicable: this is an internal restructuring of one server tool file with no change to tool names, schemas, result shapes, or error strings, so no client cache, generated skill, or agent canary sees anything different.
