### PR TITLE
refactor(liveness-observer): bring server/capture/liveness-observer.ts to the lint standard (#780)

### DIFF
--- a/server/capture/liveness-observer.ts
+++ b/server/capture/liveness-observer.ts
@@ -176,6 +176,96 @@ interface RoleCountRow {
 }
 
 /**
+ * The four per-signal classifications, decided once and read by both the fault
+ * sentences and the published block.
+ *
+ * Split out so each signal is named where it is decided rather than inline in
+ * one judge: the predicates, their `active` gating, and the sentences they
+ * produce are the part a future reader has to check against the Python twin,
+ * and they are easier to check when each carries its own name.
+ */
+interface CaptureFaultSignals {
+  readonly watermarkWedged: boolean;
+  readonly spoolUnannounced: boolean;
+  readonly silentRoles: readonly string[];
+  readonly quarantined: number | undefined;
+}
+
+/**
+ * Roles that delivered nothing while the lane was above quorum.
+ *
+ * Below quorum this is empty rather than "every role": a quiet night is not a
+ * dead speaker, and `MIN_SESSIONS_FOR_SILENCE` is the boundary that says so.
+ */
+function classifySilentRoles(
+  observation: CaptureObservation,
+  active: boolean,
+): string[] {
+  if (!active) return [];
+  return Object.entries(observation.turnsByRole)
+    .filter(([, turns]) => turns === 0)
+    .map(([role]) => role)
+    .sort();
+}
+
+/**
+ * Decide every signal from the counts, with the quorum gating each one carries.
+ *
+ * ABANDONED RECORDS ARE A FAULT WHENEVER THEY EXIST (#680), with no `active`
+ * guard. The other faults ask "is the lane working right now?", so they are
+ * meaningless below quorum — a quiet night is not a dead lane. This one is not
+ * a liveness question at all: it is a report that data is already gone and
+ * stays gone until a human acts. A quarantine count is equally true on a busy
+ * Tuesday and an idle Sunday, so gating it on sessions observed would hide
+ * exactly the deployment that stopped capturing BECAUSE its records were being
+ * abandoned.
+ */
+function classifyCaptureFaults(
+  observation: CaptureObservation,
+): CaptureFaultSignals {
+  const active = observation.sessionsObserved >= MIN_SESSIONS_FOR_SILENCE;
+  return {
+    watermarkWedged: active && observation.watermarkBytesAdvanced === 0,
+    spoolUnannounced:
+      observation.spoolPending > 0 && observation.outageAnnouncements === 0,
+    silentRoles: classifySilentRoles(observation, active),
+    quarantined: observation.spoolQuarantined,
+  };
+}
+
+/**
+ * Render the operator-facing sentence for each raised signal, in the order the
+ * reading has always published them. Order is part of the contract: `reason` is
+ * a joined string a human reads, so reordering it is a behavior change.
+ */
+function describeCaptureFaults(
+  observation: CaptureObservation,
+  signals: CaptureFaultSignals,
+): string[] {
+  const faults: string[] = [];
+  if (signals.watermarkWedged) {
+    faults.push(
+      `watermark advanced 0 bytes across ${observation.sessionsObserved} session(s)`,
+    );
+  }
+  if (signals.spoolUnannounced) {
+    faults.push(
+      `spool holds ${observation.spoolPending} record(s) with no outage announced`,
+    );
+  }
+  const quarantined = signals.quarantined;
+  if (quarantined !== undefined && quarantined > 0) {
+    faults.push(
+      `${String(quarantined)} unit(s) quarantined — replay gave up, records are lost until an operator replays the sidecar`,
+    );
+  }
+  if (signals.silentRoles.length > 0) {
+    faults.push(`role(s) delivered nothing: ${signals.silentRoles.join(", ")}`);
+  }
+  return faults;
+}
+
+/**
  * Judge one observation. The TypeScript twin of `read_capture_liveness`.
  *
  * Kept as a pure function over counts for the reason the Python module's
@@ -193,48 +283,11 @@ export function readCaptureLiveness(
     (total, turns) => total + turns,
     0,
   );
-  const active = observation.sessionsObserved >= MIN_SESSIONS_FOR_SILENCE;
 
-  const watermarkWedged = active && observation.watermarkBytesAdvanced === 0;
-  const spoolUnannounced =
-    observation.spoolPending > 0 && observation.outageAnnouncements === 0;
-  const silentRoles = active
-    ? Object.entries(observation.turnsByRole)
-        .filter(([, turns]) => turns === 0)
-        .map(([role]) => role)
-        .sort()
-    : [];
-
-  // ABANDONED RECORDS ARE A FAULT WHENEVER THEY EXIST (#680), with no
-  // `active` guard. The other faults ask "is the lane working right now?", so
-  // they are meaningless below quorum — a quiet night is not a dead lane.
-  // This one is not a liveness question at all: it is a report that data is
-  // already gone and stays gone until a human acts. A quarantine count is
-  // equally true on a busy Tuesday and an idle Sunday, so gating it on
-  // sessions observed would hide exactly the deployment that stopped
-  // capturing BECAUSE its records were being abandoned.
-  const quarantined = observation.spoolQuarantined;
-  const quarantineFault = quarantined !== undefined && quarantined > 0;
-
-  const faults: string[] = [];
-  if (watermarkWedged) {
-    faults.push(
-      `watermark advanced 0 bytes across ${observation.sessionsObserved} session(s)`,
-    );
-  }
-  if (spoolUnannounced) {
-    faults.push(
-      `spool holds ${observation.spoolPending} record(s) with no outage announced`,
-    );
-  }
-  if (quarantineFault) {
-    faults.push(
-      `${String(quarantined)} unit(s) quarantined — replay gave up, records are lost until an operator replays the sidecar`,
-    );
-  }
-  if (silentRoles.length > 0) {
-    faults.push(`role(s) delivered nothing: ${silentRoles.join(", ")}`);
-  }
+  const signals = classifyCaptureFaults(observation);
+  const { watermarkWedged, spoolUnannounced, silentRoles, quarantined } =
+    signals;
+  const faults = describeCaptureFaults(observation, signals);
 
   return {
     stale: faults.length > 0,
@@ -319,7 +372,8 @@ async function gather(
     turnsByRole[row.role] = turns;
     turnsDelivered += turns;
     sessionsObserved = Math.max(sessionsObserved, Number(row.sessions));
-    const since = row.seconds_since_last === null ? 0 : Number(row.seconds_since_last);
+    const since =
+      row.seconds_since_last === null ? 0 : Number(row.seconds_since_last);
     silenceSeconds = Math.max(silenceSeconds, 0);
     if (silenceSeconds === 0 || since < silenceSeconds) silenceSeconds = since;
   }
@@ -353,7 +407,10 @@ async function gather(
  */
 export function createCaptureLivenessObserver(
   input: CaptureObserverInput,
-  options: { readonly refreshIntervalMs?: number; readonly autoStart?: boolean } = {},
+  options: {
+    readonly refreshIntervalMs?: number;
+    readonly autoStart?: boolean;
+  } = {},
 ): CaptureLivenessObserver {
   let latest: TransportCaptureHealth | undefined;
   let latestObservation: CaptureObservation | undefined;
@@ -401,9 +458,11 @@ export function createCaptureLivenessObserver(
 }
 
 /** Env var naming the tenant whose capture lane this process reports on. */
-export const CAPTURE_HEALTH_NAMESPACE_ENV = "OPENBRAIN_CAPTURE_HEALTH_NAMESPACE";
+export const CAPTURE_HEALTH_NAMESPACE_ENV =
+  "OPENBRAIN_CAPTURE_HEALTH_NAMESPACE";
 /** Env var overriding the observation window, in minutes. */
-export const CAPTURE_HEALTH_WINDOW_ENV = "OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES";
+export const CAPTURE_HEALTH_WINDOW_ENV =
+  "OPENBRAIN_CAPTURE_HEALTH_WINDOW_MINUTES";
 /** Env var overriding the refresh cadence, in milliseconds. */
 export const CAPTURE_HEALTH_REFRESH_ENV = "OPENBRAIN_CAPTURE_HEALTH_REFRESH_MS";
 


### PR DESCRIPTION
## Summary

- `readCaptureLiveness` in `server/capture/liveness-observer.ts` carried a complexity of 12 against the rule value of 10 (#780): one body decided four independent per-signal classifications, rendered a sentence for each, and assembled the published block.
- Split deciding from rendering into module-level named helpers, following the shape `main` already uses across `server/tools/*`: `classifyCaptureFaults` returns the four signals as one `CaptureFaultSignals` object, `classifySilentRoles` isolates the below-quorum empty case, and `describeCaptureFaults` renders the operator-facing sentences.
- No behavior change. Predicates are identical field for field, the `active`/quorum gate is unchanged, the `!== undefined && > 0` quarantine fault test is unchanged while the published `quarantined_count` still keys off the raw value (a reported `0` still publishes a count and raises no fault sentence), sentence order in `reason` is unchanged, and `stale`/`silence_seconds` are computed as before. No SQL, no log event name, no threshold, and no exported signature moved.
- One file touched. The helpers stay module-private rather than moving to a shared sibling: no other module classifies capture faults, so a shared file would have exactly one consumer.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`./node_modules/.bin/oxlint --deny-warnings server/capture/liveness-observer.ts` -> exit 0 on the committed tree (exit 1 before, with the complexity finding above). `bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 0, diff-derived against `origin/main`. `bunx tsc --noEmit` -> clean. `bun run test:isolated server/capture/ server/config.test.ts` -> 100 pass, 0 fail, 301 expect() calls, existing tests unmodified.

## Critical Self-Review

- Highest-risk behavior: the `reason` string. It is a joined, operator-read sentence list, so reordering the four fault sentences would be a silent behavior change that no assertion on booleans would catch. The render helper preserves the original order (watermark, spool, quarantine, silent roles) and `liveness-observer.test.ts` asserts on `reason` contents.
- Assumptions that could be wrong: that destructuring the signals object and reusing the same names produces the same published block. Checked by reading the new body back against the pre-change body line for line, not only by the suite — a non-equivalent predicate rewrite has slipped past this suite before.
- Missing/weak tests: none added; this is a pure restructure and the existing file-level suite already pins every signal, including the reported-zero quarantine case and the below-quorum quarantine case. A new test here would test the helper split rather than the behavior.
- Security/permission risk: none. No namespace predicate, auth check, or SQL was touched; the query and its `$1`/`$2` parameters are byte-identical.
- Migration/deploy risk: none. No schema, no migration, no config key, no env var.
- Downstream client/runtime risk: none. `readCaptureLiveness`, `createCaptureLivenessObserver`, `createCaptureHealthRuntime`, and every exported constant keep their signatures; the three new helpers are module-private. The `/health` capture block shape is unchanged, so mcp2cli, rtech-hermes, and the Python twin see nothing different.
- Rollback/cleanup concern: single-commit, single-file revert.
- Fixes made before PR: the pre-commit prettier hook reformatted the staged file, so oxlint, tsc, and the done-means were all re-run against the committed tree rather than the pre-hook working tree.
- Known residual risk: the Python twin `python/openbrain/src/openbrain/apps/capture/liveness.py` is unchanged and still the parity reference; this restructure does not move the TypeScript side away from it, but a future edit to either now has one more file shape to line up against.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a lint-standard restructure with no new failure pattern, and the reviewer lesson it would carry (read a restructured predicate back against the original rather than trusting the suite) is already the standing lane-contract tightening from #806.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime behavior, schema, or contract changed, so a live smoke would exercise nothing this PR touched.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, tool schema, or wire shape changed; the edit is internal function structure inside one server module.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable throughout: no MCP tool, schema, transport, or client-facing surface changed. `git diff --cached --name-only` was exactly `server/capture/liveness-observer.ts`.
