### PR TITLE
refactor(search-tools): pass shared-namespace names from dependencies in search-brain, search-all and brain-answer (L2b-2 5c, #825)

### DIFF
--- a/server/tools/brain-answer.ts
+++ b/server/tools/brain-answer.ts
@@ -32,7 +32,10 @@ import {
   namespaceFilterFor,
   type NamespaceFilter,
 } from "./read-scope.ts";
-import { isSharedNamespace } from "./shared-namespace.ts";
+import {
+  isSharedNamespace,
+  type SharedNamespaceConfig,
+} from "./shared-namespace.ts";
 import type { Tier } from "./search-constants.ts";
 import { setActiveMcpTraceMetadata } from "../observability/langfuse-tracing.ts";
 import {
@@ -202,11 +205,15 @@ function citedAnswerResult(options: {
 function resolveRequest(
   args: BrainAnswerArgs,
   identity: ReturnType<typeof authIdentity>,
+  names?: SharedNamespaceConfig,
 ): { request: AnswerRequest } | { denial: string } {
   if (!identity) return { denial: NOT_AUTHENTICATED };
 
   const requestedNamespace = args.namespace;
-  if (requestedNamespace && !canReadNamespace(identity, requestedNamespace)) {
+  if (
+    requestedNamespace &&
+    !canReadNamespace(identity, requestedNamespace, names)
+  ) {
     return { denial: NAMESPACE_DENIED };
   }
 
@@ -220,7 +227,7 @@ function resolveRequest(
       mode: (args.search_mode as SearchMode | undefined) ?? "hybrid",
       tier: args.tier as Tier | undefined,
       maxAgeDays: args.max_age_days ?? DEFAULT_MAX_AGE_DAYS,
-      namespace: namespaceFilterFor(identity, requestedNamespace),
+      namespace: namespaceFilterFor(identity, requestedNamespace, {}, names),
       requestedNamespace,
       tables,
       includeRaw: args.include_raw === true,
@@ -249,6 +256,7 @@ export function registerBrainAnswerTool(
       const resolved = resolveRequest(
         args as BrainAnswerArgs,
         authIdentity(extra.authInfo),
+        dependencies.sharedNamespaceNames,
       );
       if ("denial" in resolved) return errorResult(resolved.denial);
       const { request } = resolved;
@@ -262,7 +270,10 @@ export function registerBrainAnswerTool(
         rows = await retrieveAnswerRows(dependencies, request, {
           shared:
             request.requestedNamespace !== undefined &&
-            isSharedNamespace(request.requestedNamespace),
+            isSharedNamespace(
+              request.requestedNamespace,
+              dependencies.sharedNamespaceNames,
+            ),
         });
       } catch (error) {
         // Retrieval failed. An empty citation list here would read as "the brain

--- a/server/tools/search-all.ts
+++ b/server/tools/search-all.ts
@@ -411,7 +411,10 @@ async function searchBrainArm(
       namespace,
       {},
       options.requestedNamespace !== undefined &&
-        isSharedNamespace(options.requestedNamespace),
+        isSharedNamespace(
+          options.requestedNamespace,
+          dependencies.sharedNamespaceNames,
+        ),
     );
     return rows.map(toUnifiedResult);
   } catch (error) {
@@ -540,12 +543,21 @@ export function registerSearchAllTool(
 
       if (
         requestedNamespace &&
-        !canReadNamespace(identity, requestedNamespace)
+        !canReadNamespace(
+          identity,
+          requestedNamespace,
+          dependencies.sharedNamespaceNames,
+        )
       ) {
         return errorResult(NAMESPACE_DENIED);
       }
 
-      const namespace = namespaceFilterFor(identity, requestedNamespace);
+      const namespace = namespaceFilterFor(
+        identity,
+        requestedNamespace,
+        {},
+        dependencies.sharedNamespaceNames,
+      );
       setActiveMcpTraceMetadata({ resolved_namespace: namespace ?? null });
 
       const plan = planFederation(dependencies, sources);

--- a/server/tools/search-brain.ts
+++ b/server/tools/search-brain.ts
@@ -197,8 +197,14 @@ export function registerSearchBrainTool(
       );
       if ("denial" in resolved) return errorResult(resolved.denial);
 
-      const { limit, offset, mode, tier, requestedNamespace, requestedFtsConfig } =
-        normalizeSearchArgs(args);
+      const {
+        limit,
+        offset,
+        mode,
+        tier,
+        requestedNamespace,
+        requestedFtsConfig,
+      } = normalizeSearchArgs(args);
 
       const fts = resolveCallerFtsConfig({
         role: identity.role,
@@ -211,11 +217,20 @@ export function registerSearchBrainTool(
 
       if (
         requestedNamespace &&
-        !canReadNamespace(identity, requestedNamespace)
+        !canReadNamespace(
+          identity,
+          requestedNamespace,
+          dependencies.sharedNamespaceNames,
+        )
       ) {
         return errorResult(NAMESPACE_DENIED);
       }
-      const namespace = namespaceFilterFor(identity, requestedNamespace);
+      const namespace = namespaceFilterFor(
+        identity,
+        requestedNamespace,
+        {},
+        dependencies.sharedNamespaceNames,
+      );
       setActiveMcpTraceMetadata({ resolved_namespace: namespace ?? null });
 
       try {
@@ -230,7 +245,10 @@ export function registerSearchBrainTool(
           namespace,
           { ftsConfig },
           requestedNamespace !== undefined &&
-            isSharedNamespace(requestedNamespace),
+            isSharedNamespace(
+              requestedNamespace,
+              dependencies.sharedNamespaceNames,
+            ),
         );
         return textResult(rows);
       } catch (error) {

--- a/server/tools/search-tools-shared-names.test.ts
+++ b/server/tools/search-tools-shared-names.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The search tools read their shared-namespace names from `dependencies`.
+ *
+ * `search_brain`, `search_all`, and `brain_answer` each gate a caller-supplied
+ * namespace with `canReadNamespace`. That gate treats the shared namespace as
+ * readable by every scoped identity, so a namespace name that ONLY the injected
+ * set defines is the sharpest available probe: with the set threaded through
+ * `dependencies.sharedNamespaceNames` the request is authorized, and with the
+ * set absent the environment default does not know the name and the request is
+ * denied before any query runs.
+ *
+ * The pool is faked and throws, so no arm can return rows; the denial envelope
+ * is what separates the two cases.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import pino from "pino";
+import type { Pool } from "pg";
+import { registerMemoryTools } from "./index.ts";
+import type { SharedNamespaceConfig } from "./shared-namespace.ts";
+
+const INJECTED_NAMES: SharedNamespaceConfig = {
+  canonicalSharedNamespace: "lane3-canonical-shared",
+  physicalSharedNamespace: "lane3-physical-shared",
+  legacySharedNamespace: "",
+  legacyFallbackEnabled: false,
+  fallbackMinResults: 5,
+};
+
+const REACHED_POOL = "reached-the-pool";
+const NAMESPACE_DENIED = "Permission denied: namespace read access denied";
+
+const closers: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(closers.splice(0).map((close) => close()));
+});
+
+async function clientWith(names?: SharedNamespaceConfig): Promise<Client> {
+  const server = new McpServer({ name: "search-names-test", version: "1.0.0" });
+  const pool = {
+    query: async () => {
+      throw new Error(REACHED_POOL);
+    },
+  } as unknown as Pool;
+  registerMemoryTools(server, {
+    pool,
+    embedFn: async () => null,
+    logger: pino({ level: "silent" }),
+    sharedNamespaceNames: names,
+  });
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const send = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message, options) =>
+    send(message, {
+      ...options,
+      authInfo: {
+        role: "agent",
+        clientId: "lane3-caller",
+        namespaceSource: "token",
+      },
+    } as unknown as Parameters<typeof send>[1]);
+  const client = new Client({ name: "search-names-test", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  closers.push(async () => {
+    await client.close();
+    await server.close();
+  });
+  return client;
+}
+
+async function textFor(
+  tool: string,
+  names: SharedNamespaceConfig | undefined,
+): Promise<string> {
+  const client = await clientWith(names);
+  const result = await client.callTool({
+    name: tool,
+    arguments: {
+      query: "anything",
+      namespace: INJECTED_NAMES.canonicalSharedNamespace,
+    },
+  });
+  return (result.content as Array<{ text: string }>)[0]?.text ?? "";
+}
+
+const TOOLS = ["search_brain", "search_all", "brain_answer"];
+
+describe("search tools take shared-namespace names from dependencies", () => {
+  for (const tool of TOOLS) {
+    test(`${tool} authorizes the injected shared namespace`, async () => {
+      expect(await textFor(tool, INJECTED_NAMES)).not.toContain(
+        NAMESPACE_DENIED,
+      );
+    });
+
+    test(`${tool} denies that namespace when no names are injected`, async () => {
+      expect(await textFor(tool, undefined)).toContain(NAMESPACE_DENIED);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- State 5c-1 of #825 (L2b-2). `shared-namespace.ts` (#850) and `read-scope.ts` (#851) already accept an already-validated `SharedNamespaceConfig` from the composition root, and `MemoryToolDependencies.sharedNamespaceNames` already carries it. The three search-facing tools were still calling those helpers with the argument omitted, so each re-derived the names from the environment instead of using the single parse the server performs at startup.
- `server/tools/search-brain.ts`, `server/tools/search-all.ts`, `server/tools/brain-answer.ts`: `dependencies.sharedNamespaceNames` is now threaded to every `isSharedNamespace`, `canReadNamespace`, and `namespaceFilterFor` call.
- In `brain-answer.ts` the gate and the filter sit inside `resolveRequest`, which had no access to `dependencies`. It now takes the names as a third parameter and its one caller — the registered handler — supplies them. Two parameters became three, so no signature grew past the four-parameter maximum and no options object was needed.
- Behavior is unchanged when the names are absent: every helper falls back to the environment exactly as before. That is what makes this safe to land ahead of the sibling lane threading the context-pack tools and the final lane that removes the fallback.
- New test `server/tools/search-tools-shared-names.test.ts` registers the tools with a shared-namespace name no environment default could produce, and asserts each tool authorizes that namespace with the names injected and denies it without them.

## Verification

- Done-means: scripts/done-means/750-l2b2-check-well-formed.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bunx tsc --noEmit` -> exit 0. `./node_modules/.bin/oxlint --deny-warnings` on all four touched files -> exit 0. `bun run test:isolated server/tools/` -> 180 pass, 0 fail across 20 files. All three re-run against the committed tree after the pre-commit prettier pass.

Red-first receipt: with the three source files stashed at `origin/main` and the new test present, `bun test server/tools/search-tools-shared-names.test.ts` -> 3 pass, 3 fail (the three "authorizes the injected shared namespace" cases). With the change restored -> 6 pass, 0 fail.

`bash scripts/done-means/750-l2b2-check-well-formed.sh` -> exit 0. That wrapper checks the inner check is well-formed, not that the migration is finished; the inner env-readers check still exits 1 and will until the final lane removes the environment fallback.

Python package untouched. No migration, no live surface change — the tools resolve the same namespaces from the same values.

## Critical Self-Review

- Highest-risk behavior: the namespace read gate. `canReadNamespace` decides whether a caller-supplied namespace is readable, so passing the wrong names object to it would be an isolation defect that still returns rows rather than erroring. Mitigated by the shape of the change: the names are `undefined` unless the composition root supplies them, and `undefined` reproduces the previous environment-derived path exactly.
- Assumptions that could be wrong: that `resolveRequest` in `brain-answer.ts` has exactly one caller. Verified with `rg -n 'resolveRequest' server/tools/brain-answer.ts` — it is module-private and called once, from the registered handler.
- Missing/weak tests: the new test drives the authorization gate, not the namespace value each arm ultimately binds. `search_all` swallows arm failures and returns an empty envelope, so the fake pool cannot distinguish "queried" from "returned nothing" there; the denial envelope is the seam that separates the two cases uniformly across all three tools. The bound-value assertions for these arms already live in `server/tools/search-read-scope.test.ts` and are unmodified and green.
- Security/permission risk: none introduced. No default changed, no role gained a namespace, and every helper's absent-names path is byte-identical to the previous call.
- Migration/deploy risk: none. No schema change, no config change, no new environment variable read.
- Downstream client/runtime risk: none. No MCP tool schema, no input or output shape, and no error envelope changed. `docs/downstream-rollout.md` classified as not applicable for that reason.
- Rollback/cleanup concern: single commit on its own branch, revertible in isolation. It does not depend on the sibling context-pack lane and does not block it.
- Fixes made before PR: the test first asserted that an injected-names call reaches the faked pool. That held for `search_brain` and `brain_answer` but not `search_all`, which catches arm failures and returns `{"total":0,...}`. Rewritten to assert on the denial envelope, which is observable at all three tools, then re-proven red.
- Known residual risk: the environment fallback is still present in the helpers, so a caller that forgets the argument silently gets environment-derived names with no error. That is the exact hazard the final lane of #825 removes, and this PR does not close it.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new failure pattern surfaced — the one problem hit (a per-tool assertion that did not generalize across arms with different error handling) was caught by the red-first step working as designed, which is already the standing practice rather than a new lesson.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime behavior, schema, or client-facing contract changed; the tools resolve identical namespaces from identical values.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: this is an internal argument-threading refactor. No tool schema, annotation, or response envelope changed, so no contract fixture moves.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, protocol, or client-facing surface changed. The diff moves an optional argument between internal functions.
- Scope held to the three named files plus one new test. `shared-namespace.ts`, `read-scope.ts`, `adjacent-context.ts`, `agent-context-pack.ts`, `list-recent.ts`, `context-pack-durable-memory.ts`, and `search-engine*.ts` are untouched, as is anything importing `src/shared-namespace.ts`. No oxlint disable comment was added.
