### PR TITLE
refactor(ingest-raw-turn): bring server/tools/ingest-raw-turn.ts to the lint standard (#780)

### DIFF
--- a/server/tools/ingest-raw-turn.ts
+++ b/server/tools/ingest-raw-turn.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { authIdentity, errorResult, textResult, type MemoryToolDependencies } from "./types.ts";
+import {
+  authIdentity,
+  errorResult,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
 import { authorize, contentHash } from "./memory-helpers.ts";
 import { RAW_TURN_ROLES } from "../domain/raw-turn-roles.ts";
 
@@ -37,7 +42,10 @@ const rawTurnSchema = z.object({
 type RawTurn = z.infer<typeof rawTurnSchema>;
 
 function isHarnessNoise(content: string): boolean {
-  return /^\s*$/.test(content) || harnessNoise.some((pattern) => pattern.test(content));
+  return (
+    /^\s*$/.test(content) ||
+    harnessNoise.some((pattern) => pattern.test(content))
+  );
 }
 
 export function registerIngestRawTurnTool(
@@ -47,7 +55,8 @@ export function registerIngestRawTurnTool(
   server.registerTool(
     "ingest_raw_turn",
     {
-      description: "Full-send ingest of raw conversation turns for server-side distillation",
+      description:
+        "Full-send ingest of raw conversation turns for server-side distillation",
       inputSchema: {
         namespace: z.string().max(500).optional(),
         turns: z.array(rawTurnSchema).min(1).max(100),
@@ -71,12 +80,22 @@ export function registerIngestRawTurnTool(
       const kept = args.turns.filter((turn) => !isHarnessNoise(turn.content));
       const filtered = args.turns.length - kept.length;
       if (kept.length === 0) {
-        return textResult({ ingested: 0, duplicates: 0, filtered, namespace: auth.namespace });
+        return textResult({
+          ingested: 0,
+          duplicates: 0,
+          filtered,
+          namespace: auth.namespace,
+        });
       }
       try {
         const values: unknown[] = [];
         const tuples = kept.map((turn, index) => {
-          appendTurnValues(values, auth.namespace, auth.identity.clientId, turn);
+          appendTurnValues(
+            values,
+            auth.namespace,
+            auth.identity.clientId,
+            turn,
+          );
           const first = index * 19 + 1;
           return `(${Array.from({ length: 19 }, (_, offset) => `$${first + offset}`).join(",")})`;
         });
@@ -93,7 +112,12 @@ export function registerIngestRawTurnTool(
         );
         const ingested = rows.rows.length;
         dependencies.logger.info(
-          { tool: "ingest_raw_turn", ingested, duplicates: kept.length - ingested, filtered },
+          {
+            tool: "ingest_raw_turn",
+            ingested,
+            duplicates: kept.length - ingested,
+            filtered,
+          },
           "tool_result",
         );
         return textResult({
@@ -104,27 +128,29 @@ export function registerIngestRawTurnTool(
         });
       } catch (error: unknown) {
         dependencies.logger.error(
-          { tool: "ingest_raw_turn", error_category: error instanceof Error ? error.name : typeof error },
+          {
+            tool: "ingest_raw_turn",
+            error_category: error instanceof Error ? error.name : typeof error,
+          },
           "tool_failure",
         );
-        return errorResult(JSON.stringify({
-          error: "retryable_outage",
-          message: `Database error during raw turn ingest: ${error instanceof Error ? error.message : String(error)}`,
-          retryable: true,
-          namespace: auth.namespace,
-        }));
+        return errorResult(
+          JSON.stringify({
+            error: "retryable_outage",
+            message: `Database error during raw turn ingest: ${error instanceof Error ? error.message : String(error)}`,
+            retryable: true,
+            namespace: auth.namespace,
+          }),
+        );
       }
     },
   );
 }
 
-function appendTurnValues(
-  values: unknown[],
-  namespace: string,
-  createdBy: string,
-  turn: RawTurn,
-): void {
-  values.push(
+// Columns 1-10: namespace and the lineage/routing identifiers that place a turn
+// in its conversation. Order matches the INSERT column list exactly.
+function turnLineageValues(namespace: string, turn: RawTurn): unknown[] {
+  return [
     namespace,
     turn.turn_uuid,
     turn.parent_turn_uuid ?? null,
@@ -135,6 +161,13 @@ function appendTurnValues(
     turn.git_branch ?? null,
     turn.turn_index,
     turn.role,
+  ];
+}
+
+// Columns 11-19: the turn's own payload plus the ingest-side stamps. Order
+// matches the INSERT column list exactly.
+function turnPayloadValues(createdBy: string, turn: RawTurn): unknown[] {
+  return [
     turn.is_human_prompt ?? false,
     turn.content,
     contentHash(turn.content),
@@ -144,5 +177,17 @@ function appendTurnValues(
     JSON.stringify([]),
     createdBy,
     turn.occurred_at ?? null,
+  ];
+}
+
+function appendTurnValues(
+  values: unknown[],
+  namespace: string,
+  createdBy: string,
+  turn: RawTurn,
+): void {
+  values.push(
+    ...turnLineageValues(namespace, turn),
+    ...turnPayloadValues(createdBy, turn),
   );
 }


### PR DESCRIPTION
## Summary

- `appendTurnValues` in `server/tools/ingest-raw-turn.ts` tripped `eslint(complexity)` at 12 against a rule value of 10 — the only finding in the file. The count came entirely from the eleven `??` defaults collapsed into a single 19-argument `values.push(...)`; there were no branches to untangle, so the seam had to come from what the columns mean rather than from control flow.
- Split into two named module-level helpers along the INSERT column list: `turnLineageValues` returns columns 1-10 (namespace plus the lineage and routing identifiers that place a turn in its conversation), and `turnPayloadValues` returns columns 11-19 (the turn's own payload plus the ingest-side stamps).
- Each helper returns a contiguous run of the column list, so `appendTurnValues` spreads the two in order and the produced values array is positionally identical by construction rather than by review.
- No behavior change: schemas, `?? null` / `?? false` defaults, `contentHash`, both `JSON.stringify` stamps, error strings, SQL text, the 19-column placeholder arithmetic, and the `tool_result` / `tool_failure` log event names are all untouched.
- `appendTurnValues` is file-local with a single caller, so no exported signature moved and no other file was touched — no other lane's callers are affected.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts, all re-run on the committed tree after the pre-commit prettier hook reformatted the staged file:

- Red first: `oxlint --deny-warnings server/tools/ingest-raw-turn.ts` → `server/tools/ingest-raw-turn.ts:121:1: error eslint(complexity): function 'appendTurnValues' has a complexity of 12. Maximum allowed is 10.`; `DONE_MEANS_780_FILES=server/tools/ingest-raw-turn.ts bash scripts/done-means/780-touched-files-lint-clean.sh` → exit 1.
- Green: `oxlint --deny-warnings server/tools/ingest-raw-turn.ts` → exit 0; `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived from `origin/main...HEAD`) → exit 0.
- `bunx tsc --noEmit` → exit 0.
- `bun run test:isolated src/tools/__tests__/ingest-raw-turn.test.ts server/domain/raw-turn-roles.test.ts server/tools/` → 179 pass, 0 fail. Existing tests unmodified.
- Equivalence read-back: the 19 value expressions extracted from `origin/main` and from HEAD `diff` clean, in the same order, both before and after prettier ran.

Python package and live smoke are not applicable: this touches one TypeScript file, changes no wire contract, and executes no query differently.

## Critical Self-Review

- Highest-risk behavior: positional correctness of the values array. Postgres binds these 19 values by position against a hand-written column list, so a reordering would silently write `repo` into `git_branch` and similar — type-compatible, so neither tsc nor a smoke test would catch it. This is why the two helpers were cut at a contiguous column run and read back expression-by-expression against `origin/main` rather than eyeballed.
- Assumptions that could be wrong: that the SQL column list is the real contract and no caller depends on `appendTurnValues` itself. Checked — it is file-local with one call site, and the placeholder arithmetic (`index * 19 + 1`, `length: 19`) still matches the 19 values produced.
- Missing/weak tests: no test asserts the column-to-value mapping directly; the pinning tests exercise ingest end to end, which would catch a missing or extra value through the insert but not a swap between two same-typed nullable text columns. I did not add one — the lane is scoped to lint compliance with no behavior change, and the read-back diff covers this change specifically. Worth an entry if this file is touched again.
- Security/permission risk: none. The `authorize(..., "write", "sessions", ...)` gate and the `auth.namespace` predicate feeding column 1 are outside the refactored region and unchanged.
- Migration/deploy risk: none. No schema, no migration, no config.
- Downstream client/runtime risk: none. `ingest_raw_turn`'s input schema, result shape, and error payloads are byte-identical, so no rtech-mcps, mcp2cli, or Hermes surface moves.
- Rollback/cleanup concern: none beyond reverting the single commit. Nothing was moved out of the file, so there is no orphaned helper.
- Fixes made before PR: none needed — oxlint, tsc, and the suite were clean on the first pass and stayed clean after prettier reformatted the commit.
- Known residual risk: low. The residual is the untested column-mapping noted above, which this change does not introduce and does not worsen.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the existing entries already cover this shape — the equivalence read-back this lane performed is the practice #806 established after a non-equivalent predicate rewrite got through the suite, and nothing new surfaced here to promote.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no wire contract, query, or runtime behavior changes; the refactor is internal to one module-local function.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface moved — the tool's input schema, result payload, and error strings are unchanged, so existing fixtures still describe it exactly.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Per `docs/downstream-rollout.md`, rollout applies to MCP tool/schema/protocol/client-facing changes. This is none of those: `ingest_raw_turn`'s registration, `inputSchema`, annotations, and every returned payload are identical to `origin/main`. The change is confined to how one file-local function assembles an array it already assembled.
