### PR TITLE
refactor(health): bring server/transport/health.ts to the lint standard (#780)

### DIFF
--- a/server/transport/health.ts
+++ b/server/transport/health.ts
@@ -162,7 +162,9 @@ const HTTP_NATS_HEALTH: TransportNatsHealth = {
   last_error: null,
 };
 
-async function probeEmbedding(input: SingleWorkerHealthInput): Promise<boolean> {
+async function probeEmbedding(
+  input: SingleWorkerHealthInput,
+): Promise<boolean> {
   if (!input.embeddingBaseUrl) return false;
   const headers = new Headers();
   if (input.embeddingApiKey) {
@@ -176,7 +178,10 @@ async function probeEmbedding(input: SingleWorkerHealthInput): Promise<boolean> 
     const connected = response.ok;
     await response.body?.cancel();
     if (!connected) {
-      input.logger.warn({ status: response.status }, "embedding_health_degraded");
+      input.logger.warn(
+        { status: response.status },
+        "embedding_health_degraded",
+      );
     }
     return connected;
   } catch (error: unknown) {
@@ -188,64 +193,55 @@ async function probeEmbedding(input: SingleWorkerHealthInput): Promise<boolean> 
   }
 }
 
-/** Probe one worker's owned dependencies without opening a listener. */
-export async function getSingleWorkerHealth(
-  input: SingleWorkerHealthInput,
-): Promise<SingleWorkerHealth> {
-  const [database, embeddingConnected] = await Promise.all([
-    input.databaseHealth(),
-    probeEmbedding(input),
-  ]);
-  const nats = input.natsHealth?.() ?? HTTP_NATS_HEALTH;
-  const natsDegraded =
-    nats.requested_transport === "nats" && nats.availability !== "available";
-  // #625: a quiet producer degrades this worker. A process that composes no
-  // producer supplies nothing here and is unaffected — absence is not staleness.
-  const producer = input.producerHealth?.();
-  const producerDegraded = producer?.stale === true;
-  // #647: a silent capture lane degrades this worker, on the same argument as
-  // the producer above. A process that composes no capture lane supplies
-  // nothing here and is unaffected — absence is not staleness.
-  const capture = input.captureHealth?.();
-  const captureDegraded = capture?.stale === true;
-  const status =
-    database.connected && !natsDegraded && !producerDegraded && !captureDegraded
-      ? "healthy"
-      : "degraded";
-  input.logger.info(
-    {
-      status,
-      database_connected: database.connected,
-      embedding_connected: embeddingConnected,
-      nats_availability: nats.availability,
-      // Emitted whenever a producer exists, not only when it is stale: the
-      // healthy reading is what makes a later stale one comparable, and a field
-      // that appears only on failure cannot be graphed.
-      ...(producer
-        ? {
-            maintenance_producer_stale: producer.stale ? 1 : 0,
-            maintenance_producer_quiet_ms: producer.quiet_ms,
-            maintenance_producer_overlapped_ticks: producer.overlapped_ticks,
-          }
-        : {}),
-      // Emitted whenever a capture lane exists, not only when it is stale, for
-      // the same reason as the producer block above: a field that appears only
-      // on failure cannot be graphed, and the healthy reading is what makes a
-      // later stale one comparable.
-      ...(capture
-        ? {
-            capture_stale: capture.stale ? 1 : 0,
-            capture_sessions_observed: capture.sessions_observed,
-            capture_turns_delivered: capture.turns_delivered,
-            capture_spool_pending: capture.spool_pending,
-            capture_silent_roles: capture.silent_roles.length,
-          }
-        : {}),
-    },
-    "worker_health_result",
-  );
-  if (producerDegraded) {
-    input.logger.warn(
+/**
+ * Log fields describing the maintenance producer, or none when a process
+ * composes no producer.
+ *
+ * Emitted whenever a producer exists, not only when it is stale: the healthy
+ * reading is what makes a later stale one comparable, and a field that appears
+ * only on failure cannot be graphed.
+ */
+function producerLogFields(
+  producer: TransportProducerHealth | undefined,
+): Record<string, number> {
+  if (!producer) return {};
+  return {
+    maintenance_producer_stale: producer.stale ? 1 : 0,
+    maintenance_producer_quiet_ms: producer.quiet_ms,
+    maintenance_producer_overlapped_ticks: producer.overlapped_ticks,
+  };
+}
+
+/**
+ * Log fields describing the capture lane, or none when a process composes no
+ * capture lane.
+ *
+ * Emitted whenever a capture lane exists, not only when it is stale, for the
+ * same reason as the producer block above: a field that appears only on
+ * failure cannot be graphed, and the healthy reading is what makes a later
+ * stale one comparable.
+ */
+function captureLogFields(
+  capture: TransportCaptureHealth | undefined,
+): Record<string, number> {
+  if (!capture) return {};
+  return {
+    capture_stale: capture.stale ? 1 : 0,
+    capture_sessions_observed: capture.sessions_observed,
+    capture_turns_delivered: capture.turns_delivered,
+    capture_spool_pending: capture.spool_pending,
+    capture_silent_roles: capture.silent_roles.length,
+  };
+}
+
+/** Warn once per degraded background lane, naming that lane's own counters. */
+function warnDegradedLanes(
+  logger: Logger,
+  producer: TransportProducerHealth | undefined,
+  capture: TransportCaptureHealth | undefined,
+): void {
+  if (producer?.stale === true) {
+    logger.warn(
       {
         quiet_ms: producer.quiet_ms,
         quiet_threshold_ms: producer.quiet_threshold_ms,
@@ -255,8 +251,8 @@ export async function getSingleWorkerHealth(
       "maintenance_producer_health_degraded",
     );
   }
-  if (captureDegraded) {
-    input.logger.warn(
+  if (capture?.stale === true) {
+    logger.warn(
       {
         reason: capture.reason,
         sessions_observed: capture.sessions_observed,
@@ -269,6 +265,68 @@ export async function getSingleWorkerHealth(
       "capture_lane_health_degraded",
     );
   }
+}
+
+/** The background lanes a worker may compose, read once per health probe. */
+interface WorkerLaneReadings {
+  readonly nats: TransportNatsHealth;
+  readonly producer: TransportProducerHealth | undefined;
+  readonly capture: TransportCaptureHealth | undefined;
+}
+
+/**
+ * Read each optional lane once.
+ *
+ * #625 and #647: a quiet producer or a silent capture lane degrades this
+ * worker. A process that composes neither supplies nothing here and is
+ * unaffected — absence is not staleness.
+ */
+function readWorkerLanes(input: SingleWorkerHealthInput): WorkerLaneReadings {
+  return {
+    nats: input.natsHealth?.() ?? HTTP_NATS_HEALTH,
+    producer: input.producerHealth?.(),
+    capture: input.captureHealth?.(),
+  };
+}
+
+/** "healthy" only while the database and every composed lane agree. */
+function resolveStatus(
+  database: DatabaseHealth,
+  lanes: WorkerLaneReadings,
+): "healthy" | "degraded" {
+  const natsDegraded =
+    lanes.nats.requested_transport === "nats" &&
+    lanes.nats.availability !== "available";
+  const healthy =
+    database.connected &&
+    !natsDegraded &&
+    lanes.producer?.stale !== true &&
+    lanes.capture?.stale !== true;
+  return healthy ? "healthy" : "degraded";
+}
+
+/** Probe one worker's owned dependencies without opening a listener. */
+export async function getSingleWorkerHealth(
+  input: SingleWorkerHealthInput,
+): Promise<SingleWorkerHealth> {
+  const [database, embeddingConnected] = await Promise.all([
+    input.databaseHealth(),
+    probeEmbedding(input),
+  ]);
+  const lanes = readWorkerLanes(input);
+  const status = resolveStatus(database, lanes);
+  input.logger.info(
+    {
+      status,
+      database_connected: database.connected,
+      embedding_connected: embeddingConnected,
+      nats_availability: lanes.nats.availability,
+      ...producerLogFields(lanes.producer),
+      ...captureLogFields(lanes.capture),
+    },
+    "worker_health_result",
+  );
+  warnDegradedLanes(input.logger, lanes.producer, lanes.capture);
   return {
     status,
     hostname: input.hostname,
@@ -280,9 +338,9 @@ export async function getSingleWorkerHealth(
       configured: Boolean(input.embeddingBaseUrl),
       connected: embeddingConnected,
     },
-    nats,
-    ...(producer ? { maintenance_producer: producer } : {}),
-    ...(capture ? { capture } : {}),
+    nats: lanes.nats,
+    ...(lanes.producer ? { maintenance_producer: lanes.producer } : {}),
+    ...(lanes.capture ? { capture: lanes.capture } : {}),
     timestamp: new Date().toISOString(),
   };
 }


### PR DESCRIPTION
## Summary

- `getSingleWorkerHealth` (`server/transport/health.ts:192` at `origin/main`) carried a complexity of 21 against the configured maximum of 10 — the only oxlint finding in the file.
- The branching was never one decision. It was four independent readings (nats, maintenance producer, capture lane, database) plus their conditional log projections and their per-lane degraded warnings, all inlined into one body. Split along those seams into named module-level helpers: `readWorkerLanes` (reads each optional lane exactly once), `resolveStatus` (owns the healthy/degraded verdict), `producerLogFields` and `captureLogFields` (own the two conditional log projections), and `warnDegradedLanes` (owns the two warnings).
- No behavior moves. The `/health` JSON payload keeps identical field order, identical status strings, identical optional-field presence rules (`revision`, `maintenance_producer`, `capture` are still omitted rather than nulled), and the same `probeTimeoutMs` handling — `core01` and the local deploy script read this shape. Log event names (`worker_health_result`, `maintenance_producer_health_degraded`, `capture_lane_health_degraded`) and their field sets are unchanged, as is the order the two warnings fire in.
- The exported signature is untouched, so every caller — `server/transport/http-app.ts:97`, `server/transport/index.ts:27`, and the `scripts/done-means/625` and `647` drivers — is unaffected. No other file is modified; no helper was moved out of the target.
- One deliberate predicate rewrite: the former `producerDegraded`/`captureDegraded` booleans (`x?.stale === true`) are now inlined as `x?.stale !== true` inside the healthy conjunction. Equivalent for all three inhabited states (`undefined`, `false`, `true`), and both drivers exercise all three.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Run on the committed tree, after the pre-commit prettier hook reformatted the staged file:

- `./node_modules/.bin/oxlint --deny-warnings server/transport/health.ts` -> exit 0, 0 findings (was 1 finding, complexity 21)
- `bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 0, PASS
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated server/transport/` -> 67 pass, 0 fail across 4 files
- `bash scripts/done-means/647-capture-liveness.sh` -> PASS, 4 clauses run, 0 failed
- `bash scripts/done-means/625-sweep-heartbeat.sh` -> PASS, 5/5 clauses

The two `done-means` drivers are the pinning evidence that matters here: they call the real `getSingleWorkerHealth` and assert the status verdict and the presence/absence of the optional blocks, which is exactly the surface the extraction touched.

Migrations are untouched, so nothing to run. No Python source changed. No live smoke is needed because the payload is byte-identical by construction and the drivers assert its shape.

## Critical Self-Review

- Highest-risk behavior: the `/health` JSON contract. `core01` and the local clone deploy script read this endpoint, so a moved field or a changed status string breaks deploy tooling silently. Mitigated by composing the return object in the same literal order as before and by the two drivers asserting block presence and absence.
- Assumptions that could be wrong: that `input.natsHealth?.()`, `producerHealth?.()`, and `captureHealth?.()` are pure enough to read once. Before this change `producerHealth` and `captureHealth` were each already read exactly once and `natsHealth` likewise, so `readWorkerLanes` preserves the call count rather than changing it — checked against the `origin/main` body line by line.
- Missing/weak tests: none added, and that is the deliberate choice for a no-behavior-change refactor. The existing suite plus the two drivers already cover the healthy path, the stale-producer path, the stale-capture path, the absent-reader path, and the reader-returns-undefined path. A test written against the new helper names would pin the refactor's shape rather than the contract, which is worth less.
- Security/permission risk: none. No auth, no namespace predicate, no SQL, no user input; the function reads injected readers and one outbound probe to the configured embedding base URL, unchanged.
- Migration/deploy risk: none. No schema, no config keys, no new dependency, no startup ordering change.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md`. No MCP tool, schema, transport, or protocol surface changed; `/health` is an HTTP endpoint whose response is unchanged field for field.
- Rollback/cleanup concern: single-file, single-commit, revert is clean.
- Fixes made before PR: re-read the rewritten body against `origin/main` line by line before committing, specifically the predicate change, because the suite did not catch a non-equivalent predicate rewrite in #806. Re-ran oxlint and the done-means on the committed tree after prettier reformatted the staged file.
- Known residual risk: low. The residual is the predicate rewrite described in the Summary; it is the one place where the new text is not a mechanical move of the old text.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new failure pattern surfaced — this is a mechanical complexity split with no finding to generalize, and the "re-read an extracted predicate against the original" lesson is already recorded from #806.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the `/health` payload is unchanged field for field and the two done-means drivers assert that shape against the real function.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface changed — the refactor is internal to one TypeScript module and no fixture describes its private helpers.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Every downstream item is not applicable. `docs/downstream-rollout.md` scopes the gate to MCP tool, schema, protocol, and client-facing changes. This PR changes no exported signature, adds no tool, and leaves the `/health` response identical, so no downstream consumer can observe it.
