### PR TITLE
refactor(context-tools): pass shared-namespace names from dependencies in adjacent-context, agent-context-pack, list-recent and context-pack durable memory (L2b-2 5c, #825)

### DIFF
--- a/server/tools/adjacent-context.ts
+++ b/server/tools/adjacent-context.ts
@@ -264,14 +264,25 @@ function authorizeAdjacencyRead(
   }
 
   const requestedNamespace = requestedFromArgs ?? identity.clientId;
-  if (!canReadNamespace(identity, requestedNamespace)) {
+  if (
+    !canReadNamespace(
+      identity,
+      requestedNamespace,
+      dependencies.sharedNamespaceNames,
+    )
+  ) {
     return {
       denied: errorResult(
         `Permission denied: cannot read namespace '${requestedNamespace}'`,
       ),
     };
   }
-  return { namespace: physicalNamespace(requestedNamespace) };
+  return {
+    namespace: physicalNamespace(
+      requestedNamespace,
+      dependencies.sharedNamespaceNames,
+    ),
+  };
 }
 
 /**

--- a/server/tools/agent-context-pack-names.test.ts
+++ b/server/tools/agent-context-pack-names.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Injected shared-namespace names reach the context-pack authorization seam.
+ *
+ * `buildAgentContextPackPayload` gates the requested namespace before any query
+ * runs. That gate used to resolve the shared-namespace set from the environment
+ * on every call; it now takes the already-validated set carried on
+ * `dependencies.sharedNamespaceNames`. The failure this file guards against is
+ * the quiet one: the field is threaded through the call but the helper still
+ * consults the environment, so the injected value is accepted and ignored. A
+ * canonical name no environment default produces is injected, and the
+ * assertions only pass if that value is what the gate actually consulted.
+ */
+import { describe, expect, test } from "bun:test";
+import type { AuthIdentity } from "../auth/types.ts";
+import type { MemoryToolDependencies } from "./types.ts";
+import type { SharedNamespaceConfig } from "./shared-namespace.ts";
+import { buildAgentContextPackPayload } from "./agent-context-pack.ts";
+
+/** A shared-namespace set no environment default could produce by accident. */
+const injected: SharedNamespaceConfig = {
+  canonicalSharedNamespace: "lane5-canonical-kb",
+  physicalSharedNamespace: "lane5-physical-kb",
+  legacySharedNamespace: "",
+  legacyFallbackEnabled: false,
+  fallbackMinResults: 5,
+};
+
+const identity: AuthIdentity = {
+  role: "agent",
+  clientId: "rico",
+  tokenClientId: "rico",
+  namespaceSource: "token",
+};
+
+const noopLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+} as unknown as MemoryToolDependencies["logger"];
+
+/**
+ * Dependencies whose pool refuses to be used.
+ *
+ * The assertions below all resolve on the authorization path, which returns
+ * before any statement runs. A pool that throws turns "the gate silently let
+ * this through" into a loud test failure instead of a passing one.
+ */
+function dependenciesWith(
+  names?: SharedNamespaceConfig,
+): MemoryToolDependencies {
+  return {
+    pool: {
+      query: () => {
+        throw new Error("no query should run on the authorization path");
+      },
+    } as unknown as MemoryToolDependencies["pool"],
+    embedFn: async () => null,
+    logger: noopLogger,
+    sharedNamespaceNames: names,
+  };
+}
+
+const args = {
+  agent: "claude",
+  platform: "claude-code",
+  server_id: "mac",
+  channel_id: "open-brain",
+  session_key: "lane-5",
+  requested_sections: ["working_set"],
+  namespace: injected.canonicalSharedNamespace,
+} as unknown as Parameters<typeof buildAgentContextPackPayload>[0];
+
+describe("agent_context_pack honours injected shared-namespace names", () => {
+  test("the canonical shared name is denied without the injected set", async () => {
+    const result = await buildAgentContextPackPayload(
+      args,
+      identity,
+      dependenciesWith(),
+    );
+
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.payload)).toContain(
+      "cannot read namespace 'lane5-canonical-kb'",
+    );
+  });
+
+  test("the same name is authorized once the set arrives via dependencies", async () => {
+    const result = await buildAgentContextPackPayload(
+      args,
+      identity,
+      dependenciesWith(injected),
+    );
+
+    // Authorization passed, so the denial payload is gone. Anything past the
+    // gate is out of scope here; what matters is that the gate consulted the
+    // injected names rather than the environment.
+    expect(JSON.stringify(result.payload)).not.toContain(
+      "cannot read namespace",
+    );
+  });
+});

