### PR TITLE
feat(config): let shared-namespace helpers take validated names and pass them from the composition root (L2b-2 5a, #825)

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -5,9 +5,19 @@
  */
 import { describe, expect, it, test } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { loadServerConfig, OPTIONAL_SECRET_KEYS, parseServerConfig } from "./config.ts";
+import {
+  loadServerConfig,
+  OPTIONAL_SECRET_KEYS,
+  parseServerConfig,
+} from "./config.ts";
 import { resolveFtsConfig } from "./tools/fts-config.ts";
 import { resolveQmdPath } from "./tools/search-all.ts";
+import {
+  canonicalNamespace,
+  isSharedNamespace,
+  physicalNamespace,
+  sharedNamespaceConfig,
+} from "./tools/shared-namespace.ts";
 import { parseAllowedOrigins } from "./transport/rest.ts";
 import { readMcpTracingConfig } from "./observability/langfuse-tracing.ts";
 
@@ -23,14 +33,27 @@ describe("server configuration boundary", () => {
     const result = parseServerConfig({ LOG_FILE: "logs/test.log" });
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error("expected invalid configuration");
-    expect(result.issues.map((issue) => issue.path)).toEqual(["DB_HOST", "DB_NAME", "DB_USER"]);
+    expect(result.issues.map((issue) => issue.path)).toEqual([
+      "DB_HOST",
+      "DB_NAME",
+      "DB_USER",
+    ]);
   });
 
   it("rejects malformed configured user tokens visibly", () => {
-    const result = parseServerConfig({ ...REQUIRED, AUTH_TOKEN_USER_BILBY: "agent" });
+    const result = parseServerConfig({
+      ...REQUIRED,
+      AUTH_TOKEN_USER_BILBY: "agent",
+    });
     expect(result).toEqual({
       ok: false,
-      issues: [{ path: "AUTH_TOKEN_USER_BILBY", message: "Invalid option: expected one of \"admin\"|\"agent\"|\"discord\"|\"ob-admin\"|\"promoter\"|\"readonly\"" }],
+      issues: [
+        {
+          path: "AUTH_TOKEN_USER_BILBY",
+          message:
+            'Invalid option: expected one of "admin"|"agent"|"discord"|"ob-admin"|"promoter"|"readonly"',
+        },
+      ],
     });
   });
 
@@ -42,7 +65,12 @@ describe("server configuration boundary", () => {
     });
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("expected valid configuration");
-    expect(result.config.authTokens.map(({ role, clientId }) => ({ role, clientId }))).toEqual([
+    expect(
+      result.config.authTokens.map(({ role, clientId }) => ({
+        role,
+        clientId,
+      })),
+    ).toEqual([
       { role: "agent", clientId: "agent" },
       { role: "promoter", clientId: "openbrain-promoter" },
     ]);
@@ -74,14 +102,17 @@ describe("server configuration boundary", () => {
  * way on the next environment that sets one to empty.
  */
 describe("optional secrets that are present but empty", () => {
-  test.each([...OPTIONAL_SECRET_KEYS])("%s: empty string parses as absent", (key) => {
-    const result = parseServerConfig({ ...REQUIRED, [key]: "" });
-    if (!result.ok) {
-      throw new Error(
-        `empty ${key} must not fail the config boundary: ${JSON.stringify(result.issues)}`,
-      );
-    }
-  });
+  test.each([...OPTIONAL_SECRET_KEYS])(
+    "%s: empty string parses as absent",
+    (key) => {
+      const result = parseServerConfig({ ...REQUIRED, [key]: "" });
+      if (!result.ok) {
+        throw new Error(
+          `empty ${key} must not fail the config boundary: ${JSON.stringify(result.issues)}`,
+        );
+      }
+    },
+  );
 
   it("covers every field declared with the shared optional-secret schema", () => {
     // Guards the parameterization above: a NEW optionalSecret field added to the
@@ -128,7 +159,9 @@ describe("optional secrets that are present but empty", () => {
   it("still parses when EVERY optional secret is empty at once", () => {
     // The real clone environment sets several of these blank together; the
     // per-field cases above would all pass even if the combination did not.
-    const empties = Object.fromEntries(OPTIONAL_SECRET_KEYS.map((key) => [key, ""]));
+    const empties = Object.fromEntries(
+      OPTIONAL_SECRET_KEYS.map((key) => [key, ""]),
+    );
     const result = parseServerConfig({ ...REQUIRED, ...empties });
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("expected valid configuration");
@@ -193,7 +226,10 @@ describe("EMBEDDING_API_KEY across every observed state", () => {
    */
   it("whitespace-only: treated as absent, matching the launcher's own check", () => {
     for (const blank of [" ", "   ", "\t", "\n", " \t\n "]) {
-      const result = parseServerConfig({ ...REQUIRED, EMBEDDING_API_KEY: blank });
+      const result = parseServerConfig({
+        ...REQUIRED,
+        EMBEDDING_API_KEY: blank,
+      });
       expect(result.ok).toBe(true);
       if (!result.ok) throw new Error("expected valid configuration");
       expect("embeddingApiKey" in result.config.transport).toBe(false);
@@ -204,7 +240,10 @@ describe("EMBEDDING_API_KEY across every observed state", () => {
     // Only the blank/non-blank DECISION is normalized. A key whose padding is
     // genuine must not be silently altered into a different credential.
     const padded = "  padded-key  ";
-    const result = parseServerConfig({ ...REQUIRED, EMBEDDING_API_KEY: padded });
+    const result = parseServerConfig({
+      ...REQUIRED,
+      EMBEDDING_API_KEY: padded,
+    });
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("expected valid configuration");
     expect(result.config.transport.embeddingApiKey).toBe(padded);
@@ -213,7 +252,9 @@ describe("EMBEDDING_API_KEY across every observed state", () => {
   it("applies the blank rule to every optional secret, not just the embedding key", () => {
     // Same reasoning as the empty-string parameterization above: the defect is
     // in the shared schema, so a whitespace value in ANY of them must be absent.
-    const blanks = Object.fromEntries(OPTIONAL_SECRET_KEYS.map((key) => [key, "   "]));
+    const blanks = Object.fromEntries(
+      OPTIONAL_SECRET_KEYS.map((key) => [key, "   "]),
+    );
     const result = parseServerConfig({ ...REQUIRED, ...blanks });
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error("expected valid configuration");
@@ -235,11 +276,17 @@ describe("EMBEDDING_API_KEY across every observed state", () => {
 describe("loadServerConfig against a real process.env", () => {
   const OWNED = [...OPTIONAL_SECRET_KEYS, ...Object.keys(REQUIRED)];
 
-  function withEnv<T>(overrides: Record<string, string | undefined>, run: () => T): T {
+  function withEnv<T>(
+    overrides: Record<string, string | undefined>,
+    run: () => T,
+  ): T {
     const saved = new Map(OWNED.map((key) => [key, process.env[key]]));
     try {
       for (const key of OWNED) delete process.env[key];
-      for (const [key, value] of Object.entries({ ...REQUIRED, ...overrides })) {
+      for (const [key, value] of Object.entries({
+        ...REQUIRED,
+        ...overrides,
+      })) {
         if (value === undefined) delete process.env[key];
         else process.env[key] = value;
       }
@@ -258,13 +305,17 @@ describe("loadServerConfig against a real process.env", () => {
   });
 
   it("starts with EMBEDDING_API_KEY absent", () => {
-    const config = withEnv({ EMBEDDING_API_KEY: undefined }, () => loadServerConfig());
+    const config = withEnv({ EMBEDDING_API_KEY: undefined }, () =>
+      loadServerConfig(),
+    );
     expect("embeddingApiKey" in config.transport).toBe(false);
   });
 
   it("starts with EMBEDDING_API_KEY set, and carries the key through", () => {
     const key = `real-${randomUUID()}`;
-    const config = withEnv({ EMBEDDING_API_KEY: key }, () => loadServerConfig());
+    const config = withEnv({ EMBEDDING_API_KEY: key }, () =>
+      loadServerConfig(),
+    );
     expect(config.transport.embeddingApiKey).toBe(key);
   });
 
@@ -306,7 +357,9 @@ describe("loadServerConfig against a real process.env", () => {
 function extendedConfig(overrides: Record<string, string | undefined> = {}) {
   const result = parseServerConfig({ ...REQUIRED, ...overrides });
   if (!result.ok) {
-    throw new Error(`expected valid configuration: ${JSON.stringify(result.issues)}`);
+    throw new Error(
+      `expected valid configuration: ${JSON.stringify(result.issues)}`,
+    );
   }
   return result.config;
 }
@@ -318,13 +371,15 @@ describe("extended env — search", () => {
 
   it("takes an explicit timeout", () => {
     expect(
-      extendedConfig({ OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: "750" }).search.embeddingTimeoutMs,
+      extendedConfig({ OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: "750" }).search
+        .embeddingTimeoutMs,
     ).toBe(750);
   });
 
   it("falls back to the legacy name when the preferred one is absent", () => {
     expect(
-      extendedConfig({ SEARCH_EMBEDDING_TIMEOUT_MS: "900" }).search.embeddingTimeoutMs,
+      extendedConfig({ SEARCH_EMBEDDING_TIMEOUT_MS: "900" }).search
+        .embeddingTimeoutMs,
     ).toBe(900);
   });
 
@@ -357,11 +412,15 @@ describe("extended env — fts", () => {
   });
 
   it("takes an explicit supported configuration", () => {
-    expect(extendedConfig({ OPENBRAIN_FTS_CONFIG: "simple" }).fts.corpusConfig).toBe("simple");
+    expect(
+      extendedConfig({ OPENBRAIN_FTS_CONFIG: "simple" }).fts.corpusConfig,
+    ).toBe("simple");
   });
 
   it("maps a language token to its configuration", () => {
-    expect(extendedConfig({ OPENBRAIN_FTS_CONFIG: " Spanish " }).fts.corpusConfig).toBe("spanish");
+    expect(
+      extendedConfig({ OPENBRAIN_FTS_CONFIG: " Spanish " }).fts.corpusConfig,
+    ).toBe("spanish");
   });
 
   // The unrecognized-token fallback is asserted against `resolveFtsConfig`
@@ -374,7 +433,9 @@ describe("extended env — qmd", () => {
   });
 
   it("takes an explicit path", () => {
-    expect(extendedConfig({ QMD_PATH: "/usr/local/bin/qmd" }).qmd.path).toBe("/usr/local/bin/qmd");
+    expect(extendedConfig({ QMD_PATH: "/usr/local/bin/qmd" }).qmd.path).toBe(
+      "/usr/local/bin/qmd",
+    );
   });
 
   it("treats a blank path as unset, which is the dogfood shape QMD_PATH=", () => {
@@ -390,29 +451,33 @@ describe("extended env — recovery", () => {
   });
 
   it("takes an explicit WAL path", () => {
-    expect(extendedConfig({ OPENBRAIN_RECOVERY_WAL_PATH: "var/wal.log" }).recovery.walPath).toBe(
-      "var/wal.log",
-    );
+    expect(
+      extendedConfig({ OPENBRAIN_RECOVERY_WAL_PATH: "var/wal.log" }).recovery
+        .walPath,
+    ).toBe("var/wal.log");
   });
 
   it("treats a blank WAL path as null", () => {
-    expect(extendedConfig({ OPENBRAIN_RECOVERY_WAL_PATH: "" }).recovery.walPath).toBeNull();
+    expect(
+      extendedConfig({ OPENBRAIN_RECOVERY_WAL_PATH: "" }).recovery.walPath,
+    ).toBeNull();
   });
 });
 
 describe("extended env — sharedNamespaceNames", () => {
   it("defaults physical to the canonical name and legacy to empty", () => {
     const names = extendedConfig().sharedNamespaceNames;
-    expect(names.physical).toBe("shared-kb");
+    expect(names.physicalSharedNamespace).toBe("shared-kb");
     // #167 retired `collab`; an empty legacy name must never match input.
-    expect(names.legacy).toBe("");
+    expect(names.legacySharedNamespace).toBe("");
     expect(names.legacyFallbackEnabled).toBe(false);
     expect(names.fallbackMinResults).toBe(5);
   });
 
   it("takes an explicit physical name pointed away from the canonical one", () => {
     expect(
-      extendedConfig({ SHARED_NAMESPACE_PHYSICAL: "shared-kb-v2" }).sharedNamespaceNames.physical,
+      extendedConfig({ SHARED_NAMESPACE_PHYSICAL: "shared-kb-v2" })
+        .sharedNamespaceNames.physicalSharedNamespace,
     ).toBe("shared-kb-v2");
   });
 
@@ -421,43 +486,44 @@ describe("extended env — sharedNamespaceNames", () => {
       SHARED_NAMESPACE_LEGACY: "collab",
       OPENBRAIN_LEGACY_SHARED_NAMESPACE: "older",
     }).sharedNamespaceNames;
-    expect(names.legacy).toBe("collab");
+    expect(names.legacySharedNamespace).toBe("collab");
   });
 
   it("falls back to OPENBRAIN_LEGACY_SHARED_NAMESPACE", () => {
     expect(
-      extendedConfig({ OPENBRAIN_LEGACY_SHARED_NAMESPACE: "collab" }).sharedNamespaceNames.legacy,
+      extendedConfig({ OPENBRAIN_LEGACY_SHARED_NAMESPACE: "collab" })
+        .sharedNamespaceNames.legacySharedNamespace,
     ).toBe("collab");
   });
 
   it("enables the legacy fallback on each permissive true token", () => {
     for (const token of ["1", "true", "YES", " on "]) {
       expect(
-        extendedConfig({ OPENBRAIN_LEGACY_SHARED_FALLBACK: token }).sharedNamespaceNames
-          .legacyFallbackEnabled,
+        extendedConfig({ OPENBRAIN_LEGACY_SHARED_FALLBACK: token })
+          .sharedNamespaceNames.legacyFallbackEnabled,
       ).toBe(true);
     }
   });
 
   it("treats an unrecognized flag token as false rather than failing startup", () => {
     expect(
-      extendedConfig({ OPENBRAIN_LEGACY_SHARED_FALLBACK: "maybe" }).sharedNamespaceNames
-        .legacyFallbackEnabled,
+      extendedConfig({ OPENBRAIN_LEGACY_SHARED_FALLBACK: "maybe" })
+        .sharedNamespaceNames.legacyFallbackEnabled,
     ).toBe(false);
   });
 
   it("takes an explicit fallback minimum", () => {
     expect(
-      extendedConfig({ OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS: "12" }).sharedNamespaceNames
-        .fallbackMinResults,
+      extendedConfig({ OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS: "12" })
+        .sharedNamespaceNames.fallbackMinResults,
     ).toBe(12);
   });
 
   it("ignores a non-positive fallback minimum rather than failing startup", () => {
     for (const bad of ["0", "-1", "abc"]) {
       expect(
-        extendedConfig({ OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS: bad }).sharedNamespaceNames
-          .fallbackMinResults,
+        extendedConfig({ OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS: bad })
+          .sharedNamespaceNames.fallbackMinResults,
       ).toBe(5);
     }
   });
@@ -478,7 +544,10 @@ describe("extended env — tracing", () => {
   });
 
   it("is on only when the flag is set AND all three coordinates are present", () => {
-    const tracing = extendedConfig({ ...COORDINATES, OPENBRAIN_TRACING_ENABLED: "1" }).tracing;
+    const tracing = extendedConfig({
+      ...COORDINATES,
+      OPENBRAIN_TRACING_ENABLED: "1",
+    }).tracing;
     expect(tracing.enabled).toBe(true);
     expect(tracing.endpoint).toBe("https://langfuse.internal");
     expect(tracing.publicKey).toBe("pk-test");
@@ -487,7 +556,8 @@ describe("extended env — tracing", () => {
   it("stays off when the coordinates are complete but the flag is not exactly 1", () => {
     // An external payload-carrying export is opt-in; `true` is not the flag.
     expect(
-      extendedConfig({ ...COORDINATES, OPENBRAIN_TRACING_ENABLED: "true" }).tracing.enabled,
+      extendedConfig({ ...COORDINATES, OPENBRAIN_TRACING_ENABLED: "true" })
+        .tracing.enabled,
     ).toBe(false);
   });
 
@@ -495,11 +565,13 @@ describe("extended env — tracing", () => {
   // `readMcpTracingConfig` itself in the start-equivalence block below.
 
   it("disables masking only on an exact 0", () => {
-    expect(extendedConfig({ OPENBRAIN_TRACING_MASKING_ENABLED: "0" }).tracing.maskingEnabled).toBe(
-      false,
-    );
     expect(
-      extendedConfig({ OPENBRAIN_TRACING_MASKING_ENABLED: "false" }).tracing.maskingEnabled,
+      extendedConfig({ OPENBRAIN_TRACING_MASKING_ENABLED: "0" }).tracing
+        .maskingEnabled,
+    ).toBe(false);
+    expect(
+      extendedConfig({ OPENBRAIN_TRACING_MASKING_ENABLED: "false" }).tracing
+        .maskingEnabled,
     ).toBe(true);
   });
 });
@@ -524,9 +596,11 @@ describe("extended env — captureHealth", () => {
   });
 
   it("treats a blank namespace as unset, which is what disables the observer", () => {
-    expect("namespace" in extendedConfig({ OPENBRAIN_CAPTURE_HEALTH_NAMESPACE: "  " }).captureHealth).toBe(
-      false,
-    );
+    expect(
+      "namespace" in
+        extendedConfig({ OPENBRAIN_CAPTURE_HEALTH_NAMESPACE: "  " })
+          .captureHealth,
+    ).toBe(false);
   });
 
   // The unparseable and non-positive cases are asserted against
@@ -553,21 +627,22 @@ describe("extended env — http", () => {
     // the start-equivalence block below.
     const result = parseServerConfig({ ...REQUIRED, PORT: "not-a-port" });
     expect(result.ok).toBe(false);
-    if (result.ok) throw new Error("expected an unbindable port to be rejected");
+    if (result.ok)
+      throw new Error("expected an unbindable port to be rejected");
     expect(result.issues.map((issue) => issue.path)).toEqual(["PORT"]);
   });
 
   it("splits, trims, and drops blanks from the origin list", () => {
     expect(
-      extendedConfig({ ALLOWED_ORIGINS: "https://a.example, ,https://b.example " }).http
-        .allowedOrigins,
+      extendedConfig({
+        ALLOWED_ORIGINS: "https://a.example, ,https://b.example ",
+      }).http.allowedOrigins,
     ).toEqual(["https://a.example", "https://b.example"]);
   });
 
   // The blank list is asserted against `parseAllowedOrigins` itself in the
   // start-equivalence table below, over the whole input set.
 });
-
 
 /**
  * START-EQUIVALENCE: the schema must answer what the READER answers.
@@ -583,12 +658,28 @@ describe("extended env — http", () => {
  * fails a test rather than drifting apart quietly.
  */
 const DIVERGENCE_INPUTS = [
-  "3000ms", "10.5", "1e3", " 42 ", "0x10", "abc", "-1", "0", "", "   ",
-  undefined, "007", "3,000", "+5", "Infinity",
+  "3000ms",
+  "10.5",
+  "1e3",
+  " 42 ",
+  "0x10",
+  "abc",
+  "-1",
+  "0",
+  "",
+  "   ",
+  undefined,
+  "007",
+  "3,000",
+  "+5",
+  "Infinity",
 ] as const;
 
 /** `server/capture/liveness-observer.ts:535-550`, reproduced: `Number`, not `parseInt`. */
-function readPositiveInteger(raw: string | undefined, fallback: number): number {
+function readPositiveInteger(
+  raw: string | undefined,
+  fallback: number,
+): number {
   if (raw === undefined || raw.trim() === "") return fallback;
   const parsed = Number(raw.trim());
   const ok = Number.isFinite(parsed) && Number.isInteger(parsed) && parsed > 0;
@@ -614,7 +705,8 @@ function searchEmbeddingTimeoutMs(
  */
 function expectPortMatchesReader(input: string | undefined): void {
   const expected = Number(input ?? 3_100);
-  const bindable = Number.isInteger(expected) && expected >= 0 && expected <= 65_535;
+  const bindable =
+    Number.isInteger(expected) && expected >= 0 && expected <= 65_535;
   const result = parseServerConfig({ ...REQUIRED, PORT: input });
   if (bindable) {
     expect(result.ok).toBe(true);
@@ -638,10 +730,12 @@ function expectCaptureHealthMatchesReader(input: string | undefined): void {
 
 function expectSearchTimeoutMatchesReader(input: string | undefined): void {
   expect(
-    extendedConfig({ OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: input }).search.embeddingTimeoutMs,
+    extendedConfig({ OPENBRAIN_SEARCH_EMBEDDING_TIMEOUT_MS: input }).search
+      .embeddingTimeoutMs,
   ).toBe(searchEmbeddingTimeoutMs(input, undefined));
   expect(
-    extendedConfig({ SEARCH_EMBEDDING_TIMEOUT_MS: input }).search.embeddingTimeoutMs,
+    extendedConfig({ SEARCH_EMBEDDING_TIMEOUT_MS: input }).search
+      .embeddingTimeoutMs,
   ).toBe(searchEmbeddingTimeoutMs(undefined, input));
 }
 
@@ -706,11 +800,25 @@ describe("start-equivalence — shared-namespace canonical precedence", () => {
     // canonical unset -> the override is what `envString` reaches next
     [{ OPENBRAIN_SHARED_NAMESPACE: "other" }, "other"],
     // both set -> the CANONICAL name wins; the group had this inverted
-    [{ SHARED_NAMESPACE_CANONICAL: "shared-kb", OPENBRAIN_SHARED_NAMESPACE: "other" }, "shared-kb"],
+    [
+      {
+        SHARED_NAMESPACE_CANONICAL: "shared-kb",
+        OPENBRAIN_SHARED_NAMESPACE: "other",
+      },
+      "shared-kb",
+    ],
     // an explicit physical name outranks either canonical coordinate
-    [{ OPENBRAIN_SHARED_NAMESPACE: "other", SHARED_NAMESPACE_PHYSICAL: "shared-kb-v2" }, "shared-kb-v2"],
+    [
+      {
+        OPENBRAIN_SHARED_NAMESPACE: "other",
+        SHARED_NAMESPACE_PHYSICAL: "shared-kb-v2",
+      },
+      "shared-kb-v2",
+    ],
   ])("resolves the physical name from %o", (env, expected) => {
-    expect(extendedConfig(env).sharedNamespaceNames.physical).toBe(expected);
+    expect(
+      extendedConfig(env).sharedNamespaceNames.physicalSharedNamespace,
+    ).toBe(expected);
   });
 
   it("matches readMcpTracingConfig on the complete and incomplete shapes", () => {
@@ -721,7 +829,12 @@ describe("start-equivalence — shared-namespace canonical precedence", () => {
       OPENBRAIN_TRACING_SECRET_KEY: "sk",
     };
     const incomplete = { ...complete, OPENBRAIN_TRACING_ENDPOINT: "  " };
-    for (const shape of [{}, { OPENBRAIN_TRACING_ENABLED: "1" }, complete, incomplete]) {
+    for (const shape of [
+      {},
+      { OPENBRAIN_TRACING_ENABLED: "1" },
+      complete,
+      incomplete,
+    ]) {
       const reader = readMcpTracingConfig(shape);
       const schema = extendedConfig(shape).tracing;
       expect(schema.enabled).toBe(reader.enabled);
@@ -729,5 +842,68 @@ describe("start-equivalence — shared-namespace canonical precedence", () => {
       expect(schema.endpoint).toBe(reader.endpoint);
       expect(schema.publicKey).toBe(reader.publicKey);
     }
+  });
+});
+
+/**
+ * Agreement between the validated group and the environment reader it mirrors.
+ *
+ * L2b-2 rung 5a leaves BOTH paths in force: `sharedNamespaceConfig()` still
+ * derives from `process.env`, and `config.sharedNamespaceNames` now carries the
+ * same five fields. While that lasts, the only thing that keeps the doubled
+ * state honest is a test that drives one input at a time through both and
+ * asserts they answer the same. A disagreement here is a real defect in one
+ * side, not a test to relax — namespace resolution is a security frontier
+ * (`docs/sme/security.md`).
+ */
+describe("sharedNamespaceNames agrees with sharedNamespaceConfig()", () => {
+  const NAMES = [
+    "SHARED_NAMESPACE_PHYSICAL",
+    "SHARED_NAMESPACE_LEGACY",
+    "OPENBRAIN_SHARED_NAMESPACE",
+    "OPENBRAIN_LEGACY_SHARED_NAMESPACE",
+    "OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS",
+  ] as const;
+  const VALUES = [undefined, "", "   ", "7"] as const;
+
+  for (const name of NAMES) {
+    for (const value of VALUES) {
+      it(`agrees for ${name}=${JSON.stringify(value)}`, () => {
+        const saved = process.env[name];
+        try {
+          if (value === undefined) delete process.env[name];
+          else process.env[name] = value;
+          const fromReader = sharedNamespaceConfig();
+          const fromConfig = extendedConfig({
+            [name]: value,
+          }).sharedNamespaceNames;
+          expect(fromConfig).toEqual(fromReader);
+        } finally {
+          if (saved === undefined) delete process.env[name];
+          else process.env[name] = saved;
+        }
+      });
+    }
+  }
+});
+
+describe("shared-namespace helpers honour a passed name set", () => {
+  const NAMES = {
+    canonicalSharedNamespace: "shared-kb",
+    physicalSharedNamespace: "shared-kb-v2",
+    legacySharedNamespace: "collab",
+    legacyFallbackEnabled: false,
+    fallbackMinResults: 5,
+  };
+
+  it("uses the passed set rather than the environment", () => {
+    expect(isSharedNamespace("shared-kb-v2", NAMES)).toBe(true);
+    expect(canonicalNamespace("shared-kb-v2", NAMES)).toBe("shared-kb");
+    expect(canonicalNamespace("collab", NAMES)).toBe("shared-kb");
+    expect(physicalNamespace("shared-kb", NAMES)).toBe("shared-kb-v2");
+  });
+
+  it("still reads the environment when no set is passed", () => {
+    expect(physicalNamespace("shared-kb")).toBe("shared-kb");
   });
 });

--- a/server/config/env-groups.ts
+++ b/server/config/env-groups.ts
@@ -48,17 +48,18 @@
  * cannot receive the string it would get from `process.env`.
  */
 import { z } from "zod";
-import { ftsConfigSchema, resolveFtsConfig, type FtsConfig } from "../tools/fts-config.ts";
+import {
+  ftsConfigSchema,
+  resolveFtsConfig,
+  type FtsConfig,
+} from "../tools/fts-config.ts";
 
 /** Trim, and treat a blank value as absent. Present-but-empty is unset. */
-const blankAsAbsent = z.preprocess(
-  (value) => {
-    if (typeof value !== "string") return value;
-    const trimmed = value.trim();
-    return trimmed === "" ? undefined : trimmed;
-  },
-  z.string().optional(),
-);
+const blankAsAbsent = z.preprocess((value) => {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
+}, z.string().optional());
 
 /**
  * A base-10 integer at or above `minimum`, falling back on anything else.
@@ -153,7 +154,8 @@ const strictZeroDisablesFlag = z.preprocess(
  * allowlist here would be a second opinion on the same question.
  */
 const ftsConfigEnv = z.preprocess(
-  (value) => resolveFtsConfig(typeof value === "string" ? value.trim() : undefined),
+  (value) =>
+    resolveFtsConfig(typeof value === "string" ? value.trim() : undefined),
   ftsConfigSchema,
 );
 
@@ -215,7 +217,9 @@ export const extendedEnvironmentFields = {
   PORT: portNumber,
 } as const;
 
-type ExtendedEnvironment = z.infer<z.ZodObject<typeof extendedEnvironmentFields>>;
+type ExtendedEnvironment = z.infer<
+  z.ZodObject<typeof extendedEnvironmentFields>
+>;
 
 /** No namespace is legacy by default; #167 retired `collab`. */
 const DEFAULT_LEGACY_SHARED_NAMESPACE = "";
@@ -242,10 +246,25 @@ export interface RecoveryConfigGroup {
   readonly walPath: string | null;
 }
 
+/**
+ * The full shared-namespace name set, canonical included.
+ *
+ * Field names match `server/tools/shared-namespace.ts`'s own reader shape
+ * exactly, so the validated group can be handed straight to the helpers there
+ * without a translation step that could invert a name. That module re-exports
+ * this type under its historical name `SharedNamespaceConfig`; the type lives
+ * HERE because `server/config` must never import from `server/tools`.
+ */
 export interface SharedNamespaceGroup {
-  readonly physical: string;
-  readonly legacy: string;
+  /** The name callers pass and results report. */
+  readonly canonicalSharedNamespace: string;
+  /** The name the `namespace` column actually holds. */
+  readonly physicalSharedNamespace: string;
+  /** Non-empty only while an operator has configured a migration source. */
+  readonly legacySharedNamespace: string;
+  /** Whether reads may top up from the legacy namespace. */
   readonly legacyFallbackEnabled: boolean;
+  /** Shared-hit count at or above which the legacy fallback is skipped. */
   readonly fallbackMinResults: number;
 }
 
@@ -305,15 +324,16 @@ export function qmdGroup(parsed: ExtendedEnvironment): QmdConfigGroup {
   return parsed.QMD_PATH ? { path: parsed.QMD_PATH } : {};
 }
 
-export function recoveryGroup(parsed: ExtendedEnvironment): RecoveryConfigGroup {
+export function recoveryGroup(
+  parsed: ExtendedEnvironment,
+): RecoveryConfigGroup {
   return { walPath: parsed.OPENBRAIN_RECOVERY_WAL_PATH ?? null };
 }
 
 /**
- * Physical and legacy shared-namespace names.
+ * Canonical, physical, and legacy shared-namespace names.
  *
- * The canonical name stays on `ServerConfig.sharedNamespace`, which is a
- * `"shared-kb"` literal by decision (`docs/decisions/shared-kb-canonical-namespace.md`).
+ * `ServerConfig.sharedNamespace` remains the `"shared-kb"` literal by decision (`docs/decisions/shared-kb-canonical-namespace.md`).
  * The PHYSICAL name defaults to whatever the canonical override resolved to, so
  * the two are equal in every normal deployment and diverge only when an
  * operator points them apart during a migration —
@@ -337,8 +357,10 @@ export function sharedNamespaceGroup(
   const resolvedCanonical =
     rawCanonical?.trim() || parsed.OPENBRAIN_SHARED_NAMESPACE || "shared-kb";
   return {
-    physical: parsed.SHARED_NAMESPACE_PHYSICAL ?? resolvedCanonical,
-    legacy:
+    canonicalSharedNamespace: resolvedCanonical,
+    physicalSharedNamespace:
+      parsed.SHARED_NAMESPACE_PHYSICAL ?? resolvedCanonical,
+    legacySharedNamespace:
       parsed.SHARED_NAMESPACE_LEGACY ??
       parsed.OPENBRAIN_LEGACY_SHARED_NAMESPACE ??
       DEFAULT_LEGACY_SHARED_NAMESPACE,

--- a/server/main.ts
+++ b/server/main.ts
@@ -188,6 +188,7 @@ function createServerFactory(input: {
       // needs an env record at all. Spread rather than assigned because the key
       // is optional and must stay ABSENT, not present-and-undefined.
       ...(config.qmd.path ? { qmdPath: config.qmd.path } : {}),
+      sharedNamespaceNames: config.sharedNamespaceNames,
       recoveryWalPath: config.recovery.walPath,
       natsRuntimeBoundary: nats.boundary,
       ...realtime,

--- a/server/tools/search-engine-types.ts
+++ b/server/tools/search-engine-types.ts
@@ -16,6 +16,7 @@ import type { Logger } from "pino";
 import type { Pool } from "pg";
 import type { ResourceTable } from "../auth/types.ts";
 import type { FtsConfig } from "./fts-config.ts";
+import type { SharedNamespaceConfig } from "./shared-namespace.ts";
 
 export type SearchMode = "hybrid" | "vector" | "keyword";
 
@@ -71,6 +72,8 @@ export interface SearchDependencies {
    * environment produced when this was read here directly.
    */
   readonly searchEmbeddingTimeoutMs?: number;
+  /** Validated shared-namespace names; env-derived when absent. */
+  readonly sharedNamespaceNames?: SharedNamespaceConfig;
 }
 
 export interface ExecuteSearchOptions {

--- a/server/tools/shared-namespace.ts
+++ b/server/tools/shared-namespace.ts
@@ -24,6 +24,8 @@
  * make `""` "legacy" and match unnamespaced input.
  */
 
+import type { SharedNamespaceGroup } from "../config/env-groups.ts";
+
 /** Public name for shared truth when no operator override is configured. */
 const DEFAULT_SHARED_NAMESPACE = "shared-kb";
 /** No namespace is legacy by default; #167 retired `collab`. */
@@ -55,18 +57,15 @@ function envPositiveInteger(name: string, defaultValue: number): number {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : defaultValue;
 }
 
-export interface SharedNamespaceConfig {
-  /** The name callers pass and results report. */
-  readonly canonicalSharedNamespace: string;
-  /** The name the `namespace` column actually holds. */
-  readonly physicalSharedNamespace: string;
-  /** Non-empty only while an operator has configured a migration source. */
-  readonly legacySharedNamespace: string;
-  /** Whether reads may top up from the legacy namespace. */
-  readonly legacyFallbackEnabled: boolean;
-  /** Shared-hit count at or above which the legacy fallback is skipped. */
-  readonly fallbackMinResults: number;
-}
+/**
+ * The shared-namespace name set.
+ *
+ * Declared in `server/config/env-groups.ts` as `SharedNamespaceGroup` and
+ * re-exported here under its historical name so callers do not change: the
+ * dependency direction only runs one way, and `server/config` must never
+ * import from `server/tools`.
+ */
+export type { SharedNamespaceGroup as SharedNamespaceConfig };
 
 /**
  * Resolve the shared-namespace configuration from the environment.
@@ -74,8 +73,16 @@ export interface SharedNamespaceConfig {
  * Read on every call rather than cached at module load: tests and operators
  * both repoint these values at runtime, and a cached copy would silently serve
  * a stale namespace to the predicate that enforces isolation.
+ *
+ * @param names When supplied, the already-validated set from `ServerConfig` is
+ * used verbatim and the environment is not consulted. Omitting it preserves the
+ * historical environment-derived behavior exactly; the reads below go away in a
+ * later rung, once every caller passes the value down.
  */
-export function sharedNamespaceConfig(): SharedNamespaceConfig {
+export function sharedNamespaceConfig(
+  names?: SharedNamespaceGroup,
+): SharedNamespaceGroup {
+  if (names) return names;
   const canonicalSharedNamespace = envString(
     ["SHARED_NAMESPACE_CANONICAL", "OPENBRAIN_SHARED_NAMESPACE"],
     DEFAULT_SHARED_NAMESPACE,
@@ -90,7 +97,10 @@ export function sharedNamespaceConfig(): SharedNamespaceConfig {
       ["SHARED_NAMESPACE_LEGACY", "OPENBRAIN_LEGACY_SHARED_NAMESPACE"],
       DEFAULT_LEGACY_SHARED_NAMESPACE,
     ),
-    legacyFallbackEnabled: envBoolean("OPENBRAIN_LEGACY_SHARED_FALLBACK", false),
+    legacyFallbackEnabled: envBoolean(
+      "OPENBRAIN_LEGACY_SHARED_FALLBACK",
+      false,
+    ),
     fallbackMinResults: envPositiveInteger(
       "OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS",
       DEFAULT_FALLBACK_MIN_RESULTS,
@@ -99,8 +109,11 @@ export function sharedNamespaceConfig(): SharedNamespaceConfig {
 }
 
 /** @returns Whether the name refers to shared truth, canonical or physical. */
-export function isSharedNamespace(namespace: string): boolean {
-  const config = sharedNamespaceConfig();
+export function isSharedNamespace(
+  namespace: string,
+  names?: SharedNamespaceGroup,
+): boolean {
+  const config = sharedNamespaceConfig(names);
   return (
     namespace === config.canonicalSharedNamespace ||
     namespace === config.physicalSharedNamespace
@@ -113,8 +126,11 @@ export function isSharedNamespace(namespace: string): boolean {
  * Applied to emitted rows so a result never exposes the physical partition or
  * the retired legacy name.
  */
-export function canonicalNamespace(namespace: string): string {
-  const config = sharedNamespaceConfig();
+export function canonicalNamespace(
+  namespace: string,
+  names?: SharedNamespaceGroup,
+): string {
+  const config = sharedNamespaceConfig(names);
   if (
     config.legacySharedNamespace !== "" &&
     namespace === config.legacySharedNamespace
@@ -132,8 +148,11 @@ export function canonicalNamespace(namespace: string): string {
  * Applied before building SQL so an authorized canonical name matches the rows
  * that physically carry the partition name.
  */
-export function physicalNamespace(namespace: string): string {
-  const config = sharedNamespaceConfig();
+export function physicalNamespace(
+  namespace: string,
+  names?: SharedNamespaceGroup,
+): string {
+  const config = sharedNamespaceConfig(names);
   return namespace === config.canonicalSharedNamespace
     ? config.physicalSharedNamespace
     : namespace;

--- a/server/tools/types.ts
+++ b/server/tools/types.ts
@@ -4,6 +4,7 @@ import type { Pool } from "pg";
 import type { AuthIdentity } from "../auth/types.ts";
 import type { NatsRuntimeBoundary } from "../../src/nats-runtime.ts";
 import type { FtsConfig } from "./fts-config.ts";
+import type { SharedNamespaceConfig } from "./shared-namespace.ts";
 import type { WorkingSetStore } from "../realtime/working-set.ts";
 import type { RecoveryWalStore } from "../realtime/recovery-wal.ts";
 
@@ -12,6 +13,13 @@ export interface MemoryToolDependencies {
   readonly embedFn: (text: string) => Promise<number[] | null>;
   readonly logger: Logger;
   readonly embeddingModel?: string;
+  /**
+   * Validated shared-namespace names from the composition root.
+   *
+   * Absent means the helpers in `./shared-namespace.ts` derive them from the
+   * environment as they always have; present means this one parse is in force.
+   */
+  readonly sharedNamespaceNames?: SharedNamespaceConfig;
   /**
    * Resolved qmd entry point for `search_all`'s file-index arm.
    *


### PR DESCRIPTION
## Summary

- State 5a of the L2b-2 sequence (#825): the shared-namespace helpers can now be handed the ONE validated name set, and the composition root hands it down. The `process.env` reads stay in `server/tools/shared-namespace.ts` for this step and go away in the rung that follows, once every caller passes the value.
- `sharedNamespaceConfig()`, `isSharedNamespace()`, `canonicalNamespace()`, and `physicalNamespace()` each gain a trailing optional `names` parameter. Supplied, the validated set is used verbatim; omitted, behavior is byte-for-byte what it was, so no caller outside that file changes here.
- `config.sharedNamespaceNames` now carries the full five-field shape rather than four. `sharedNamespaceGroup` already resolved the canonical name internally in order to default the physical one, so exposing it adds no new parsing rule — the same names in the same order with the same default.
- The group's field names are aligned to the reader's spelling (`canonicalSharedNamespace`, `physicalSharedNamespace`, `legacySharedNamespace`) so the validated value passes straight through with no translation step that could invert a name. Only `server/config.test.ts` read the old `.physical`/`.legacy` spellings; no non-test code did.
- The type is declared in `server/config/env-groups.ts` and re-exported from `server/tools/shared-namespace.ts` under its historical name `SharedNamespaceConfig`, because `server/config` must not import from `server/tools`.

## Verification

- Done-means: scripts/done-means/750-l2b2-check-well-formed.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable — no Python touched
- [x] Live Open Brain smoke passed or is not applicable — no runtime behavior change; both paths still answer identically

Evidence:

- RED at `origin/main`: `scripts/done-means/750-l2b2-env-readers-take-config.sh` exit 1, clause 4 reporting `server/main.ts: found 0, expected 1 — "sharedNamespaceNames: config.sharedNamespaceNames"`.
- GREEN here: that clause now counts the arrival — `CLAUSE 4 ... 2/4 values arrive` with only `searchAllEnv:` and `readMcpTracingConfig(config.` outstanding, both owned by later lanes in the sequence. Clause 2 still lists `shared-namespace.ts`, which is expected by design of this sequence: this rung adds the injection point, the following rung removes the environment fallback.
- `scripts/done-means/750-l2b2-check-well-formed.sh` -> exit 0.
- `bunx tsc --noEmit` -> exit 0. `oxlint --deny-warnings` on every touched non-test file -> exit 0.
- `bun run test:isolated server/config.test.ts server/tools/` -> 270 pass, 0 fail across 19 files.

## Critical Self-Review

- Highest-risk behavior: namespace resolution is a security frontier, so a name silently swapped between canonical and physical would mis-bind an isolation predicate. That is exactly why the group's fields were renamed to the reader's spelling rather than mapped positionally at the call site — a positional map is where that inversion hides.
- Assumptions that could be wrong: that the group and the reader already agreed on all five values. Not assumed — asserted, input by input, in the new agreement suite.
- Missing/weak tests: no test yet drives a real tool call end to end with an injected name set, because no caller passes it in this PR by design. The following rung, which threads the value into callers, is where that test belongs.
- Security/permission risk: none added. No predicate, token, or role path is touched, and the default (no `names` argument) is the existing code path unchanged.
- Migration/deploy risk: none. No schema, no migration, no new environment variable, and no changed default, trim rule, or fallback.
- Downstream client/runtime risk: none. No MCP tool schema, transport, or Python client surface changes; the new dependency fields are optional and the exported type name is unchanged for every importer.
- Rollback/cleanup concern: revert is a single commit — the optional parameters are additive and nothing else reads the new field yet.
- Fixes made before PR: resolved the rebase conflict in `SearchDependencies` by keeping BOTH sibling lanes' fields (`searchEmbeddingTimeoutMs` from #847/#848 and `sharedNamespaceNames` here) rather than either side alone, then re-ran typecheck, the done-means, and the suite on the rebased tree.
- Known residual risk: the doubled state persists for one more rung — the validated group and the environment reader both exist, and only the reader is consulted at runtime. The agreement suite is what keeps that honest until the fallback is removed.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no new MEDIUM+ finding — the two hazards it navigated (dependency direction from `server/config` into `server/tools`, and positional field mapping across two spellings of the same names) are already covered by the charter’s dependency-direction rule and `docs/sme/security.md`, and both were designed out rather than discovered late.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime behavior changes in this rung; the injected path is additive and unused by any caller yet.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the change is internal to the TypeScript server's composition root and touches no wire contract or fixture.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- No MCP tool, schema, protocol, or client-facing surface changes, so every downstream step is not applicable. The only exported-name change is internal (`SharedNamespaceGroup` gains fields); `SharedNamespaceConfig` is still exported from the same module for the same importers.
