### PR TITLE
refactor(repo-facts): bring server/tools/repo-facts.ts to the lint standard (#780)

### DIFF
--- a/server/tools/repo-facts.ts
+++ b/server/tools/repo-facts.ts
@@ -43,6 +43,48 @@ import {
 const REPO_FACT_COLUMNS = `id, entity_type, name, canonical_id, namespace,
   metadata, created_by, created_at, updated_at`;
 
+/** Input schema for `upsert_repo_fact`, hoisted so the registrar stays small. */
+const UPSERT_REPO_FACT_SCHEMA = {
+  namespace: z
+    .string()
+    .trim()
+    .min(1)
+    .max(500)
+    .optional()
+    .describe("Namespace for isolation (defaults to agent's clientId)."),
+  metadata: repoFactMetadata.describe(
+    "Curated qmd-derived repository fact metadata.",
+  ),
+};
+
+/** Input schema for `list_repo_facts`, hoisted so the registrar stays small. */
+const LIST_REPO_FACTS_SCHEMA = {
+  namespace: z.string().trim().min(1).max(500).optional(),
+  repo: z.string().trim().min(1).max(300).optional(),
+  collection: z.string().trim().min(1).max(300).optional(),
+  path: z.string().trim().min(1).max(1000).optional(),
+  fact_type: z.enum(FACT_TYPES).optional(),
+  subject: z.string().trim().min(1).max(500).optional(),
+  limit: z.number().int().min(1).max(250).optional(),
+  offset: z.number().int().min(0).optional(),
+};
+
+type UpsertRepoFactArgs = {
+  namespace?: string;
+  metadata: z.infer<typeof repoFactMetadata>;
+};
+
+type ListRepoFactsArgs = {
+  namespace?: string;
+  repo?: string;
+  collection?: string;
+  path?: string;
+  fact_type?: (typeof FACT_TYPES)[number];
+  subject?: string;
+  limit?: number;
+  offset?: number;
+};
+
 export function registerRepoFactTools(
   server: McpServer,
   dependencies: MemoryToolDependencies,
@@ -53,18 +95,7 @@ export function registerRepoFactTools(
       description:
         "Upsert a curated qmd-derived repository fact into Open Brain graph entity metadata. " +
         "This stores stable operating knowledge plus source pointers, not raw code chunks.",
-      inputSchema: {
-        namespace: z
-          .string()
-          .trim()
-          .min(1)
-          .max(500)
-          .optional()
-          .describe("Namespace for isolation (defaults to agent's clientId)."),
-        metadata: repoFactMetadata.describe(
-          "Curated qmd-derived repository fact metadata.",
-        ),
-      },
+      inputSchema: UPSERT_REPO_FACT_SCHEMA,
       annotations: {
         title: "Upsert Repo Fact",
         readOnlyHint: false,
@@ -72,84 +103,8 @@ export function registerRepoFactTools(
         idempotentHint: true,
       },
     },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      if (!identity || !canWrite(identity.role, "sessions")) {
-        return errorResult("Permission denied: cannot write repo facts");
-      }
-      const namespace = args.namespace ?? identity.clientId;
-      if (!canTargetNamespace(identity, "write", namespace)) {
-        return errorResult("Permission denied: namespace write denied");
-      }
-
-      const metadata = repoFactMetadata.parse(args.metadata);
-      // A repo fact is knowledge ABOUT code, not the code itself, and never a
-      // credential. Both checks run before anything is stored or embedded.
-      if (looksLikeRawCodeDump(metadata.fact)) {
-        return errorResult(
-          "Rejected repo fact: fact appears to contain a raw code chunk",
-        );
-      }
-      if (containsSecretLikeValue(metadata.fact)) {
-        return errorResult(
-          "Rejected repo fact: fact appears to contain credential-like material",
-        );
-      }
-
-      const factCanonicalId = canonicalId(metadata);
-      const storedMetadata = {
-        ...metadata,
-        fact_id: factCanonicalId,
-        promoted_as: "repo_fact",
-      };
-
-      // A failed embedding must not fail the write: the fact is the durable
-      // value and the vector is derived from it.
-      let embedding: number[] | null = null;
-      try {
-        embedding = await dependencies.embedFn(
-          `${metadata.repo} ${metadata.path} ${factSubject(metadata)} ${metadata.fact}`,
-        );
-      } catch (error) {
-        dependencies.logger.warn(
-          {
-            canonicalId: factCanonicalId,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          "upsert_repo_fact_embed_failed",
-        );
-      }
-
-      const { rows } = await dependencies.pool.query(
-        `INSERT INTO ob_entities
-           (entity_type, name, canonical_id, namespace, metadata, embedding, created_by)
-         VALUES ('repo_fact', $1, $2, $3, $4::jsonb, $5, $6)
-         ON CONFLICT (namespace, entity_type, lower(name))
-         WHERE archived_at IS NULL
-         DO UPDATE SET
-           canonical_id = EXCLUDED.canonical_id,
-           metadata = EXCLUDED.metadata,
-           embedding = COALESCE(EXCLUDED.embedding, ob_entities.embedding),
-           archived_at = NULL,
-           updated_at = NOW()
-         RETURNING id, (xmax = 0) AS is_new, entity_type, name, canonical_id,
-                   namespace, metadata, created_at, updated_at`,
-        [
-          entityName(metadata),
-          factCanonicalId,
-          namespace,
-          JSON.stringify(storedMetadata),
-          embedding ? toSql(embedding) : null,
-          identity.clientId,
-        ],
-      );
-
-      dependencies.logger.info(
-        { tool: "upsert_repo_fact", canonicalId: factCanonicalId },
-        "tool_result",
-      );
-      return textResult(rows[0]);
-    },
+    async (args, extra) =>
+      handleUpsertRepoFact(dependencies, args, authIdentity(extra.authInfo)),
   );
 
   server.registerTool(
@@ -157,16 +112,7 @@ export function registerRepoFactTools(
     {
       description:
         "List curated qmd-derived repository facts from Open Brain graph entity metadata.",
-      inputSchema: {
-        namespace: z.string().trim().min(1).max(500).optional(),
-        repo: z.string().trim().min(1).max(300).optional(),
-        collection: z.string().trim().min(1).max(300).optional(),
-        path: z.string().trim().min(1).max(1000).optional(),
-        fact_type: z.enum(FACT_TYPES).optional(),
-        subject: z.string().trim().min(1).max(500).optional(),
-        limit: z.number().int().min(1).max(250).optional(),
-        offset: z.number().int().min(0).optional(),
-      },
+      inputSchema: LIST_REPO_FACTS_SCHEMA,
       annotations: {
         title: "List Repo Facts",
         readOnlyHint: true,
@@ -174,82 +120,217 @@ export function registerRepoFactTools(
         idempotentHint: true,
       },
     },
-    async (args, extra) => {
-      const identity = authIdentity(extra.authInfo);
-      if (!identity || !canRead(identity.role, "sessions")) {
-        return errorResult("Permission denied: cannot read repo facts");
-      }
-      if (args.namespace && !canTargetNamespace(identity, "read", args.namespace)) {
-        return errorResult("Permission denied: namespace read access denied");
-      }
-
-      const rowCap = args.limit ?? 50;
-      const offset = args.offset ?? 0;
-      const config = sharedNamespaceConfig();
-
-      /** Run the fact query against one explicit namespace scope. */
-      const queryRows = async (
-        scope: string | readonly string[] | undefined,
-        queryOffset: number,
-      ): Promise<Array<Record<string, unknown>>> => {
-        const values: unknown[] = [];
-        const filters = ["entity_type = 'repo_fact'", "archived_at IS NULL"];
-        if (typeof scope === "string") {
-          values.push(scope);
-          filters.push(`namespace = $${values.length}`);
-        } else if (Array.isArray(scope)) {
-          values.push(scope);
-          filters.push(`namespace = ANY($${values.length}::text[])`);
-        }
-        for (const [column, value] of [
-          ["repo", args.repo],
-          ["collection", args.collection],
-          ["path", args.path],
-          ["fact_type", args.fact_type],
-        ] as const) {
-          if (!value) continue;
-          values.push(value);
-          filters.push(`metadata->>'${column}' = $${values.length}`);
-        }
-        if (args.subject) {
-          values.push(args.subject);
-          filters.push(
-            `(metadata->>'subject' = $${values.length} OR metadata->>'symbol' = $${values.length})`,
-          );
-        }
-        values.push(rowCap, queryOffset);
-        const { rows } = await dependencies.pool.query(
-          `SELECT ${REPO_FACT_COLUMNS}
-             FROM ob_entities
-            WHERE ${filters.join(" AND ")}
-            ORDER BY updated_at DESC, created_at DESC
-            LIMIT $${values.length - 1} OFFSET $${values.length}`,
-          values,
-        );
-        return rows as Array<Record<string, unknown>>;
-      };
-
-      // Scope comes from the request when one was named and authorized, and
-      // otherwise from the auth-derived read predicate.
-      const predicate = namespacePredicate(identity, "read", 1);
-      const scope: string | readonly string[] | undefined = args.namespace
-        ? args.namespace
-        : ((predicate.values[0] as readonly string[] | undefined) ?? undefined);
-
-      const rows = await readWithLegacyFallback({
-        scope,
-        offset,
-        rowCap,
-        config,
-        queryRows,
-      });
-      dependencies.logger.info(
-        { tool: "list_repo_facts", returned: rows.length },
-        "tool_result",
-      );
-      return textResult(canonicalizeRepoFactRows(rows));
-    },
+    async (args, extra) =>
+      handleListRepoFacts(dependencies, args, authIdentity(extra.authInfo)),
   );
+}
+
+/**
+ * Embed the fact text, or give up and keep the write.
+ *
+ * A failed embedding must not fail the write: the fact is the durable value and
+ * the vector is derived from it. The failure is logged with the canonical id so
+ * a missing vector is traceable, then the caller proceeds without one.
+ */
+async function embedRepoFact(
+  dependencies: MemoryToolDependencies,
+  metadata: z.infer<typeof repoFactMetadata>,
+  factCanonicalId: string,
+): Promise<number[] | null> {
+  try {
+    return await dependencies.embedFn(
+      `${metadata.repo} ${metadata.path} ${factSubject(metadata)} ${metadata.fact}`,
+    );
+  } catch (error) {
+    dependencies.logger.warn(
+      {
+        canonicalId: factCanonicalId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "upsert_repo_fact_embed_failed",
+    );
+    return null;
+  }
+}
+
+/**
+ * Refuse a fact that is not stable operating knowledge.
+ *
+ * A repo fact is knowledge ABOUT code, not the code itself, and never a
+ * credential. Both checks run before anything is stored or embedded. Returns
+ * the ready-to-return refusal envelope, or `null` when the fact is acceptable.
+ */
+function refuseUnstorableFact(
+  metadata: z.infer<typeof repoFactMetadata>,
+): ReturnType<typeof errorResult> | null {
+  if (looksLikeRawCodeDump(metadata.fact)) {
+    return errorResult(
+      "Rejected repo fact: fact appears to contain a raw code chunk",
+    );
+  }
+  if (containsSecretLikeValue(metadata.fact)) {
+    return errorResult(
+      "Rejected repo fact: fact appears to contain credential-like material",
+    );
+  }
+  return null;
+}
+
+/** Write one repo fact, upserting on the active (namespace, type, name) key. */
+async function handleUpsertRepoFact(
+  dependencies: MemoryToolDependencies,
+  args: UpsertRepoFactArgs,
+  identity: ReturnType<typeof authIdentity>,
+): Promise<ReturnType<typeof textResult>> {
+  if (!identity || !canWrite(identity.role, "sessions")) {
+    return errorResult("Permission denied: cannot write repo facts");
+  }
+  const namespace = args.namespace ?? identity.clientId;
+  if (!canTargetNamespace(identity, "write", namespace)) {
+    return errorResult("Permission denied: namespace write denied");
+  }
+
+  const metadata = repoFactMetadata.parse(args.metadata);
+  const refusal = refuseUnstorableFact(metadata);
+  if (refusal) return refusal;
+
+  const factCanonicalId = canonicalId(metadata);
+  const storedMetadata = {
+    ...metadata,
+    fact_id: factCanonicalId,
+    promoted_as: "repo_fact",
+  };
+
+  const embedding = await embedRepoFact(
+    dependencies,
+    metadata,
+    factCanonicalId,
+  );
+
+  const { rows } = await dependencies.pool.query(
+    `INSERT INTO ob_entities
+       (entity_type, name, canonical_id, namespace, metadata, embedding, created_by)
+     VALUES ('repo_fact', $1, $2, $3, $4::jsonb, $5, $6)
+     ON CONFLICT (namespace, entity_type, lower(name))
+     WHERE archived_at IS NULL
+     DO UPDATE SET
+       canonical_id = EXCLUDED.canonical_id,
+       metadata = EXCLUDED.metadata,
+       embedding = COALESCE(EXCLUDED.embedding, ob_entities.embedding),
+       archived_at = NULL,
+       updated_at = NOW()
+     RETURNING id, (xmax = 0) AS is_new, entity_type, name, canonical_id,
+               namespace, metadata, created_at, updated_at`,
+    [
+      entityName(metadata),
+      factCanonicalId,
+      namespace,
+      JSON.stringify(storedMetadata),
+      embedding ? toSql(embedding) : null,
+      identity.clientId,
+    ],
+  );
+
+  dependencies.logger.info(
+    { tool: "upsert_repo_fact", canonicalId: factCanonicalId },
+    "tool_result",
+  );
+  return textResult(rows[0]);
+}
+
+/**
+ * Build the parameterized filter set for one fact query.
+ *
+ * Column names come from a closed literal list in this module, never from the
+ * caller, so the only interpolated text is our own; every caller-supplied value
+ * is bound as a parameter.
+ */
+function repoFactFilters(
+  args: ListRepoFactsArgs,
+  scope: string | readonly string[] | undefined,
+): { filters: string[]; values: unknown[] } {
+  const values: unknown[] = [];
+  const filters = ["entity_type = 'repo_fact'", "archived_at IS NULL"];
+  if (typeof scope === "string") {
+    values.push(scope);
+    filters.push(`namespace = $${values.length}`);
+  } else if (Array.isArray(scope)) {
+    values.push(scope);
+    filters.push(`namespace = ANY($${values.length}::text[])`);
+  }
+  for (const [column, value] of [
+    ["repo", args.repo],
+    ["collection", args.collection],
+    ["path", args.path],
+    ["fact_type", args.fact_type],
+  ] as const) {
+    if (!value) continue;
+    values.push(value);
+    filters.push(`metadata->>'${column}' = $${values.length}`);
+  }
+  if (args.subject) {
+    values.push(args.subject);
+    filters.push(
+      `(metadata->>'subject' = $${values.length} OR metadata->>'symbol' = $${values.length})`,
+    );
+  }
+  return { filters, values };
+}
+
+/** List repo facts for the authorized read scope, with the legacy top-up. */
+async function handleListRepoFacts(
+  dependencies: MemoryToolDependencies,
+  args: ListRepoFactsArgs,
+  identity: ReturnType<typeof authIdentity>,
+): Promise<ReturnType<typeof textResult>> {
+  if (!identity || !canRead(identity.role, "sessions")) {
+    return errorResult("Permission denied: cannot read repo facts");
+  }
+  if (args.namespace && !canTargetNamespace(identity, "read", args.namespace)) {
+    return errorResult("Permission denied: namespace read access denied");
+  }
+
+  const rowCap = args.limit ?? 50;
+  const offset = args.offset ?? 0;
+  const config = sharedNamespaceConfig();
+
+  /** Run the fact query against one explicit namespace scope. */
+  const queryRows = async (
+    scope: string | readonly string[] | undefined,
+    queryOffset: number,
+  ): Promise<Array<Record<string, unknown>>> => {
+    const { filters, values } = repoFactFilters(args, scope);
+    values.push(rowCap, queryOffset);
+    const { rows } = await dependencies.pool.query(
+      `SELECT ${REPO_FACT_COLUMNS}
+         FROM ob_entities
+        WHERE ${filters.join(" AND ")}
+        ORDER BY updated_at DESC, created_at DESC
+        LIMIT $${values.length - 1} OFFSET $${values.length}`,
+      values,
+    );
+    return rows as Array<Record<string, unknown>>;
+  };
+
+  // Scope comes from the request when one was named and authorized, and
+  // otherwise from the auth-derived read predicate.
+  const predicate = namespacePredicate(identity, "read", 1);
+  const scope: string | readonly string[] | undefined = args.namespace
+    ? args.namespace
+    : ((predicate.values[0] as readonly string[] | undefined) ?? undefined);
+
+  const rows = await readWithLegacyFallback({
+    scope,
+    offset,
+    rowCap,
+    config,
+    queryRows,
+  });
+  dependencies.logger.info(
+    { tool: "list_repo_facts", returned: rows.length },
+    "tool_result",
+  );
+  return textResult(canonicalizeRepoFactRows(rows));
 }
 
 /**
@@ -272,7 +353,9 @@ async function readWithLegacyFallback(input: {
 }): Promise<Array<Record<string, unknown>>> {
   const { scope, offset, rowCap, config, queryRows } = input;
   const fallbackAvailable =
-    config.legacyFallbackEnabled && config.legacySharedNamespace !== "" && offset === 0;
+    config.legacyFallbackEnabled &&
+    config.legacySharedNamespace !== "" &&
+    offset === 0;
 
   if (!fallbackAvailable) return queryRows(scope, offset);
 
@@ -289,7 +372,10 @@ async function readWithLegacyFallback(input: {
     typeof scope === "string"
       ? primary
       : await queryRows(config.physicalSharedNamespace, 0);
-  if (sharedRows.length >= rowCap || sharedRows.length >= config.fallbackMinResults) {
+  if (
+    sharedRows.length >= rowCap ||
+    sharedRows.length >= config.fallbackMinResults
+  ) {
     return primary;
   }
   const legacyRows = await queryRows(config.legacySharedNamespace, 0);


### PR DESCRIPTION
## Summary

- `registerRepoFactTools` in `server/tools/repo-facts.ts` was 191 lines against a rule value of 100, because both tool handlers were written inline inside the registrar. This splits registration from the work, following the shape `main` already landed in `search-all.ts`, `list-recent.ts`, `get-entry.ts`, and `tiering.ts`.
- Hoisted `UPSERT_REPO_FACT_SCHEMA` and `LIST_REPO_FACTS_SCHEMA` verbatim, and extracted `handleUpsertRepoFact`, `handleListRepoFacts`, `refuseUnstorableFact`, `embedRepoFact`, and `repoFactFilters` as named module-level functions.
- `authIdentity(extra.authInfo)` is resolved at the registration site and passed in, so neither handler reaches for transport state.
- No behavior change: tool names, descriptions, schemas, annotations, defaults, error strings, SQL text, log event names, and result shapes are byte-identical. `readWithLegacyFallback` is untouched.
- One file changed. No test file was modified.

Reuse was checked and declined with reasons. `authorize` in `server/tools/memory-helpers.ts` runs the same auth-then-namespace sequence but emits different denial strings (`cannot read namespace 'x'` versus this tool's `namespace read access denied`); `embeddingFields` throws rather than swallowing, and returns a different field set. Adopting either would have moved observable behavior. `server/tools/context-pack-repo-facts.ts` (#817) is the read-side pack section and shares no shape with this write path; it is not touched.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Red first, on the untouched file at `origin/main` 83e7d01:

```
server/tools/repo-facts.ts:46:8: error eslint(max-lines-per-function): The function `registerRepoFactTools` has too many lines (191). Maximum allowed is 100.
```

`DONE_MEANS_780_FILES=server/tools/repo-facts.ts bash scripts/done-means/780-touched-files-lint-clean.sh` exited 1 on that tree.

Green, re-run on the committed tree after the pre-commit prettier pass:

- `./node_modules/.bin/oxlint --deny-warnings server/tools/repo-facts.ts` -> exit 0
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated src/tools/__tests__/repo-facts.test.ts src/contract.test.ts server/tools/` -> 193 pass, 0 fail, 794 expect() calls, 19 files
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived) -> exit 0

Python package checks are not applicable: nothing under `python/openbrain-memory/` is touched. Live smoke is not applicable: this is a pure in-process refactor with no wire-visible change.

## Critical Self-Review

- Highest-risk behavior: the `list_repo_facts` SQL parameter numbering. The original built the `values` array inside the `queryRows` closure; `repoFactFilters` now returns a fresh array per call and the caller pushes the row count and offset onto that same array afterward, so the trailing `$n-1` / `$n` indices are computed against the identical array in the identical order. A fresh array per call also means no accumulation across the two-to-three calls the legacy fallback makes.
- Assumptions that could be wrong: that no caller outside this module reaches the former inline handlers. Checked — `registerRepoFactTools` is the only export, and no test imports it directly; the tool surface is exercised through `src/contract.test.ts`.
- Missing/weak tests: no test was added, deliberately. This is a refactor with no behavior delta, so a new test would assert what the existing suite already covers. The extraction was read back line by line against the original rather than trusted to the suite, because #806 showed the suite did not catch a non-equivalent predicate rewrite.
- Security/permission risk: none introduced. Both permission gates keep their original order and strings — role check before namespace check, so an unprivileged caller still cannot learn whether a namespace exists. `repoFactFilters` interpolates only column names drawn from a closed literal list in this module; every caller-supplied value stays a bound parameter.
- Migration/deploy risk: none. No schema, no migration, no config.
- Downstream client/runtime risk: none. Per `docs/downstream-rollout.md` this is not an MCP tool, schema, protocol, or client-facing change — the registered tool names, input schemas, annotations, and result shapes are unchanged, so no downstream client can observe this commit.
- Rollback/cleanup concern: single-file, single-commit; revert is clean.
- Fixes made before PR: the refusal order in `refuseUnstorableFact` was checked to keep raw-code-dump ahead of the credential check, since the two produce different messages and a caller can tell them apart.
- Known residual risk: low. The `embedRepoFact` extraction converts an assignment-in-`catch` into a `return null`, which is equivalent only because the original initialized `embedding` to `null` before the `try`. That was confirmed against the original text.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new failure pattern surfaced — the reuse-declined-with-reasons check and the read-back-against-original discipline are both already recorded in the lane contract (round 38) and in the #806 entry.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no wire-visible change; the tool contract is byte-identical.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface moved, so no fixture changes — `src/contract.test.ts` passes unmodified against the existing fixtures, which is the evidence that parity holds.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All four are not applicable: the registered tool names, descriptions, input schemas, annotations, defaults, error strings, and result shapes are unchanged, so nothing downstream can observe this commit. `docs/downstream-rollout.md` scopes rollout to MCP tool/schema/protocol/client-facing changes; this is an internal function-boundary refactor.
