### PR TITLE
refactor(context-pack-fit): bring server/tools/context-pack-b*.ts to the lint standard (#780)

### DIFF
--- a/server/tools/context-pack-budget.ts
+++ b/server/tools/context-pack-budget.ts
@@ -97,6 +97,104 @@ export function durableLaneContentChars(section: DurableLaneSection): number {
 }
 
 /**
+ * Options for rebuilding a durable-lane section from what survived fitting.
+ */
+type DurableLaneRebuildOptions = {
+  section: Record<string, unknown>;
+  lane: Record<string, unknown> | undefined;
+  keptEvents: DurableLaneEvent[];
+  contextMd: unknown;
+};
+
+/**
+ * Rebuild the section around the events and checkpoint that survived, marking
+ * it truncated and reconciling `event_count` to what remains.
+ */
+function rebuildDurableLaneSection(
+  options: DurableLaneRebuildOptions,
+): Record<string, unknown> {
+  const { section, lane, keptEvents, contextMd } = options;
+  const next: Record<string, unknown> = {
+    ...section,
+    events: keptEvents,
+    event_count: keptEvents.length,
+  };
+  if (lane) next.lane = { ...lane, current_context_md: contextMd };
+  next.truncated = true;
+  return next;
+}
+
+/**
+ * Options for the oldest-first event drop pass.
+ */
+type DurableLaneDropOptions = {
+  section: Record<string, unknown>;
+  lane: Record<string, unknown> | undefined;
+  events: DurableLaneEvent[];
+  contextMd: unknown;
+  remainingChars: number;
+};
+
+/**
+ * Drop the OLDEST event (index 0) until the serialized section fits, so the
+ * freshest lane evidence survives pressure. Returns the surviving events once a
+ * prefix drop fits, or `null` when even an empty event list does not.
+ */
+function dropOldestDurableLaneEvents(
+  options: DurableLaneDropOptions,
+): DurableLaneEvent[] | null {
+  const { section, lane, events, contextMd, remainingChars } = options;
+  const kept = [...events];
+  while (kept.length > 0) {
+    kept.shift();
+    const candidate = rebuildDurableLaneSection({
+      section,
+      lane,
+      keptEvents: kept,
+      contextMd,
+    });
+    if (serializedLength(candidate) <= remainingChars) return kept;
+  }
+  return null;
+}
+
+/**
+ * Options for shrinking the lane checkpoint to the largest prefix that fits.
+ */
+type DurableLaneCheckpointOptions = {
+  section: Record<string, unknown>;
+  lane: Record<string, unknown> | undefined;
+  contextMd: unknown;
+  remainingChars: number;
+};
+
+/**
+ * Binary-search the largest checkpoint prefix that fits, or drop the checkpoint
+ * entirely. Linear shrinking here would be O(n) serializations of a potentially
+ * very large checkpoint.
+ */
+function shrinkDurableLaneCheckpoint(
+  options: DurableLaneCheckpointOptions,
+): unknown {
+  const { section, lane, contextMd, remainingChars } = options;
+  if (typeof contextMd !== "string" || contextMd.length === 0) return contextMd;
+  let low = 0;
+  let high = contextMd.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    const candidate = rebuildDurableLaneSection({
+      section,
+      lane,
+      keptEvents: [],
+      contextMd: contextMd.slice(0, mid),
+    });
+    if (serializedLength(candidate) <= remainingChars) low = mid;
+    else high = mid - 1;
+  }
+  return low > 0 ? contextMd.slice(0, low) : null;
+}
+
+/**
  * Fit a loaded durable-lane section inside the remaining budget by its
  * SERIALIZED size.
  *
@@ -128,52 +226,42 @@ export function fitDurableLaneSection(
       ? { ...(section.lane as Record<string, unknown>) }
       : undefined;
 
-  const rebuild = (
-    keptEvents: DurableLaneEvent[],
-    contextMd: unknown,
-  ): Record<string, unknown> => {
-    const next: Record<string, unknown> = {
-      ...section,
-      events: keptEvents,
-      event_count: keptEvents.length,
+  const contextMd = lane?.current_context_md ?? null;
+
+  const kept = dropOldestDurableLaneEvents({
+    section,
+    lane,
+    events,
+    contextMd,
+    remainingChars,
+  });
+  if (kept) {
+    return {
+      section: rebuildDurableLaneSection({
+        section,
+        lane,
+        keptEvents: kept,
+        contextMd,
+      }),
+      citations: reconcileDurableCitations(citations, kept),
+      truncated: true,
     };
-    if (lane) next.lane = { ...lane, current_context_md: contextMd };
-    next.truncated = true;
-    return next;
-  };
-
-  let contextMd = lane?.current_context_md ?? null;
-
-  // Drop the oldest event (index 0) until the serialized section fits.
-  const kept = [...events];
-  while (kept.length > 0) {
-    kept.shift();
-    if (serializedLength(rebuild(kept, contextMd)) <= remainingChars) {
-      return {
-        section: rebuild(kept, contextMd),
-        citations: reconcileDurableCitations(citations, kept),
-        truncated: true,
-      };
-    }
   }
 
-  // No events left: binary-search the largest checkpoint prefix that fits, or
-  // drop it entirely. Linear shrinking here would be O(n) serializations of a
-  // potentially very large checkpoint.
-  if (typeof contextMd === "string" && contextMd.length > 0) {
-    let low = 0;
-    let high = contextMd.length;
-    while (low < high) {
-      const mid = Math.ceil((low + high) / 2);
-      const candidate = rebuild([], contextMd.slice(0, mid));
-      if (serializedLength(candidate) <= remainingChars) low = mid;
-      else high = mid - 1;
-    }
-    contextMd = low > 0 ? (contextMd as string).slice(0, low) : null;
-  }
+  const fittedContextMd = shrinkDurableLaneCheckpoint({
+    section,
+    lane,
+    contextMd,
+    remainingChars,
+  });
 
   return {
-    section: rebuild([], contextMd),
+    section: rebuildDurableLaneSection({
+      section,
+      lane,
+      keptEvents: [],
+      contextMd: fittedContextMd,
+    }),
     citations: reconcileDurableCitations(citations, []),
     truncated: true,
   };
@@ -240,7 +328,11 @@ export function fitItemSection<T extends { items: Array<{ id: string }> }>(
       (candidate as Record<keyof T, unknown>)[countKey] = kept.length;
     }
     if (serializedLength(candidate) <= remainingChars) {
-      return { section: candidate, truncated: true, starved: kept.length === 0 };
+      return {
+        section: candidate,
+        truncated: true,
+        starved: kept.length === 0,
+      };
     }
   }
 


### PR DESCRIPTION
## Summary

- `fitDurableLaneSection` in `server/tools/context-pack-b*.ts` carried a complexity of 14 against the rule value of 10 — the last lint finding in that file. One function held the early fit check, the oldest-first event drop scan, the checkpoint binary search, and a rebuild closure that all three phases called.
- Split into three named module-level helpers, each taking a single options object instead of positional arguments, matching how `search-all.ts`, `entities.ts`, and `promotion.ts` already read on `main`: `rebuildDurableLaneSection` (the former inner closure, now a top-level function with one owner), `dropOldestDurableLaneEvents` (returns the surviving events, or `null` when no prefix drop fits), and `shrinkDurableLaneCheckpoint` (returns the fitted checkpoint value).
- No behavior change and no new helper invented. The design authority for this module is `docs/agent-context-pack-contract.md` ("Response Shape"), cited in the file's own header; this PR changes none of what it specifies. The fit predicate, the oldest-first drop order, the binary-search boundaries, the citation reconciliation calls, `event_count`, `truncated`, and the returned object shape are the same logic; the checkpoint helper returns its input unchanged in exactly the cases where the original left the variable untouched. No exported signature moved, so all seven importers of this module under `server/tools/` are untouched.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Red first, on the untouched file: `oxlint --deny-warnings` reported `server/tools/context-pack-budget.ts:110:8: error eslint(complexity): function fitDurableLaneSection has a complexity of 14. Maximum allowed is 10.`, and the done-means script exited 1.

Green, re-run on the COMMITTED tree after the pre-commit prettier hook reformatted the staged file:

- `./node_modules/.bin/oxlint --deny-warnings server/tools/context-pack-b*.ts` -> exit 0, no findings
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated server/tools/` -> 163 pass, 0 fail, 534 expect() calls across 17 files
- `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived against `origin/main...HEAD`) -> exit 0

## Critical Self-Review

- Highest-risk behavior: the durable-lane fitting path decides which lane evidence survives when a pack does not fit. A non-equivalent predicate rewrite would silently change what agents see. Each extraction was read back line-by-line against the original before the commit, because #806 showed the suite does not catch that class on its own.
- Assumptions that could be wrong: that returning `contextMd` unchanged from `shrinkDurableLaneCheckpoint` when it is not a non-empty string matches the original. Checked directly — the original's `if (typeof contextMd === "string" && contextMd.length > 0)` guard meant the variable was left as-is in every other case, which is what the helper does.
- Missing/weak tests: no test names `fitDurableLaneSection` directly; `server/tools/context-pack.test.ts` exercises it through the pack assembly path (trimming, citation bijection after a trim, the pointer/durable dedupe). This PR adds no test because it adds no behavior — the pinning coverage is the pre-existing suite, run green.
- Security/permission risk: none. Pure, store-agnostic functions with no auth, namespace, SQL, or network surface; nothing reads a token or a namespace here.
- Migration/deploy risk: none. No schema, no migration, no config, no startup path.
- Downstream client/runtime risk: none. Per `docs/downstream-rollout.md` this is not an MCP tool, schema, protocol, or client-facing change — the module exports the same names with the same signatures, and the three new helpers are module-private.
- Rollback/cleanup concern: single-file, single-commit, revert is clean. No file was moved, added, or deleted.
- Fixes made before PR: verified none of the seven `server/tools/` importers of this module needed a change, so no other existing file is touched.
- Known residual risk: `src/tools/agent-context-pack-budget.ts` holds a legacy twin of this function that still carries the same finding. It is a separate file with separate callers and belongs to its own lane; deliberately left alone rather than widened into scope here.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical lint conformance change with no new failure pattern — nothing surfaced that a future reviewer would need warned about, and the read-back-after-extraction discipline is already the standing lane rule from #806.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: pure functions with no service, database, or endpoint surface; the isolated suite is the whole exercise.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, schema, or fixture is involved — the change is internal to one module and every exported signature is unchanged.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, protocol, or client-facing surface moved. The module's exported names and signatures are identical to `origin/main`, so no downstream consumer can observe this change.
