### PR TITLE
refactor(observability): make readMcpTracingConfig take env explicitly from validated config (L2b-2, #825)

### DIFF
--- a/scripts/done-means/750-l2b2-env-readers-take-config.sh
+++ b/scripts/done-means/750-l2b2-env-readers-take-config.sh
@@ -264,21 +264,32 @@ fi
 #       `?? resolveQmdPath()` fallback at the consumer, because either one reads
 #       as injected and behaves as a direct read.
 #
-#   (d) server/observability/langfuse-tracing.ts  `readMcpTracingConfig(config.`
-#       TO SATISFY: drop the `= process.env` default from `readMcpTracingConfig`
-#       (server/observability/trace-config.ts:33) and pass the validated group at
-#       its only two non-test call sites (langfuse-tracing.ts:402,506, both
-#       currently `readMcpTracingConfig()` with no argument).
-#       `ServerConfig.tracing` is server/config.ts:246,367, built by
-#       `tracingGroup` at server/config/env-groups.ts:359. The count of exactly 1
-#       is deliberate even though there are two call sites: the two must resolve
-#       through ONE shared `deps.config ?? …` expression rather than each
-#       building its own, which is the same "two composition paths" defect the
-#       exact-1 rule catches everywhere else in this file.
+#   (d) server/main.ts  `createTracingRuntime({ config: config.tracing })`
+#       SATISFIED by L2b-2 (#825). The `= process.env` default is gone from
+#       `readMcpTracingConfig` (server/observability/trace-config.ts:32), and
+#       the composition root now hands the validated group down at
+#       server/main.ts:505. `ServerConfig.tracing` is server/config.ts:246,367,
+#       built by `tracingGroup` at server/config/env-groups.ts:359.
+#
+#       PATTERN CHANGED, and here is why. This entry originally asserted
+#       `readMcpTracingConfig(config.` in langfuse-tracing.ts. That string
+#       cannot exist alongside the correct wiring: `TracingConfigGroup` is
+#       already field-for-field `McpTracingConfig`, so the validated value is
+#       handed straight to `deps.config` and the reader is never called on the
+#       wired path at all. Asserting the old string would have forced a pointless
+#       re-derivation from an env record `ServerConfig` does not even expose.
+#       The arrival being proven is the same one: ONE validated parse reaching
+#       the tracing lane, exactly once, from the composition root.
+#
+#       Both langfuse-tracing.ts call sites (:404, :508) now go through one
+#       module-private `resolveTracingConfig(deps)`, so the two-composition-paths
+#       defect the exact-1 rule catches is closed inside that file too. Its
+#       `readMcpTracingConfig(process.env)` fallback serves only the legacy root
+#       `src/index.ts:318`, which has no `ServerConfig` to pass.
 ARRIVALS="server/main.ts|searchEmbeddingTimeoutMs: config.search.embeddingTimeoutMs
 server/main.ts|sharedNamespaceNames: config.sharedNamespaceNames
 server/main.ts|qmdPath: config.qmd.path
-server/observability/langfuse-tracing.ts|readMcpTracingConfig(config."
+server/main.ts|createTracingRuntime({ config: config.tracing })"
 
 ARRIVAL_BAD=""
 ARRIVAL_OK=0

--- a/server/main.ts
+++ b/server/main.ts
@@ -508,7 +508,7 @@ export async function startServer(
   // set all four OPENBRAIN_TRACING_* variables; `createTracingRuntime` never
   // throws, so a misconfigured or unreachable Langfuse can never keep the
   // service from starting.
-  const tracing = createTracingRuntime();
+  const tracing = createTracingRuntime({ config: config.tracing });
   logger.info(
     { enabled: tracing.sink !== undefined },
     "mcp_tracing_configured",

--- a/server/observability/langfuse-tracing.test.ts
+++ b/server/observability/langfuse-tracing.test.ts
@@ -12,6 +12,7 @@
  * seam `McpAuditDeps.now` provides for the audit lane.
  */
 import { describe, expect, test } from "bun:test";
+import { tracingGroup } from "../config/env-groups.ts";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -668,9 +669,9 @@ describe("installMcpTracing", () => {
 
     const spans = sink.bodies[0]?.spans ?? [];
     expect(spans).toHaveLength(2);
-    expect(
-      spans.every((span) => span.metadata.payload_degraded === true),
-    ).toBe(true);
+    expect(spans.every((span) => span.metadata.payload_degraded === true)).toBe(
+      true,
+    );
     expect(JSON.stringify(spans)).not.toContain(large);
     expect(Buffer.byteLength(JSON.stringify(spans), "utf8")).toBeLessThan(
       MAX_ACTIVE_SPAN_BYTES,
@@ -725,9 +726,7 @@ describe("installMcpTracing", () => {
       { vector: equalRows, keyword: [], limit: 2 },
     ];
     const baseline = {
-      rrf: cases.map((item) =>
-        rrfMerge(item.vector, item.keyword, item.limit),
-      ),
+      rrf: cases.map((item) => rrfMerge(item.vector, item.keyword, item.limit)),
       srcFallback: [
         mergeFallbackSearchRows([], [], 3),
         mergeFallbackSearchRows(equalRows.slice(0, 2), [equalRows[2]!], 2),
@@ -813,7 +812,11 @@ describe("installMcpTracing", () => {
     await handlers.get("fallback_classification")?.({}, AUTH);
 
     const output = sink.bodies[0]?.spans?.[0]?.output as {
-      candidates: Array<{ row_id: string; chosen: boolean; filtered_by: string | null }>;
+      candidates: Array<{
+        row_id: string;
+        chosen: boolean;
+        filtered_by: string | null;
+      }>;
     };
     expect(output.candidates).toMatchObject([
       { row_id: "primary", chosen: true, filtered_by: null },
@@ -1542,9 +1545,8 @@ describe("background job tracing", () => {
  */
 describe("the SDK's own logger cannot bypass the content-free discipline", () => {
   test("building the real sink silences SDK-level error and warn output", async () => {
-    const { configureGlobalLogger, getGlobalLogger, LogLevel } = await import(
-      "@langfuse/core"
-    );
+    const { configureGlobalLogger, getGlobalLogger, LogLevel } =
+      await import("@langfuse/core");
 
     // Asserted through the SDK's OWN level gate rather than by capturing
     // `console.error`: Bun's runner installs its own console, so a swapped
@@ -1971,5 +1973,39 @@ describe("the release stamped on every trace", () => {
     // A subprocess per emit would put a fork on the request path, which is the
     // one thing this lane is built not to do.
     expect(repoRelease()).toBe(repoRelease());
+  });
+});
+
+describe("tracing configuration arrives from the composition root (#825)", () => {
+  test("createTracingRuntime observes the validated group, not the ambient environment", () => {
+    // The exact shape `server/main.ts:505` passes: `config.tracing`, produced
+    // by `tracingGroup` (server/config/env-groups.ts:359) from the one
+    // validated parse. Disabled, so nothing is constructed and no socket opens.
+    const fromValidatedConfig = tracingGroup({
+      OPENBRAIN_TRACING_ENDPOINT: "http://from-config:3000",
+      OPENBRAIN_TRACING_PUBLIC_KEY: "pk-from-config",
+      OPENBRAIN_TRACING_SECRET_KEY: "sk-from-config",
+      OPENBRAIN_TRACING_ENABLED: false,
+      OPENBRAIN_TRACING_MASKING_ENABLED: false,
+    } as never);
+
+    // The ambient environment says something DIFFERENT. Before #825 the reader
+    // defaulted its parameter to `process.env`, so a caller that forgot to pass
+    // the value silently answered from here instead.
+    const previousEndpoint = process.env.OPENBRAIN_TRACING_ENDPOINT;
+    process.env.OPENBRAIN_TRACING_ENDPOINT = "http://from-ambient-env:9999";
+    try {
+      const runtime = createTracingRuntime({ config: fromValidatedConfig });
+      expect(runtime.config.endpoint).toBe("http://from-config:3000");
+      expect(runtime.config.publicKey).toBe("pk-from-config");
+      expect(runtime.config.maskingEnabled).toBe(false);
+      expect(runtime.sink).toBeUndefined();
+    } finally {
+      if (previousEndpoint === undefined) {
+        delete process.env.OPENBRAIN_TRACING_ENDPOINT;
+      } else {
+        process.env.OPENBRAIN_TRACING_ENDPOINT = previousEndpoint;
+      }
+    }
   });
 });

--- a/server/observability/langfuse-tracing.ts
+++ b/server/observability/langfuse-tracing.ts
@@ -382,6 +382,23 @@ export function traceRetrievalSpanSync<T>(input: RetrievalSpanInput<T, T>): T {
 type RegisterTool = McpServer["registerTool"];
 
 /**
+ * The ONE place tracing configuration is resolved for this module.
+ *
+ * `installMcpTracing` and `createTracingRuntime` both need it, and each having
+ * its own `deps.config ?? …` expression is two composition paths that can
+ * disagree. The composition root (`server/main.ts`) passes `config.tracing`
+ * from the single validated parse, so `deps.config` is the normal path there.
+ *
+ * The fallback exists only for the legacy root `src/index.ts:318`, which has no
+ * `ServerConfig` and still calls with no arguments. `readMcpTracingConfig` no
+ * longer defaults its parameter (#825, L2b-2), so the environment is named
+ * HERE, once, instead of hiding inside the reader's signature.
+ */
+function resolveTracingConfig(deps: McpTracingDeps): McpTracingConfig {
+  return deps.config ?? readMcpTracingConfig(process.env);
+}
+
+/**
  * Install content-ful tracing on every tool registered after this call.
  *
  * ORDER MATTERS, exactly as it does for `installMcpAudit`: this works by
@@ -399,7 +416,7 @@ export function installMcpTracing(
   server: McpServer,
   deps: McpTracingDeps = {},
 ): McpTracingHandle {
-  const config = deps.config ?? readMcpTracingConfig();
+  const config = resolveTracingConfig(deps);
   if (!config.enabled) return INACTIVE_HANDLE;
   if (tracingInstalledServers.has(server)) return INACTIVE_HANDLE;
 
@@ -503,7 +520,7 @@ export function createTracingRuntime(deps: McpTracingDeps = {}): {
   readonly background?: BackgroundTraceEmitter;
   shutdown(): Promise<void>;
 } {
-  const config = deps.config ?? readMcpTracingConfig();
+  const config = resolveTracingConfig(deps);
   if (!config.enabled) return { config, shutdown: () => Promise.resolve() };
   const built = deps.sink ?? createSinkSafely(config, deps.createSink);
   if (!built) return { config, shutdown: () => Promise.resolve() };

--- a/server/observability/trace-config.ts
+++ b/server/observability/trace-config.ts
@@ -30,7 +30,7 @@ function trimmedEnv(
  * Key VALUES are never logged — only whether each one was present.
  */
 export function readMcpTracingConfig(
-  env: Record<string, string | undefined> = process.env,
+  env: Record<string, string | undefined>,
 ): McpTracingConfig {
   const endpoint = trimmedEnv(env, "OPENBRAIN_TRACING_ENDPOINT");
   const publicKey = trimmedEnv(env, "OPENBRAIN_TRACING_PUBLIC_KEY");


### PR DESCRIPTION
## Summary

- `readMcpTracingConfig(env = process.env)` (`server/observability/trace-config.ts:32`) was the doubled state in miniature: it looked injected and behaved as a direct environment read for every caller that omitted the argument, and both of its non-test callers omitted it. The default parameter is removed, and the file no longer contains the string `process.env`.
- The composition root now hands the validated group down. `TracingConfigGroup` (`server/config/env-groups.ts:359`) is already field-for-field identical to `McpTracingConfig`, so `server/main.ts:505` passes `config.tracing` straight into `createTracingRuntime`'s existing `deps.config` seam — one validated parse, reaching the tracing lane once.
- Inside `server/observability/langfuse-tracing.ts`, `installMcpTracing` and `createTracingRuntime` each carried their own `deps.config ?? readMcpTracingConfig()` expression, which is two composition paths that can disagree. Both now resolve through one module-private `resolveTracingConfig(deps)`. Its `readMcpTracingConfig(process.env)` fallback serves only the legacy root `src/index.ts:318`, which has no `ServerConfig` to pass; the environment is named there once, in the open, instead of hiding inside a signature.
- **The done-means assertion for this reader changed, deliberately.** Arrival (d) of `scripts/done-means/750-l2b2-env-readers-take-config.sh` asserted the fixed string `readMcpTracingConfig(config.` inside langfuse-tracing.ts. That string cannot coexist with the correct wiring: because the validated group already has the reader's exact output shape, it goes to `deps.config` and the reader is never called on the wired path at all. Satisfying the old spelling would have forced a pointless re-derivation from an env record `ServerConfig` does not expose. The entry now asserts `createTracingRuntime({ config: config.tracing })` in `server/main.ts`, which proves the same arrival — one validated parse reaching the tracing lane, exactly once, from the composition root. The reasoning is written into the script's own (d) comment block, not only here.
- Behavior is unchanged: `readMcpTracingConfig` returns the same result for the same input. Every existing test already passed its env explicitly, so **no existing test was modified**.
- One functional test is added (`server/observability/langfuse-tracing.test.ts`), proving the value the composition root passes is the value the tracing runtime observes: it builds the group through the real `tracingGroup`, sets a *conflicting* `OPENBRAIN_TRACING_ENDPOINT` in the ambient environment, and asserts the runtime still reports the injected one.

This is one of four lanes closing #825 (rung L2b-2, `_plans/server-hardening-ladder.md`). It closes the `trace-config.ts` reader only; `search-engine.ts`, `shared-namespace.ts`, and `search-all.ts` belong to the other three lanes.

## Verification

- Done-means: scripts/done-means/750-l2b2-check-well-formed.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

**The env-readers check stays RED until all four lanes land**, by design — it gates the whole rung, not this lane. What this lane moved, measured on the committed tree:

RED, at `origin/main`:

```
CLAUSE 2 (no process.env in any of the 4):              FAIL — 7 process.env read(s) remain:
    server/observability/trace-config.ts:33:  env: Record<string, string | undefined> = process.env,
CLAUSE 4 (values arrive from validated config):         FAIL — 0/4 values arrive; the rest are not wired:
```

After this change:

```
CLAUSE 2 (no process.env in any of the 4):              FAIL — 6 process.env read(s) remain:
CLAUSE 4 (values arrive from validated config):         FAIL — 1/4 values arrive; the rest are not wired:
```

`trace-config.ts` is gone from clause 2's list and the tracing arrival is counted. The six remaining reads and the three unwired arrivals are the other lanes'.

Checks run on the COMMITTED tree (the pre-commit hook reformatted files with prettier, so every check below was re-run after the commit):

- `bash scripts/done-means/750-l2b2-check-well-formed.sh` -> exit 0
- `bash scripts/done-means/750-l2b2-env-readers-take-config.sh` -> exit 1, as quoted above
- `./node_modules/.bin/oxlint --deny-warnings server/observability/trace-config.ts server/observability/langfuse-tracing.ts server/main.ts` -> exit 0, no oxlint disable comments added
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated server/observability/` -> 69 pass, 0 fail, 159 expect() calls, exit 0

The new test was proven able to fail before it was trusted: neutering `resolveTracingConfig` to ignore `deps.config` turned 4 assertions red; restoring it returned 69 pass / 0 fail.

## Critical Self-Review

- Highest-risk behavior: the `readMcpTracingConfig(process.env)` fallback inside `resolveTracingConfig`. It is the one place tracing can still answer from the ambient environment, and it exists solely so the legacy root `src/index.ts:318` — which has no `ServerConfig` — keeps behaving exactly as it did. If a future `server/`-side caller reaches `createTracingRuntime()` with no `deps.config`, it silently gets the environment rather than a failure. That is the pre-existing behavior preserved, not a regression, but it is the seam a later lane should close when `src/index.ts` is retired.
- Assumptions that could be wrong: (1) that `TracingConfigGroup` and `McpTracingConfig` are interchangeable. Checked field by field — both are `{enabled, maskingEnabled, endpoint, publicKey, secretKey}` with the same types (`server/config/env-groups.ts:359-372`, `server/observability/trace-types.ts:13-19`), and `tsc --noEmit` passes with the value assigned straight across. (2) That `tracingGroup` and `readMcpTracingConfig` agree on the *values*, not just the shape. They apply the same rule — off unless the flag is set and all three coordinates are non-empty — but by different routes: the reader trims raw strings and compares `OPENBRAIN_TRACING_ENABLED === "1"`, while the group receives already-Zod-coerced values. A deployment whose flag is set to something Zod coerces to `true` but that is not the literal `"1"` would now enable tracing where it previously did not. I did not find such a spelling in the schema, but I did not exhaustively enumerate Zod's boolean coercion either, so this is stated as unverified rather than ruled out.
- Missing/weak tests: the added test covers the `server/main.ts` path (validated group in, observed out). It does NOT cover the `src/index.ts` fallback path end to end — that root is out of this lane's scope and has no test harness here. The incomplete-flag WARN branch in `readMcpTracingConfig` is covered by pre-existing tests, which still pass unmodified.
- Security/permission risk: none identified. No namespace predicate, auth token, or role check is touched. The change moves *where* three tracing coordinates are read, not who may read them, and the values still never reach a log — the existing content-free WARN branch (booleans only, field names chosen to dodge `SENSITIVE_KEY_PARTS`) is unchanged.
- Migration/deploy risk: none. No schema change, no migration, no config *variable* added or renamed. The same four `OPENBRAIN_TRACING_*` variables control the same behavior; an operator changes nothing. Both roots resolve to the same values as before.
- Downstream client/runtime risk: not applicable per `docs/downstream-rollout.md`. No MCP tool, schema, transport, protocol, or Python client surface is touched. `readMcpTracingConfig`'s exported signature does change (the parameter is now required), but its only importers are inside this repo — `langfuse-tracing.ts` and its test — and both were updated in this commit.
- Rollback/cleanup concern: a clean revert. Five files, no state written anywhere, nothing to undo outside the tree. The one coupling is the done-means script: reverting this commit restores the original arrival (d) assertion along with the code, so the check and the tree stay consistent either way.
- Fixes made before PR: the first shape I wrote satisfied the literal `readMcpTracingConfig(config.` assertion by re-deriving the config from an env record. I discarded it — `ServerConfig` exposes no raw env, so that shape would have invented a field purely to make a string match, which is the check driving the design rather than the other way round. Changed the assertion and documented why instead. Also consolidated the two `deps.config ?? …` expressions into one resolver after noticing the exact-1 rule's own rationale applies inside the file, not just at the call sites.
- Known residual risk: the Zod-coercion question in the assumptions bullet is the only open one, and it is narrow — it can only differ for a `OPENBRAIN_TRACING_ENABLED` value that is neither `"1"` nor obviously falsy. Worth a reviewer's eye on `extendedEnvironmentFields`.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no MEDIUM+ review finding surfaced in this lane — the one design correction (a done-means assertion that could only be satisfied by a worse design) is recorded in the script's own comment block and in the PR comment, which is where the next lane on this rung will actually look.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this is an internal composition-root rewiring with no observable service behavior change and no deployed surface to smoke.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: nothing crosses a runtime boundary. `readMcpTracingConfig` is a TypeScript-internal function with no Python counterpart and no fixture.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable on every line: no MCP tool, schema, transport, protocol, or client-facing surface is touched. The changed export is internal to this repo and both of its importers are updated in this commit.
