### PR TITLE
test(done-means): add the L2b-2 env-reader check, RED at a80484b (#825)

### DIFF
--- a/scripts/done-means/750-l2b2-check-well-formed.sh
+++ b/scripts/done-means/750-l2b2-check-well-formed.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for the DONE-MEANS check of lane L2b-2 (issue #825).
+#
+#   bash scripts/done-means/750-l2b2-check-well-formed.sh
+#
+# ---------------------------------------------------------------------------
+# Why a check about a check
+# ---------------------------------------------------------------------------
+# `scripts/done-means/750-l2b2-env-readers-take-config.sh` is written RED first:
+# it asserts a state four later rewiring PRs will create, so at the head that
+# INTRODUCES it the honest answer is exit 1. `scripts/verify-lane.ts` refuses to
+# post a receipt for a done-means that exits non-zero, so the PR that adds the
+# red check has no receipt line it can name — and the usual escapes (weaken the
+# check, name an unrelated one) both destroy the thing being landed.
+#
+# The way out is to receipt a DIFFERENT property, one that is true today and
+# stays true after the rewirings land: the L2b-2 check is WELL-FORMED. It runs
+# without harness error, it reports every clause it claims to, its structural
+# clauses (targets present, scanner proven to match) are green, and its exit
+# code agrees with the state clauses it printed. A red check that is well-formed
+# is a working gate pointed at unfinished work; a red check that is malformed is
+# a typo nobody has read. This script tells the two apart.
+#
+# Four clauses, and all four must pass:
+#
+# CLAUSE 1 — THE INNER CHECK RAN AND JUDGED.
+#   Exit 0 (the rewirings have landed) or exit 1 (they have not) are both fine.
+#   Anything else — the inner script's own 3 for a harness error, a 127 for a
+#   missing interpreter, a 2 from a shell syntax error — means the check did not
+#   reach a verdict, so nothing it printed can be trusted. That is a harness
+#   error HERE too, not a fail: this script cannot judge a check that did not run.
+#
+# CLAUSE 2 — THE STRUCTURAL CLAUSE IS GREEN.
+#   Exactly one `CLAUSE 1` line, saying PASS. That clause asserts the four target
+#   files exist; if it goes red the inner scan is over missing paths and every
+#   other clause is vacuous. Exactly one, because two would mean the output is
+#   being generated twice and the reader cannot tell which verdict is in force.
+#
+# CLAUSE 3 — THE POSITIVE CONTROL IS GREEN.
+#   Exactly one `CLAUSE 3` line, saying PASS. That is the inner check's own
+#   proof that its scanner still matches a hit where one MUST exist. It is the
+#   clause that separates "clean tree" from "broken scan", and it is the one
+#   clause whose value does not change when the rewirings land — so requiring it
+#   green here costs the rewiring lanes nothing and catches a dead scanner today.
+#
+# CLAUSE 4 — THE EXIT CODE AGREES WITH THE STATE CLAUSES.
+#   `CLAUSE 2` and `CLAUSE 4` are the STATE clauses: red until the rewirings
+#   land, green after. Both lines must be present, and the exit code must agree
+#   with them — exit 0 demands both PASS, exit 1 demands at least one FAIL. A
+#   check that exits 1 while printing all-PASS, or exits 0 while printing a FAIL,
+#   is reporting one thing and returning another, which is the failure mode that
+#   makes a gate worse than no gate.
+#
+# The four clauses hold at BOTH ends of the rung. Today: 1 and 3 PASS, 2 and 4
+# FAIL, inner exit 1, and clause 4 is satisfied by the FAILs. After the four
+# rewirings: every inner clause PASSes, inner exit 0, and clause 4 is satisfied
+# by the PASSes. Nothing here has to be edited out when the work finishes, which
+# is the property that makes it a permanent check rather than scaffolding.
+#
+# NO ARGUMENTS. `DONE_MEANS_L2B2_INNER` exists ONLY so this script's own
+# red/green can be demonstrated against a deliberately broken stand-in; it
+# defaults to the real sibling and no caller in the repo sets it.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v rg >/dev/null 2>&1 || fail_hard "rg (ripgrep) not on PATH"
+
+INNER="${DONE_MEANS_L2B2_INNER:-$REPO_ROOT/scripts/done-means/750-l2b2-env-readers-take-config.sh}"
+[ -f "$INNER" ] || fail_hard "inner check not found at $INNER"
+
+CLAUSE1=FAIL; CLAUSE1_EVIDENCE=""
+CLAUSE2=FAIL; CLAUSE2_EVIDENCE=""
+CLAUSE3=FAIL; CLAUSE3_EVIDENCE=""
+CLAUSE4=FAIL; CLAUSE4_EVIDENCE=""
+
+INNER_OUT="$(cd "$REPO_ROOT" && bash "$INNER" 2>&1)"
+INNER_STATUS=$?
+
+# Count and read back a single clause line by its leading label.
+clause_lines() {
+  printf '%s\n' "$INNER_OUT" | rg -c "^$1" || true
+}
+clause_text() {
+  printf '%s\n' "$INNER_OUT" | rg -m 1 "^$1" || true
+}
+
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — the inner check reached a verdict.
+# ---------------------------------------------------------------------------
+if [ "$INNER_STATUS" -eq 0 ] || [ "$INNER_STATUS" -eq 1 ]; then
+  CLAUSE1=PASS
+  CLAUSE1_EVIDENCE="inner check exited $INNER_STATUS — a real verdict (0 = wired, 1 = not yet)"
+else
+  CLAUSE1_EVIDENCE="inner check exited $INNER_STATUS — no verdict was reached, so its output cannot be judged"
+fi
+
+if [ "$CLAUSE1" != PASS ]; then
+  printf 'CLAUSE 1 (inner check reached a verdict):        %s — %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+  printf '%s\n' "$INNER_OUT" | sed 's/^/    /'
+  fail_hard "inner check exited $INNER_STATUS; it did not run to a verdict"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 2 — the structural clause (targets exist) is green.
+# ---------------------------------------------------------------------------
+C1_N="$(clause_lines 'CLAUSE 1')"
+C1_TEXT="$(clause_text 'CLAUSE 1')"
+if [ "$C1_N" -ne 1 ]; then
+  CLAUSE2_EVIDENCE="expected exactly one 'CLAUSE 1' line, found $C1_N"
+elif printf '%s' "$C1_TEXT" | rg -q 'PASS'; then
+  CLAUSE2=PASS
+  CLAUSE2_EVIDENCE="the inner structural clause is green: $C1_TEXT"
+else
+  CLAUSE2_EVIDENCE="the inner structural clause is not green, so every later clause is vacuous: $C1_TEXT"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 3 — the positive control is green.
+# ---------------------------------------------------------------------------
+C3_N="$(clause_lines 'CLAUSE 3')"
+C3_TEXT="$(clause_text 'CLAUSE 3')"
+if [ "$C3_N" -ne 1 ]; then
+  CLAUSE3_EVIDENCE="expected exactly one 'CLAUSE 3' line, found $C3_N"
+elif printf '%s' "$C3_TEXT" | rg -q 'PASS'; then
+  CLAUSE3=PASS
+  CLAUSE3_EVIDENCE="the inner scanner is proven to still match: $C3_TEXT"
+else
+  CLAUSE3_EVIDENCE="the inner positive control is red — its clean results mean nothing: $C3_TEXT"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 4 — the exit code agrees with the state clauses.
+# ---------------------------------------------------------------------------
+C2_N="$(clause_lines 'CLAUSE 2')"
+C4_N="$(clause_lines 'CLAUSE 4')"
+C2_TEXT="$(clause_text 'CLAUSE 2')"
+C4_TEXT="$(clause_text 'CLAUSE 4')"
+
+STATE_PASSES=0
+printf '%s' "$C2_TEXT" | rg -q 'PASS' && STATE_PASSES=$((STATE_PASSES + 1))
+printf '%s' "$C4_TEXT" | rg -q 'PASS' && STATE_PASSES=$((STATE_PASSES + 1))
+
+if [ "$C2_N" -ne 1 ] || [ "$C4_N" -ne 1 ]; then
+  CLAUSE4_EVIDENCE="expected exactly one each of 'CLAUSE 2' and 'CLAUSE 4', found $C2_N and $C4_N"
+elif [ "$INNER_STATUS" -eq 0 ] && [ "$STATE_PASSES" -ne 2 ]; then
+  CLAUSE4_EVIDENCE="inner exited 0 but only $STATE_PASSES/2 state clauses say PASS — it returns success while reporting a failure"
+elif [ "$INNER_STATUS" -eq 1 ] && [ "$STATE_PASSES" -eq 2 ]; then
+  CLAUSE4_EVIDENCE="inner exited 1 but both state clauses say PASS — it returns failure while reporting success"
+else
+  CLAUSE4=PASS
+  CLAUSE4_EVIDENCE="exit $INNER_STATUS agrees with $STATE_PASSES/2 state clauses passing"
+fi
+
+printf 'CLAUSE 1 (inner check reached a verdict):        %s — %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+printf 'CLAUSE 2 (inner structural clause is green):     %s — %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+printf 'CLAUSE 3 (inner positive control is green):      %s — %s\n' "$CLAUSE3" "$CLAUSE3_EVIDENCE"
+printf 'CLAUSE 4 (exit code agrees with its clauses):    %s — %s\n' "$CLAUSE4" "$CLAUSE4_EVIDENCE"
+
+if [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ] && [ "$CLAUSE4" = PASS ]; then
+  exit 0
+fi
+exit 1

--- a/scripts/done-means/750-l2b2-env-readers-take-config.sh
+++ b/scripts/done-means/750-l2b2-env-readers-take-config.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for lane L2b-2 of the server/ hardening ladder
+# (`_plans/server-hardening-ladder.md`, rung L2 "Composition root", issue #825).
+#
+#   bash scripts/done-means/750-l2b2-env-readers-take-config.sh
+#
+# ---------------------------------------------------------------------------
+# The defect this gates
+# ---------------------------------------------------------------------------
+# The rewrite charter (`_plans/463-server-rewrite-charter.md:108,119`) puts ALL
+# env parsing behind `server/config/` and forbids domain code from importing
+# `process.env`. L2a (#778) delivered the SCHEMA half — every one of these reads
+# is typed and parsed into a `ServerConfig` group — and L2b-1
+# (`scripts/done-means/750-l2b1-tool-readers-take-config.sh`) closed the first
+# four readers. This lane closes the REMAINDER, including the two that L2b-1
+# explicitly deferred behind the lint-debt ruling.
+#
+# The state it ends is the doubled one: a validated group AND the original
+# scattered reader both exist, and only the reader is consulted. Nothing fails
+# while that lasts; `config.search.embeddingTimeoutMs` can be correct, tested,
+# and reported in `/health` while `server/tools/search-engine.ts` reads
+# `process.env` and answers something else. The two drift, and the config
+# becomes a record of an intention rather than the value in force.
+#
+# ABSENCE ALONE IS NOT THE BAR. A reader that stopped reading `process.env` and
+# whose caller never started passing the value is not wired — it runs on its
+# `?? default` forever, and an absence-only check goes green on exactly that
+# state. So clause 4 asserts ARRIVAL: each value must be handed down from the
+# ONE validated parse, at the call site that reaches the reader.
+#
+# ---------------------------------------------------------------------------
+# The four readers, and what "wired" means for each
+# ---------------------------------------------------------------------------
+# Measured on origin/main a80484b:
+#
+#   server/tools/search-engine.ts:124-125
+#     `searchEmbeddingTimeoutMs()` reads OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS
+#     then SEARCH_EMBEDDING_TIMEOUT_MS. `server/config/env-groups.ts:289`
+#     already parses both into `SearchConfigGroup.embeddingTimeoutMs`, exposed
+#     as `config.search` (`server/config.ts:236,359`).
+#
+#   server/tools/shared-namespace.ts:37,45,52
+#     `sharedNamespaceConfig()` re-derives five values from the environment on
+#     every call. `server/config/env-groups.ts:333` (`sharedNamespaceGroup`)
+#     already parses the identical name list into the identical shape, exposed
+#     as `config.sharedNamespaceNames` (`server/config.ts:245,363`).
+#
+#   server/tools/search-all.ts:124
+#     `resolveQmdPath(env = process.env)` already TAKES an env parameter and
+#     defaults it to `process.env`. A default parameter is the doubled state in
+#     miniature: it looks injected and behaves like a direct read for every
+#     caller that omits the argument. The default goes away, callers pass.
+#
+#   server/observability/trace-config.ts:33
+#     `readMcpTracingConfig(env = process.env)` has the same shape. Its only
+#     non-test callers are `server/observability/langfuse-tracing.ts:402,506`,
+#     both of which call it with no argument.
+#
+# ---------------------------------------------------------------------------
+# WHY CLAUSE 3 EXISTS — the vacuous-pass problem
+# ---------------------------------------------------------------------------
+# The natural check is "rg finds no `process.env` in these files", and that
+# assertion passes for two very different reasons: because the reads are gone,
+# or because the scan examined nothing. A renamed file, a typo in a path, an
+# `rg` that is not on PATH, a bad `--glob` — every one produces a silent clean
+# sweep and an exit 0 that means nothing. So the check proves the scanner can
+# still see a hit somewhere it MUST see one.
+#
+# Four clauses, and all four must pass:
+#
+# CLAUSE 1 — ALL FOUR TARGET FILES EXIST.
+#   Each path is `test -f`'d individually and named in the output. A renamed or
+#   deleted file makes clause 2 vacuous, so it fails loudly here instead.
+#
+# CLAUSE 2 — NONE OF THEM READS `process.env`.
+#   `rg -n 'process\.env' <four files>` must produce no output. Any match is
+#   printed, so a failure names the file and line instead of just refusing.
+#
+# CLAUSE 3 — THE SCANNER IS PROVEN TO MATCH.
+#   `rg -c 'process\.env' server/config.ts` must be > 0. That file is the
+#   composition root's own env reader: the one file in `server/` that MUST read
+#   the environment, because it is the boundary the charter puts the parsing
+#   behind. If the same pattern, tool, and invocation find nothing THERE, the
+#   clean result in clause 2 is a broken scan, not a clean tree. Deliberately
+#   pointed at a file this lane does not touch and no future lane should empty.
+#
+# CLAUSE 4 — THE VALUES ARRIVE AT THEIR CALL SITES.
+#   Four anchored fixed-string patterns, each matching EXACTLY once: 0 means
+#   unwired, >1 means two composition paths that can disagree, which is the
+#   doubled state this rung exists to end. Each pattern names the field
+#   spelling that already exists in `ServerConfig`, so a rewiring lane adds the
+#   call-site line and nothing else. See the ARRIVALS list below for the
+#   per-pattern contract.
+#
+# CLAUSE 5 IS DELIBERATELY ABSENT.
+#   L2b-1 carries a fifth clause that RUNS `server/tools/dependency-arrival.test.ts`
+#   and asserts observable behavior at the far end. That clause is only writable
+#   because the test file name was decided before the check was. No arrival-test
+#   file name is decided for L2b-2, and inventing one here would assert against
+#   a path no lane has agreed to create — a clause that can only ever fail is
+#   not a gate, it is a typo waiting to be edited out.
+#
+#   Arrival for this rung is therefore proven by clause 4 PLUS the rewiring
+#   lanes' own tests: each of the four rewirings is a signature change, so its
+#   own lane must ship a test that passes a value in and observes it come out,
+#   and that test is reviewed with the change that needs it. If a later lane
+#   does settle on one exercising test file for all four, growing this script a
+#   clause 5 in the L2b-1 shape is the right follow-up.
+#
+# Exit 0 only when all four clauses pass. Exit 3 is a harness error (missing
+# tool / wrong repo root), which is NOT a fail of the thing under test.
+#
+# NO ARGUMENTS. Every input comes from the tree at $REPO_ROOT. A check that
+# takes a path can be pointed at a tree where it passes, which makes its green
+# a statement about the caller rather than about the repo.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v rg >/dev/null 2>&1 || fail_hard "rg (ripgrep) not on PATH"
+[ -d "$REPO_ROOT/.git" ] || [ -f "$REPO_ROOT/.git" ] || fail_hard "not a git repo at $REPO_ROOT"
+
+# The four readers this lane rewires. Listed literally rather than globbed: a
+# glob that stops matching is exactly the vacuous pass clause 3 guards against,
+# and naming them makes a rename fail loudly in clause 1.
+TARGETS="server/tools/search-engine.ts
+server/tools/shared-namespace.ts
+server/tools/search-all.ts
+server/observability/trace-config.ts"
+
+# The positive control: the composition root's OWN env reader, which must keep
+# reading `process.env` for the boundary to exist at all.
+CONTROL="server/config.ts"
+
+CLAUSE1=FAIL; CLAUSE1_EVIDENCE=""
+CLAUSE2=FAIL; CLAUSE2_EVIDENCE=""
+CLAUSE3=FAIL; CLAUSE3_EVIDENCE=""
+CLAUSE4=FAIL; CLAUSE4_EVIDENCE=""
+
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — every target file is present.
+# ---------------------------------------------------------------------------
+MISSING=""
+N_TARGETS=0
+while IFS= read -r t; do
+  [ -n "$t" ] || continue
+  N_TARGETS=$((N_TARGETS + 1))
+  [ -f "$REPO_ROOT/$t" ] || MISSING="${MISSING}${t} "
+done <<EOF
+$TARGETS
+EOF
+
+if [ "$N_TARGETS" -ne 4 ]; then
+  CLAUSE1_EVIDENCE="expected 4 target paths, the list yielded $N_TARGETS — the check itself is miswritten"
+elif [ -n "$MISSING" ]; then
+  CLAUSE1_EVIDENCE="target file(s) NOT found: ${MISSING}— a scan over missing files passes vacuously"
+else
+  CLAUSE1=PASS
+  CLAUSE1_EVIDENCE="all 4 target files present under $REPO_ROOT"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 2 — none of the four reads process.env.
+# ---------------------------------------------------------------------------
+if [ "$CLAUSE1" != PASS ]; then
+  CLAUSE2_EVIDENCE="skipped — target files are not all present, so any result is vacuous"
+else
+  # Build the argument list from the same literal set clause 1 verified.
+  set --
+  while IFS= read -r t; do
+    [ -n "$t" ] || continue
+    set -- "$@" "$REPO_ROOT/$t"
+  done <<EOF
+$TARGETS
+EOF
+
+  HITS="$(cd "$REPO_ROOT" && rg -n 'process\.env' "$@" 2>/dev/null)"
+  RG_STATUS=$?
+  # rg exits 1 for "no matches" (the pass) and 2 for a real error. A 2 is a
+  # harness problem, not a clean tree, and must not be read as success.
+  if [ "$RG_STATUS" -ge 2 ]; then
+    fail_hard "rg failed with status $RG_STATUS scanning the four target files"
+  fi
+
+  if [ -n "$HITS" ]; then
+    CLAUSE2_EVIDENCE="$(printf '%s\n' "$HITS" | wc -l | tr -d ' ') process.env read(s) remain:"
+    CLAUSE2_HITS="$HITS"
+  else
+    CLAUSE2=PASS
+    CLAUSE2_EVIDENCE="no process.env read in any of the 4 files — each value now arrives from validated config"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 3 — positive control: the scanner still finds a known hit.
+# ---------------------------------------------------------------------------
+if [ ! -f "$REPO_ROOT/$CONTROL" ]; then
+  CLAUSE3_EVIDENCE="positive control $CONTROL does not exist — cannot prove the scan matches anything"
+else
+  CONTROL_COUNT="$(cd "$REPO_ROOT" && rg -c 'process\.env' "$CONTROL" 2>/dev/null)"
+  CONTROL_COUNT="${CONTROL_COUNT:-0}"
+  if [ "$CONTROL_COUNT" -gt 0 ]; then
+    CLAUSE3=PASS
+    CLAUSE3_EVIDENCE="$CONTROL still contains $CONTROL_COUNT process.env line(s) — the pattern, tool, and invocation are proven to match"
+  else
+    CLAUSE3_EVIDENCE="$CONTROL contains ZERO process.env lines — either the composition root stopped reading the environment, or this scan is broken and clause 2's clean result is meaningless"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 4 — the values ARRIVE at their call sites.
+# ---------------------------------------------------------------------------
+# Each entry is `<file>|<fixed-string pattern>`. `rg -F` so the pattern is read
+# literally, and the count must be exactly 1: 0 is unwired, >1 is two
+# composition paths. Every `config.` spelling below already exists on
+# origin/main a80484b, so a rewiring lane adds the call-site line and does not
+# have to invent a config field first:
+#
+#   (a) server/main.ts  `searchEmbeddingTimeoutMs: config.search.embeddingTimeoutMs`
+#       TO SATISFY: add a `searchEmbeddingTimeoutMs?: number` field to
+#       `MemoryToolDependencies` (server/tools/types.ts), have
+#       `searchEmbeddingTimeoutMs()` in search-engine.ts take it as a parameter
+#       instead of reading the env, and write this line into the dependencies
+#       literal in server/main.ts (alongside `ftsCorpusConfig:` at :184).
+#       `config.search.embeddingTimeoutMs` is server/config/env-groups.ts:227,
+#       exposed as `ServerConfig.search` at server/config.ts:236,359.
+#
+#   (b) server/main.ts  `sharedNamespaceNames: config.sharedNamespaceNames`
+#       TO SATISFY: add a `sharedNamespaceNames?: SharedNamespaceGroup` field to
+#       `MemoryToolDependencies`, have `sharedNamespaceConfig()` take the group
+#       rather than re-deriving it, and write this line into the dependencies
+#       literal in server/main.ts. NOTE the spelling: the brief proposed
+#       `sharedNamespaceEnv: config.sharedNamespace`, and `config.sharedNamespace`
+#       is NOT that value — server/config.ts:235 declares it as the literal type
+#       `"shared-kb"`, the canonical NAME only. The parsed five-field group is
+#       `config.sharedNamespaceNames` (server/config.ts:245,363, built by
+#       `sharedNamespaceGroup` at server/config/env-groups.ts:333), whose shape
+#       already matches `SharedNamespaceConfig` field for field. Asserting the
+#       proposed spelling would have gated on a value that cannot carry the
+#       legacy names, the fallback flag, or the minimum result count.
+#
+#   (c) server/main.ts  `searchAllEnv:`
+#       TO SATISFY: drop the `= process.env` default from `resolveQmdPath`
+#       (server/tools/search-all.ts:124), add a `searchAllEnv` field to
+#       `MemoryToolDependencies` carrying the env slice that supplies `QMD_PATH`,
+#       and write it into the dependencies literal in server/main.ts. The
+#       pattern is the field name plus its colon, so the lane picks the source
+#       expression; what it may not do is leave the parameter defaulted, because
+#       a defaulted parameter reads as injected and behaves as a direct read.
+#
+#   (d) server/observability/langfuse-tracing.ts  `readMcpTracingConfig(config.`
+#       TO SATISFY: drop the `= process.env` default from `readMcpTracingConfig`
+#       (server/observability/trace-config.ts:33) and pass the validated group at
+#       its only two non-test call sites (langfuse-tracing.ts:402,506, both
+#       currently `readMcpTracingConfig()` with no argument).
+#       `ServerConfig.tracing` is server/config.ts:246,367, built by
+#       `tracingGroup` at server/config/env-groups.ts:359. The count of exactly 1
+#       is deliberate even though there are two call sites: the two must resolve
+#       through ONE shared `deps.config ?? …` expression rather than each
+#       building its own, which is the same "two composition paths" defect the
+#       exact-1 rule catches everywhere else in this file.
+ARRIVALS="server/main.ts|searchEmbeddingTimeoutMs: config.search.embeddingTimeoutMs
+server/main.ts|sharedNamespaceNames: config.sharedNamespaceNames
+server/main.ts|searchAllEnv:
+server/observability/langfuse-tracing.ts|readMcpTracingConfig(config."
+
+ARRIVAL_BAD=""
+ARRIVAL_OK=0
+N_ARRIVALS=0
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  N_ARRIVALS=$((N_ARRIVALS + 1))
+  a_file="${entry%%|*}"
+  a_pat="${entry#*|}"
+  if [ ! -f "$REPO_ROOT/$a_file" ]; then
+    ARRIVAL_BAD="${ARRIVAL_BAD}
+    MISSING FILE $a_file (for: $a_pat)"
+    continue
+  fi
+  a_count="$(cd "$REPO_ROOT" && rg -cF -- "$a_pat" "$a_file" 2>/dev/null)"
+  a_count="${a_count:-0}"
+  if [ "$a_count" -eq 1 ]; then
+    ARRIVAL_OK=$((ARRIVAL_OK + 1))
+  else
+    ARRIVAL_BAD="${ARRIVAL_BAD}
+    $a_file: found $a_count, expected 1 — \"$a_pat\""
+  fi
+done <<EOF
+$ARRIVALS
+EOF
+
+if [ "$N_ARRIVALS" -ne 4 ]; then
+  CLAUSE4_EVIDENCE="expected 4 arrival assertions, the list yielded $N_ARRIVALS — the check itself is miswritten"
+elif [ -n "$ARRIVAL_BAD" ]; then
+  CLAUSE4_EVIDENCE="$ARRIVAL_OK/4 values arrive; the rest are not wired:${ARRIVAL_BAD}"
+else
+  CLAUSE4=PASS
+  CLAUSE4_EVIDENCE="all 4 values are passed exactly once from validated config"
+fi
+
+printf 'CLAUSE 1 (all 4 target files exist):                    %s — %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+printf 'CLAUSE 2 (no process.env in any of the 4):              %s — %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+if [ "$CLAUSE2" != PASS ] && [ -n "${CLAUSE2_HITS:-}" ]; then
+  printf '%s\n' "$CLAUSE2_HITS" | sed 's/^/    /'
+fi
+printf 'CLAUSE 3 (scanner proven to match in %s):   %s — %s\n' "$CONTROL" "$CLAUSE3" "$CLAUSE3_EVIDENCE"
+printf 'CLAUSE 4 (values arrive from validated config):         %s — %s\n' "$CLAUSE4" "$CLAUSE4_EVIDENCE"
+
+if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ] && [ "$CLAUSE4" = PASS ]; then
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary

- Adds `scripts/done-means/750-l2b2-env-readers-take-config.sh`, the acceptance gate for lane L2b-2 of the server hardening ladder (#825): the four remaining `process.env` readers that L2a (#778) already typed into `ServerConfig` groups but nothing consults — `server/tools/search-engine.ts`, `server/tools/shared-namespace.ts`, `server/tools/search-all.ts`, `server/observability/trace-config.ts`. Two of those are the pair L2b-1 explicitly deferred behind the lint-debt ruling.
- **This PR is expected RED (exit 1) by design. The RED receipt is the deliverable.** The check is written before the rewiring, so its failure output is what proves it can distinguish the unwired state from the wired one. It goes green only when all four rewirings land in their own lanes.
- Modelled clause for clause on `scripts/done-means/750-l2b1-tool-readers-take-config.sh`: same `fail_hard`, same `REPO_ROOT` resolution, same no-argv contract (inputs come from the tree, never from `$1` — a check that takes a path can be pointed at a tree where it passes), same positive control on `server/config.ts` so a broken scan cannot read as a clean tree.
- Clause 4 is the part that matters. Absence of `process.env` proves a reader stopped guessing; it does not prove anyone started telling it. A reader that took a parameter no caller supplies runs on its `?? default` forever, and an absence-only check goes green on exactly that state. Clause 4 asserts each value arrives exactly once from the validated parse — 0 is unwired, more than 1 is two composition paths that can disagree.
- Every `config.` spelling clause 4 names already exists on `origin/main` a80484b, and each carries a one-line comment saying what a rewiring lane must add. Two recon corrections to the proposed patterns are recorded in the script's own comments: the shared-namespace arrival is `config.sharedNamespaceNames` (the parsed five-field group from `sharedNamespaceGroup`, `server/config/env-groups.ts:333`, exposed at `server/config.ts:245,363`), **not** `config.sharedNamespace`, which `server/config.ts:235` declares as the literal type `"shared-kb"` — the canonical name only, unable to carry the legacy names, the fallback flag, or the minimum result count; and the `readMcpTracingConfig` arrival is asserted in `server/observability/langfuse-tracing.ts`, which holds the only two non-test call sites (`:402`, `:506`), not in `server/main.ts`.
- Clause 5 is deliberately absent and the header says so and why. L2b-1's fifth clause runs a named arrival test, which is only writable because that test file name was decided before the check was. No such name is decided for L2b-2, and a clause asserting a path no lane has agreed to create can only ever fail — that is a typo waiting to be edited out, not a gate. Arrival for this rung is proven by clause 4 plus each rewiring lane's own test, reviewed alongside the signature change that needs it.
- Adds a second, permanent script `scripts/done-means/750-l2b2-check-well-formed.sh` (1029fab). It runs the env-readers check, captures its output and exit code, and passes only when that check is well-formed: it reached a real verdict (exit 0 or 1; anything else is a harness error, because a check that did not run cannot be judged by its output), printed exactly one `CLAUSE 1` line saying PASS (targets exist, without which every later inner clause is vacuous), exactly one `CLAUSE 3` line saying PASS (the positive control, which separates a clean tree from a broken scanner), and returned an exit code consistent with its state clauses — exit 0 demands `CLAUSE 2` and `CLAUSE 4` both PASS, exit 1 demands at least one FAIL. Nothing in it has to be edited out when the rewirings land: today the inner check exits 1 with two red state clauses and this passes; afterwards it exits 0 with every clause green and this still passes.
- Scope is the two new scripts. No `server/` file is touched, no existing done-means script is edited, no behavior changes.

## Verification

- Done-means: scripts/done-means/750-l2b2-check-well-formed.sh
- The env-readers check is RED by design at this head — it asserts the state four later rewiring PRs will create — and since `scripts/verify-lane.ts` refuses to post a receipt for a done-means that exits non-zero, the well-formed check added in 1029fab is what receipts this PR: it runs the env-readers check and passes only when that check reached a real verdict, printed exactly one green structural clause and one green positive control, and returned an exit code that agrees with the state clauses it printed.
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bash scripts/done-means/750-l2b2-env-readers-take-config.sh` on the committed tree exits 1, which is the intended state for this PR:

```
CLAUSE 1 (all 4 target files exist):                    PASS — all 4 target files present
CLAUSE 2 (no process.env in any of the 4):              FAIL — 7 process.env read(s) remain:
    server/observability/trace-config.ts:33:  env: Record<string, string | undefined> = process.env,
    server/tools/search-all.ts:124:  env: Record<string, string | undefined> = process.env,
    server/tools/shared-namespace.ts:37:    const raw = process.env[name]?.trim();
    server/tools/shared-namespace.ts:45:  const raw = process.env[name];
    server/tools/shared-namespace.ts:52:  const raw = process.env[name];
    server/tools/search-engine.ts:124:    process.env.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS ??
    server/tools/search-engine.ts:125:    process.env.SEARCH_EMBEDDING_TIMEOUT_MS;
CLAUSE 3 (scanner proven to match in server/config.ts): PASS — 4 process.env line(s)
CLAUSE 4 (values arrive from validated config):         FAIL — 0/4 values arrive
    server/main.ts: found 0, expected 1 — "searchEmbeddingTimeoutMs: config.search.embeddingTimeoutMs"
    server/main.ts: found 0, expected 1 — "sharedNamespaceNames: config.sharedNamespaceNames"
    server/main.ts: found 0, expected 1 — "searchAllEnv:"
    server/observability/langfuse-tracing.ts: found 0, expected 1 — "readMcpTracingConfig(config."
```

Clauses 1 and 3 PASS while 2 and 4 FAIL is the diagnostic shape that matters: the scanner is proven to see a hit where one must exist (clause 3), so clause 2's failure is a real finding about the tree and not a broken scan. A check whose failure could equally mean "nothing was examined" is worth nothing.

Other checks on the committed tree:

- `bash -n scripts/done-means/750-l2b2-env-readers-take-config.sh` → clean.
- `shellcheck scripts/done-means/750-l2b2-env-readers-take-config.sh` → exit 0, no findings.
- `bunx tsc --noEmit` → clean, no output. No TypeScript is touched by this PR.
- oxlint and `bun run test:isolated` are not applicable: the only file added is a shell script, no `.ts` file is added or modified, and no existing test's subject changes. Running the suite here would prove something about `origin/main`, not about this change.

## Critical Self-Review

- Highest-risk behavior: clause 4's fixed-string patterns. `rg -cF` on a literal is brittle by construction — a rewiring lane that writes the same wiring with different whitespace or through an intermediate variable satisfies the intent and fails the check. That is a deliberate trade: a loose pattern (`rg 'config\.search'`) matches an unrelated line and goes green on nothing. The mitigation is that each pattern carries a comment naming exactly what to add, so the contract is readable rather than guessable, and every `config.` spelling was verified to exist on a80484b rather than invented.
- Assumptions that could be wrong: (1) that `sharedNamespaceGroup`'s shape is a drop-in for `SharedNamespaceConfig` — the five fields line up name for name at `server/config/env-groups.ts:333-347` against `server/tools/shared-namespace.ts:58-70`, but the precedence inside `envString` versus the group's `??` chain is a behavior detail a rewiring lane must diff, not assume. (2) That `searchAllEnv` is the right shape for the `QMD_PATH` value — the pattern is only the field name plus its colon precisely because that source expression is the rewiring lane's call, not this check's. (3) That `readMcpTracingConfig` has exactly two non-test callers: verified this session with `rg -n 'readMcpTracingConfig\(' server --glob '!*.test.ts'`, which returned the definition plus `:402` and `:506`.
- Missing/weak tests: this script has no test of its own, and its RED output at a80484b is the only evidence it can fail. It is not yet proven it can go GREEN — no tree exists where all four rewirings have landed. The first rewiring lane to turn a clause green is what establishes that, and if it turns out the check cannot go green for a reason other than missing work, that is a defect in this script to fix there.
- Security/permission risk: none. The script reads files with `rg` and writes nothing; it runs no network call, spawns no subprocess other than `rg`, and takes no argument that could steer it at a path outside the repo.
- Migration/deploy risk: none. Nothing ships; no runtime code, schema, or config is touched.
- Downstream client/runtime risk: none. No MCP tool, transport, schema, or Python client surface changes, so `docs/downstream-rollout.md` classification is not applicable. The four rewiring lanes this gates DO touch the search and tracing paths and will each need that classification on their own.
- Rollback/cleanup concern: reverting is deleting one file. No other script, workflow, or CI job references it yet.
- Fixes made before PR: two arrival patterns were corrected against the tree rather than accepted as briefed. `sharedNamespaceEnv: config.sharedNamespace` would have gated on the canonical name literal instead of the parsed group; `readMcpTracingConfig(config.` was to be asserted in `server/main.ts`, which contains no call site at all, so the clause would have been unsatisfiable by any correct rewiring.
- Known residual risk: clause 4's exact-1 count on `readMcpTracingConfig(config.` requires the two call sites in `langfuse-tracing.ts` to resolve through one shared expression. That is the intended design — two independently-built configs is the doubled state this rung ends — but it constrains the rewiring lane's shape, and if review there concludes two call sites genuinely need two expressions, this count is what must be revisited, in the open, rather than worked around.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new defect class surfaced. The one lesson here — that a check written from a brief's proposed patterns must verify each spelling against the tree before asserting it, or it gates on a value that cannot carry the data — is the vacuous-pass pattern `docs/sme/` already records, applied to arrival patterns rather than absence scans.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime code, tool schema, or database surface is touched; the change is one shell script that reads the tree.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, tool schema, or wire shape changes — nothing for a fixture to record.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All four are not applicable. The classification in `docs/downstream-rollout.md` keys on MCP tool, schema, protocol, or client-facing changes; this PR adds a repo-local acceptance check and modifies no client-visible surface. The rewiring lanes it gates will each need their own classification, since `search-engine.ts` and `search-all.ts` sit on the search path.

