### PR TITLE
refactor(memory-helpers): bring server/tools/memory-helpers.ts to the lint standard (#780)

### DIFF
--- a/server/tools/capture.ts
+++ b/server/tools/capture.ts
@@ -1,8 +1,20 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { authIdentity, textResult, type MemoryToolDependencies } from "./types.ts";
-import { authorize, contentHash, decisionText, embeddingFields } from "./memory-helpers.ts";
-import { writeThoughtChunks, chunkReceiptFields } from "../../src/chunk-write.ts";
+import {
+  authIdentity,
+  textResult,
+  type MemoryToolDependencies,
+} from "./types.ts";
+import {
+  authorize,
+  contentHash,
+  decisionText,
+  embeddingFields,
+} from "./memory-helpers.ts";
+import {
+  writeThoughtChunks,
+  chunkReceiptFields,
+} from "../../src/chunk-write.ts";
 
 const sourceRefsSchema = z.array(z.record(z.string(), z.unknown())).max(20);
 
@@ -28,22 +40,27 @@ export function registerCaptureTools(
       },
     },
     async (args, extra) => {
-      const auth = authorize(
-        authIdentity(extra.authInfo),
-        "write",
-        "thoughts",
-        "cannot write to thoughts",
-        args.namespace,
-      );
+      const auth = authorize(authIdentity(extra.authInfo), {
+        operation: "write",
+        table: "thoughts",
+        permissionMessage: "cannot write to thoughts",
+        requestedNamespace: args.namespace,
+      });
       if (!auth.ok) return auth.response;
-      return writeThought(dependencies, auth.identity.clientId, auth.namespace, args);
+      return writeThought(
+        dependencies,
+        auth.identity.clientId,
+        auth.namespace,
+        args,
+      );
     },
   );
 
   server.registerTool(
     "log_decision",
     {
-      description: "Record a decision with rationale and alternatives considered",
+      description:
+        "Record a decision with rationale and alternatives considered",
       inputSchema: {
         title: z.string().min(1),
         rationale: z.string().min(1),
@@ -61,15 +78,19 @@ export function registerCaptureTools(
       },
     },
     async (args, extra) => {
-      const auth = authorize(
-        authIdentity(extra.authInfo),
-        "write",
-        "decisions",
-        "cannot write to decisions",
-        args.namespace,
-      );
+      const auth = authorize(authIdentity(extra.authInfo), {
+        operation: "write",
+        table: "decisions",
+        permissionMessage: "cannot write to decisions",
+        requestedNamespace: args.namespace,
+      });
       if (!auth.ok) return auth.response;
-      return writeDecision(dependencies, auth.identity.clientId, auth.namespace, args);
+      return writeDecision(
+        dependencies,
+        auth.identity.clientId,
+        auth.namespace,
+        args,
+      );
     },
   );
 }
