### PR TITLE
refactor(application-root): bring server/application/index.ts to the lint standard (#780)

### DIFF
--- a/server/application/index.ts
+++ b/server/application/index.ts
@@ -3,7 +3,10 @@ import type { Logger } from "pino";
 import { natsHealthFromConfig, type ServerConfig } from "../config.ts";
 import type { Database } from "../db/pool.ts";
 import type { ServerModuleBoundary } from "../module.ts";
-import { createMaintenanceRuntime } from "../maintenance/index.ts";
+import {
+  createMaintenanceRuntime,
+  type MaintenanceRuntime,
+} from "../maintenance/index.ts";
 import {
   readCaptureLiveness,
   type CaptureObservation,
@@ -134,27 +137,41 @@ export interface ShadowApplication {
   close(): Promise<void>;
 }
 
-/** Compose the phase-4 shadow implementation without binding a network socket. */
-export function createShadowApplication(
+/**
+ * Compose the session transport handlers.
+ *
+ * `transportFactory` stays conditionally spread rather than defaulted: the
+ * transport builder owns its own default, and passing an explicit `undefined`
+ * is not the same call.
+ */
+function composeSessions(
   input: ShadowApplicationInput,
-): ShadowApplication {
-  const transportLogger = input.logger.child({ component: "transport" });
-  const sessions = createSessionTransportHandlers({
+  transportLogger: Logger,
+): SessionTransportHandlers {
+  return createSessionTransportHandlers({
     config: input.config.transport,
     logger: transportLogger,
     serverFactory: input.serverFactory,
-    ...(input.transportFactory ? { transportFactory: input.transportFactory } : {}),
+    ...(input.transportFactory
+      ? { transportFactory: input.transportFactory }
+      : {}),
   });
-  const health = {
-    databaseHealth: input.database.health,
-    hostname: input.config.transport.hostname,
-    serverIp: input.config.transport.serverIp,
-    serverIps: input.config.transport.serverIps,
+}
+
+/**
+ * The optional fields of the `/health` block, kept as conditional spreads.
+ *
+ * Each one is present-or-absent rather than present-and-undefined, because the
+ * health builder distinguishes the two: an absent `revision` publishes no
+ * revision, an explicit `undefined` is a different call. Split out only so the
+ * composition root stays under the branch count; every read is the same read
+ * from the same place, in the same order.
+ */
+function composeHealthOverrides(input: ShadowApplicationInput) {
+  return {
     ...(input.config.transport.deployedRevision
       ? { revision: input.config.transport.deployedRevision }
       : {}),
-    probeTimeoutMs: input.config.transport.healthProbeTimeoutMs,
-    logger: transportLogger,
     ...(input.config.transport.embeddingBaseUrl
       ? { embeddingBaseUrl: input.config.transport.embeddingBaseUrl }
       : {}),
@@ -162,6 +179,29 @@ export function createShadowApplication(
       ? { embeddingApiKey: input.config.transport.embeddingApiKey }
       : {}),
     ...(input.fetch ? { fetch: input.fetch } : {}),
+  };
+}
+
+/**
+ * Compose the `/health` inputs.
+ *
+ * `readProducerHealth` is passed in rather than read from a captured value for
+ * the LATE-BINDING reason spelled out at its call site: the maintenance runtime
+ * is composed after this object, and the reading must be taken per request.
+ */
+function composeHealth(
+  input: ShadowApplicationInput,
+  transportLogger: Logger,
+  readProducerHealth: () => MaintenanceProducerHealth | undefined,
+) {
+  return {
+    databaseHealth: input.database.health,
+    hostname: input.config.transport.hostname,
+    serverIp: input.config.transport.serverIp,
+    serverIps: input.config.transport.serverIps,
+    probeTimeoutMs: input.config.transport.healthProbeTimeoutMs,
+    logger: transportLogger,
+    ...composeHealthOverrides(input),
     // Config is the DEFAULT source of the `nats` health block, not an optional
     // extra. `server/transport/health.ts` falls back to a hardcoded
     // http/available literal when nothing supplies one, which is correct only
@@ -173,24 +213,7 @@ export function createShadowApplication(
     // cannot.
     natsHealth:
       input.natsHealth ?? (() => natsHealthFromConfig(input.config.nats)),
-    // #625. Deliberately LATE-BOUND: `maintenance` is composed below this
-    // object, because the health block is an input to the transport app and
-    // the runner is a shutdown-order concern. Reading `maintenance` through a
-    // closure invoked per request — rather than reordering the composition —
-    // keeps that ordering intact and, more importantly, keeps the reading
-    // LIVE. A value captured here would be the producer's liveness at boot,
-    // which is exactly the stale-but-confident answer the issue is about.
-    producerHealth: () => {
-      const liveness = maintenance?.producerLiveness();
-      if (!liveness) return undefined;
-      return {
-        quiet_ms: liveness.quietMs,
-        stale: liveness.stale,
-        quiet_threshold_ms: liveness.quietThresholdMs,
-        overlapped_ticks: liveness.overlappedTicks,
-        completed_ticks: liveness.completedTicks,
-      };
-    },
+    producerHealth: readProducerHealth,
     // #652. The reading #648 built and nothing composed. Same LATE-BINDING as
     // `producerHealth` above and for the same reason: the closure is invoked
     // per request, so `/health` publishes what the capture lane looks like NOW
@@ -203,7 +226,63 @@ export function createShadowApplication(
     // most workers rather than an edge (core01 runs several — `AGENTS.md`).
     captureHealth: () => readCaptureLiveness(input.captureObserver?.()),
   };
-  const app = createSingleWorkerTransportApp({
+}
+
+/** The `producer` block of `/health`, as the transport layer publishes it. */
+interface MaintenanceProducerHealth {
+  readonly quiet_ms: number;
+  readonly stale: boolean;
+  readonly quiet_threshold_ms: number;
+  readonly overlapped_ticks: number;
+  readonly completed_ticks: number;
+}
+
+/** Snake-case the runner's producer liveness for `/health`. */
+function readMaintenanceProducerHealth(
+  maintenance: MaintenanceRuntime | undefined,
+): MaintenanceProducerHealth | undefined {
+  const liveness = maintenance?.producerLiveness();
+  if (!liveness) return undefined;
+  return {
+    quiet_ms: liveness.quietMs,
+    stale: liveness.stale,
+    quiet_threshold_ms: liveness.quietThresholdMs,
+    overlapped_ticks: liveness.overlappedTicks,
+    completed_ticks: liveness.completedTicks,
+  };
+}
+
+/**
+ * Compose the maintenance runner, or nothing.
+ *
+ * `createMaintenanceRuntime` returns undefined when the operator disabled
+ * maintenance for this process, and a process that dispatches no job kinds
+ * composes none at all. `autoStart` stays conditionally spread so the runtime's
+ * own default applies when the caller expressed no preference.
+ */
+function composeMaintenance(
+  input: ShadowApplicationInput,
+): MaintenanceRuntime | undefined {
+  if (!input.maintenanceHandlers) return undefined;
+  return createMaintenanceRuntime({
+    config: input.config.maintenance,
+    logger: input.logger.child({ component: "maintenance" }),
+    pool: input.database.pool,
+    handlers: input.maintenanceHandlers,
+    ...(input.maintenanceAutoStart !== undefined
+      ? { autoStart: input.maintenanceAutoStart }
+      : {}),
+  });
+}
+
+/** Compose the transport app from the session handlers and health inputs. */
+function composeTransportApp(
+  input: ShadowApplicationInput,
+  transportLogger: Logger,
+  sessions: SessionTransportHandlers,
+  health: ReturnType<typeof composeHealth>,
+): Express {
+  return createSingleWorkerTransportApp({
     authenticate: input.authenticate,
     parseRequestBody: input.parseRequestBody,
     sessions,
@@ -212,25 +291,33 @@ export function createShadowApplication(
     ...(input.beforeRoutes ? { beforeRoutes: input.beforeRoutes } : {}),
     ...(input.routers ? { routers: input.routers } : {}),
   });
+}
+
+/** Compose the phase-4 shadow implementation without binding a network socket. */
+export function createShadowApplication(
+  input: ShadowApplicationInput,
+): ShadowApplication {
+  const transportLogger = input.logger.child({ component: "transport" });
+  const sessions = composeSessions(input, transportLogger);
+  // #625. The producer reading is deliberately LATE-BOUND: `maintenance` is
+  // composed below this object, because the health block is an input to the
+  // transport app and the runner is a shutdown-order concern. Reading
+  // `maintenance` through a closure invoked per request — rather than
+  // reordering the composition — keeps that ordering intact and, more
+  // importantly, keeps the reading LIVE. A value captured here would be the
+  // producer's liveness at boot, which is exactly the stale-but-confident
+  // answer the issue is about.
+  const health = composeHealth(input, transportLogger, () =>
+    readMaintenanceProducerHealth(maintenance),
+  );
+  const app = composeTransportApp(input, transportLogger, sessions, health);
   // Compose maintenance BEFORE returning, so the runner and its place in the
-  // shutdown order are created together. `createMaintenanceRuntime` returns
-  // undefined when the operator disabled maintenance for this process, and a
-  // process that dispatches no job kinds composes none at all.
+  // shutdown order are created together.
   //
   // Caller-supplied runtimes stop first, then maintenance. The queue runner is
   // the drain that needs the database longest -- it must finish jobs it has
   // already leased -- so it sits closest to the database in the ordering.
-  const maintenance = input.maintenanceHandlers
-    ? createMaintenanceRuntime({
-        config: input.config.maintenance,
-        logger: input.logger.child({ component: "maintenance" }),
-        pool: input.database.pool,
-        handlers: input.maintenanceHandlers,
-        ...(input.maintenanceAutoStart !== undefined
-          ? { autoStart: input.maintenanceAutoStart }
-          : {}),
-      })
-    : undefined;
+  const maintenance = composeMaintenance(input);
   const backgroundRuntimes: readonly BackgroundRuntime[] = [
     ...(input.backgroundRuntimes ?? []),
     ...(maintenance ? [maintenance] : []),


### PR DESCRIPTION
## Summary

- `createShadowApplication` carried a complexity of 13 against a rule value of 10. Every branch in it was a conditional spread: the composition root reads a dozen optional fields and passes each one present-or-absent rather than present-and-undefined, because the transport and maintenance builders own their own defaults and an explicit `undefined` is a different call.
- Split the wiring into named module-level helpers that each return one wired piece — `composeSessions`, `composeHealthOverrides`, `composeHealth`, `composeMaintenance`, `composeTransportApp`. Every read stays the same read from the same place, every conditional spread stays a conditional spread, and construction order is unchanged.
- The late-bound producer reading is carried across deliberately. `maintenance` is composed AFTER the health object, and `producerHealth` reads it through a closure invoked per request so `/health` publishes the runner's liveness NOW rather than at boot (#625). That closure is now passed into `composeHealth` as an argument and still closes over the `maintenance` binding at the call site, so both the ordering and the liveness are intact.
- The optional health fields moved into one spread instead of three interleaved ones. No key collides with another, so the object is field-for-field identical; `server/transport/health.ts` consumes it by property access and rebuilds the `/health` JSON in its own fixed order (`server/transport/health.ts:335`), so nothing observes key insertion order.
- One file touched. No exported signature changed, so no caller was touched. No behavior change: schemas, defaults, error strings, SQL, log event names, and section ordering are identical, and the existing tests are unmodified.

## Verification

- Done-means: scripts/done-means/780-touched-files-lint-clean.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Evidence, all on the committed (prettier-formatted) tree:

- `./node_modules/.bin/oxlint --deny-warnings server/application/index.ts` -> exit 0 (red first at `origin/main`: `server/application/index.ts:138:8: error eslint(complexity): function 'createShadowApplication' has a complexity of 13. Maximum allowed is 10.`)
- `bash scripts/done-means/780-touched-files-lint-clean.sh` -> exit 0 (red first with `DONE_MEANS_780_FILES=server/application/index.ts` -> exit 1)
- `bunx tsc --noEmit` -> clean
- `bun run test:isolated server/application/ server/main.pg.test.ts` -> 35 pass, 0 fail, 3 files

## Critical Self-Review

- Highest-risk behavior: the late-bound `producerHealth` closure. If it had been evaluated eagerly during the extraction, `/health` would report the maintenance producer's liveness at boot forever — a stale-but-confident answer that reads as healthy. It is still a closure, still invoked per request, and still resolves the `maintenance` binding declared after the health object; `server/application/shadow-application.test.ts` and `server/main.pg.test.ts` exercise the composed `/health`.
- Assumptions that could be wrong: that the health options object has no key-order dependency. Checked rather than assumed — `server/transport/health.ts` reads it by property access and constructs the response object itself at line 335, so the order the fields were inserted in is not observable.
- Missing/weak tests: no test asserts that a conditionally-spread field is ABSENT rather than present-and-undefined. That distinction is the reason each spread is written the way it is, and it is currently protected by the shape of the code and by review, not by an assertion. Not added here because it would be a new test in a lint-only change.
- Security/permission risk: none. No auth, namespace predicate, or token handling is in this file; `authenticate` and `parseRequestBody` are passed straight through unchanged.
- Migration/deploy risk: none. No SQL, no migration, no config key added or renamed.
- Downstream client/runtime risk: none. No MCP tool, schema, transport protocol, or Python client surface changed. `docs/downstream-rollout.md` classifies this as not applicable.
- Rollback/cleanup concern: single-file, single-commit, revertable on its own.
- Fixes made before PR: none needed — oxlint and tsc were clean on the first extraction, and the diff was read back against the original line by line for equivalence before committing.
- Known residual risk: the equivalence argument for moving three interleaved conditional spreads into one block rests on there being no key collision among `revision`, `embeddingBaseUrl`, `embeddingApiKey`, and `fetch`. There is not, and tsc would reject a duplicate, but it is the one place where the diff is not a literal line move.
- SME review-memory update: [x] not applicable because: no new reviewable pattern surfaced — this is the same composition-root extraction shape `docs/sme/quality.md` already covers, applied to one more file.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] not applicable because: no runtime, transport, or tool-facing behavior changed; the composed app is proven by the isolated suite above.

## Contract Parity

- Contract parity: [x] runtime-specific because: no contract, fixture, or wire shape is touched — this is an internal refactor of one composition function.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable on every line: no MCP tool, schema, protocol, or client-facing surface changed. The only export in this file is `createShadowApplication`, whose signature is unchanged, so every caller (`server/main.ts`, `server/index.ts`, `server/application/nats.ts`, four `scripts/done-means/` drivers) compiles and runs against it untouched.
