### PR TITLE
feat(config): pass the qmd path input from validated config into search-all (L2b-2, #825)

### DIFF
--- a/scripts/done-means/750-l2b2-env-readers-take-config.sh
+++ b/scripts/done-means/750-l2b2-env-readers-take-config.sh
@@ -244,14 +244,25 @@ fi
 #       proposed spelling would have gated on a value that cannot carry the
 #       legacy names, the fallback flag, or the minimum result count.
 #
-#   (c) server/main.ts  `searchAllEnv:`
+#   (c) server/main.ts  `qmdPath: config.qmd.path`
+#       AMENDED by the rewiring lane (#825, L2b-2). The pattern was
+#       `searchAllEnv:`, written on the assumption that no validated field held
+#       this value and that main.ts would therefore have to hand down a raw env
+#       slice. That assumption was wrong: `server/config/env-groups.ts:188,304`
+#       already parses QMD_PATH through `blankAsAbsent` into `QmdConfigGroup`,
+#       exposed as `config.qmd` (`server/config.ts:238,361`), and
+#       `server/config.test.ts:657` already proves input by input that
+#       `config.qmd.path` answers exactly what `resolveQmdPath` answers.
+#       Passing an env record beside an equivalent validated field would have
+#       created the very second composition path the exact-1 rule exists to
+#       catch, so the arrival asserts the validated field instead.
 #       TO SATISFY: drop the `= process.env` default from `resolveQmdPath`
-#       (server/tools/search-all.ts:124), add a `searchAllEnv` field to
-#       `MemoryToolDependencies` carrying the env slice that supplies `QMD_PATH`,
-#       and write it into the dependencies literal in server/main.ts. The
-#       pattern is the field name plus its colon, so the lane picks the source
-#       expression; what it may not do is leave the parameter defaulted, because
-#       a defaulted parameter reads as injected and behaves as a direct read.
+#       (server/tools/search-all.ts:124) and write this line into the
+#       dependencies literal in server/main.ts. `MemoryToolDependencies.qmdPath`
+#       (server/tools/types.ts:25) already exists, so no new field is needed.
+#       What the lane may NOT do is leave the parameter defaulted, or leave a
+#       `?? resolveQmdPath()` fallback at the consumer, because either one reads
+#       as injected and behaves as a direct read.
 #
 #   (d) server/observability/langfuse-tracing.ts  `readMcpTracingConfig(config.`
 #       TO SATISFY: drop the `= process.env` default from `readMcpTracingConfig`
@@ -266,7 +277,7 @@ fi
 #       exact-1 rule catches everywhere else in this file.
 ARRIVALS="server/main.ts|searchEmbeddingTimeoutMs: config.search.embeddingTimeoutMs
 server/main.ts|sharedNamespaceNames: config.sharedNamespaceNames
-server/main.ts|searchAllEnv:
+server/main.ts|qmdPath: config.qmd.path
 server/observability/langfuse-tracing.ts|readMcpTracingConfig(config."
 
 ARRIVAL_BAD=""

--- a/server/main.ts
+++ b/server/main.ts
@@ -182,6 +182,11 @@ function createServerFactory(input: {
       // would give the doctor a boundary object that can drift from the one the
       // bridge and `/health` actually run on.
       ftsCorpusConfig: config.fts.corpusConfig,
+      // `config.qmd.path` is the validated parse of QMD_PATH (blank reads as
+      // absent, `server/config/env-groups.ts:188,304`), so the handler no longer
+      // needs an env record at all. Spread rather than assigned because the key
+      // is optional and must stay ABSENT, not present-and-undefined.
+      ...(config.qmd.path ? { qmdPath: config.qmd.path } : {}),
       recoveryWalPath: config.recovery.walPath,
       natsRuntimeBoundary: nats.boundary,
       ...realtime,
@@ -503,7 +508,10 @@ export async function startServer(
   // throws, so a misconfigured or unreachable Langfuse can never keep the
   // service from starting.
   const tracing = createTracingRuntime();
-  logger.info({ enabled: tracing.sink !== undefined }, "mcp_tracing_configured");
+  logger.info(
+    { enabled: tracing.sink !== undefined },
+    "mcp_tracing_configured",
+  );
   let application: ShadowApplication | undefined;
   try {
     await applyMigrations({
@@ -624,7 +632,6 @@ async function shutdown(running: RunningProcess): Promise<void> {
   logger.info({}, "server_shutdown_complete");
   if (firstFailure !== undefined) throw firstFailure;
 }
-
 
 /**
  * The launchd-facing process wrapper: signals, exit codes, nothing else.

--- a/server/tools/dependency-arrival.test.ts
+++ b/server/tools/dependency-arrival.test.ts
@@ -1,5 +1,5 @@
 /**
- * ARRIVAL regressions for the three values the composition root injects.
+ * ARRIVAL regressions for the four values the composition root injects.
  *
  * `scripts/done-means/750-l2b1-tool-readers-take-config.sh` clause 4 reads
  * `server/main.ts` and proves each value is WRITTEN at the call site. That is a
@@ -16,13 +16,14 @@
  *   - `ftsCorpusConfig` -> the SQL text `search_brain` actually sends.
  *   - `recoveryWalPath` -> a JSONL file that exists on disk afterwards.
  *   - `natsRuntimeBoundary` -> the transport `operator_doctor` reports.
+ *   - `qmdPath` -> the entry point `search_all` actually spawns.
  *
  * No database is involved: the pool is a fake that records or answers queries,
  * the same shape `search-read-scope.test.ts` and `src/operator-doctor.test.ts`
  * already use.
  */
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -68,7 +69,8 @@ async function clientFor(
     logger: pino({ level: "silent" }),
     ...dependencies,
   });
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
   const send = clientTransport.send.bind(clientTransport);
   clientTransport.send = (message, options_) =>
     send(message, {
@@ -107,7 +109,8 @@ function onlyQuery(queries: readonly CapturedQuery[]): CapturedQuery {
 function payloadOf(result: unknown): Record<string, unknown> {
   const content = (result as { content?: Array<{ text?: string }> }).content;
   const text = content?.[0]?.text;
-  if (typeof text !== "string") throw new Error("tool returned no text content");
+  if (typeof text !== "string")
+    throw new Error("tool returned no text content");
   return JSON.parse(text) as Record<string, unknown>;
 }
 
@@ -237,7 +240,9 @@ describe("recoveryWalPath arrives at the fallback recovery WAL store", () => {
 
     expect(existsSync(firstPath)).toBe(true);
     expect(existsSync(secondPath)).toBe(true);
-    expect(readFileSync(firstPath, "utf8")).toContain('"content":"first-arrival"');
+    expect(readFileSync(firstPath, "utf8")).toContain(
+      '"content":"first-arrival"',
+    );
     expect(readFileSync(secondPath, "utf8")).toContain(
       '"content":"second-arrival"',
     );
@@ -295,5 +300,71 @@ describe("natsRuntimeBoundary arrives at operator_doctor", () => {
     const transport = payloadOf(result).transport as Record<string, unknown>;
     expect(transport.mode).toBe("nats");
     expect(transport.availability).toBe("not_runtime_available");
+  });
+});
+
+/**
+ * A stub standing in for the qmd entry point, printing one hit as JSON.
+ *
+ * `searchQmdInternal` runs `bun <qmdPath> search …`, so a script IS the qmd
+ * binary as far as the handler is concerned. Writing it under the same
+ * `mkdtempSync` root the WAL cases use keeps this runnable on a fresh runner,
+ * which a repo-relative scratch path would not be.
+ *
+ * @returns The absolute path to the stub.
+ */
+function stubQmdEntryPoint(marker: string): string {
+  const path = join(
+    mkdtempSync(join(tmpdir(), "ob-arrival-qmd-")),
+    "qmd-stub.ts",
+  );
+  writeFileSync(
+    path,
+    `console.log(JSON.stringify([{ path: ${JSON.stringify(marker)}, content: "stub hit", score: 0.9 }]));\n`,
+  );
+  return path;
+}
+
+describe("qmdPath arrives at the search_all qmd arm", () => {
+  test("an injected entry point is the one search_all runs", async () => {
+    const marker = "arrival/injected-qmd-path.md";
+    const client = await clientFor(
+      { pool: capturingPool([]), qmdPath: stubQmdEntryPoint(marker) },
+      "admin",
+      "operator",
+    );
+
+    // `sources: "qmd"` isolates the arm: no brain query runs, so every hit in
+    // the payload came from the injected entry point and nowhere else.
+    const result = await client.callTool({
+      name: "search_all",
+      arguments: { query: "needle", sources: "qmd" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const payload = payloadOf(result);
+    expect(payload.qmd_hits).toBe(1);
+    const results = payload.results as Array<Record<string, unknown>>;
+    // The marker is unforgeable: it exists only inside the stub this case
+    // wrote, so observing it proves the injected value reached the spawn.
+    expect(results[0]?.path).toBe(marker);
+  });
+
+  test("no injected entry point leaves the qmd arm off rather than falling back to the environment", async () => {
+    const client = await clientFor(
+      { pool: capturingPool([]) },
+      "admin",
+      "operator",
+    );
+
+    const result = await client.callTool({
+      name: "search_all",
+      arguments: { query: "needle", sources: "qmd" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    // Zero even on a machine whose QMD_PATH is set and usable: the handler has
+    // no ambient read left, so an absent dependency is an absent arm (#825).
+    expect(payloadOf(result).qmd_hits).toBe(0);
   });
 });

--- a/server/tools/search-all.ts
+++ b/server/tools/search-all.ts
@@ -121,7 +121,7 @@ interface QmdDocument {
  * @returns The configured path, or `undefined` when none is usable.
  */
 export function resolveQmdPath(
-  env: Record<string, string | undefined> = process.env,
+  env: Record<string, string | undefined>,
 ): string | undefined {
   const configured = env.QMD_PATH?.trim();
   return configured ? configured : undefined;
@@ -354,7 +354,11 @@ function planFederation(
   dependencies: MemoryToolDependencies,
   sources: "all" | "brain" | "qmd",
 ): FederationPlan {
-  const qmdPath = dependencies.qmdPath ?? resolveQmdPath();
+  // The ONE source. There is no fallback read here on purpose: a `?? resolveQmdPath()`
+  // tail would let this handler answer from the ambient environment whenever the
+  // composition root failed to hand the value down, which is the doubled state
+  // rung L2 exists to end (#825).
+  const qmdPath = dependencies.qmdPath;
   const qmdRequested = sources === "all" || sources === "qmd";
   if (qmdRequested && qmdPath === undefined) {
     // Say it once, at the boundary. Without this the qmd arm's absence is


### PR DESCRIPTION
## Summary

- `resolveQmdPath` (`server/tools/search-all.ts:123`) took `env: Record<string, string | undefined> = process.env`. A defaulted parameter is the doubled state in miniature: it reads as injected and behaves as a direct ambient read for every caller that omits the argument, and its one non-test caller (`:357`, same file) omitted it. The default is gone, so the file no longer contains the string `process.env`.
- `planFederation` compounded that with a `dependencies.qmdPath ?? resolveQmdPath()` tail, which let the handler answer from the ambient environment whenever the composition root failed to hand the value down. The tail is gone; `dependencies.qmdPath` is now the one source, with a comment recording why there is no fallback.
- The value arrives from the ONE validated parse: `server/main.ts` passes `qmdPath: config.qmd.path` into the `registerMemoryTools` dependencies literal, in the `ftsCorpusConfig` shape #779 established. It is spread rather than assigned because the key is optional and must stay absent, not present-and-undefined.
- **Why the validated field rather than an env record.** The lane brief allowed either, deciding on whether a validated field already held this value. It does: `server/config/env-groups.ts:188,304` parses `QMD_PATH` through `blankAsAbsent` into `QmdConfigGroup`, exposed as `config.qmd` (`server/config.ts:238,361`). `server/config.test.ts:657` already proves, input by input through the exported parser across the shared divergence inputs, that `config.qmd.path` answers exactly what `resolveQmdPath` answers. Handing down a raw env record beside an equivalent validated field would have created a second composition path that can disagree with the first — the exact defect this rung exists to end, and the one the check's exact-1 rule catches everywhere else.
- Accordingly the ARRIVALS entry in `scripts/done-means/750-l2b2-env-readers-take-config.sh` moves from the placeholder `server/main.ts|searchAllEnv:` to `server/main.ts|qmdPath: config.qmd.path`, and its `(c)` block records the amendment and the evidence for it. `scripts/done-means/750-l2b2-check-well-formed.sh` still exits 0.
- No new dependency field was needed: `MemoryToolDependencies.qmdPath` (`server/tools/types.ts:25`) already existed, so `server/tools/types.ts` is untouched.
- Behavior is unchanged for every input. `resolveQmdPath` is the same function minus its default, still exported, still the reference the config equivalence test compares against. The one observable difference is the intended one: with no value injected the qmd arm is off and says so via `qmd_search_unconfigured`, rather than reaching for the ambient environment.

This is one of four lanes on issue #825 (rung L2b-2 of `_plans/server-hardening-ladder.md`). The env-readers check stays RED overall until all four land — `server/tools/search-engine.ts`, `server/tools/shared-namespace.ts`, and `server/observability/trace-config.ts` are other lanes' files and are deliberately untouched here.

## Verification

- Done-means: scripts/done-means/750-l2b2-check-well-formed.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED at `origin/main` (`bash scripts/done-means/750-l2b2-env-readers-take-config.sh` -> exit 1):

```
CLAUSE 2 ... FAIL — 7 process.env read(s) remain:
    server/tools/search-all.ts:124:  env: Record<string, string | undefined> = process.env,
CLAUSE 4 ... FAIL — 0/4 values arrive; the rest are not wired:
    server/main.ts: found 0, expected 1 — "searchAllEnv:"
```

GREEN for this lane (same script after the change -> still exit 1 overall, because the other three readers remain):

```
CLAUSE 2 (no process.env in any of the 4):              FAIL — 6 process.env read(s) remain:
    (search-all.ts is no longer among them; trace-config.ts, shared-namespace.ts x3, search-engine.ts x2 remain)
CLAUSE 4 (values arrive from validated config):         FAIL — 1/4 values arrive; the rest are not wired:
    server/main.ts: found 0, expected 1 — "searchEmbeddingTimeoutMs: config.search.embeddingTimeoutMs"
    server/main.ts: found 0, expected 1 — "sharedNamespaceNames: config.sharedNamespaceNames"
    server/observability/langfuse-tracing.ts: found 0, expected 1 — "readMcpTracingConfig(config."
```

The 1/4 that arrives is this lane's, and `qmdPath: config.qmd.path` is absent from the unwired list.

Other checks, all re-run on the COMMITTED tree after the pre-commit prettier pass:

- `bash scripts/done-means/750-l2b2-check-well-formed.sh` -> exit 0
- `./node_modules/.bin/oxlint --deny-warnings server/tools/search-all.ts server/main.ts` -> exit 0, no findings
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated server/tools/dependency-arrival.test.ts server/config.test.ts` -> 89 pass, 0 fail, 282 expect() calls
- `git status --short` after commit -> empty

The new test was proven able to fail before being trusted: swapping the expected marker for a string the stub never emits produced 1 fail, with the real marker as the received value (so the injected stub demonstrably ran), and the file was then restored.

## Critical Self-Review

- Highest-risk behavior: the removal of the `?? resolveQmdPath()` fallback in `planFederation`. If any deployment relied on `QMD_PATH` reaching the handler ambiently while `server/main.ts` did not pass it, qmd federation would go from on to off. It cannot: `main.ts` is the only composition root that registers these tools in production, it now passes `config.qmd.path`, and that field is parsed from the same `QMD_PATH` variable with the same blank-as-absent rule. A deployment where the old code federated and the new one does not would require `QMD_PATH` to be readable by `process.env` inside the handler but not by the config parse at startup, which is the same process and the same variable.
- Assumptions that could be wrong: that `config.qmd.path` and `resolveQmdPath` agree on every input. Not assumed — `server/config.test.ts:657` asserts it input by input through the exported parser across `DIVERGENCE_INPUTS`, and that test is unmodified and green here. Also assumed: `server/main.ts` is the only non-test registrar. Checked with `rg -n "resolveQmdPath"` and `rg -n "qmdPath"` across `server/` and `src/`; the `src/qmd-path.ts` `resolveQmdPath` is a separate function with a different return shape (`{path, source}`) serving `src/tools/search-all.ts` and `src/operator-doctor.ts`, and is deliberately not in this lane's scope.
- Missing/weak tests: there is no test that `server/main.ts` itself builds the dependencies object correctly — that half is covered textually by clause 4 of the done-means check rather than by execution, which is the documented division of labor for this rung (the check's own header explains why clause 5 is absent). The far-end behavior is covered by the new arrival cases.
- Security/permission risk: none introduced. No namespace predicate, auth check, role boundary, or SQL text is touched. The change narrows where a value may come from; it does not widen any read or mutation. The new test authenticates as `admin` for the same reason the existing `ftsCorpusConfig` case does, and asserts nothing about authorization.
- Migration/deploy risk: no schema change, no migration, no new environment variable. `QMD_PATH` keeps its existing name, parse rule, and blank-as-absent semantics. Rollout is a plain code deploy.
- Downstream client/runtime risk: none. `resolveQmdPath` is exported from `server/tools/search-all.ts` and its signature narrows — a caller relying on the default would now fail to typecheck rather than silently misbehave, which is the intended direction. Its only importer outside the file is `server/config.test.ts`, which already passed an explicit argument. No MCP tool schema, transport shape, or client-facing contract changes, so `docs/downstream-rollout.md` classifies this as not applicable.
- Rollback/cleanup concern: single commit, four files, revertable on its own. The one cross-lane coupling is the shared `registerMemoryTools` object literal in `server/main.ts`, where a sibling lane adds `searchEmbeddingTimeoutMs:`; a conflict there is resolved by keeping both lines. `git fetch` plus `git rebase origin/main` was run immediately before pushing and reported the branch up to date, so no conflict existed at push time.
- Fixes made before PR: the first draft assigned `qmdPath: config.qmd.path` directly, which is wrong under `exactOptionalPropertyTypes` for an optional field — it would have set the key to `undefined` rather than leaving it absent. Changed to the conditional spread the neighboring `embeddingModel` line already uses. Also updated the test file's header comment from "three values" to "four" so it stays an accurate index of what it covers.
- Known residual risk: the ARRIVALS pattern `qmdPath: config.qmd.path` is a fixed-string match against `server/main.ts`, so a future reformatting that splits that expression across lines would make clause 4 report it as unwired. That is inherent to the check's design and applies equally to the other three entries; prettier's pass on this commit already exercised it and left the line intact.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane found no new missed-review pattern — the defect it fixes is the one issue #825 already names and the done-means check already documents at length, and the amendment to that check is recorded in the check's own `(c)` block where the next lane will read it.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no MCP tool schema, transport, or client-facing contract changed; the change is internal wiring of an already-existing dependency field, covered by the isolated test run above.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the change is confined to the TypeScript server's composition root and one handler's dependency read. No tool schema, response shape, or wire contract is altered, so there is no fixture with a counterpart to keep in parity.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable on every line: `docs/downstream-rollout.md` scopes the gate to MCP tool/schema/protocol/client-facing changes. `search_all`'s input schema, output payload, and error shapes are byte-identical here; the only edited signature (`resolveQmdPath`) is a server-internal function whose sole non-test caller lives in the same file.