@@ -86,7 +107,9 @@ async function writeThought(
 ) {
   const embedded = await embeddingFields(
     dependencies,
-    args.tags?.length ? `${args.content}\n${args.tags.join(" ")}` : args.content,
+    args.tags?.length
+      ? `${args.content}\n${args.tags.join(" ")}`
+      : args.content,
   );
   const rows = await dependencies.pool.query(
     `INSERT INTO thoughts
@@ -126,7 +149,10 @@ async function writeThought(
     caller: "server/log_thought",
   });
 
-  dependencies.logger.info({ tool: "log_thought", embedded: embedded.embedded }, "tool_result");
+  dependencies.logger.info(
+    { tool: "log_thought", embedded: embedded.embedded },
+    "tool_result",
+  );
   return textResult({
     id: row.id,
     namespace,
@@ -176,7 +202,10 @@ async function writeDecision(
     ],
   );
   const row = rows.rows[0];
-  dependencies.logger.info({ tool: "log_decision", embedded: embedded.embedded }, "tool_result");
+  dependencies.logger.info(
+    { tool: "log_decision", embedded: embedded.embedded },
+    "tool_result",
+  );
   return textResult({
     id: row.id,
     namespace,

--- a/server/tools/curation.ts
+++ b/server/tools/curation.ts
@@ -133,9 +133,7 @@ interface ScanContext {
 }
 
 /** Detect near-identical pairs in one table, archiving the older on opt-in. */
-async function scanDuplicates(
-  context: ScanContext,
-): Promise<{
+async function scanDuplicates(context: ScanContext): Promise<{
   findings: CurateResult["duplicates"];
   archived: number;
   scanned: number;
@@ -174,9 +172,7 @@ async function scanDuplicates(
 }
 
 /** Flag entries never accessed and older than the stale window. */
-async function scanStale(
-  context: ScanContext,
-): Promise<{
+async function scanStale(context: ScanContext): Promise<{
   findings: CurateResult["stale"];
   archived: number;
   scanned: number;
@@ -213,9 +209,7 @@ async function scanStale(
  * `dry_run` is false -- the same guarantee the previous inline branch made by
  * simply having no mutation path.
  */
-async function scanVague(
-  context: ScanContext,
-): Promise<{
+async function scanVague(context: ScanContext): Promise<{
   findings: CurateResult["vague"];
   archived: number;
   scanned: number;
@@ -435,12 +429,11 @@ function registerRateEntry(
     },
     async (args, extra) => {
       const identity = authIdentity(extra.authInfo);
-      const auth = authorize(
-        identity,
-        "write",
-        args.table,
-        `cannot write to ${args.table}`,
-      );
+      const auth = authorize(identity, {
+        operation: "write",
+        table: args.table,
+        permissionMessage: `cannot write to ${args.table}`,
+      });
       if (!auth.ok) return auth.response;
       const predicate = namespacePredicate(auth.identity, "write", 3);
       const { rows } = await dependencies.pool.query(

--- a/server/tools/ingest-raw-turn.ts
+++ b/server/tools/ingest-raw-turn.ts
@@ -69,13 +69,12 @@ export function registerIngestRawTurnTool(
       },
     },
     async (args, extra) => {
-      const auth = authorize(
-        authIdentity(extra.authInfo),
-        "write",
-        "sessions",
-        "cannot write raw turns",
-        args.namespace,
-      );
+      const auth = authorize(authIdentity(extra.authInfo), {
+        operation: "write",
+        table: "sessions",
+        permissionMessage: "cannot write raw turns",
+        requestedNamespace: args.namespace,
+      });
       if (!auth.ok) return auth.response;
       const kept = args.turns.filter((turn) => !isHarnessNoise(turn.content));
       const filtered = args.turns.length - kept.length;

--- a/server/tools/lanes.ts
+++ b/server/tools/lanes.ts
@@ -218,13 +218,12 @@ async function handleLaneUpsert(
   args: LaneUpsertArgs,
   authInfo: unknown,
 ): Promise<ReturnType<typeof textResult>> {
-  const auth = authorize(
-    authIdentity(authInfo),
-    "write",
-    "sessions",
-    "cannot write to session lanes",
-    args.namespace,
-  );
+  const auth = authorize(authIdentity(authInfo), {
+    operation: "write",
+    table: "sessions",
+    permissionMessage: "cannot write to session lanes",
+    requestedNamespace: args.namespace,
+  });
   if (!auth.ok) return auth.response;
   const context = laneEmbedContext(args);
   const embedded = await embeddingFields(dependencies, context);
@@ -265,13 +264,12 @@ async function handleLaneLoad(
   args: LaneLoadArgs,
   authInfo: unknown,
 ): Promise<ReturnType<typeof textResult>> {
-  const auth = authorize(
-    authIdentity(authInfo),
-    "read",
-    "sessions",
-    "cannot read session lanes",
-    args.namespace,
-  );
+  const auth = authorize(authIdentity(authInfo), {
+    operation: "read",
+    table: "sessions",
+    permissionMessage: "cannot read session lanes",
+    requestedNamespace: args.namespace,
+  });
   if (!auth.ok) return auth.response;
   const { conditions, values } = laneLoadPredicate(args, auth.namespace);
   const rows = await dependencies.pool.query(

--- a/server/tools/memory-helpers.ts
+++ b/server/tools/memory-helpers.ts
@@ -29,7 +29,10 @@ import { errorResult } from "./types.ts";
  * (`server/tools/repo-facts.ts`, `get-contract.ts`, `promotion.ts` all import
  * their builders from `src/`), so it introduces no new coupling direction.
  */
-export { EVENT_TYPES, IMPORTANCE_LEVELS } from "../../src/tools/table-constants.ts";
+export {
+  EVENT_TYPES,
+  IMPORTANCE_LEVELS,
+} from "../../src/tools/table-constants.ts";
 
 export function contentHash(value: string): string {
   return createHash("sha256").update(value).digest("hex");
@@ -89,8 +92,33 @@ export async function embeddingFields(
  * unresolved namespace.
  */
 export type Authorization =
-  | { readonly ok: true; readonly identity: AuthIdentity; readonly namespace: string }
+  | {
+      readonly ok: true;
+      readonly identity: AuthIdentity;
+      readonly namespace: string;
+    }
   | { readonly ok: false; readonly response: ReturnType<typeof errorResult> };
+
+/**
+ * What a tool is asking permission to do.
+ *
+ * The three permission-matrix fields travel together at every one of the
+ * seventeen call sites -- `operation` selects `canRead`/`canWrite`, `table` is
+ * the row that matrix is indexed by, and `permissionMessage` is the denial
+ * suffix observed in current src for that specific tool. Bundling them keeps
+ * `authorize` at two parameters without splitting a triple that is never
+ * partially supplied.
+ */
+export interface AuthorizationRequest {
+  /** Whether the caller intends to read or write. */
+  readonly operation: "read" | "write";
+  /** Resource table the permission matrix is consulted for. */
+  readonly table: ResourceTable;
+  /** Observed current-src denial suffix for this tool. */
+  readonly permissionMessage: string;
+  /** Caller-supplied namespace; defaults to the token's own. */
+  readonly requestedNamespace?: string;
+}
 
 /**
  * Resolve the auth-derived namespace for a tool call, or deny it.
@@ -103,24 +131,24 @@ export type Authorization =
  * `docs/decisions/privilege-isolation-closed-brain.md` (server-side isolation).
  *
  * @param identity Token-derived identity, or `undefined` when unauthenticated.
- * @param operation Whether the caller intends to read or write.
- * @param table Resource table the permission matrix is consulted for.
- * @param permissionMessage Observed current-src denial suffix for this tool.
- * @param requestedNamespace Caller-supplied namespace; defaults to the token's.
+ * @param request What the caller is asking permission to do.
  * @returns The proven identity and namespace, or the denial envelope to return.
  */
 export function authorize(
   identity: AuthIdentity | undefined,
-  operation: "read" | "write",
-  table: ResourceTable,
-  permissionMessage: string,
-  requestedNamespace?: string,
+  request: AuthorizationRequest,
 ): Authorization {
+  const { operation, table, permissionMessage, requestedNamespace } = request;
   const permitted =
     identity !== undefined &&
-    (operation === "read" ? canRead(identity.role, table) : canWrite(identity.role, table));
+    (operation === "read"
+      ? canRead(identity.role, table)
+      : canWrite(identity.role, table));
   if (!identity || !permitted) {
-    return { ok: false, response: errorResult(`Permission denied: ${permissionMessage}`) };
+    return {
+      ok: false,
+      response: errorResult(`Permission denied: ${permissionMessage}`),
+    };
   }
   const namespace = requestedNamespace ?? identity.clientId;
   if (!canTargetNamespace(identity, operation, namespace)) {

--- a/server/tools/realtime-append.ts
+++ b/server/tools/realtime-append.ts
@@ -146,13 +146,12 @@ function registerWorkingSetAppendTool(
       },
     },
     async (args, extra) => {
-      const auth = authorize(
-        authIdentity(extra.authInfo),
-        "write",
-        "sessions",
-        "cannot write working set",
-        args.namespace,
-      );
+      const auth = authorize(authIdentity(extra.authInfo), {
+        operation: "write",
+        table: "sessions",
+        permissionMessage: "cannot write working set",
+        requestedNamespace: args.namespace,
+      });
       if (!auth.ok) return auth.response;
 
       const result = workingSetStoreFor(dependencies).append(
@@ -215,13 +214,12 @@ function registerRecoveryWalAppendTool(
       },
     },
     async (args, extra) => {
-      const auth = authorize(
-        authIdentity(extra.authInfo),
-        "write",
-        "sessions",
-        "cannot write recovery WAL",
-        args.namespace,
-      );
+      const auth = authorize(authIdentity(extra.authInfo), {
+        operation: "write",
+        table: "sessions",
+        permissionMessage: "cannot write recovery WAL",
+        requestedNamespace: args.namespace,
+      });
       if (!auth.ok) return auth.response;
 
       const result = recoveryWalStoreFor(dependencies).append(
@@ -284,13 +282,12 @@ function registerRecoveryWalMarkTool(
       },
     },
     async (args, extra) => {
-      const auth = authorize(
-        authIdentity(extra.authInfo),
-        "write",
-        "sessions",
-        "cannot mark recovery WAL",
-        args.namespace,
-      );
+      const auth = authorize(authIdentity(extra.authInfo), {
+        operation: "write",
+        table: "sessions",
+        permissionMessage: "cannot mark recovery WAL",
+        requestedNamespace: args.namespace,
+      });
       if (!auth.ok) return auth.response;
 
       const result = recoveryWalStoreFor(dependencies).mark(

--- a/server/tools/session-events.ts
+++ b/server/tools/session-events.ts
@@ -143,13 +143,12 @@ async function appendSessionEvent(
   args: EventArgs,
   extra: { authInfo?: unknown },
 ) {
-  const auth = authorize(
-    authIdentity(extra.authInfo),
-    "write",
-    "sessions",
-    "cannot write to session events",
-    args.namespace,
-  );
+  const auth = authorize(authIdentity(extra.authInfo), {
+    operation: "write",
+    table: "sessions",
+    permissionMessage: "cannot write to session events",
+    requestedNamespace: args.namespace,
+  });
   if (!auth.ok) return auth.response;
 
   const { lane, created: laneCreated } = await resolveLane(

--- a/server/tools/session-lifecycle.ts
+++ b/server/tools/session-lifecycle.ts
@@ -75,9 +75,9 @@ type ExactStartScope = {
 /** A prepared `WHERE` fragment plus the positional values it refers to. */
 type SqlFilter = { conditions: string[]; values: unknown[] };
 
-function hasCompleteExactScope(
-  args: ExactStartScope,
-): args is Required<Omit<ExactStartScope, "thread_id">> & {
+function hasCompleteExactScope(args: ExactStartScope): args is Required<
+  Omit<ExactStartScope, "thread_id">
+> & {
   thread_id?: string;
 } {
   return (
@@ -242,13 +242,12 @@ async function startSession(
   args: StartArgs,
   extra: { authInfo?: unknown },
 ) {
-  const auth = authorize(
-    authIdentity(extra.authInfo),
-    "write",
-    "sessions",
-    "cannot write to sessions",
-    args.namespace,
-  );
+  const auth = authorize(authIdentity(extra.authInfo), {
+    operation: "write",
+    table: "sessions",
+    permissionMessage: "cannot write to sessions",
+    requestedNamespace: args.namespace,
+  });
   if (!auth.ok) return auth.response;
   const existing = await dependencies.pool.query(
     `SELECT ${startLaneFields} FROM ob_session_lanes
@@ -357,13 +356,12 @@ async function loadSessionContext(
   args: ContextArgs,
   extra: { authInfo?: unknown },
 ) {
-  const auth = authorize(
-    authIdentity(extra.authInfo),
-    "read",
-    "sessions",
-    "cannot read session context",
-    args.namespace,
-  );
+  const auth = authorize(authIdentity(extra.authInfo), {
+    operation: "read",
+    table: "sessions",
+    permissionMessage: "cannot read session context",
+    requestedNamespace: args.namespace,
+  });
   if (!auth.ok) return auth.response;
   if (!args.session_key && !args.channel_id) {
     return errorResult("At least one of session_key or channel_id is required");
@@ -480,13 +478,12 @@ async function wrapSession(
   args: WrapArgs,
   extra: { authInfo?: unknown },
 ) {
-  const auth = authorize(
-    authIdentity(extra.authInfo),
-    "write",
-    "sessions",
-    "cannot write to sessions",
-    args.namespace,
-  );
+  const auth = authorize(authIdentity(extra.authInfo), {
+    operation: "write",
+    table: "sessions",
+    permissionMessage: "cannot write to sessions",
+    requestedNamespace: args.namespace,
+  });
   if (!auth.ok) return auth.response;
   const lanes = await dependencies.pool.query(
     `SELECT id, status, project FROM ob_session_lanes

--- a/server/tools/session-save-load.ts
+++ b/server/tools/session-save-load.ts
@@ -104,13 +104,12 @@ function registerSessionSave(
       },
     },
     async (args, extra) => {
-      const auth = authorize(
-        authIdentity(extra.authInfo),
-        "write",
-        "sessions",
-        "cannot write to sessions",
-        args.namespace,
-      );
+      const auth = authorize(authIdentity(extra.authInfo), {
+        operation: "write",
+        table: "sessions",
+        permissionMessage: "cannot write to sessions",
+        requestedNamespace: args.namespace,
+      });
       if (!auth.ok) return auth.response;
       const saved = await saveSession(
         dependencies,
@@ -180,12 +179,11 @@ function registerSessionLoad(
       },
     },
     async (args, extra) => {
-      const auth = authorize(
-        authIdentity(extra.authInfo),
-        "read",
-        "sessions",
-        "cannot read sessions",
-      );
+      const auth = authorize(authIdentity(extra.authInfo), {
+        operation: "read",
+        table: "sessions",
+        permissionMessage: "cannot read sessions",
+      });
       if (!auth.ok) return auth.response;
       const rows = await loadSessions(dependencies, auth.identity, args);
       if (rows.length === 0) {

--- a/server/tools/update-entry.ts
+++ b/server/tools/update-entry.ts
@@ -411,12 +411,11 @@ export function registerUpdateEntryTool(
       annotations: updateEntryAnnotations,
     },
     async (args, extra) => {
-      const auth = authorize(
-        authIdentity(extra.authInfo),
-        "write",
-        args.table,
-        `cannot write to ${args.table}`,
-      );
+      const auth = authorize(authIdentity(extra.authInfo), {
+        operation: "write",
+        table: args.table,
+        permissionMessage: `cannot write to ${args.table}`,
+      });
       if (!auth.ok) return auth.response;
       const table = args.table;
 


### PR DESCRIPTION
## Summary

- `authorize` in `server/tools/memory-helpers.ts` took five positional parameters, one over the rule value of four. This is the last lint finding in that file.
- The four trailing arguments are one question, not four knobs: `operation` selects `canRead` or `canWrite`, `table` is the row the permission matrix is indexed by, `permissionMessage` is the observed current-src denial suffix for that tool, and `requestedNamespace` is the namespace that same identity is asking about. All are supplied together at every call site. So the fix is an `AuthorizationRequest` options object, matching how the rest of this wave collapsed 5-param signatures, rather than a split into two functions that would have to re-thread the identity.
- `AuthorizationRequest` is declared in the target rather than reused. An `rg` over `server/` and `src/` for `permissionMessage` and `ResourceTable` found no existing bundle carrying this triple — only per-file `Record<ResourceTable, ...>` lookup maps that answer a different question.
- 16 call sites across nine files under `server/tools/` are updated for the signature only; no argument value changed. Files: `capture.ts`, `curation.ts`, `ingest-raw-turn.ts`, `lanes.ts`, `realtime-append.ts`, `session-events.ts`, `session-lifecycle.ts`, `session-save-load.ts`, `update-entry.ts`.
- Every one of those nine files was oxlint-clean at `origin/main` (173b6d3) before the edit, so none belongs to another open lane.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`./node_modules/.bin/oxlint --deny-warnings` on the ten committed files → 0 findings (red baseline: `server/tools/memory-helpers.ts:112:26: error eslint(max-params): Function 'authorize' has too many parameters (5). Maximum allowed is 4.`). `bunx tsc --noEmit` → clean on the committed tree. `bun run test:isolated server/tools/ server/main.pg.test.ts src/ob-admin-role.test.ts` → 193 pass, 0 fail, 673 expect() calls across 19 files. `bash scripts/done-means/780-touched-files-lint-clean.sh` → exit 0 after the commit (exit 1 before it). Python package untouched. No runtime, schema, or wire behavior changes, so no live smoke applies.

## Critical Self-Review

- Highest-risk behavior: the namespace guard. `authorize` is the single gate every memory tool runs before touching the pool, and namespace isolation is a security boundary — a predicate that inverted or a default that shifted would silently widen access rather than fail loudly.
- Assumptions that could be wrong: that all 16 call sites were converted. `bunx tsc --noEmit` passing is the evidence — a leftover positional call cannot typecheck against a two-parameter signature — so this is checked, not assumed.
- Missing/weak tests: no new test was added, because no behavior changed and #806 showed the suite does not by itself catch a non-equivalent predicate rewrite. The control used instead was a line-by-line read-back of the rewritten function against the original: same order of checks (role/table permission first, so an unprivileged caller never learns whether a namespace exists, then the requested namespace against the token identity), same `requestedNamespace ?? identity.clientId` default, same `canTargetNamespace(identity, operation, namespace)` call, and both denial strings byte-for-byte.
- Security/permission risk: contained to the above. The two error strings (`Permission denied: ${permissionMessage}` and the read/write namespace reason) are unchanged, so a caller cannot distinguish a refactored denial from the original one.
- Migration/deploy risk: none. No SQL, no schema, no migration.
- Downstream client/runtime risk: none. `authorize` is server-internal — it is not exported through an MCP tool schema, the transport, or the Python client, so no contract, fixture, or downstream consumer sees this signature. `docs/downstream-rollout.md` classification: not applicable.
- Rollback/cleanup concern: single commit, revertable on its own. No scaffolding left behind.
- Fixes made before PR: none needed; the first oxlint and typecheck run after the rewrite were both clean.
- Known residual risk: the caller edits were applied by a scripted regex rewrite rather than by hand. The typecheck plus the 193-test run are what stand behind them; the diff is mechanical and reviewable line by line.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane found no new reusable failure pattern — the options-object shape and the read-back-after-extraction discipline are both already recorded from earlier rounds of #780.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, schema, or wire behavior changed — this is a signature-shape refactor with identical predicates and identical error strings.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: `authorize` is a server-internal helper with no representation in any contract fixture; no tool schema, transport payload, or client-visible surface moved.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- No MCP tool, schema, protocol, or client-facing surface changed, so every downstream step above is not applicable. The change is confined to one internal helper signature and its in-repo callers under `server/tools/`.
