### PR TITLE
refactor(session-save-load): bring server/tools/session-save-load.ts to the lint standard (#780)

### DIFF
--- a/server/tools/session-save-load.ts
+++ b/server/tools/session-save-load.ts
@@ -1,27 +1,101 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { authIdentity, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import { namespacePredicate } from "../auth/namespace-policy.ts";
-import { authorize, contentHash, embeddingFields, sessionEmbedText } from "./memory-helpers.ts";
+import {
+  authorize,
+  contentHash,
+  embeddingFields,
+  sessionEmbedText,
+} from "./memory-helpers.ts";
+
+/**
+ * The declared input shapes of the two tools, lifted out of their registration
+ * calls so each registration body stays readable. Values and constraints are
+ * unchanged from the inline schemas they replace.
+ */
+const SAVE_INPUT_SCHEMA = {
+  summary: z.string().min(1),
+  project: z.string().optional(),
+  session_id: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  blockers: z.array(z.string()).optional(),
+  next_steps: z.array(z.string()).optional(),
+  key_decisions: z.array(z.string()).optional(),
+  namespace: z.string().min(1).max(500).optional(),
+};
+
+const LOAD_INPUT_SCHEMA = { project: z.string().optional() };
+
+type SaveArgs = z.infer<z.ZodObject<typeof SAVE_INPUT_SCHEMA>>;
+type LoadArgs = z.infer<z.ZodObject<typeof LOAD_INPUT_SCHEMA>>;
 
 export function registerSessionSaveLoadTools(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
+  registerSessionSave(server, dependencies);
+  registerSessionLoad(server, dependencies);
+}
+
+/**
+ * Upsert the session row, keyed on (namespace, session_id) when the caller
+ * supplied one. `xmax = 0` distinguishes an insert from an update on the same
+ * statement, which is what the tool reports back as `merged`.
+ */
+async function saveSession(
+  dependencies: MemoryToolDependencies,
+  namespace: string,
+  clientId: string,
+  args: SaveArgs,
+): Promise<{ id: unknown; merged: boolean; embedded: boolean }> {
+  const embedded = await embeddingFields(dependencies, sessionEmbedText(args));
+  const rows = await dependencies.pool.query(
+    `INSERT INTO sessions
+       (session_id, project, summary, tags, blockers, next_steps, key_decisions,
+        created_by, namespace, embedding, content_hash, embedded_at, embedding_model)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+     ON CONFLICT (namespace, session_id) WHERE session_id IS NOT NULL
+     DO UPDATE SET summary = EXCLUDED.summary, tags = EXCLUDED.tags,
+       blockers = EXCLUDED.blockers, next_steps = EXCLUDED.next_steps,
+       key_decisions = EXCLUDED.key_decisions, embedding = EXCLUDED.embedding,
+       content_hash = EXCLUDED.content_hash, embedded_at = EXCLUDED.embedded_at,
+       embedding_model = EXCLUDED.embedding_model, updated_at = NOW()
+     RETURNING id, (xmax = 0) AS is_new`,
+    [
+      args.session_id ?? null,
+      args.project ?? null,
+      args.summary,
+      args.tags ?? [],
+      args.blockers ?? [],
+      args.next_steps ?? [],
+      args.key_decisions ?? [],
+      clientId,
+      namespace,
+      embedded.embedding,
+      contentHash(`${args.summary}|${args.project ?? ""}`),
+      embedded.embeddedAt,
+      embedded.model,
+    ],
+  );
+  const row = rows.rows[0];
+  return { id: row.id, merged: !row.is_new, embedded: embedded.embedded };
+}
+
+function registerSessionSave(
   server: McpServer,
   dependencies: MemoryToolDependencies,
 ): void {
   server.registerTool(
     "session_save",
     {
-      description: "Save a session summary with structured fields for session continuity across context compactions",
-      inputSchema: {
-        summary: z.string().min(1),
-        project: z.string().optional(),
-        session_id: z.string().optional(),
-        tags: z.array(z.string()).optional(),
-        blockers: z.array(z.string()).optional(),
-        next_steps: z.array(z.string()).optional(),
-        key_decisions: z.array(z.string()).optional(),
-        namespace: z.string().min(1).max(500).optional(),
-      },
+      description:
+        "Save a session summary with structured fields for session continuity across context compactions",
+      inputSchema: SAVE_INPUT_SCHEMA,
       annotations: {
         title: "Save Session",
         readOnlyHint: false,
@@ -38,52 +112,66 @@ export function registerSessionSaveLoadTools(
         args.namespace,
       );
       if (!auth.ok) return auth.response;
-      const embedded = await embeddingFields(dependencies, sessionEmbedText(args));
-      const rows = await dependencies.pool.query(
-        `INSERT INTO sessions
-           (session_id, project, summary, tags, blockers, next_steps, key_decisions,
-            created_by, namespace, embedding, content_hash, embedded_at, embedding_model)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-         ON CONFLICT (namespace, session_id) WHERE session_id IS NOT NULL
-         DO UPDATE SET summary = EXCLUDED.summary, tags = EXCLUDED.tags,
-           blockers = EXCLUDED.blockers, next_steps = EXCLUDED.next_steps,
-           key_decisions = EXCLUDED.key_decisions, embedding = EXCLUDED.embedding,
-           content_hash = EXCLUDED.content_hash, embedded_at = EXCLUDED.embedded_at,
-           embedding_model = EXCLUDED.embedding_model, updated_at = NOW()
-         RETURNING id, (xmax = 0) AS is_new`,
-        [
-          args.session_id ?? null,
-          args.project ?? null,
-          args.summary,
-          args.tags ?? [],
-          args.blockers ?? [],
-          args.next_steps ?? [],
-          args.key_decisions ?? [],
-          auth.identity.clientId,
-          auth.namespace,
-          embedded.embedding,
-          contentHash(`${args.summary}|${args.project ?? ""}`),
-          embedded.embeddedAt,
-          embedded.model,
-        ],
+      const saved = await saveSession(
+        dependencies,
+        auth.namespace,
+        auth.identity.clientId,
+        args,
       );
-      const row = rows.rows[0];
-      dependencies.logger.info({ tool: "session_save", namespace: auth.namespace }, "tool_result");
+      dependencies.logger.info(
+        { tool: "session_save", namespace: auth.namespace },
+        "tool_result",
+      );
       return textResult({
-        id: row.id,
+        id: saved.id,
         namespace: auth.namespace,
         ...(args.session_id ? { session_id: args.session_id } : {}),
-        embedded: embedded.embedded,
-        merged: !row.is_new,
+        embedded: saved.embedded,
+        merged: saved.merged,
       });
     },
   );
+}
 
+/**
+ * Read the most recent unarchived session, newest first.
+ *
+ * Global roles read every namespace, so the predicate builder returns an
+ * empty clause for them. Hardcoding the caller's own namespace list here
+ * would silently hide rows from admin, ob-admin, and promoter.
+ */
+async function loadSessions(
+  dependencies: MemoryToolDependencies,
+  identity: Parameters<typeof namespacePredicate>[0],
+  args: LoadArgs,
+): Promise<Record<string, unknown>[]> {
+  const values: unknown[] = [];
+  const projectClause = args.project
+    ? ` AND project = $${values.push(args.project)}`
+    : "";
+  const predicate = namespacePredicate(identity, "read", values.length + 1);
+  values.push(...predicate.values);
+  const rows = await dependencies.pool.query(
+    `SELECT id, project, summary, tags, blockers, next_steps, key_decisions,
+            created_by, created_at
+       FROM sessions
+      WHERE archived_at IS NULL${projectClause}${predicate.clause}
+      ORDER BY created_at DESC`,
+    values,
+  );
+  return rows.rows;
+}
+
+function registerSessionLoad(
+  server: McpServer,
+  dependencies: MemoryToolDependencies,
+): void {
   server.registerTool(
     "session_load",
     {
-      description: "Load the most recent session summary, optionally filtered by project",
-      inputSchema: { project: z.string().optional() },
+      description:
+        "Load the most recent session summary, optionally filtered by project",
+      inputSchema: LOAD_INPUT_SCHEMA,
       annotations: {
         title: "Load Session",
         readOnlyHint: true,
@@ -92,28 +180,26 @@ export function registerSessionSaveLoadTools(
       },
     },
     async (args, extra) => {
-      const auth = authorize(authIdentity(extra.authInfo), "read", "sessions", "cannot read sessions");
-      if (!auth.ok) return auth.response;
-      // Global roles read every namespace, so the predicate builder returns an
-      // empty clause for them. Hardcoding the caller's own namespace list here
-      // would silently hide rows from admin, ob-admin, and promoter.
-      const values: unknown[] = [];
-      const projectClause = args.project ? ` AND project = $${values.push(args.project)}` : "";
-      const predicate = namespacePredicate(auth.identity, "read", values.length + 1);
-      values.push(...predicate.values);
-      const rows = await dependencies.pool.query(
-        `SELECT id, project, summary, tags, blockers, next_steps, key_decisions,
-                created_by, created_at
-           FROM sessions
-          WHERE archived_at IS NULL${projectClause}${predicate.clause}
-          ORDER BY created_at DESC`,
-        values,
+      const auth = authorize(
+        authIdentity(extra.authInfo),
+        "read",
+        "sessions",
+        "cannot read sessions",
       );
-      if (rows.rows.length === 0) {
-        return textResult(args.project ? `No sessions found for project: ${args.project}` : "No sessions found");
+      if (!auth.ok) return auth.response;
+      const rows = await loadSessions(dependencies, auth.identity, args);
+      if (rows.length === 0) {
+        return textResult(
+          args.project
+            ? `No sessions found for project: ${args.project}`
+            : "No sessions found",
+        );
       }
-      dependencies.logger.info({ tool: "session_load", project: args.project ?? null }, "tool_result");
-      return textResult(rows.rows[0]);
+      dependencies.logger.info(
+        { tool: "session_load", project: args.project ?? null },
+        "tool_result",
+      );
+      return textResult(rows[0]);
     },
   );
 }


### PR DESCRIPTION
## Summary

- `registerSessionSaveLoadTools` in `server/tools/session-save-load.ts` was 109 code lines against a rule value of 100, because both tool registrations — schema, annotations, and the whole async handler body — sat inline in one function. This is the single #780 finding on the file.
- Split it the way `main` already split `search-all.ts`, `entities.ts`, and `session-lifecycle.ts` (#823): the two input shapes are hoisted to module-level `SAVE_INPUT_SCHEMA` / `LOAD_INPUT_SCHEMA`, each registration moves into its own named `registerSessionSave` / `registerSessionLoad`, and the database work moves into `saveSession` and `loadSessions` so each registration body reads as authorize -> query -> report.
- No behavior moves. Tool names, descriptions, schema fields and their constraints, annotation flags, defaults, both SQL statements, the `No sessions found` strings, and both `tool_result` log events are unchanged. The upsert SQL is byte-identical apart from the indentation shift that follows the template literal moving out one nesting level, which Postgres does not read; that was diffed explicitly rather than eyeballed.
- Helpers reused as-is, none written: `authorize`, `embeddingFields`, `sessionEmbedText`, `contentHash` from `memory-helpers.ts`, and `namespacePredicate` from `../auth/namespace-policy.ts`. The shapes in `session-lifecycle.ts` and `session-events.ts` are field-for-field different from these two tools, so nothing was lifted into a shared sibling and neither file was touched. One file changed in this PR.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Red first, on the untouched file: `oxlint --deny-warnings server/tools/session-save-load.ts` reported `server/tools/session-save-load.ts:7:8: error eslint(max-lines-per-function): The function registerSessionSaveLoadTools has too many lines (109). Maximum allowed is 100.`, and `DONE_MEANS_780_FILES=server/tools/session-save-load.ts bash scripts/done-means/780-touched-files-lint-clean.sh` exited 1.

Green, re-run on the COMMITTED tree after the pre-commit prettier pass reformatted the file: `oxlint --deny-warnings` exit 0; `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived from `origin/main...HEAD`) exit 0; `bunx tsc --noEmit` clean; `bun run test:isolated server/tools/read-scope.test.ts server/tools/ported-tools-scope.test.ts server/tools/namespace-denial.test.ts` 31 pass 0 fail; `bun run test:isolated server/tools/` 163 pass 0 fail across 17 files. No test was modified.

Python package checks are not applicable — nothing under `python/openbrain-memory/` changed. Live smoke is not applicable — this is an internal function-shape refactor with no contract, schema, or wire change.

## Critical Self-Review

- Highest-risk behavior: the `session_load` namespace predicate. `loadSessions` still receives `auth.identity` and calls `namespacePredicate(identity, "read", values.length + 1)` with the same offset arithmetic and the same `values.push(...predicate.values)` ordering, so the positional parameter numbering is unchanged; a rewrite that silently changed the predicate would widen a security boundary, which is why `read-scope.test.ts` was run as the pinning test rather than assumed.
- Assumptions that could be wrong: that no caller depends on the module exporting only `registerSessionSaveLoadTools`. Checked — `server/tools/index.ts` is the sole importer and imports exactly that name, which keeps its existing signature; the four new functions are module-private and not exported.
- Missing/weak tests: `session_save` has no server-side test of its own in `server/tools/`; the coverage that exists is `read-scope.test.ts` on `session_load` plus `ported-tools-scope.test.ts`. `saveSession` is therefore covered by typecheck and by-hand equivalence diff rather than by an executing assertion. Adding a `session_save` pg test is real value but is behavior-test work outside a lint sweep's scope, so it is named here rather than smuggled in.
- Security/permission risk: none intended. Both `authorize` calls keep their exact argument lists, including the `args.namespace` override on the write path and its absence on the read path, and both still return `auth.response` before any query runs.
- Migration/deploy risk: none. No SQL semantics, no schema, no migration.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classifies by MCP tool/schema/protocol/client-facing change; tool names, input schemas, annotations, and response shapes are all identical, so no downstream surface moves.
- Rollback/cleanup concern: single-file, single-commit, revertible with no coordination.
- Fixes made before PR: none needed beyond the extraction itself; the first oxlint and tsc run after the rewrite were both clean.
- Known residual risk: the `session_save` gap named above. Everything else is covered by the 163 green tests in the touched directory.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical extraction against an already-established repo pattern (search-all.ts, entities.ts, session-lifecycle.ts #823) and produced no new MEDIUM+ finding; the reuse and equivalence-diff discipline it exercised is already recorded in the lane contract's Tightenings rather than in the review-swarm SME lanes.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no wire, schema, or tool-contract change — the running service serves byte-identical tool definitions.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: `contracts/server/server-session-save-load.fixture.json` records the tool contract, and this refactor changes no tool name, description, input schema, or annotation, so the existing fixture still describes the file exactly and needed no regeneration.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Every downstream item is not-applicable for the same reason: the MCP surface is unchanged. The tool names `session_save` and `session_load`, their input schemas field for field, their annotation flags, and their response payload keys (`id`, `namespace`, `session_id`, `embedded`, `merged` on save; the raw session row on load) are identical to `origin/main`. Nothing a downstream client can observe moved, so there is no cache to refresh and no canary to run.