--- a/server/tools/agent-context-pack.ts
+++ b/server/tools/agent-context-pack.ts
@@ -68,6 +68,7 @@ import {
 import { canReadNamespace } from "./read-scope.ts";
 import { recoveryWalStoreFor, workingSetStoreFor } from "./realtime-stores.ts";
 import { physicalNamespace } from "./shared-namespace.ts";
+import type { SharedNamespaceConfig } from "./shared-namespace.ts";
 import { authIdentity, errorResult, textResult } from "./types.ts";
 import type { MemoryToolDependencies } from "./types.ts";
 
@@ -87,6 +88,7 @@ export interface AgentContextPackBuildResult {
 function authorizePack(
   args: AgentContextPackArgs,
   auth: AuthIdentity | undefined,
+  names?: SharedNamespaceConfig,
 ):
   { denial: AgentContextPackBuildResult } | { auth: AuthIdentity; ns: string } {
   if (!auth || !canRead(auth.role, "sessions")) {
@@ -101,7 +103,7 @@ function authorizePack(
   // Gate BEFORE any query runs, so an unauthorized namespace argument is a
   // denial rather than an empty result set — the two are indistinguishable to a
   // caller, and only one of them is honest.
-  if (!canReadNamespace(auth, ns)) {
+  if (!canReadNamespace(auth, ns, names)) {
     return {
       denial: {
         payload: {
@@ -134,16 +136,9 @@ function loadAppendStores(options: {
   };
 }
 
-export async function buildAgentContextPackPayload(
-  args: AgentContextPackArgs,
-  auth: AuthIdentity | undefined,
-  dependencies: MemoryToolDependencies,
-): Promise<AgentContextPackBuildResult> {
-  const authorized = authorizePack(args, auth);
-  if ("denial" in authorized) return authorized.denial;
-  const { auth: identity, ns } = authorized;
-
-  const scope: WorkingSetScope = {
+/** The working-set scope every section of one pack is keyed by. */
+function packScope(args: AgentContextPackArgs, ns: string): WorkingSetScope {
+  return {
     namespace: ns,
     agent: args.agent,
     platform: args.platform,
@@ -152,6 +147,19 @@ export async function buildAgentContextPackPayload(
     thread_id: args.thread_id ?? null,
     session_key: args.session_key,
   };
+}
+
+export async function buildAgentContextPackPayload(
+  args: AgentContextPackArgs,
+  auth: AuthIdentity | undefined,
+  dependencies: MemoryToolDependencies,
+): Promise<AgentContextPackBuildResult> {
+  const names = dependencies.sharedNamespaceNames;
+  const authorized = authorizePack(args, auth, names);
+  if ("denial" in authorized) return authorized.denial;
+  const { auth: identity, ns } = authorized;
+
+  const scope = packScope(args, ns);
   const normalizedScope = normalizeWorkingSetScope(scope);
   const selection = selectSections(args);
 
@@ -161,7 +169,7 @@ export async function buildAgentContextPackPayload(
   // the canonical shared alias to its physical partition exactly as every other
   // isolated read path does, so two namespaces sharing a scope key or repo slug
   // never bleed across the boundary.
-  const readNamespace = physicalNamespace(ns);
+  const readNamespace = physicalNamespace(ns, names);
 
   const allocator = createAllocator(
     wholePackBudgetFor(args.budget?.max_tokens),

--- a/server/tools/context-pack-durable-memory.ts
+++ b/server/tools/context-pack-durable-memory.ts
@@ -511,8 +511,18 @@ function prepareRecall(
   // namespace argument was already authorized by the caller before any query
   // ran; otherwise fall back to the caller's own readable namespaces.
   const namespaceFilter = request.args.namespace
-    ? namespaceFilterFor(request.auth, request.namespace)
-    : namespaceFilterFor(request.auth);
+    ? namespaceFilterFor(
+        request.auth,
+        request.namespace,
+        {},
+        request.dependencies.sharedNamespaceNames,
+      )
+    : namespaceFilterFor(
+        request.auth,
+        undefined,
+        {},
+        request.dependencies.sharedNamespaceNames,
+      );
 
   return { accessibleTables, namespaceFilter };
 }

--- a/server/tools/list-recent.ts
+++ b/server/tools/list-recent.ts
@@ -366,7 +366,11 @@ export function registerListRecentTool(
       const request = normalizeListRecentArgs(args);
       // `undefined` here means a global read, which is only reachable for a role
       // whose reads are global by design; every other role gets the predicate.
-      const readable = readableNamespaces(identity);
+      const readable = readableNamespaces(
+        identity,
+        {},
+        dependencies.sharedNamespaceNames,
+      );
       const queries = buildListRecentQueries({
         tables: scope.tables,
         request,


### PR DESCRIPTION
## Summary

- State 5c-2 of #825. `server/tools/shared-namespace.ts` (#850) and `server/tools/read-scope.ts` (#851) now accept the already-validated shared-namespace name set from `ServerConfig` as a trailing optional argument, and `MemoryToolDependencies` carries it as `sharedNamespaceNames`. Until callers actually pass it, every call still re-derives those names from the environment, so the single parse at the composition root is not yet in force.
- This threads `dependencies.sharedNamespaceNames` into every shared-namespace and read-scope call in four context-oriented tools: `adjacent-context.ts` (`canReadNamespace`, `physicalNamespace`), `agent-context-pack.ts` (`physicalNamespace`, plus `canReadNamespace` inside `authorizePack`, which had no `dependencies` and now takes the name set as its own parameter from its caller), `list-recent.ts` (`readableNamespaces`), and `context-pack-durable-memory.ts` (both `namespaceFilterFor` calls, reached through `request.dependencies`).
- Behavior with the field absent is unchanged: each helper falls back to the environment-derived set exactly as before, which is what the remaining unconverted callers still rely on. Removing that fallback is the final lane of this sequence, not this one.
- The pack scope literal moves into a `packScope` helper. Threading the name set added lines to `buildAgentContextPackPayload`, which sat one line under the repo lint rule for function length; the extraction is the smallest change that keeps it green, and it names a seam the file already had.
- No signature in `shared-namespace.ts` or `read-scope.ts` is touched, no default changes, and no lint rule is disabled.

## Verification

- Done-means: scripts/done-means/750-l2b2-check-well-formed.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bunx tsc --noEmit` → exit 0. `./node_modules/.bin/oxlint --deny-warnings` on the four changed non-test files → exit 0, no diagnostics. `bun run test:isolated server/tools/ src/tools/__tests__/agent-context-pack.test.ts` → 186 pass, 0 fail across 21 files. `bun run test:isolated src/tools/__tests__/adjacent-context.test.ts src/tools/__tests__/agent-context-pack.test.ts src/tools/__tests__/list-recent.test.ts src/tools/__tests__/agent-context-pack-durable-memory.test.ts` → 63 pass, 0 fail. `bash scripts/done-means/750-l2b2-check-well-formed.sh` → exit 0, all four clauses PASS; its inner env-readers check still exits 1 by design, because that clause only flips once the final lane removes the environment fallback.

New test: `server/tools/agent-context-pack-names.test.ts`. It injects a canonical shared name no environment default produces and asserts the context-pack authorization gate consults it rather than the environment. Proven to fail first — reverting the `canReadNamespace` threading restored the denial and the run reported 1 fail; restoring it gave 2 pass. Its stub pool throws if any statement runs, so a gate that silently let the request through fails loudly instead of passing quietly. No existing test was modified.

Python package untouched, so its checks do not apply. No migration, no schema change, and no wire-format change, so a live smoke adds nothing over the isolated suite.

## Critical Self-Review

- Highest-risk behavior: namespace isolation. Every call changed here sits on a read-authorization or physical-namespace-mapping path, so passing the wrong name set would either deny a legitimate read or, worse, map a namespace to the wrong physical partition. The mitigation is that the injected value is `undefined` on every current caller, which is the exact environment-derived path that shipped before.
- Assumptions that could be wrong: that `namespaceFilterFor` and `readableNamespaces` take `names` as their last parameter, after an options object, rather than immediately after the identity. I got this wrong on the first pass and `tsc` caught it — the argument positions are now read off the live signatures in `read-scope.ts`, not assumed.
- Missing/weak tests: only one of the seven threaded call sites is covered by the new test. The other six are covered by typecheck plus the existing suites, which prove no regression but do not prove the injected value reaches those specific calls. A per-seam test for each would be more thorough; one distinctive-value test at a representative seam is what this lane's scope asked for.
- Security/permission risk: `canReadNamespace` in `authorizePack` is a permission gate, and it now takes its name set from a parameter instead of the environment. A caller that forgets to pass it silently falls back to environment behavior rather than failing open — the gate still runs either way, so the failure mode is a stale name set, never a skipped check.
- Migration/deploy risk: none. No schema change, no migration, and no config key added or renamed.
- Downstream client/runtime risk: none identified. No MCP tool schema, no transport, no wire payload, and no Python client surface changes; the edits are internal argument threading behind unchanged exported signatures.
- Rollback/cleanup concern: revertible as a single commit. Nothing outside these four files and one new test file depends on the change, and the fallback it preserves is what a revert would restore anyway.
- Fixes made before PR: corrected the `names` argument position for `readableNamespaces` and `namespaceFilterFor` after `tsc` rejected the first attempt; dropped a non-existent `Logger` type import from the test in favor of an indexed type off `MemoryToolDependencies`; extracted `packScope` after the pre-commit lint pass showed `buildAgentContextPackPayload` had crossed the function-length rule.
- Known residual risk: the environment fallback is still live in every helper, so this PR moves the repo toward one parse without yet achieving it. The done-means inner check reflects that honestly by still exiting 1.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no new MEDIUM+ finding — the two defects hit were an argument-position mistake and a missing export, both caught by `tsc` in the normal loop, and the function-length overrun was caught by the pre-commit lint gate; each is an existing gate working as designed rather than a pattern a future review swarm would need warning about.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no schema, transport, or wire-format change — the isolated suite exercises every changed path.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface changes. The edits thread an existing optional argument between internal functions; no exported tool schema, payload, or client-facing signature moves.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Per `docs/downstream-rollout.md`, rollout applies to MCP tool, schema, protocol, or client-facing changes. This PR changes none of those: it is internal argument threading behind unchanged exported signatures, with identical behavior when the new optional field is absent. No downstream consumer can observe the difference, so every rollout step is not applicable.
