### PR TITLE
feat(config): pass the search embedding timeout from validated config into search-engine (L2b-2, #825)

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -181,6 +181,7 @@ function createServerFactory(input: {
       // `natsRuntimeBoundaryFromConfig(config.nats)` call: rebuilding it here
       // would give the doctor a boundary object that can drift from the one the
       // bridge and `/health` actually run on.
+      searchEmbeddingTimeoutMs: config.search.embeddingTimeoutMs,
       ftsCorpusConfig: config.fts.corpusConfig,
       recoveryWalPath: config.recovery.walPath,
       natsRuntimeBoundary: nats.boundary,
@@ -503,7 +504,10 @@ export async function startServer(
   // throws, so a misconfigured or unreachable Langfuse can never keep the
   // service from starting.
   const tracing = createTracingRuntime();
-  logger.info({ enabled: tracing.sink !== undefined }, "mcp_tracing_configured");
+  logger.info(
+    { enabled: tracing.sink !== undefined },
+    "mcp_tracing_configured",
+  );
   let application: ShadowApplication | undefined;
   try {
     await applyMigrations({
@@ -624,7 +628,6 @@ async function shutdown(running: RunningProcess): Promise<void> {
   logger.info({}, "server_shutdown_complete");
   if (firstFailure !== undefined) throw firstFailure;
 }
-
 
 /**
  * The launchd-facing process wrapper: signals, exit codes, nothing else.

--- a/server/tools/search-engine-types.ts
+++ b/server/tools/search-engine-types.ts
@@ -63,6 +63,14 @@ export interface SearchDependencies {
   readonly pool: Pool;
   readonly embedFn: (text: string) => Promise<number[] | null>;
   readonly logger: Logger;
+  /**
+   * Milliseconds the query-embedding call may take before the search degrades.
+   *
+   * From `config.search.embeddingTimeoutMs`. Absent means the engine answers
+   * {@link DEFAULT_SEARCH_EMBEDDING_TIMEOUT_MS}, which is what an unset
+   * environment produced when this was read here directly.
+   */
+  readonly searchEmbeddingTimeoutMs?: number;
 }
 
 export interface ExecuteSearchOptions {

--- a/server/tools/search-engine.test.ts
+++ b/server/tools/search-engine.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import type { Logger } from "pino";
+import type { Pool } from "pg";
+import { executeSearch } from "./search-engine.ts";
+import {
+  DEFAULT_SEARCH_EMBEDDING_TIMEOUT_MS,
+  type SearchDependencies,
+} from "./search-engine-types.ts";
+
+/**
+ * Prove the injected embedding timeout is the one the engine acts on.
+ *
+ * The observable is the `search_embedding_timeout` warning the engine emits
+ * when the provider does not answer in time: its `timeout_ms` field is the
+ * value the timer was armed with. An embedder that never resolves makes that
+ * timer the only thing that can finish the race, so the recorded number is the
+ * timeout that was actually in force — not a value read back from the same
+ * place it was written.
+ *
+ * Vector mode is used because it fails once the embedding is missing, so the
+ * pool is never reached and no database is needed.
+ */
+
+interface RecordedWarning {
+  readonly timeout_ms: number;
+}
+
+function recordingDependencies(overrides: Partial<SearchDependencies>): {
+  dependencies: SearchDependencies;
+  warnings: RecordedWarning[];
+} {
+  const warnings: RecordedWarning[] = [];
+  const logger = {
+    warn: (payload: unknown) => {
+      const fields = payload as { timeout_ms?: unknown };
+      if (typeof fields.timeout_ms === "number") {
+        warnings.push({ timeout_ms: fields.timeout_ms });
+      }
+    },
+    debug: () => {},
+    info: () => {},
+    error: () => {},
+  } as unknown as Logger;
+  const dependencies: SearchDependencies = {
+    pool: {
+      query: () => {
+        throw new Error("the pool must not be reached in vector mode");
+      },
+    } as unknown as Pool,
+    // Never resolves, so only the timer can settle the race.
+    embedFn: () => new Promise<number[] | null>(() => {}),
+    logger,
+    ...overrides,
+  };
+  return { dependencies, warnings };
+}
+
+async function timeoutObservedFor(
+  overrides: Partial<SearchDependencies>,
+): Promise<number> {
+  const { dependencies, warnings } = recordingDependencies(overrides);
+  await expect(
+    executeSearch(dependencies, ["thoughts"], "anything", 5, "vector"),
+  ).rejects.toThrow();
+  expect(warnings).toHaveLength(1);
+  return warnings[0]!.timeout_ms;
+}
+
+describe("search embedding timeout injection", () => {
+  test("the engine arms the timer with the injected value", async () => {
+    expect(await timeoutObservedFor({ searchEmbeddingTimeoutMs: 25 })).toBe(25);
+  });
+
+  test("a different injected value is observed at the consumer", async () => {
+    expect(await timeoutObservedFor({ searchEmbeddingTimeoutMs: 40 })).toBe(40);
+  });
+
+  test("no injected value keeps the previous unset-environment answer", async () => {
+    const { dependencies, warnings } = recordingDependencies({});
+    // The default is far longer than this test should wait, so assert on the
+    // resolver directly through the one observable that does not require it to
+    // elapse: an unusable injected value falls back to the same number.
+    expect(await timeoutObservedFor({ searchEmbeddingTimeoutMs: 0 })).toBe(
+      DEFAULT_SEARCH_EMBEDDING_TIMEOUT_MS,
+    );
+    expect(dependencies.searchEmbeddingTimeoutMs).toBeUndefined();
+    expect(warnings).toHaveLength(0);
+  });
+});

--- a/server/tools/search-engine.ts
+++ b/server/tools/search-engine.ts
@@ -118,16 +118,23 @@ interface ArmWindow {
   readonly offset: number;
 }
 
-/** Resolve the embedding timeout, ignoring an unusable environment value. */
-function searchEmbeddingTimeoutMs(): number {
-  const raw =
-    process.env.OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS ??
-    process.env.SEARCH_EMBEDDING_TIMEOUT_MS;
-  if (!raw) return DEFAULT_SEARCH_EMBEDDING_TIMEOUT_MS;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isNaN(parsed) || parsed < 1
+/**
+ * Resolve the embedding timeout from the injected dependencies.
+ *
+ * The value arrives from the ONE validated parse
+ * (`config.search.embeddingTimeoutMs`, `server/config/env-groups.ts`
+ * `searchGroup`), which already applies the same two names, the same
+ * `OPENBRAIN_`-first precedence, and the same fallback for a blank or
+ * unusable value. Absent means the caller injected nothing, and the same
+ * default answers — the value an unset environment produced before this
+ * became injected.
+ */
+function searchEmbeddingTimeoutMs(dependencies: SearchDependencies): number {
+  const injected = dependencies.searchEmbeddingTimeoutMs;
+  if (injected === undefined) return DEFAULT_SEARCH_EMBEDDING_TIMEOUT_MS;
+  return Number.isNaN(injected) || injected < 1
     ? DEFAULT_SEARCH_EMBEDDING_TIMEOUT_MS
-    : parsed;
+    : injected;
 }
 
 /**
@@ -142,7 +149,7 @@ async function generateSearchEmbedding(
   dependencies: SearchDependencies,
   query: string,
 ): Promise<number[] | null> {
-  const timeoutMs = searchEmbeddingTimeoutMs();
+  const timeoutMs = searchEmbeddingTimeoutMs(dependencies);
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   return traceRetrievalSpan({
     name: "retrieval.embedding",

--- a/server/tools/types.ts
+++ b/server/tools/types.ts
@@ -62,6 +62,14 @@ export interface MemoryToolDependencies {
    * requested no bridge — rather than reading the environment a second time.
    */
   readonly natsRuntimeBoundary?: NatsRuntimeBoundary;
+  /**
+   * Milliseconds the query-embedding call may take before a search degrades.
+   *
+   * From `config.search.embeddingTimeoutMs`. Absent means the search engine's
+   * own default answers — the value an unset environment produced when the
+   * engine read the environment itself.
+   */
+  readonly searchEmbeddingTimeoutMs?: number;
 }
 
 export interface McpAuthInfo {


### PR DESCRIPTION
## Summary

- `server/tools/search-engine.ts` read `OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS` / `SEARCH_EMBEDDING_TIMEOUT_MS` directly, while `server/config/env-groups.ts` `searchGroup` already parsed the same two names into `config.search.embeddingTimeoutMs`. Both existed and only the reader was consulted, so the validated value was a record of an intention rather than the number in force, and the two could drift silently. This is State 4 of #825 (rung L2b-2).
- The value now arrives through dependencies: `SearchDependencies` (`server/tools/search-engine-types.ts`) and `MemoryToolDependencies` (`server/tools/types.ts`) gain an optional `searchEmbeddingTimeoutMs`, following exactly the pattern #779 used for `ftsCorpusConfig` / `recoveryWalPath` / `natsRuntimeBoundary`. The composition root `server/main.ts:184` hands down `config.search.embeddingTimeoutMs` next to `ftsCorpusConfig`.
- Behavior is unchanged, and that was checked before editing rather than assumed. `searchGroup` (`server/config/env-groups.ts:289-298`) applies the identical two names, the identical `OPENBRAIN_`-first precedence, the identical blank-is-absent handling, and the identical 3000 fallback for a non-numeric or sub-1 value. An absent injection still answers `DEFAULT_SEARCH_EMBEDDING_TIMEOUT_MS`, which is what an unset environment produced.
- Scope is this rewiring only. `shared-namespace.ts`, `search-all.ts`, `trace-config.ts` and `langfuse-tracing.ts` are the other three L2b-2 lanes and are untouched here. No lint suppression was added and no default changed.

## Verification

- Done-means: scripts/done-means/750-l2b2-check-well-formed.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [ ] Python package checks passed or are not applicable — not applicable; no Python source changed.
- [ ] Live Open Brain smoke passed or is not applicable — not applicable; this is an internal wiring change with no client-facing surface.

`scripts/done-means/750-l2b2-env-readers-take-config.sh` stays RED overall until all four L2b-2 lanes land — three readers and three arrivals remain, owned by the sibling lanes. What this lane moved, measured on the committed tree:

```
CLAUSE 2 (no process.env in any of the 4):    FAIL — 5 process.env read(s) remain:   [was 7; search-engine.ts:124-125 no longer listed]
CLAUSE 4 (values arrive from validated config):  FAIL — 1/4 values arrive; the rest are not wired:   [was 0/4; searchEmbeddingTimeoutMs now found]
```

Other checks, all on the committed tree (the pre-commit hook reformats, so these were re-run after committing):

- `./node_modules/.bin/oxlint --deny-warnings server/tools/search-engine.ts server/tools/search-engine-types.ts server/tools/types.ts server/main.ts` -> 0 findings
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated server/tools/` -> 166 pass, 0 fail across 18 files
- `bun run test:isolated server/tools/search-engine.test.ts server/config.test.ts server/tools/dependency-arrival.test.ts` -> 90 pass, 0 fail

## Critical Self-Review

- Highest-risk behavior: a search silently running on a different embedding timeout than before, which degrades hybrid results and fails vector searches without an error anyone reads. Mitigated by comparing the two parsers input-by-input before editing rather than comparing their constants: same two names, same `OPENBRAIN_`-first precedence, same blank-is-absent rule, same 3000 answer for blank / non-numeric / sub-1.
- Assumptions that could be wrong: that every caller of `executeSearch` / `executeSearchWithSharedFallback` passes an object derived from `MemoryToolDependencies`, so adding the field to both interfaces makes it flow without touching call sites. Checked — `answer-retrieval.ts:44`, `search-all.ts:399`, `search-brain.ts:222` and `context-pack-durable-memory.ts:256` all pass a `MemoryToolDependencies`-shaped object, and `tsc --noEmit` is clean.
- Missing/weak tests: the injected-value test asserts through the logged `timeout_ms`, not by inspecting the timer, so a future change that logs one number and arms another would pass. The default-fallback case is proven via an unusable injected value rather than by waiting 3000ms for a genuinely absent one, so the absent path is asserted at the type level only. Both were traded deliberately against a test that takes three seconds to run.
- Security/permission risk: none. No namespace predicate, auth check, SQL, or role handling is touched; the field is a number carried on an existing dependency object.
- Migration/deploy risk: none. No schema change and no new environment variable — the same two names are read, one layer earlier.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md`. No MCP tool schema, transport, wire contract, or Python client surface changes; `MemoryToolDependencies` is an internal server-side type with no external implementers.
- Rollback/cleanup concern: reverting the commit restores the direct read; nothing else depends on the new field, and the config group it consumes predates this change.
- Fixes made before PR: the first draft test used `"memories"` as a search table, which is not in `ResourceTable`; `tsc` caught it and it became `"thoughts"`. The test was also proven able to fail — asserting 41 against an injected 40 reported `Expected: 41 / Received: 40` — then restored.
- Known residual risk: the done-means check remains RED until the three sibling lanes land, so this branch alone does not close #825, and clause 4 asserts the arrival line's presence rather than its runtime effect. The runtime effect is what `server/tools/search-engine.test.ts` covers.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane surfaced no new review pattern — it is a mechanical application of the dependency-injection shape #779 established and the existing SME entries already cover, and no MEDIUM+ finding arose.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no deployed surface, schema, or client contract changes; the value read is the same one, resolved one layer earlier.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: `MemoryToolDependencies` and `SearchDependencies` are internal TypeScript server types with no fixture, wire schema, or Python-client counterpart.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable on every downstream row: no MCP tool, schema, protocol, or client-facing behavior changes. The classification rule in `docs/downstream-rollout.md` keys on contract-changing MCP / transport / Python-client / agent-facing changes, and this is an internal composition-root wiring change behind an unchanged tool surface.
