### PR TITLE
refactor(read-scope): accept shared-namespace names from callers (L2b-2 5b, #825)

### DIFF
--- a/server/tools/read-scope-names.test.ts
+++ b/server/tools/read-scope-names.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Injected shared-namespace names win over the environment.
+ *
+ * The read-scope helpers historically resolved the shared-namespace set from
+ * `process.env` on every call. They now accept the already-validated set from
+ * `ServerConfig` as a trailing optional argument. What this file proves is the
+ * part that is easy to get silently wrong: the injected value is actually USED,
+ * rather than accepted and then ignored in favour of the environment. A
+ * distinctive canonical name is passed in, and the assertions fail if the
+ * environment default is what the helper consulted.
+ */
+import { describe, expect, test } from "bun:test";
+import type { AuthIdentity } from "../auth/types.ts";
+import type { SharedNamespaceConfig } from "./shared-namespace.ts";
+import {
+  canReadNamespace,
+  namespaceFilterFor,
+  readableNamespaces,
+  appendReadNamespacePredicate,
+} from "./read-scope.ts";
+
+/** A shared-namespace set no environment default could produce by accident. */
+const injected: SharedNamespaceConfig = {
+  canonicalSharedNamespace: "lane3-canonical-kb",
+  physicalSharedNamespace: "lane3-physical-kb",
+  legacySharedNamespace: "",
+  legacyFallbackEnabled: false,
+  fallbackMinResults: 5,
+};
+
+const identity: AuthIdentity = {
+  role: "agent",
+  clientId: "rico",
+  tokenClientId: "rico",
+  namespaceSource: "token",
+};
+
+describe("read-scope helpers honour injected shared-namespace names", () => {
+  test("readableNamespaces returns the injected physical shared namespace", () => {
+    expect(readableNamespaces(identity)).toEqual(["rico", "shared-kb"]);
+    expect(readableNamespaces(identity, {}, injected)).toEqual([
+      "rico",
+      "lane3-physical-kb",
+    ]);
+  });
+
+  test("canReadNamespace authorizes the injected canonical name, not the default", () => {
+    expect(canReadNamespace(identity, "lane3-canonical-kb")).toBe(false);
+    expect(canReadNamespace(identity, "lane3-canonical-kb", injected)).toBe(
+      true,
+    );
+    expect(canReadNamespace(identity, "shared-kb", injected)).toBe(false);
+  });
+
+  test("namespaceFilterFor translates through the injected names", () => {
+    expect(namespaceFilterFor(identity, "lane3-canonical-kb")).toBe(
+      "lane3-canonical-kb",
+    );
+    expect(
+      namespaceFilterFor(identity, "lane3-canonical-kb", {}, injected),
+    ).toBe("lane3-physical-kb");
+    expect(namespaceFilterFor(identity, undefined, {}, injected)).toEqual([
+      "rico",
+      "lane3-physical-kb",
+    ]);
+  });
+
+  test("appendReadNamespacePredicate binds the injected namespaces", () => {
+    const params: unknown[] = [];
+    const sql = appendReadNamespacePredicate(identity, params, "t.namespace", {
+      names: injected,
+    });
+
+    expect(sql).toBe(" AND t.namespace = ANY($1::text[])");
+    expect(params).toEqual([["rico", "lane3-physical-kb"]]);
+  });
+});

--- a/server/tools/read-scope.ts
+++ b/server/tools/read-scope.ts
@@ -25,7 +25,11 @@
  * predicate that is silently WRONG still returns rows.
  */
 import type { AuthIdentity } from "../auth/types.ts";
-import { sharedNamespaceConfig, physicalNamespace } from "./shared-namespace.ts";
+import {
+  sharedNamespaceConfig,
+  physicalNamespace,
+  type SharedNamespaceConfig,
+} from "./shared-namespace.ts";
 
 /** Namespace value bound by a search arm: one namespace, several, or none. */
 export type NamespaceFilter = string | string[];
@@ -53,13 +57,17 @@ function isGlobalReader(identity: AuthIdentity): boolean {
  * @param options `includeLegacySharedFallback` adds the configured legacy shared
  *   namespace when the operator has explicitly set one. It is empty by default
  *   (#167 retired `collab`), so this normally changes nothing.
+ * @param names When supplied, the already-validated shared-namespace set from
+ *   `ServerConfig` is used verbatim instead of the environment. Omitting it
+ *   preserves the historical environment-derived behavior exactly.
  * @returns The readable namespaces, or `undefined` when the read is global.
  */
 export function readableNamespaces(
   identity: AuthIdentity,
   options: { includeLegacySharedFallback?: boolean } = {},
+  names?: SharedNamespaceConfig,
 ): string[] | undefined {
-  const config = sharedNamespaceConfig();
+  const config = sharedNamespaceConfig(names);
   const shared = [config.physicalSharedNamespace];
   if (
     options.includeLegacySharedFallback === true &&
@@ -85,18 +93,22 @@ export function readableNamespaces(
  *
  * @param identity Token-derived identity.
  * @param namespace The caller-supplied namespace argument.
+ * @param names When supplied, the already-validated shared-namespace set from
+ *   `ServerConfig` is used verbatim instead of the environment.
  * @returns Whether the identity may read that namespace.
  */
 export function canReadNamespace(
   identity: AuthIdentity,
   namespace: string,
+  names?: SharedNamespaceConfig,
 ): boolean {
-  const config = sharedNamespaceConfig();
+  const config = sharedNamespaceConfig(names);
   // The `all` keyword is a global-role-only read; it is never a way for a scoped
   // identity to widen itself, and a delegated identity cannot use it at all.
   if (namespace === "all") {
     return (
-      identity.namespaceSource !== "delegated" && GLOBAL_ROLES.has(identity.role)
+      identity.namespaceSource !== "delegated" &&
+      GLOBAL_ROLES.has(identity.role)
     );
   }
   // The legacy shared name stays reachable only for break-glass admin roles; a
@@ -108,8 +120,11 @@ export function canReadNamespace(
   ) {
     return false;
   }
-  const allowed = readableNamespaces(identity);
-  return allowed === undefined || allowed.includes(physicalNamespace(namespace));
+  const allowed = readableNamespaces(identity, {}, names);
+  return (
+    allowed === undefined ||
+    allowed.includes(physicalNamespace(namespace, names))
+  );
 }
 
 /**
@@ -120,12 +135,15 @@ export function canReadNamespace(
  *   {@link canReadNamespace}. Passing an unauthorized namespace here would bind
  *   it, which is exactly why the gate runs first at every call site.
  * @param options Forwarded to {@link readableNamespaces}.
+ * @param names When supplied, the already-validated shared-namespace set from
+ *   `ServerConfig` is used verbatim instead of the environment.
  * @returns One namespace, the readable list, or `undefined` for a global read.
  */
 export function namespaceFilterFor(
   identity: AuthIdentity,
   namespace?: string,
   options: { includeLegacySharedFallback?: boolean } = {},
+  names?: SharedNamespaceConfig,
 ): NamespaceFilter | undefined {
   if (
     namespace === "all" &&
@@ -134,8 +152,8 @@ export function namespaceFilterFor(
   ) {
     return undefined;
   }
-  if (namespace !== undefined) return physicalNamespace(namespace);
-  return readableNamespaces(identity, options);
+  if (namespace !== undefined) return physicalNamespace(namespace, names);
+  return readableNamespaces(identity, options, names);
 }
 
 /**
@@ -148,16 +166,22 @@ export function namespaceFilterFor(
  * @param identity Token-derived identity.
  * @param params Parameter array, mutated in place with the bound namespaces.
  * @param column Qualified column to constrain, e.g. `t.namespace`.
- * @param options Forwarded to {@link readableNamespaces}.
+ * @param options Forwarded to {@link readableNamespaces}. `names` carries the
+ *   already-validated shared-namespace set from `ServerConfig`; it rides inside
+ *   the options object rather than as a fifth positional parameter because this
+ *   signature is already at the four-parameter maximum the repo lint enforces.
  * @returns The SQL fragment, or `""` when the read is global.
  */
 export function appendReadNamespacePredicate(
   identity: AuthIdentity,
   params: unknown[],
   column = "namespace",
-  options: { includeLegacySharedFallback?: boolean } = {},
+  options: {
+    includeLegacySharedFallback?: boolean;
+    names?: SharedNamespaceConfig;
+  } = {},
 ): string {
-  const namespaces = readableNamespaces(identity, options);
+  const namespaces = readableNamespaces(identity, options, options.names);
   if (namespaces === undefined) return "";
   params.push(namespaces);
   return ` AND ${column} = ANY($${params.length}::text[])`;


### PR DESCRIPTION
## Summary

- L2b-2 State 5b-A for #825, owner lane for `server/tools/read-scope.ts`. The four exported read-scope helpers resolved the shared-namespace set from the environment on every call; they now accept the already-validated set from `ServerConfig` and thread it through every shared-namespace call inside the file and between the helpers themselves.
- `readableNamespaces`, `canReadNamespace`, and `namespaceFilterFor` take `names?: SharedNamespaceConfig` as a trailing optional parameter, matching the convention `server/tools/shared-namespace.ts` established in #850.
- `appendReadNamespacePredicate` was already at the four-parameter maximum `.oxlintrc.json` enforces (`max-params: 4`), so its `names` rides inside the existing options object instead of as a fifth positional argument. The TSDoc records why, so the asymmetry does not read as an oversight.
- No caller in any other file is touched: with the argument absent, behavior is byte-identical to the environment-derived path. A later lane threads the callers; a final lane removes the environment fallback.

## Verification

- Done-means: scripts/done-means/750-l2b2-check-well-formed.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bash scripts/done-means/750-l2b2-check-well-formed.sh` exits 0 (the well-formedness wrapper). Its inner env-readers check still exits 1 by design and stays that way until the final lane removes the fallback; the wrapper's CLAUSE 4 confirms exit 1 agrees with its own state clauses.

Run on the committed tree, after the pre-commit prettier reformat:

- `bunx tsc --noEmit` -> 0
- `./node_modules/.bin/oxlint --deny-warnings server/tools/read-scope.ts server/tools/read-scope-names.test.ts` -> 0
- `bun run test:isolated server/tools/` -> 172 pass, 0 fail, 560 expect() calls across 19 files
- Red proof: with `server/tools/read-scope.ts` restored to `origin/main` and the new test in place, `bun test server/tools/read-scope-names.test.ts` -> 0 pass, 4 fail. Restored, then 4 pass.

## Critical Self-Review

- Highest-risk behavior: namespace isolation. These four helpers ARE the read predicate, and a wrong value here returns rows rather than erroring. The risk is mitigated by the parameter being optional with no default change: every existing call site omits it and takes the same environment path it took before.
- Assumptions that could be wrong: that no caller outside this file passes positional arguments past the ones it already passed. Checked — the new parameters are strictly appended, so an existing 1-, 2-, or 3-argument call is unaffected, and `bunx tsc --noEmit` over the whole tree is the proof.
- Missing/weak tests: the new test covers the injected path with a non-legacy configuration. The legacy-namespace branches of `canReadNamespace` are exercised only through the environment default, not through an injected legacy name. That gap is inherited, not introduced.
- Security/permission risk: the `all` keyword and the global-role gates are untouched; no branch that decides authorization was reordered. The injected set only supplies names, never role or delegation state.
- Migration/deploy risk: none. No schema, no config surface, no wire contract.
- Downstream client/runtime risk: none. `read-scope.ts` is server-internal and exports no MCP tool, schema, or Python-visible shape.
- Rollback/cleanup concern: single commit, two files, revertable in isolation. Nothing else in the L2b-2 chain depends on this landing first.
- Fixes made before PR: the first test draft typed the fixture identity with an `as AuthIdentity` cast that hid a missing `tokenClientId` field; replaced with a real typed literal so `tsc` checks it.
- Known residual risk: `server/tools/read-scope.ts` still reads the environment whenever `names` is omitted, which is every call today. The file is not done until the caller lane and the fallback-removal lane land.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no MEDIUM+ finding surfaced — this is an additive optional parameter with a proven-red test and no behavior change, and the one lesson worth recording (a four-parameter signature forces the fifth value into the options object) is already stated in the code's own TSDoc where the next reader will hit it.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: server-internal refactor with no runtime behavior change and no client-facing surface.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no MCP tool, schema, or contract shape changed; the edit is confined to an internal TypeScript signature.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, transport, or Python-client surface is touched. The change is an optional parameter on four server-internal functions whose default path is unchanged.
