### PR TITLE
refactor(auth-middleware): bring server/auth/middleware.ts to the lint standard (#780)

### DIFF
--- a/server/auth/middleware.ts
+++ b/server/auth/middleware.ts
@@ -51,6 +51,84 @@ export function requestAuth(request: Request): RequestAuthInfo | undefined {
   return (request as Request & { auth?: RequestAuthInfo }).auth;
 }
 
+/** A refusal the handler should send instead of continuing the chain. */
+interface AuthRefusal {
+  readonly status: number;
+  readonly error: string;
+}
+
+/**
+ * Resolve the bearer token in the `Authorization` header to a token identity.
+ *
+ * Both failure modes stay distinct on purpose: a missing header and a header
+ * carrying an unknown token are different operator problems, and collapsing
+ * them into one message is what makes a misconfigured client unreadable.
+ */
+function authenticateBearerHeader(
+  header: string | undefined,
+  configuredTokens: readonly AuthTokenConfig[],
+): AuthIdentity | AuthRefusal {
+  if (!header?.startsWith("Bearer ")) {
+    return { status: 401, error: "Missing Bearer token" };
+  }
+  const identity = resolveBearerToken(
+    header.slice("Bearer ".length),
+    configuredTokens,
+  );
+  if (!identity) return { status: 401, error: "Invalid token" };
+  return identity;
+}
+
+function isRefusal(value: AuthIdentity | AuthRefusal): value is AuthRefusal {
+  return "status" in value;
+}
+
+/**
+ * Check that this role may delegate a namespace at all, then that the value
+ * presented has the delegated-id shape.
+ *
+ * A role that may not delegate is refused rather than downgraded: silently
+ * ignoring the header leaves the caller believing it wrote somewhere it did not.
+ */
+function checkDelegatedNamespace(
+  namespace: string | undefined,
+  role: AuthIdentity["role"],
+): AuthRefusal | undefined {
+  if (!namespace) return undefined;
+  if (role !== "admin" && role !== "ob-admin") {
+    return { status: 403, error: "Role not permitted to delegate namespace" };
+  }
+  if (!DELEGATED_ID_RE.test(namespace)) {
+    return { status: 400, error: "Invalid X-Namespace header" };
+  }
+  return undefined;
+}
+
+/** Check the delegated agent id has the delegated-id shape. */
+function checkDelegatedAgentId(
+  agentId: string | undefined,
+): AuthRefusal | undefined {
+  if (agentId && !DELEGATED_ID_RE.test(agentId)) {
+    return { status: 400, error: "Invalid X-Agent-Id header" };
+  }
+  return undefined;
+}
+
+/** Compose the token identity and the validated delegated values into `req.auth`. */
+function buildRequestAuthInfo(
+  identity: AuthIdentity,
+  namespace: string | undefined,
+  agentId: string | undefined,
+): RequestAuthInfo {
+  return {
+    role: identity.role,
+    clientId: namespace ?? identity.clientId,
+    tokenClientId: identity.clientId,
+    namespaceSource: namespace ? "delegated" : "token",
+    ...(agentId ? { agentId } : {}),
+  };
+}
+
 /**
  * Build the Express handler that turns a bearer token into `req.auth`.
  *
@@ -63,42 +141,27 @@ export function createAuthMiddleware(
   configuredTokens: readonly AuthTokenConfig[],
 ): RequestHandler {
   return (request: Request, response: Response, next: NextFunction): void => {
-    const header = request.headers.authorization;
-    if (!header?.startsWith("Bearer ")) {
-      response.status(401).json({ error: "Missing Bearer token" });
-      return;
-    }
-    const identity = resolveBearerToken(
-      header.slice("Bearer ".length),
+    const authenticated = authenticateBearerHeader(
+      request.headers.authorization,
       configuredTokens,
     );
-    if (!identity) {
-      response.status(401).json({ error: "Invalid token" });
+    if (isRefusal(authenticated)) {
+      response
+        .status(authenticated.status)
+        .json({ error: authenticated.error });
       return;
     }
     const namespace = headerValue(request.headers["x-namespace"]);
-    if (namespace && identity.role !== "admin" && identity.role !== "ob-admin") {
-      response
-        .status(403)
-        .json({ error: "Role not permitted to delegate namespace" });
-      return;
-    }
-    if (namespace && !DELEGATED_ID_RE.test(namespace)) {
-      response.status(400).json({ error: "Invalid X-Namespace header" });
-      return;
-    }
     const agentId = headerValue(request.headers["x-agent-id"]);
-    if (agentId && !DELEGATED_ID_RE.test(agentId)) {
-      response.status(400).json({ error: "Invalid X-Agent-Id header" });
+    const refusal =
+      checkDelegatedNamespace(namespace, authenticated.role) ??
+      checkDelegatedAgentId(agentId);
+    if (refusal) {
+      response.status(refusal.status).json({ error: refusal.error });
       return;
     }
-    (request as Request & { auth?: RequestAuthInfo }).auth = {
-      role: identity.role,
-      clientId: namespace ?? identity.clientId,
-      tokenClientId: identity.clientId,
-      namespaceSource: namespace ? "delegated" : "token",
-      ...(agentId ? { agentId } : {}),
-    };
+    (request as Request & { auth?: RequestAuthInfo }).auth =
+      buildRequestAuthInfo(authenticated, namespace, agentId);
     next();
   };
 }


### PR DESCRIPTION
## Summary

- `server/auth/middleware.ts` carried the whole bearer/delegation chain in one anonymous handler: complexity 14 against a rule value of 10 (`eslint(complexity)` at `middleware.ts:65:10`).
- Split by the check each branch performs, following the pattern `main` already uses across `server/tools/`: named module-level helpers, one concern each — `authenticateBearerHeader`, `checkDelegatedNamespace`, `checkDelegatedAgentId`, `buildRequestAuthInfo`.
- **Auth behavior is identical.** Every predicate, header name, status code, error string, and refusal precedence is unchanged. Proved two ways: (1) read-back of the split file against the pre-change original — all five `status`/`error` pairs and `DELEGATED_ID_RE` are byte-identical, and the namespace 403 → namespace 400 → agent-id 400 precedence is preserved because the helpers are chained with `??` in the original order; (2) the regression tests that pin this boundary were not touched and pass unmodified.
- Extraction only. No helper was reused from elsewhere: `src/auth.ts` holds a near-identical `DELEGATED_ID_RE` and `headerValue`, but that is the legacy implementation this module deliberately adapts rather than shares (see the module header), so coupling the two would be a behavior change rather than a lint fix. No other file was touched.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`oxlint --deny-warnings server/auth/middleware.ts` → exit 0 (was: 1 complexity finding). `bunx tsc --noEmit` → exit 0. `bun run test:isolated server/auth/ server/transport/ server/application/sdk-protocol.pg.test.ts` → exits 0, 0 fail (18 tests in `server/auth/` + `sdk-protocol`, 67 in `server/transport/`). `scripts/done-means/780-touched-files-lint-clean.sh` → exit 0 on the committed, prettier-formatted tree. Python is untouched; nothing deploys.

## Critical Self-Review

- Highest-risk behavior: this file is the namespace-isolation boundary — `req.auth` is what the MCP SDK turns into `extra.authInfo` and every downstream namespace predicate. A non-equivalent predicate rewrite here would be an isolation bug, not a style bug, which is why the change is extraction with no rewritten conditions and why it was read back line by line rather than trusted to the suite (#806 is the precedent for the suite missing exactly that).
- Assumptions that could be wrong: that reading the `x-agent-id` header before the namespace checks rather than after is unobservable. It is — `headerValue` is a pure string function that touches neither the request nor the response, so the only ordering that matters is refusal precedence, and that is preserved by the `??` chain.
- Missing/weak tests: no new tests. The pinning tests already cover the paths this touches, and adding tests to a behavior-preserving extraction would test the new shape rather than the contract. `server/auth/auth.test.ts` covers `delegateNamespace` in the sibling policy module, not this handler; the handler's chain is covered end to end by the `sdk-protocol` bearer → middleware → `req.auth` → namespace-predicate test.
- Security/permission risk: none introduced. The role gate still refuses a non-admin delegator with 403 rather than downgrading it, which is the dangerous variant the module header calls out; both delegated values are still shape-validated before reaching `req.auth`.
- Migration/deploy risk: none. No schema, no config, no startup path.
- Downstream client/runtime risk: none. No exported signature changed — `createAuthMiddleware`, `requestAuth`, and `RequestAuthInfo` keep their shapes; the four new helpers are module-private.
- Rollback/cleanup concern: single-file revert, no state.
- Fixes made before PR: none needed beyond the split; the first read-back matched.
- Known residual risk: the duplicated `DELEGATED_ID_RE`/`headerValue` between `src/auth.ts` and this module remains. Deliberate and pre-existing — deduping it is a migration decision for whoever retires the legacy path, not this lane.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a behavior-preserving lint extraction that surfaced no new review pattern; the "read the extraction back against the original, the suite will not catch a non-equivalent predicate" lesson is already the standing lane-contract instruction that this lane followed.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, contract, or client-facing behavior changed.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface is touched — the change is internal to one Express middleware module.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, protocol, transport, or client-facing shape changed. The classification is "internal refactor", which `docs/downstream-rollout.md` puts outside the rollout gate.
