### PR TITLE
refactor(search-engine): pass shared-namespace names from dependencies (L2b-2 5b, #825)

### DIFF
--- a/server/tools/search-engine-rows.ts
+++ b/server/tools/search-engine-rows.ts
@@ -13,6 +13,7 @@
  * make the legacy top-up compare a canonical name against a physical one.
  */
 import { canonicalNamespace } from "./shared-namespace.ts";
+import type { SharedNamespaceConfig } from "./shared-namespace.ts";
 import type { SearchRow } from "./search-engine-types.ts";
 
 /** Convert a timestamp-ish value to an ISO string, or `undefined`. */
@@ -47,18 +48,26 @@ export function withSourceRefs(rows: SearchRow[]): SearchRow[] {
   }));
 }
 
-/** Report the canonical shared name on emitted rows and their source refs. */
-export function withCanonicalNamespaces(rows: SearchRow[]): SearchRow[] {
+/**
+ * Report the canonical shared name on emitted rows and their source refs.
+ *
+ * @param names Validated shared-namespace names from `ServerConfig`. Omitting
+ * it leaves the environment-derived resolution unchanged.
+ */
+export function withCanonicalNamespaces(
+  rows: SearchRow[],
+  names?: SharedNamespaceConfig,
+): SearchRow[] {
   return rows.map((row) => ({
     ...row,
     namespace: row.namespace
-      ? canonicalNamespace(row.namespace)
+      ? canonicalNamespace(row.namespace, names)
       : row.namespace,
     source_ref: row.source_ref
       ? {
           ...row.source_ref,
           namespace: row.source_ref.namespace
-            ? canonicalNamespace(row.source_ref.namespace)
+            ? canonicalNamespace(row.source_ref.namespace, names)
             : row.source_ref.namespace,
         }
       : row.source_ref,

--- a/server/tools/search-engine.test.ts
+++ b/server/tools/search-engine.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import type { Logger } from "pino";
 import type { Pool } from "pg";
-import { executeSearch } from "./search-engine.ts";
+import {
+  executeSearch,
+  executeSearchWithSharedFallback,
+} from "./search-engine.ts";
+import type { SharedNamespaceConfig } from "./shared-namespace.ts";
 import {
   DEFAULT_SEARCH_EMBEDDING_TIMEOUT_MS,
   type SearchDependencies,
@@ -85,5 +89,84 @@ describe("search embedding timeout injection", () => {
     );
     expect(dependencies.searchEmbeddingTimeoutMs).toBeUndefined();
     expect(warnings).toHaveLength(0);
+  });
+});
+
+/**
+ * Prove the injected shared-namespace names are the ones the search path
+ * resolves against.
+ *
+ * The observable is the namespace reported on an emitted row. A row is stored
+ * under the PHYSICAL name; `executeSearchWithSharedFallback` canonicalises it
+ * on the way out. Injecting a distinctive canonical name that no environment
+ * default could produce makes the emitted value proof that the injected set —
+ * not the environment — drove the resolution.
+ *
+ * Keyword mode is used so no embedder is needed; the pool is faked so no
+ * database is required.
+ */
+
+const INJECTED_NAMES = {
+  canonicalSharedNamespace: "lane5-canonical-shared",
+  physicalSharedNamespace: "lane5-physical-shared",
+  legacySharedNamespace: "",
+  legacyFallbackEnabled: false,
+  fallbackMinResults: 5,
+} as const;
+
+function poolReturningPhysicalRow(): Pool {
+  return {
+    query: async () => ({
+      rows: [
+        {
+          id: "row-1",
+          source_type: "thoughts",
+          namespace: INJECTED_NAMES.physicalSharedNamespace,
+          content_preview: "shared truth",
+          created_by: "tester",
+        },
+      ],
+    }),
+  } as unknown as Pool;
+}
+
+async function namespaceEmittedWith(
+  names?: SharedNamespaceConfig,
+): Promise<string | undefined> {
+  const dependencies: SearchDependencies = {
+    pool: poolReturningPhysicalRow(),
+    embedFn: async () => null,
+    logger: {
+      warn: () => {},
+      debug: () => {},
+      info: () => {},
+      error: () => {},
+    } as unknown as Logger,
+    sharedNamespaceNames: names,
+  };
+  const rows = await executeSearchWithSharedFallback(
+    dependencies,
+    ["thoughts"],
+    "shared",
+    5,
+    "keyword",
+    undefined,
+    0,
+    INJECTED_NAMES.physicalSharedNamespace,
+  );
+  return rows[0]?.namespace;
+}
+
+describe("shared-namespace name injection on the search path", () => {
+  test("injected names drive the canonical namespace on emitted rows", async () => {
+    expect(await namespaceEmittedWith(INJECTED_NAMES)).toBe(
+      INJECTED_NAMES.canonicalSharedNamespace,
+    );
+  });
+
+  test("no injected names leaves the physical name untranslated", async () => {
+    expect(await namespaceEmittedWith(undefined)).toBe(
+      INJECTED_NAMES.physicalSharedNamespace,
+    );
   });
 });

--- a/server/tools/search-engine.ts
+++ b/server/tools/search-engine.ts
@@ -50,6 +50,7 @@ import {
 } from "./search-constants.ts";
 import { DEFAULT_FTS_CONFIG, type FtsConfig } from "./fts-config.ts";
 import { sharedNamespaceConfig } from "./shared-namespace.ts";
+import type { SharedNamespaceConfig } from "./shared-namespace.ts";
 import type { NamespaceFilter } from "./read-scope.ts";
 import {
   traceRetrievalSpan,
@@ -599,12 +600,16 @@ export function executeSearch(
  * top-up depends on how many canonical rows the CURRENT page found, so pages
  * would overlap or skip rows), and when the request is not actually scoped to
  * the shared namespace.
+ *
+ * @param names Validated shared-namespace names from `ServerConfig`. Omitting
+ * it leaves the environment-derived resolution unchanged.
  */
 function sharedFallbackApplies(
   request: SearchRequest,
   requestedShared: boolean,
+  names?: SharedNamespaceConfig,
 ): boolean {
-  const config = sharedNamespaceConfig();
+  const config = sharedNamespaceConfig(names);
   if (!config.legacyFallbackEnabled) return false;
   if (config.legacySharedNamespace === "") return false;
   if (request.offset !== 0) return false;
@@ -620,7 +625,7 @@ async function searchWithLegacyTopUp(
   dependencies: SearchDependencies,
   request: SearchRequest,
 ): Promise<SearchRow[]> {
-  const config = sharedNamespaceConfig();
+  const config = sharedNamespaceConfig(dependencies.sharedNamespaceNames);
   const primaryRows = await executeSearchInternal(dependencies, request);
   // Enough shared truth was found; the legacy namespace has nothing to add.
   if (
@@ -654,7 +659,8 @@ export async function executeSearchWithSharedFallback(
     args;
   const request = toSearchRequest(args);
   const requestedShared = args[9] ?? false;
-  if (!sharedFallbackApplies(request, requestedShared)) {
+  const names = dependencies.sharedNamespaceNames;
+  if (!sharedFallbackApplies(request, requestedShared, names)) {
     return withCanonicalNamespaces(
       await executeSearch(
         dependencies,
@@ -667,10 +673,12 @@ export async function executeSearchWithSharedFallback(
         namespace,
         args[8] ?? {},
       ),
+      names,
     );
   }
   return withCanonicalNamespaces(
     await searchWithLegacyTopUp(dependencies, request),
+    names,
   );
 }
 


### PR DESCRIPTION
## Summary

- `sharedNamespaceConfig()` re-reads the environment on every call unless it is handed an already-validated name set. #850 gave every shared-namespace export a trailing optional `names?: SharedNamespaceConfig` and put `sharedNamespaceNames` on `SearchDependencies`; this threads that value through the search path so the engine resolves against the validated set instead of a second environment read.
- `server/tools/search-engine.ts`: `sharedFallbackApplies` gains a trailing optional `names` and resolves with it (it carries no `dependencies` of its own, so the caller supplies the value); `executeSearchWithSharedFallback` reads `dependencies.sharedNamespaceNames` once and passes it to `sharedFallbackApplies` and to both `withCanonicalNamespaces` calls; `searchWithLegacyTopUp` already has `dependencies` and resolves from `dependencies.sharedNamespaceNames` directly.
- `server/tools/search-engine-rows.ts`: `withCanonicalNamespaces` gains a trailing optional `names` and forwards it to both `canonicalNamespace` calls.
- The design authority for both files is `docs/decisions/shared-kb-canonical-namespace.md` (canonical vs physical translation on read), already cited in both file headers. This change adds no new structure and reverses no direction of translation; it only changes where the name set comes from. Every added parameter is optional and trailing, so an absent set keeps the previous environment-derived answer exactly. No signature exceeds four parameters, no default changes, and the env fallback inside `shared-namespace.ts` is untouched — a later lane removes it once every caller threads the value.

## Verification

- Done-means: scripts/done-means/750-l2b2-check-well-formed.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Evidence, all run in the lane clone on the committed tree (4ef882a):

- `bunx tsc --noEmit` -> exit 0
- `./node_modules/.bin/oxlint --deny-warnings server/tools/search-engine.ts server/tools/search-engine-rows.ts` -> exit 0
- `bun run test:isolated server/tools/` -> 170 pass, 0 fail, 170 tests across 18 files
- `bash scripts/done-means/750-l2b2-check-well-formed.sh` -> exit 0, all four clauses PASS. Its INNER check still exits 1 by design: the env-readers clause stays red until the final lane deletes the fallback, and the well-formed wrapper asserts that the inner check reaches a real verdict and that its positive control still matches.

Red proof for the new test: removing the `names` argument from the two `withCanonicalNamespaces` calls turned it red (1 fail / 4 pass, on `injected names drive the canonical namespace on emitted rows`); restoring it returned 5 pass. The test drives `executeSearchWithSharedFallback` in keyword mode with a faked pool, so it needs no database and no embedder. Python package is untouched, and this is pure internal parameter threading with no live surface, so no hosted smoke applies.

## Critical Self-Review

- Highest-risk behavior: namespace canonicalisation on emitted rows. If a wrong name set reached `withCanonicalNamespaces`, a row could report a namespace it does not physically live in. Mitigated by the value coming from `SearchDependencies`, which the caller populates from validated config, and by the parameter being optional so an unpopulated caller gets the prior behavior exactly.
- Assumptions that could be wrong: that `dependencies.sharedNamespaceNames` is populated from the same validated group the environment path would have produced. That is #850's contract, not this change's; if a caller injects a divergent set, this change makes that divergence visible on the search path rather than causing it.
- Missing/weak tests: the legacy top-up arm is not exercised end to end here, because the fallback is off by default (`legacySharedNamespace` is empty since #167) and driving it needs a real database. `searchWithLegacyTopUp` is covered only by typecheck and by the existing `server/tools/` suite.
- Security/permission risk: none added. Namespace isolation is enforced by the SQL predicate built from `physicalNamespace`, which this change does not touch; `withCanonicalNamespaces` runs after the predicate and only renames what is already authorized for output.
- Migration/deploy risk: none. No schema change, no config key added or renamed, no default changed. Both new parameters are optional and trailing, so a stale caller compiles and behaves identically.
- Downstream client/runtime risk: none. `withCanonicalNamespaces` and `sharedFallbackApplies` are internal to `server/tools/`; no MCP tool schema, transport shape, REST response, or Python client surface changes. Per `docs/downstream-rollout.md` this is not a contract-changing change.
- Rollback/cleanup concern: revertible as a single commit with no state to unwind. The temporary edit used to prove the test red was restored from a scratch copy and the committed tree was re-verified clean (`git status --short` empty, tsc and oxlint both 0).
- Fixes made before PR: the first draft of the test used `"lexical"` as the search mode, which is not in the `SearchMode` union (`"hybrid" | "vector" | "keyword"`); tsc caught it and it became `"keyword"`.
- Known residual risk: `shared-namespace.ts` still falls back to `process.env` when `names` is absent, so this file pair is threaded but the repo-wide environment read is not yet gone. That is the deliberate state of #825 State 5b, and the sibling lanes plus the final removal lane close it.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no MEDIUM+ finding surfaced — this is mechanical parameter threading behind an optional trailing argument, and the existing entries on canonical-vs-physical namespace resolution already cover the failure mode it touches.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: internal parameter threading only, with no live surface or client-facing behavior change.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no MCP tool schema, transport shape, or client contract is touched — both changed signatures are internal to `server/tools/`.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- No MCP tool, schema, protocol, or client-facing surface changes, so every downstream step is not applicable. The two changed signatures are internal to `server/tools/`, both new parameters are optional and trailing, and behavior with the value absent is unchanged.

Refs #825.
