### PR TITLE
refactor(working-set): bring server/realtime/working-set.ts to the lint standard (#780)

### DIFF
--- a/server/realtime/working-set.ts
+++ b/server/realtime/working-set.ts
@@ -265,6 +265,85 @@ export interface WorkingSetStoreOptions {
   logger?: Logger;
 }
 
+/**
+ * The accepted shape of an append candidate: the trimmed content and the
+ * metadata object the item will carry, once every rejection has been ruled out.
+ */
+interface AcceptedWorkingSetInput {
+  content: string;
+  metadata: Record<string, unknown>;
+}
+
+type ScreenedWorkingSetInput =
+  | { rejection: NonNullable<WorkingSetAppendResult["reason"]> }
+  | { rejection: null; accepted: AcceptedWorkingSetInput };
+
+interface ScreenWorkingSetInputOptions {
+  input: WorkingSetItemInput;
+  budget: WorkingSetBudget;
+  logger: Logger | undefined;
+}
+
+/**
+ * Every reason an append is refused, in the order the store has always checked
+ * them: kind, then empty content, then content size, then metadata. The order is
+ * observable — a call that is both an invalid kind and oversized reports
+ * `invalid_kind` — so it is preserved exactly rather than regrouped.
+ */
+function screenWorkingSetInput(
+  options: ScreenWorkingSetInputOptions,
+): ScreenedWorkingSetInput {
+  const { input, budget, logger } = options;
+  if (!WORKING_SET_ITEM_KIND_SET.has(input.kind)) {
+    return { rejection: "invalid_kind" };
+  }
+
+  const content = input.content.trim();
+  if (content.length === 0) {
+    return { rejection: "empty_content" };
+  }
+  if (content.length > budget.max_item_chars) {
+    return { rejection: "content_too_large" };
+  }
+
+  const metadata = input.metadata ?? {};
+  const metadataChars = serializedJsonLength(metadata, logger);
+  if (metadataChars === null || metadataChars > budget.max_metadata_chars) {
+    return { rejection: "metadata_too_large" };
+  }
+
+  return { rejection: null, accepted: { content, metadata } };
+}
+
+interface BuildWorkingSetItemOptions {
+  input: WorkingSetItemInput;
+  accepted: AcceptedWorkingSetInput;
+  id: string;
+  now: Date;
+  ttlMs: number;
+}
+
+/** Field-for-field materialization of the stored item; no policy lives here. */
+function buildWorkingSetItem(
+  options: BuildWorkingSetItemOptions,
+): WorkingSetItem {
+  const { input, accepted, id, now, ttlMs } = options;
+  return {
+    id,
+    kind: input.kind,
+    label: WORKING_SET_LABEL,
+    content: accepted.content,
+    confidence: input.confidence ?? null,
+    stale_at: input.stale_at ?? null,
+    trace_id: input.trace_id ?? null,
+    source_ref: input.source_ref ?? null,
+    durable_ref: input.durable_ref ?? null,
+    metadata: accepted.metadata,
+    created_at: now.toISOString(),
+    expires_at: new Date(now.getTime() + ttlMs).toISOString(),
+  };
+}
+
 export class WorkingSetStore {
   readonly budget: WorkingSetBudget;
   private readonly logger: Logger | undefined;
@@ -284,28 +363,14 @@ export class WorkingSetStore {
   ): WorkingSetAppendResult {
     this.purgeExpired(now);
 
-    if (!WORKING_SET_ITEM_KIND_SET.has(input.kind)) {
+    const screened = screenWorkingSetInput({
+      input,
+      budget: this.budget,
+      logger: this.logger,
+    });
+    if (screened.rejection !== null) {
       this.counters.dropped += 1;
-      return this.rejected("invalid_kind");
-    }
-
-    const content = input.content.trim();
-    if (content.length === 0) {
-      this.counters.dropped += 1;
-      return this.rejected("empty_content");
-    }
-    if (content.length > this.budget.max_item_chars) {
-      this.counters.dropped += 1;
-      return this.rejected("content_too_large");
-    }
-    const metadata = input.metadata ?? {};
-    const metadataChars = serializedJsonLength(metadata, this.logger);
-    if (
-      metadataChars === null ||
-      metadataChars > this.budget.max_metadata_chars
-    ) {
-      this.counters.dropped += 1;
-      return this.rejected("metadata_too_large");
+      return this.rejected(screened.rejection);
     }
 
     const normalizedScope = normalizeWorkingSetScope(scope);
@@ -317,20 +382,13 @@ export class WorkingSetStore {
       updated_at_ms: nowMs,
     };
 
-    const item: WorkingSetItem = {
+    const item = buildWorkingSetItem({
+      input,
+      accepted: screened.accepted,
       id: input.id ?? `ws-${this.nextId++}`,
-      kind: input.kind,
-      label: WORKING_SET_LABEL,
-      content,
-      confidence: input.confidence ?? null,
-      stale_at: input.stale_at ?? null,
-      trace_id: input.trace_id ?? null,
-      source_ref: input.source_ref ?? null,
-      durable_ref: input.durable_ref ?? null,
-      metadata,
-      created_at: now.toISOString(),
-      expires_at: new Date(nowMs + this.budget.ttl_ms).toISOString(),
-    };
+      now,
+      ttlMs: this.budget.ttl_ms,
+    });
 
     session.items.push(item);
     session.updated_at_ms = nowMs;


### PR DESCRIPTION
## Summary

- `WorkingSetStore.append` in `server/realtime/working-set.ts` carried a complexity of 15 against the rule value of 10 — it screened four rejection cases, materialized the twelve-field item, and drove the session bookkeeping in one body.
- Split the branching into two named module-level helpers over the input, matching the shape `server/realtime/recovery-wal-store-parts.ts` already uses in this same directory: pure functions that need no store identity, so `append` reads as a sequence of steps rather than a container for every branch the module has.
- `screenWorkingSetInput` returns a discriminated result — either the single rejection reason, or the trimmed content and metadata the item will carry. The four checks run in the order the store has always used (kind, empty content, content size, metadata), because that order is observable: an append that is both an invalid kind and oversized still reports `invalid_kind`.
- `buildWorkingSetItem` materializes the stored item field for field, with every `??` default carried across unchanged. No policy lives there.
- Both helpers take an options object rather than positional arguments, per the standard the earlier #780 lanes established.
- One file changed. No test file was modified, no exported signature changed, and `src/realtime/working-set.ts` (a separate, already-divergent variant of this module) was deliberately left alone.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Red first, on the untouched file: `oxlint --deny-warnings server/realtime/working-set.ts` reported `server/realtime/working-set.ts:280:9: error eslint(complexity): method 'append' has a complexity of 15. Maximum allowed is 10.`, and the done-means with `DONE_MEANS_780_FILES` set to that path exited 1.

Green, re-run on the committed tree after the pre-commit prettier hook: `oxlint --deny-warnings server/realtime/working-set.ts` exits 0; `bunx tsc --noEmit` exits 0; `bash scripts/done-means/780-touched-files-lint-clean.sh` (diff-derived against `origin/main...HEAD`) exits 0.

Pinning tests — the two test files that construct `WorkingSetStore` against the server module, found by ripgrep on its exported names: `bun run test:isolated server/tools/context-pack.test.ts server/application/sdk-protocol.pg.test.ts` — 40 pass, 0 fail, 163 expect() calls. `server/realtime/` contains no test file of its own.

Python package is untouched, and this is an in-process RAM-only store with no database, migration, or network surface, so the live smoke has nothing to exercise.

## Critical Self-Review

- Highest-risk behavior: the rejection ORDER inside `append`. The four checks are not independent — an input that is both an invalid kind and over the content size has two valid answers, and the store has always returned the first. Regrouping them (say, hoisting the cheap size check) would silently change which reason a caller sees. The extracted helper keeps the original sequence verbatim, and the ordering is now stated in a comment on the function so the next reader does not "tidy" it.
- Assumptions that could be wrong: that `src/realtime/working-set.ts` is a separate module rather than a copy to keep in sync. I diffed the two before touching anything — they have genuinely diverged (the src variant imports the repo logger directly, takes a bare budget in its constructor, and names its rejection helper `result` rather than `rejected`), so they are two implementations, not one duplicated file. I changed only the server one, as scoped.
- Missing/weak tests: no test exercises the `metadata_too_large` path caused by an unserializable value (a cycle or a BigInt) as distinct from a genuinely oversized one, so the misleading-label behavior the module's own comment describes is still uncovered. That gap predates this change and this PR does not widen it — I left it rather than adding tests to a lint lane.
- Security/permission risk: none. The exact-scope isolation boundary lives in `normalizeWorkingSetScope` / `workingSetScopeKey` / `scopeDenialsFor`, none of which this change touches. The content-free denial reporting is untouched, so no scope value can leak by a path that did not already exist.
- Migration/deploy risk: none. No schema, no SQL, no config, no startup path. The store is RAM-only and dies with the process by design.
- Downstream client/runtime risk: none. No exported signature changed — the two new helpers are module-private, and `WorkingSetStore`'s public surface (`append`, `buildContextPackFragment`, `getCounters`, `budget`) is byte-identical. I checked the callers before touching anything: `server/tools/realtime-stores.ts`, `server/tools/context-pack-assembly.ts`, and `server/main.ts` all construct the store and never reach inside it.
- Rollback/cleanup concern: none. Single commit, single file, revertible on its own.
- Fixes made before PR: my first pass gave the screening helper a nullable-pair return, which forced an unreachable `?? "invalid_kind"` fallback at the call site — a branch that existed only to satisfy the type. Replaced it with a discriminated union so `append` narrows on `rejection !== null` and the dead fallback is gone.
- Known residual risk: low. The refactor is mechanical and behavior-preserving; the remaining exposure is the untested unserializable-metadata path noted above, which is pre-existing.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane found no new reviewable pattern — the extraction follows the options-object and named-module-helper shape already recorded from the earlier #780 lanes and already demonstrated by `recovery-wal-store-parts.ts` next door.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the change is confined to an in-process RAM-only store with no database, network, or MCP surface, and the parity fixtures that freeze its output are exercised by the two pinning test files above.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract-visible output changed. The fragment shape, schema constant, label, result reasons, and counters are identical, so `contracts/server/server-realtime-working-recovery.fixture.json` and `contracts/server/server-context-pack-sections.fixture.json` need no update — and `server/tools/context-pack.test.ts`, which reads them, passes unmodified.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Rollout does not apply: this is an internal refactor with no MCP tool, schema, protocol, or client-facing change. No tool definition, no wire shape, and no exported signature moved, so there is nothing for a downstream client to pick up.
