### PR TITLE
refactor(sanitize): bring server/logging/sanitize.ts to the lint standard (#780)

### DIFF
--- a/server/logging/sanitize.ts
+++ b/server/logging/sanitize.ts
@@ -26,42 +26,72 @@ function normalizedKey(key: string): string {
 
 function isSensitiveKey(key: string): boolean {
   const normalized = normalizedKey(key);
-  return [...SENSITIVE_PARTS].some((part) =>
-    normalized === part || normalized.startsWith(`${part}_`) || normalized.endsWith(`_${part}`)
+  return [...SENSITIVE_PARTS].some(
+    (part) =>
+      normalized === part ||
+      normalized.startsWith(`${part}_`) ||
+      normalized.endsWith(`_${part}`),
   );
 }
 
 function shape(value: object): Record<string, unknown> {
   if (Array.isArray(value)) return { type: "array", item_count: value.length };
-  return { type: value.constructor?.name ?? "object", key_count: Object.keys(value).length };
+  return {
+    type: value.constructor?.name ?? "object",
+    key_count: Object.keys(value).length,
+  };
 }
 
 function sanitizeObject(value: object, depth: number): unknown {
   if (depth >= 4) return shape(value);
   if (Array.isArray(value)) {
-    const items = value.slice(0, 50).map((item) => sanitizeValue(item, depth + 1));
-    return value.length > 50 ? [...items, { remaining_items: value.length - 50 }] : items;
+    const items = value
+      .slice(0, 50)
+      .map((item) => sanitizeValue(item, depth + 1));
+    return value.length > 50
+      ? [...items, { remaining_items: value.length - 50 }]
+      : items;
   }
   if (Object.getPrototypeOf(value) !== Object.prototype) return shape(value);
   const output: Record<string, unknown> = {};
   const keys = Object.keys(value);
   for (const [key, item] of Object.entries(value).slice(0, 50)) {
-    output[key] = isSensitiveKey(key) ? "[REDACTED]" : sanitizeValue(item, depth + 1);
+    output[key] = isSensitiveKey(key)
+      ? "[REDACTED]"
+      : sanitizeValue(item, depth + 1);
   }
   if (keys.length > 50) output.remaining_keys = keys.length - 50;
   return output;
 }
 
+/** Project a long string down to its safe structured form. */
+function sanitizeString(value: string): string {
+  return value.length > 200
+    ? `${value.slice(0, 200)}…[${value.length - 200} characters omitted]`
+    : value;
+}
+
+/**
+ * Project the non-object values that carry a shape of their own.
+ *
+ * Returns `undefined` when `value` has no such projection, which leaves the
+ * caller to fall through to the plain-value and object branches.
+ */
+function sanitizeNonObject(value: unknown): { projected: unknown } | undefined {
+  if (typeof value === "string") return { projected: sanitizeString(value) };
+  if (value instanceof Error)
+    return { projected: { type: value.name || "Error" } };
+  if (typeof value === "bigint") return { projected: value.toString() };
+  if (typeof value === "function" || typeof value === "symbol") {
+    return { projected: { type: typeof value } };
+  }
+  return undefined;
+}
+
 /** Convert an untrusted value into safe structured data. */
 export function sanitizeValue(value: unknown, depth = 0): unknown {
-  if (typeof value === "string") {
-    return value.length > 200
-      ? `${value.slice(0, 200)}…[${value.length - 200} characters omitted]`
-      : value;
-  }
-  if (value instanceof Error) return { type: value.name || "Error" };
-  if (typeof value === "bigint") return value.toString();
-  if (typeof value === "function" || typeof value === "symbol") return { type: typeof value };
+  const projection = sanitizeNonObject(value);
+  if (projection) return projection.projected;
   if (typeof value !== "object" || value === null) return value;
   return sanitizeObject(value, depth);
 }


### PR DESCRIPTION
## Summary

- `sanitizeValue` in `server/logging/sanitize.ts` carried every non-object type branch inline, putting it at complexity 11 against the repo's rule value of 10 — the last lint finding in that file for #780.
- Split the per-type projection into two named module-level helpers: `sanitizeString` for the long-string projection, and `sanitizeNonObject` for the string/Error/bigint/function/symbol dispatch. `sanitizeValue` keeps its exported signature and now reads as the three-step projection it always was.
- `sanitizeNonObject` returns a `{ projected }` wrapper rather than the value directly, so "this type has a projection" stays distinct from "the projection happens to be undefined". No current branch projects `undefined`; the wrapper keeps that true by construction rather than by coincidence.
- This is a redaction boundary, so nothing about the output moved: branch order, every redaction result, and the sensitive-key handling are byte-identical. The extraction was read back line by line against the original before commit.
- No other file changed. No helper was moved out, and none was reused: the existing design keeps a dedicated sanitizer per boundary — the transport boundary owns `sanitizeThrownTransportError` and `redactToolFailure`, `server/observability/trace-masking.ts` owns trace masking, and `scripts/obsidian-sync.ts` does filename character replacement. None matches this shape field for field, so this change keeps that separation and only splits the logging sanitizer internally.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Run on the committed tree, after the pre-commit prettier hook reformatted the file:

- `./node_modules/.bin/oxlint --deny-warnings server/logging/sanitize.ts` -> exit 0. Before: `server/logging/sanitize.ts:56:8: error eslint(complexity): function sanitizeValue has a complexity of 11. Maximum allowed is 10.`
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated server/logging/` -> 5 pass, 0 fail, 18 expect() calls
- `bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 0 (diff-derived; before the change, the same check with `DONE_MEANS_780_FILES=server/logging/sanitize.ts` exited 1)

Python package is untouched. No migration, no schema, no wire contract.

## Critical Self-Review

- Highest-risk behavior: this file is the redaction boundary for every structured log line — a dropped or reordered branch would silently leak a secret or change what an operator sees in a log. Mitigated by keeping the branch order identical and reading the extraction back against the original rather than trusting the suite alone.
- Assumptions that could be wrong: that no branch in `sanitizeNonObject` can ever project `undefined`, which is what would make a bare-value return ambiguous. True today for all five branches; the `{ projected }` wrapper means it stays correct even if a future branch breaks that assumption.
- Missing/weak tests: `server/logging/logging.test.ts` exercises the string projection and the `URL` shape path, but has no direct case for the `bigint`, `function`, or `symbol` branches, so those three rest on read-back rather than on a test. Pre-existing gap; not widened here, and not closed here because this lane adds no behavior.
- Security/permission risk: none added. No auth, namespace, or SQL surface is touched; the sensitive-key set and `isSensitiveKey` are unchanged.
- Migration/deploy risk: none. Pure in-process refactor, no schema and no config.
- Downstream client/runtime risk: none. `sanitizeValue` keeps its exported signature; the two new helpers are module-local and unexported. In-repo callers (`server/logging/logger.ts`, `server/logging/crash-handlers.ts`, `server/logging/logging.test.ts`) are unchanged and were located with `rg`. No MCP tool, schema, or transport surface moved, so `docs/downstream-rollout.md` does not apply.
- Rollback/cleanup concern: single-commit, single-file; revert is clean.
- Fixes made before PR: none needed — oxlint, tsc, and the pinning tests were green on the first extraction and re-verified after the prettier hook reformatted the committed file.
- Known residual risk: the three untested type branches named above. They are covered by read-back only.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new MEDIUM+ finding surfaced — this is a mechanical extraction with no behavior delta, and the pattern it follows is already the lane contract's own standard.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or client-facing surface changed.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface is touched — the change is internal to one TypeScript module and exports the same signature.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, protocol, or client-facing shape changed. The only export is `sanitizeValue`, whose signature and output are unchanged.
