### PR TITLE
refactor(promotion-shared): bring server/tools/promotion.ts and server/tools/promote-entry.ts to the lint standard (#780)

### DIFF
--- a/server/tools/promote-entry.ts
+++ b/server/tools/promote-entry.ts
@@ -44,16 +44,10 @@ import {
   type MemoryToolDependencies,
 } from "./types.ts";
 import { tableEnum } from "./curation-helpers.ts";
-
-/**
- * The pre-rename shared namespace.
- *
- * Refused as a promotion TARGET unconditionally, matching `promotion.ts` and
- * `server/auth/namespace-policy.ts`. `legacySharedNamespace` is empty by
- * default, so a config-gated check would permit `collab` in exactly the default
- * deployment -- the rule is about the name, not the setting.
- */
-const LEGACY_SHARED_NAMESPACE = "collab";
+import {
+  isPromotionIdentity,
+  legacyTargetRefusal,
+} from "./promotion-shared.ts";
 
 /**
  * Convert the server identity into the promotion service's shape.
@@ -69,15 +63,6 @@ function promotionAuth(identity: AuthIdentity): AuthInfo {
     namespaceSource:
       identity.namespaceSource === "delegated" ? "header" : "token",
   } as AuthInfo;
-}
-
-/** @returns Whether this identity may promote entries between namespaces. */
-function isPromotionIdentity(identity: AuthIdentity): boolean {
-  return (
-    identity.role === "admin" ||
-    identity.role === "ob-admin" ||
-    identity.role === "promoter"
-  );
 }
 
 /** Input schema for `promote_entry`. */
@@ -130,18 +115,12 @@ function resolvePromotionTarget(
   requested: string | undefined,
 ): { target: string } | { refusal: string } {
   const shared = sharedNamespaceConfig();
+  // The default is the PHYSICAL shared namespace here, where `promote_shared`
+  // defaults to the canonical one; the two differ under a split config and
+  // that difference is behavior, so each tool keeps its own default.
   const target = requested ?? shared.sharedNamespace;
-  // The legacy name is a migration SOURCE, never a write target: accepting
-  // it would recreate the two-names-for-one-lane split the canonical
-  // namespace decision exists to end.
-  if (
-    target === LEGACY_SHARED_NAMESPACE ||
-    target === shared.legacySharedNamespace
-  ) {
-    return {
-      refusal: `Permission denied: '${target}' is a legacy migration source and cannot be a promotion target; use '${shared.canonicalSharedNamespace}'`,
-    };
-  }
+  const refusal = legacyTargetRefusal(target, shared);
+  if (refusal) return { refusal };
   return { target };
 }
 

--- a/server/tools/promotion-shared.ts
+++ b/server/tools/promotion-shared.ts
@@ -1,0 +1,71 @@
+/**
+ * Helpers shared by the two promotion tools.
+ *
+ * `promote_shared` (`promotion.ts`) and `promote_entry` (`promote-entry.ts`)
+ * answer different questions -- curated thoughts/decisions with a content gate
+ * versus any table into any writable namespace -- but they enforce the SAME two
+ * rules, and each kept its own copy because the two files were owned
+ * concurrently. Those rules live here so there is one place to change them:
+ *
+ * 1. Who may promote at all (`isPromotionIdentity`).
+ * 2. That the pre-rename shared namespace is a migration SOURCE and is refused
+ *    as a write target (`LEGACY_SHARED_NAMESPACE`, `legacyTargetRefusal`).
+ *
+ * Design authority: `docs/decisions/shared-kb-canonical-namespace.md`,
+ * `docs/decisions/admin-and-promoter-identities.md`.
+ *
+ * Deliberately NOT shared: each tool's `promotionAuth` mapping and its
+ * `runPromotion`. `promote_shared` carries `tokenClientId` into the promotion
+ * service and `promote_entry` does not, and the service reads that field to
+ * stamp `promoted_by` (`src/promotion-service.ts`) -- so the two mappings
+ * differ in observable behavior, not just in spelling. The `runPromotion`
+ * pair differ in log event fields, error mapping, and result shape.
+ */
+import type { AuthIdentity } from "../auth/types.ts";
+import type { SharedNamespaceConfig } from "../../src/shared-namespace.ts";
+
+/**
+ * The pre-rename shared namespace.
+ *
+ * Named as a constant rather than read from config because it is refused as a
+ * write target unconditionally: `legacySharedNamespace` is empty by default, so
+ * a config-only check would permit `collab` in exactly the default deployment
+ * -- the rule is about the name, not the setting. Matches
+ * `LEGACY_SHARED_NAMESPACE` in `server/auth/namespace-policy.ts`.
+ */
+export const LEGACY_SHARED_NAMESPACE = "collab";
+
+/** @returns Whether this identity may promote entries between namespaces. */
+export function isPromotionIdentity(identity: AuthIdentity): boolean {
+  return (
+    identity.role === "promoter" ||
+    identity.role === "admin" ||
+    identity.role === "ob-admin"
+  );
+}
+
+/**
+ * Judge a requested promotion target against the legacy-name rule.
+ *
+ * The legacy name is a migration SOURCE, never a write target: accepting it
+ * would recreate the two-names-for-one-lane split that the canonical-namespace
+ * decision exists to end.
+ *
+ * The caller supplies the already-resolved `target` because the two tools
+ * default it differently -- `promote_shared` to the canonical shared namespace
+ * and `promote_entry` to the physical one -- and those defaults are behavior.
+ *
+ * @returns The refusal message, or undefined when the target is allowed.
+ */
+export function legacyTargetRefusal(
+  target: string,
+  shared: SharedNamespaceConfig,
+): string | undefined {
+  if (
+    target === LEGACY_SHARED_NAMESPACE ||
+    target === shared.legacySharedNamespace
+  ) {
+    return `Permission denied: '${target}' is a legacy migration source and cannot be a promotion target; use '${shared.canonicalSharedNamespace}'`;
+  }
+  return undefined;
+}

--- a/server/tools/promotion.ts
+++ b/server/tools/promotion.ts
@@ -37,20 +37,14 @@ import {
   type MemoryToolDependencies,
 } from "./types.ts";
 import { ALL_TABLES } from "./curation-helpers.ts";
+import {
+  isPromotionIdentity,
+  legacyTargetRefusal,
+} from "./promotion-shared.ts";
 
 /** Tables `promote_shared` can lift into shared truth. */
 const PROMOTABLE_TABLES = ["thoughts", "decisions"] as const;
 type PromotableTable = (typeof PROMOTABLE_TABLES)[number];
-
-/**
- * The pre-rename shared namespace.
- *
- * Named here as a constant rather than read from config because it is refused
- * as a write target unconditionally: `legacySharedNamespace` is empty by
- * default, so a config-only check would permit `collab` in the default
- * deployment. Matches `LEGACY_SHARED_NAMESPACE` in `server/auth/namespace-policy.ts`.
- */
-const LEGACY_SHARED_NAMESPACE = "collab";
 
 /**
  * Convert the server identity into the promotion service's shape.
@@ -80,15 +74,6 @@ function shareContent(
     return `${title} ${rationale}`.trim();
   }
   return (row.content as string | null) ?? "";
-}
-
-/** @returns Whether this identity may attempt a shared-truth promotion. */
-function isPromotionIdentity(identity: AuthIdentity): boolean {
-  return (
-    identity.role === "promoter" ||
-    identity.role === "admin" ||
-    identity.role === "ob-admin"
-  );
 }
 
 /** Frozen `list_namespaces` argument contract: the names and types are the API. */
@@ -271,22 +256,8 @@ function authorizePromotion(
 
   const shared = sharedNamespaceConfig();
   const target = requestedNamespace ?? shared.canonicalSharedNamespace;
-  // The legacy name is a migration SOURCE, never a write target: accepting
-  // it here would recreate the two-names-for-one-lane split that the
-  // canonical-namespace decision exists to end.
-  //
-  // `collab` is refused UNCONDITIONALLY, not just when it is the configured
-  // legacy name. `legacySharedNamespace` defaults to empty, so a
-  // config-gated check would silently allow `collab` as a target in exactly
-  // the default deployment -- the rule is about the name, not the setting.
-  if (
-    target === LEGACY_SHARED_NAMESPACE ||
-    target === shared.legacySharedNamespace
-  ) {
-    return errorResult(
-      `Permission denied: '${target}' is a legacy migration source and cannot be a promotion target; use '${shared.canonicalSharedNamespace}'`,
-    );
-  }
+  const refusal = legacyTargetRefusal(target, shared);
+  if (refusal) return errorResult(refusal);
 
   return { identity, target };
 }


### PR DESCRIPTION
## Summary

- `server/tools/promotion.ts` and `server/tools/promote-entry.ts` were each already lint-clean (#802, #797), but each carried a private copy of the same two promotion rules: the lanes that cleaned them ran concurrently, so neither could safely reach into the other's file.
- Moves the genuinely identical helpers into one shared sibling, `server/tools/promotion-shared.ts`, imported by both: `LEGACY_SHARED_NAMESPACE` (`promotion.ts:53` / `promote-entry.ts:56`), `isPromotionIdentity` (`promotion.ts:86` / `promote-entry.ts:75`), and the legacy-target refusal as `legacyTargetRefusal()` (`promotion.ts:282` / `promote-entry.ts:137`).
- `isPromotionIdentity` admitted exactly `promoter`, `admin`, `ob-admin` in both copies and differed only in the operand order of a side-effect-free `||` chain. The refusal predicate and its message template were byte-identical in both copies.
- Each caller keeps its **own** default target: `promote_shared` resolves to `canonicalSharedNamespace` and `promote_entry` to `sharedNamespace`. Those differ under a split config, so only the refusal is shared, never the default.
- Left deliberately duplicated because the pairs are not identical field for field: `promotionAuth` (`promotion.ts` carries `tokenClientId`, `promote-entry.ts` does not, and `src/promotion-service.ts:216` reads it to stamp `promoted_by`), `runPromotion` (different log fields, different error mapping, different result shape), and the identity-denial responses (different log event names and messages).
- No behavior change: schemas, defaults, error strings, SQL, log event names, and section ordering are identical. No existing test was modified. No file outside the two targets and the new sibling was touched.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`./node_modules/.bin/oxlint --deny-warnings` on all three files exits 0. `bunx tsc --noEmit` exits 0. `bun run test:isolated` over the pinning tests (`src/tools/__tests__/promote-shared.test.ts`, `src/tools/__tests__/promote-entry.test.ts`, `src/tools/__tests__/promote-entry.pg.test.ts`, `server/tools/promotion.pg.test.ts`, `server/tools/ported-tools-scope.test.ts`, `src/ob-admin-role.test.ts`) reports 74 pass / 0 fail; `bun run test:isolated server/tools/` reports 163 pass / 0 fail. The done-means script, run on the committed tree, derives its file list from `git diff --name-only origin/main...HEAD`, picks up all three files, and exits 0. Python package is untouched, so its checks are not applicable; this is a pure internal refactor with no MCP contract change, so no live smoke applies.

## Critical Self-Review

- Highest-risk behavior: sharing the legacy-target refusal between two tools whose default target namespaces genuinely differ. Handled by sharing only the refusal predicate and message and having each caller resolve and pass its own `target`, so the defaults never converge.
- Assumptions that could be wrong: that reordering the operands of `isPromotionIdentity`'s `||` chain is unobservable. It holds because the three comparisons are pure string equality against `identity.role` with no side effects, and the merged body admits exactly the same role set as each original.
- Missing/weak tests: no test was added, because this change is defined as behavior-preserving and the existing suites already pin both tools' identity refusals and legacy-target refusals. A new test here would assert the same thing the existing ones do.
- Security/permission risk: `isPromotionIdentity` is a permission predicate, so a wrong role set would widen who may promote. Verified by reading the merged body back against both originals: the same three roles, no additions.
- Migration/deploy risk: none. No schema, migration, or config change.
- Downstream client/runtime risk: none. No MCP tool name, input schema, annotation, output shape, or error string changed, so no client observes a difference. `docs/downstream-rollout.md` checked; nothing applies.
- Rollback/cleanup concern: a single revertable commit adding one file and editing two.
- Fixes made before PR: none needed; the extraction was read back against the originals predicate by predicate before the first check ran.
- Known residual risk: `errorResult(refusal)` narrows a `string | undefined` with a truthiness test, so an empty-string refusal would fall through. It cannot be empty because the message template always begins with `Permission denied:`.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the duplication was a known consequence of two concurrent single-owner lint lanes, already recorded as lane-contract round 38 and rule 32, and this PR is that rule being applied rather than a new lesson.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no MCP contract, transport, or client-facing surface changed.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface changed, so no fixture describes anything different.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Internal refactor only. The `promote_shared` and `promote_entry` tool registrations, input schemas, annotations, descriptions, result shapes, and error strings are unchanged, so nothing downstream observes this.
