### PR TITLE
feat(config): remove the process.env fallback from shared-namespace so names arrive only from validated config (L2b-2 final, #825)

### DIFF
--- a/server/application/sdk-protocol.pg.test.ts
+++ b/server/application/sdk-protocol.pg.test.ts
@@ -54,7 +54,14 @@
  * `OPENBRAIN_TEST_DATABASE_URL`, which must point at an isolated test/playground
  * database. Never the dogfood database.
  */
-import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
 import type { AddressInfo } from "node:net";
 import type { Server } from "node:http";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -73,17 +80,29 @@ import { RecoveryWalStore } from "../realtime/recovery-wal.ts";
 import { WorkingSetStore } from "../realtime/working-set.ts";
 import { SERVER_REWRITE_STATE } from "../state.ts";
 import { registerMemoryTools } from "../tools/index.ts";
+import { DEFAULT_SHARED_NAMESPACE_NAMES } from "../tools/shared-namespace-fixture.ts";
 import { createWorkerProxyHandler } from "../transport/index.ts";
-import type { AggregateHealth, SingleWorkerHealth } from "../transport/index.ts";
+import type {
+  AggregateHealth,
+  SingleWorkerHealth,
+} from "../transport/index.ts";
 import { silentLogger } from "../transport/testing/silent-logger.ts";
-import { expectRecordedShape, loadServerFixture } from "../../contracts/fixture-shape.ts";
+import {
+  expectRecordedShape,
+  loadServerFixture,
+} from "../../contracts/fixture-shape.ts";
 
 const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
 const dbDescribe = DB_URL ? describe : describe.skip;
 const pool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
 
 const TEST_TOKEN = "sdk-protocol-proof-token";
-const CONNECTED: DatabaseHealth = { connected: true, total: 2, idle: 2, waiting: 0 };
+const CONNECTED: DatabaseHealth = {
+  connected: true,
+  total: 2,
+  idle: 2,
+  waiting: 0,
+};
 
 /**
  * One namespace per TEST, not per run.
@@ -141,7 +160,9 @@ function testConfig(): ServerConfig {
     OPEN_BRAIN_SERVER_IP: "127.0.0.1",
   });
   if (!result.ok) {
-    throw new Error(`invalid test configuration: ${JSON.stringify(result.issues)}`);
+    throw new Error(
+      `invalid test configuration: ${JSON.stringify(result.issues)}`,
+    );
   }
   return result.config;
 }
@@ -264,11 +285,15 @@ async function startWorkerApplication(): Promise<{
     authenticate: bearerAuth(),
     parseRequestBody: express.json(),
     serverFactory: () => {
-      const server = new McpServer({ name: "open-brain-rewrite", version: "1.0.0" });
+      const server = new McpServer({
+        name: "open-brain-rewrite",
+        version: "1.0.0",
+      });
       registerMemoryTools(server, {
         pool,
         embedFn: async () => Array(768).fill(0.01) as number[],
         logger: pino({ level: "silent" }),
+        sharedNamespaceNames: DEFAULT_SHARED_NAMESPACE_NAMES,
         embeddingModel: "sdk-protocol-proof",
         ...realtime,
       });
@@ -276,7 +301,9 @@ async function startWorkerApplication(): Promise<{
     },
   });
   const server = await new Promise<Server>((resolve) => {
-    const listener = application.app.listen(0, "127.0.0.1", () => resolve(listener));
+    const listener = application.app.listen(0, "127.0.0.1", () =>
+      resolve(listener),
+    );
   });
   const { port } = server.address() as AddressInfo;
   extraApplications.push(application);
@@ -305,11 +332,15 @@ async function connectRealClient(): Promise<Client> {
     authenticate: bearerAuth(),
     parseRequestBody: express.json(),
     serverFactory: () => {
-      const server = new McpServer({ name: "open-brain-rewrite", version: "1.0.0" });
+      const server = new McpServer({
+        name: "open-brain-rewrite",
+        version: "1.0.0",
+      });
       registerMemoryTools(server, {
         pool,
         embedFn: async () => Array(768).fill(0.01) as number[],
         logger: pino({ level: "silent" }),
+        sharedNamespaceNames: DEFAULT_SHARED_NAMESPACE_NAMES,
         embeddingModel: "sdk-protocol-proof",
         ...realtime,
       });
@@ -320,7 +351,9 @@ async function connectRealClient(): Promise<Client> {
 
   // Port 0 asks the kernel for an ephemeral port; nothing well-known is bound.
   const httpServer = await new Promise<Server>((resolve) => {
-    const listener = application.app.listen(0, "127.0.0.1", () => resolve(listener));
+    const listener = application.app.listen(0, "127.0.0.1", () =>
+      resolve(listener),
+    );
   });
   live.server = httpServer;
   const { port } = httpServer.address() as AddressInfo;
@@ -390,307 +423,280 @@ afterAll(async () => {
 // with the job still green. Observed on this branch before the rename: the guard
 // reported this suite as MISSING while the JUnit record showed `tests="8"
 // failures="0" skipped="0"`.
-dbDescribe("rewrite candidate over the real MCP SDK and real HTTP transport (live Postgres)", () => {
-  beforeAll(() => {
-    process.env.SHARED_NAMESPACE_CANONICAL = SHARED_ISOLATION;
-    process.env.SHARED_NAMESPACE_PHYSICAL = SHARED_ISOLATION;
-  });
-
-  test("proves protocol behavior for the implementation the cutover made the serving target", () => {
-    expect(SERVER_REWRITE_STATE.servesTraffic).toBe(true);
-    expect(SERVER_REWRITE_STATE.cutoverStarted).toBe(true);
-  });
-
-  test("completes a real initialize handshake and issues an Mcp-Session-Id", async () => {
-    const client = await connectRealClient();
-
-    // A server-assigned session id only exists if the handshake really happened:
-    // the SDK client reads it off the `Mcp-Session-Id` response header, and the
-    // session manager only sets one from `onsessioninitialized`.
-    expect(live.transport?.sessionId).toBeString();
-    expect(live.transport!.sessionId!).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
-    );
-    // The composed session boundary now holds exactly this one live session.
-    expect(live.application?.sessions.sessionCount()).toBe(1);
-    expect(client.getServerVersion()?.name).toBe("open-brain-rewrite");
-  });
-
-  test("lists the registered tool surface over the wire", async () => {
-    const client = await connectRealClient();
-    const listed = await client.listTools();
-    const names = listed.tools.map((tool) => tool.name);
-
-    // Every tool exercised below must be reachable through protocol discovery,
-    // not merely present in the registry: a tool that is registered but not
-    // advertised is invisible to a real client.
-    for (const required of [
-      "session_start",
-      "append_session_event",
-      "session_context",
-      "session_wrap",
-      "log_thought",
-      "search_all",
-      "agent_context_pack",
-    ]) {
-      expect(names).toContain(required);
-    }
-    // Discovery must return real schemas, not bare names.
-    const sessionStart = listed.tools.find((tool) => tool.name === "session_start");
-    expect(sessionStart?.inputSchema).toBeObject();
-  });
-
-  test("round-trips the session lifecycle against the recorded fixture shape", async () => {
-    const client = await connectRealClient();
-    const fixture = await loadServerFixture("server-session-lifecycle");
-    const sessionKey = `sdk-proof/lifecycle-${Date.now()}`;
-
-    for (const step of fixture.steps) {
-      const args = { ...step.arguments, session_key: sessionKey };
-      const observed = await callTool(client, step.tool, args);
-
-      expect(observed.isError).toBe(step.expectation.is_error);
-      expectRecordedShape(observed.body, step.expectation.json, {
-        "{{namespace}}": NAMESPACE,
-        "parity/lifecycle": sessionKey,
-      });
-    }
-  });
-
-  test("performs a capture write that lands a real row and matches the recorded shape", async () => {
-    const client = await connectRealClient();
-    const fixture = await loadServerFixture("server-capture-checkpoint");
-    const logThought = fixture.steps.find((step) => step.tool === "log_thought");
-    if (!logThought) throw new Error("fixture no longer records a log_thought step");
-
-    const content = `sdk protocol proof capture ${Date.now()}`;
-    const observed = await callTool(client, "log_thought", {
-      ...logThought.arguments,
-      content,
+dbDescribe(
+  "rewrite candidate over the real MCP SDK and real HTTP transport (live Postgres)",
+  () => {
+    beforeAll(() => {
+      process.env.SHARED_NAMESPACE_CANONICAL = SHARED_ISOLATION;
+      process.env.SHARED_NAMESPACE_PHYSICAL = SHARED_ISOLATION;
     });
 
-    expect(observed.isError).toBe(false);
-    expectRecordedShape(observed.body, logThought.expectation.json, {
-      "{{namespace}}": NAMESPACE,
+    test("proves protocol behavior for the implementation the cutover made the serving target", () => {
+      expect(SERVER_REWRITE_STATE.servesTraffic).toBe(true);
+      expect(SERVER_REWRITE_STATE.cutoverStarted).toBe(true);
     });
 
-    // The wire said it wrote; Postgres is the authority on whether it did.
-    // "A row was written" is an assertion, not an assumption.
-    const written = (observed.body as { id: string }).id;
-    const { rows } = await pool!.query(
-      "SELECT namespace, content FROM thoughts WHERE id = $1 AND archived_at IS NULL",
-      [written],
-    );
-    expect(rows.length).toBe(1);
-    expect(rows[0].namespace).toBe(NAMESPACE);
-    expect(rows[0].content).toBe(content);
-  });
+    test("completes a real initialize handshake and issues an Mcp-Session-Id", async () => {
+      const client = await connectRealClient();
 
-  test("performs a search read that finds what this session wrote", async () => {
-    const client = await connectRealClient();
-    const content = `sdk protocol proof searchable ${Date.now()}`;
-    const write = await callTool(client, "log_thought", {
-      content,
-      tags: ["parity"],
-    });
-    expect(write.isError).toBe(false);
-    const writtenId = (write.body as { id: string }).id;
-
-    const observed = await callTool(client, "search_all", { query: content });
-    expect(observed.isError).toBe(false);
-
-    // Compared against the recall fixture's recorded envelope, with the ids and
-    // content this run actually produced substituted in.
-    const fixture = await loadServerFixture("server-recall-family");
-    const searchStep = fixture.steps.find((step) => step.tool === "search_all");
-    if (!searchStep) throw new Error("fixture no longer records a search_all step");
-    expectRecordedShape(observed.body, searchStep.expectation.json, {
-      "{{namespace}}": NAMESPACE,
-      "{{thought_id}}": writtenId,
-      "parity recall probe thought": content,
-    });
-  });
-
-  test("fetches agent_context_pack with every requested section over the wire", async () => {
-    const client = await connectRealClient();
-    const fixture = await loadServerFixture("server-context-pack-sections");
-    const packStep = fixture.steps.find((step) => step.tool === "agent_context_pack");
-    if (!packStep) throw new Error("fixture no longer records an agent_context_pack step");
-
-    const sessionKey = `sdk-proof/pack-${Date.now()}`;
-    const observed = await callTool(client, "agent_context_pack", {
-      ...packStep.arguments,
-      session_key: sessionKey,
+      // A server-assigned session id only exists if the handshake really happened:
+      // the SDK client reads it off the `Mcp-Session-Id` response header, and the
+      // session manager only sets one from `onsessioninitialized`.
+      expect(live.transport?.sessionId).toBeString();
+      expect(live.transport!.sessionId!).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+      // The composed session boundary now holds exactly this one live session.
+      expect(live.application?.sessions.sessionCount()).toBe(1);
+      expect(client.getServerVersion()?.name).toBe("open-brain-rewrite");
     });
 
-    expect(observed.isError).toBe(false);
-    expectRecordedShape(observed.body, packStep.expectation.json, {
-      "{{namespace}}": NAMESPACE,
-      "parity/pack": sessionKey,
-    });
-  });
+    test("lists the registered tool surface over the wire", async () => {
+      const client = await connectRealClient();
+      const listed = await client.listTools();
+      const names = listed.tools.map((tool) => tool.name);
 
-  test("refuses an unauthenticated client at the transport before any tool runs", async () => {
-    // The identity chain is the thing this file exists to prove, so its failure
-    // path is behavior too: no token means no `req.auth`, and the SDK must never
-    // reach a handler. Asserted as a rejected connect, not a tool-level error.
-    if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
-    freshNamespace();
-    const application = createShadowApplication({
-      config: testConfig(),
-      logger: silentLogger(),
-      database: fakeHealthDatabase(),
-      authenticate: bearerAuth(),
-      parseRequestBody: express.json(),
-      serverFactory: () => {
-        const server = new McpServer({ name: "open-brain-rewrite", version: "1.0.0" });
-        registerMemoryTools(server, {
-          pool,
-          embedFn: async () => Array(768).fill(0.01) as number[],
-          logger: pino({ level: "silent" }),
-          embeddingModel: "sdk-protocol-proof",
+      // Every tool exercised below must be reachable through protocol discovery,
+      // not merely present in the registry: a tool that is registered but not
+      // advertised is invisible to a real client.
+      for (const required of [
+        "session_start",
+        "append_session_event",
+        "session_context",
+        "session_wrap",
+        "log_thought",
+        "search_all",
+        "agent_context_pack",
+      ]) {
+        expect(names).toContain(required);
+      }
+      // Discovery must return real schemas, not bare names.
+      const sessionStart = listed.tools.find(
+        (tool) => tool.name === "session_start",
+      );
+      expect(sessionStart?.inputSchema).toBeObject();
+    });
+
+    test("round-trips the session lifecycle against the recorded fixture shape", async () => {
+      const client = await connectRealClient();
+      const fixture = await loadServerFixture("server-session-lifecycle");
+      const sessionKey = `sdk-proof/lifecycle-${Date.now()}`;
+
+      for (const step of fixture.steps) {
+        const args = { ...step.arguments, session_key: sessionKey };
+        const observed = await callTool(client, step.tool, args);
+
+        expect(observed.isError).toBe(step.expectation.is_error);
+        expectRecordedShape(observed.body, step.expectation.json, {
+          "{{namespace}}": NAMESPACE,
+          "parity/lifecycle": sessionKey,
         });
-        return server;
-      },
+      }
     });
-    live.application = application;
-    const httpServer = await new Promise<Server>((resolve) => {
-      const listener = application.app.listen(0, "127.0.0.1", () => resolve(listener));
+
+    test("performs a capture write that lands a real row and matches the recorded shape", async () => {
+      const client = await connectRealClient();
+      const fixture = await loadServerFixture("server-capture-checkpoint");
+      const logThought = fixture.steps.find(
+        (step) => step.tool === "log_thought",
+      );
+      if (!logThought)
+        throw new Error("fixture no longer records a log_thought step");
+
+      const content = `sdk protocol proof capture ${Date.now()}`;
+      const observed = await callTool(client, "log_thought", {
+        ...logThought.arguments,
+        content,
+      });
+
+      expect(observed.isError).toBe(false);
+      expectRecordedShape(observed.body, logThought.expectation.json, {
+        "{{namespace}}": NAMESPACE,
+      });
+
+      // The wire said it wrote; Postgres is the authority on whether it did.
+      // "A row was written" is an assertion, not an assumption.
+      const written = (observed.body as { id: string }).id;
+      const { rows } = await pool!.query(
+        "SELECT namespace, content FROM thoughts WHERE id = $1 AND archived_at IS NULL",
+        [written],
+      );
+      expect(rows.length).toBe(1);
+      expect(rows[0].namespace).toBe(NAMESPACE);
+      expect(rows[0].content).toBe(content);
     });
-    live.server = httpServer;
-    const { port } = httpServer.address() as AddressInfo;
 
-    const transport = new StreamableHTTPClientTransport(
-      new URL(`http://127.0.0.1:${port}/mcp`),
-    );
-    const client = new Client({ name: "sdk-protocol-proof-anon", version: "1.0.0" });
-    await expect(client.connect(transport)).rejects.toThrow();
-    // Nothing was admitted: the session boundary stayed empty.
-    expect(application.sessions.sessionCount()).toBe(0);
-  });
+    test("performs a search read that finds what this session wrote", async () => {
+      const client = await connectRealClient();
+      const content = `sdk protocol proof searchable ${Date.now()}`;
+      const write = await callTool(client, "log_thought", {
+        content,
+        tags: ["parity"],
+      });
+      expect(write.isError).toBe(false);
+      const writtenId = (write.body as { id: string }).id;
 
-  test("appends realtime working-set and recovery state against the recorded shapes", async () => {
-    // The realtime WRITE half only became reachable in this wave. Before it, the
-    // fixture was marked `scaffold-declared` for the rewrite provider: the
-    // stores existed and the context pack READ them, but no tool could put
-    // anything in, so every recorded shape here was asserted against
-    // `current-src` alone.
-    const client = await connectRealClient();
-    const fixture = await loadServerFixture("server-realtime-working-recovery");
-    const sessionKey = `sdk-proof/realtime-${Date.now()}`;
+      const observed = await callTool(client, "search_all", { query: content });
+      expect(observed.isError).toBe(false);
 
-    for (const step of fixture.steps) {
-      const observed = await callTool(client, step.tool, {
-        ...step.arguments,
+      // Compared against the recall fixture's recorded envelope, with the ids and
+      // content this run actually produced substituted in.
+      const fixture = await loadServerFixture("server-recall-family");
+      const searchStep = fixture.steps.find(
+        (step) => step.tool === "search_all",
+      );
+      if (!searchStep)
+        throw new Error("fixture no longer records a search_all step");
+      expectRecordedShape(observed.body, searchStep.expectation.json, {
+        "{{namespace}}": NAMESPACE,
+        "{{thought_id}}": writtenId,
+        "parity recall probe thought": content,
+      });
+    });
+
+    test("fetches agent_context_pack with every requested section over the wire", async () => {
+      const client = await connectRealClient();
+      const fixture = await loadServerFixture("server-context-pack-sections");
+      const packStep = fixture.steps.find(
+        (step) => step.tool === "agent_context_pack",
+      );
+      if (!packStep)
+        throw new Error("fixture no longer records an agent_context_pack step");
+
+      const sessionKey = `sdk-proof/pack-${Date.now()}`;
+      const observed = await callTool(client, "agent_context_pack", {
+        ...packStep.arguments,
         session_key: sessionKey,
       });
-      expect(observed.isError).toBe(step.expectation.is_error);
-      expectRecordedShape(observed.body, step.expectation.json, {
+
+      expect(observed.isError).toBe(false);
+      expectRecordedShape(observed.body, packStep.expectation.json, {
         "{{namespace}}": NAMESPACE,
-        "parity/realtime": sessionKey,
+        "parity/pack": sessionKey,
       });
-    }
-  });
-
-  test("a working-set append is visible to the context pack that reads the same store", async () => {
-    // This is the join the two halves share and neither one proves alone. The
-    // stores are RAM-only and process-lifetime, so a write that landed in a
-    // DIFFERENT store object than the pack reads would still return
-    // `accepted: true` and then be invisible forever -- and nothing durable
-    // would ever contradict it, because nothing about this state is durable.
-    // Asserting the append's own response cannot catch that; only reading it
-    // back through the other tool can.
-    const client = await connectRealClient();
-    const sessionKey = `sdk-proof/join-${Date.now()}`;
-    const scope = {
-      agent: "fixture-agent",
-      platform: "test",
-      server_id: "server-1",
-      channel_id: "channel-1",
-      session_key: sessionKey,
-    };
-    const content = `working-set join proof ${Date.now()}`;
-
-    const appended = await callTool(client, "working_set_append", {
-      ...scope,
-      kind: "current_intent",
-      content,
-    });
-    expect(appended.isError).toBe(false);
-    expect((appended.body as { accepted: boolean }).accepted).toBe(true);
-
-    const pack = await callTool(client, "agent_context_pack", {
-      ...scope,
-      requested_sections: ["working_set"],
-    });
-    expect(pack.isError).toBe(false);
-    // The exact content must come back, not merely a non-empty section: a
-    // section that happened to be populated by anything else would pass a
-    // count-only assertion while proving nothing about THIS write.
-    expect(pack.text).toContain(content);
-  });
-
-  test("the two-worker front aggregates real worker health off real sockets", async () => {
-    // Charter section 1.5: production-host runs the aggregate front and each nested
-    // worker body must be preserved. `server/transport/worker-proxy.test.ts`
-    // proves the aggregation logic, but only against an injected `fetch` that
-    // returns a hand-written `{status}` object -- so the thing it never checks
-    // is that a REAL single-worker `/health` payload survives nesting. That is
-    // the join, and this binds two real listeners to prove it.
-    const workerOne = await startWorkerApplication();
-    const workerTwo = await startWorkerApplication();
-    const workers = [
-      {
-        name: "open-brain-worker-1",
-        port: workerOne.port,
-        baseUrl: `http://127.0.0.1:${workerOne.port}`,
-      },
-      {
-        name: "open-brain-worker-2",
-        port: workerTwo.port,
-        baseUrl: `http://127.0.0.1:${workerTwo.port}`,
-      },
-    ];
-    const front = createWorkerProxyHandler({
-      workers,
-      hostname: "test-host",
-      serverIp: "127.0.0.1",
-      serverIps: ["127.0.0.1"],
-      healthProbeTimeoutMs: 2_000,
-      logger: silentLogger(),
     });
 
-    const response = await front(new Request("http://127.0.0.1/health"));
-    const aggregate = (await response.json()) as AggregateHealth;
+    test("refuses an unauthenticated client at the transport before any tool runs", async () => {
+      // The identity chain is the thing this file exists to prove, so its failure
+      // path is behavior too: no token means no `req.auth`, and the SDK must never
+      // reach a handler. Asserted as a rejected connect, not a tool-level error.
+      if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
+      freshNamespace();
+      const application = createShadowApplication({
+        config: testConfig(),
+        logger: silentLogger(),
+        database: fakeHealthDatabase(),
+        authenticate: bearerAuth(),
+        parseRequestBody: express.json(),
+        serverFactory: () => {
+          const server = new McpServer({
+            name: "open-brain-rewrite",
+            version: "1.0.0",
+          });
+          registerMemoryTools(server, {
+            pool,
+            embedFn: async () => Array(768).fill(0.01) as number[],
+            logger: pino({ level: "silent" }),
+            sharedNamespaceNames: DEFAULT_SHARED_NAMESPACE_NAMES,
+            embeddingModel: "sdk-protocol-proof",
+          });
+          return server;
+        },
+      });
+      live.application = application;
+      const httpServer = await new Promise<Server>((resolve) => {
+        const listener = application.app.listen(0, "127.0.0.1", () =>
+          resolve(listener),
+        );
+      });
+      live.server = httpServer;
+      const { port } = httpServer.address() as AddressInfo;
 
-    expect(response.status).toBe(200);
-    expect(aggregate.status).toBe("healthy");
-    expect(aggregate.workers.map((worker) => worker.name)).toEqual([
-      "open-brain-worker-1",
-      "open-brain-worker-2",
-    ]);
-    // Every nested body is a REAL single-worker payload, not a stub: it carries
-    // the fields the charter freezes for the single-worker surface.
-    for (const worker of aggregate.workers) {
-      expect(worker.ok).toBe(true);
-      const body = worker.body as SingleWorkerHealth;
-      expect(body.status).toBe("healthy");
-      expect(body.database.connected).toBe(true);
-      expect(body.nats.requested_transport).toBe("http");
-      expect(typeof body.timestamp).toBe("string");
-    }
-  });
+      const transport = new StreamableHTTPClientTransport(
+        new URL(`http://127.0.0.1:${port}/mcp`),
+      );
+      const client = new Client({
+        name: "sdk-protocol-proof-anon",
+        version: "1.0.0",
+      });
+      await expect(client.connect(transport)).rejects.toThrow();
+      // Nothing was admitted: the session boundary stayed empty.
+      expect(application.sessions.sessionCount()).toBe(0);
+    });
 
-  test("the two-worker front pins one MCP session to one worker", async () => {
-    // Session affinity is the reason the front exists at all: sessions live in
-    // a PROCESS-LOCAL map per worker (charter 1.5), so a follow-up request
-    // routed to the other worker finds no session and the client breaks. Proven
-    // over real sockets with a real SDK handshake, because the session id being
-    // pinned is one the SDK server assigned, not one the test made up.
-    const workerOne = await startWorkerApplication();
-    const workerTwo = await startWorkerApplication();
-    const front = createWorkerProxyHandler({
-      workers: [
+    test("appends realtime working-set and recovery state against the recorded shapes", async () => {
+      // The realtime WRITE half only became reachable in this wave. Before it, the
+      // fixture was marked `scaffold-declared` for the rewrite provider: the
+      // stores existed and the context pack READ them, but no tool could put
+      // anything in, so every recorded shape here was asserted against
+      // `current-src` alone.
+      const client = await connectRealClient();
+      const fixture = await loadServerFixture(
+        "server-realtime-working-recovery",
+      );
+      const sessionKey = `sdk-proof/realtime-${Date.now()}`;
+
+      for (const step of fixture.steps) {
+        const observed = await callTool(client, step.tool, {
+          ...step.arguments,
+          session_key: sessionKey,
+        });
+        expect(observed.isError).toBe(step.expectation.is_error);
+        expectRecordedShape(observed.body, step.expectation.json, {
+          "{{namespace}}": NAMESPACE,
+          "parity/realtime": sessionKey,
+        });
+      }
+    });
+
+    test("a working-set append is visible to the context pack that reads the same store", async () => {
+      // This is the join the two halves share and neither one proves alone. The
+      // stores are RAM-only and process-lifetime, so a write that landed in a
+      // DIFFERENT store object than the pack reads would still return
+      // `accepted: true` and then be invisible forever -- and nothing durable
+      // would ever contradict it, because nothing about this state is durable.
+      // Asserting the append's own response cannot catch that; only reading it
+      // back through the other tool can.
+      const client = await connectRealClient();
+      const sessionKey = `sdk-proof/join-${Date.now()}`;
+      const scope = {
+        agent: "fixture-agent",
+        platform: "test",
+        server_id: "server-1",
+        channel_id: "channel-1",
+        session_key: sessionKey,
+      };
+      const content = `working-set join proof ${Date.now()}`;
+
+      const appended = await callTool(client, "working_set_append", {
+        ...scope,
+        kind: "current_intent",
+        content,
+      });
+      expect(appended.isError).toBe(false);
+      expect((appended.body as { accepted: boolean }).accepted).toBe(true);
+
+      const pack = await callTool(client, "agent_context_pack", {
+        ...scope,
+        requested_sections: ["working_set"],
+      });
+      expect(pack.isError).toBe(false);
+      // The exact content must come back, not merely a non-empty section: a
+      // section that happened to be populated by anything else would pass a
+      // count-only assertion while proving nothing about THIS write.
+      expect(pack.text).toContain(content);
+    });
+
+    test("the two-worker front aggregates real worker health off real sockets", async () => {
+      // Charter section 1.5: production-host runs the aggregate front and each nested
+      // worker body must be preserved. `server/transport/worker-proxy.test.ts`
+      // proves the aggregation logic, but only against an injected `fetch` that
+      // returns a hand-written `{status}` object -- so the thing it never checks
+      // is that a REAL single-worker `/health` payload survives nesting. That is
+      // the join, and this binds two real listeners to prove it.
+      const workerOne = await startWorkerApplication();
+      const workerTwo = await startWorkerApplication();
+      const workers = [
         {
           name: "open-brain-worker-1",
           port: workerOne.port,
@@ -701,85 +707,141 @@ dbDescribe("rewrite candidate over the real MCP SDK and real HTTP transport (liv
           port: workerTwo.port,
           baseUrl: `http://127.0.0.1:${workerTwo.port}`,
         },
-      ],
-      hostname: "test-host",
-      serverIp: "127.0.0.1",
-      serverIps: ["127.0.0.1"],
-      healthProbeTimeoutMs: 2_000,
-      logger: silentLogger(),
+      ];
+      const front = createWorkerProxyHandler({
+        workers,
+        hostname: "test-host",
+        serverIp: "127.0.0.1",
+        serverIps: ["127.0.0.1"],
+        healthProbeTimeoutMs: 2_000,
+        logger: silentLogger(),
+      });
+
+      const response = await front(new Request("http://127.0.0.1/health"));
+      const aggregate = (await response.json()) as AggregateHealth;
+
+      expect(response.status).toBe(200);
+      expect(aggregate.status).toBe("healthy");
+      expect(aggregate.workers.map((worker) => worker.name)).toEqual([
+        "open-brain-worker-1",
+        "open-brain-worker-2",
+      ]);
+      // Every nested body is a REAL single-worker payload, not a stub: it carries
+      // the fields the charter freezes for the single-worker surface.
+      for (const worker of aggregate.workers) {
+        expect(worker.ok).toBe(true);
+        const body = worker.body as SingleWorkerHealth;
+        expect(body.status).toBe("healthy");
+        expect(body.database.connected).toBe(true);
+        expect(body.nats.requested_transport).toBe("http");
+        expect(typeof body.timestamp).toBe("string");
+      }
     });
-    freshNamespace();
 
-    const initialize = await front(
-      new Request("http://127.0.0.1/mcp", {
-        method: "POST",
-        headers: {
-          authorization: `Bearer ${TEST_TOKEN}`,
-          "content-type": "application/json",
-          accept: "application/json, text/event-stream",
-        },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          id: 1,
-          method: "initialize",
-          params: {
-            protocolVersion: "2025-06-18",
-            capabilities: {},
-            clientInfo: { name: "two-worker-affinity", version: "1.0.0" },
+    test("the two-worker front pins one MCP session to one worker", async () => {
+      // Session affinity is the reason the front exists at all: sessions live in
+      // a PROCESS-LOCAL map per worker (charter 1.5), so a follow-up request
+      // routed to the other worker finds no session and the client breaks. Proven
+      // over real sockets with a real SDK handshake, because the session id being
+      // pinned is one the SDK server assigned, not one the test made up.
+      const workerOne = await startWorkerApplication();
+      const workerTwo = await startWorkerApplication();
+      const front = createWorkerProxyHandler({
+        workers: [
+          {
+            name: "open-brain-worker-1",
+            port: workerOne.port,
+            baseUrl: `http://127.0.0.1:${workerOne.port}`,
           },
-        }),
-      }),
-    );
-    expect(initialize.status).toBe(200);
-    const sessionId = initialize.headers.get("mcp-session-id");
-    expect(sessionId).toBeString();
+          {
+            name: "open-brain-worker-2",
+            port: workerTwo.port,
+            baseUrl: `http://127.0.0.1:${workerTwo.port}`,
+          },
+        ],
+        hostname: "test-host",
+        serverIp: "127.0.0.1",
+        serverIps: ["127.0.0.1"],
+        healthProbeTimeoutMs: 2_000,
+        logger: silentLogger(),
+      });
+      freshNamespace();
 
-    // Exactly one worker admitted the session; the other saw nothing. That
-    // asymmetry is what makes affinity load-bearing rather than cosmetic.
-    const admitted = [workerOne, workerTwo].filter(
-      (worker) => worker.application.sessions.sessionCount() === 1,
-    );
-    expect(admitted.length).toBe(1);
-
-    // Each follow-up must SUCCEED, and success is the assertion that matters.
-    //
-    // The obvious version of this test compares the front's own
-    // `x-open-brain-worker` value across requests -- and it proves nothing: that
-    // header is set on the OUTBOUND request the front sends to a worker, never
-    // on the response handed back, so reading it here yields `null` on every
-    // request and `null === null` passes with affinity deliberately broken.
-    // Measured on this branch: disabling the `sessionWorkers` lookup outright
-    // left that version 12/12 green.
-    //
-    // Reaching the wrong worker is instead observable in the only place it is
-    // real -- the session map is PROCESS-LOCAL, so the other worker has never
-    // heard of this session id and answers a JSON-RPC error rather than a
-    // result. Asserting on the answered payload cannot be satisfied by routing
-    // to the wrong process.
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      const followUp = await front(
+      const initialize = await front(
         new Request("http://127.0.0.1/mcp", {
           method: "POST",
           headers: {
             authorization: `Bearer ${TEST_TOKEN}`,
             "content-type": "application/json",
             accept: "application/json, text/event-stream",
-            "mcp-session-id": sessionId!,
           },
-          body: JSON.stringify({ jsonrpc: "2.0", id: attempt + 2, method: "tools/list" }),
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              clientInfo: { name: "two-worker-affinity", version: "1.0.0" },
+            },
+          }),
         }),
       );
-      expect(followUp.status).toBe(200);
-      const answered = await followUp.text();
-      expect(answered).toContain('"result"');
-      expect(answered).toContain("working_set_append");
-      expect(answered).not.toContain("Session not found");
-    }
-    // Still exactly one session in the fleet: affinity routed, it did not
-    // create a second session on the other worker.
-    expect(
-      workerOne.application.sessions.sessionCount() +
-        workerTwo.application.sessions.sessionCount(),
-    ).toBe(1);
-  });
-});
+      expect(initialize.status).toBe(200);
+      const sessionId = initialize.headers.get("mcp-session-id");
+      expect(sessionId).toBeString();
+
+      // Exactly one worker admitted the session; the other saw nothing. That
+      // asymmetry is what makes affinity load-bearing rather than cosmetic.
+      const admitted = [workerOne, workerTwo].filter(
+        (worker) => worker.application.sessions.sessionCount() === 1,
+      );
+      expect(admitted.length).toBe(1);
+
+      // Each follow-up must SUCCEED, and success is the assertion that matters.
+      //
+      // The obvious version of this test compares the front's own
+      // `x-open-brain-worker` value across requests -- and it proves nothing: that
+      // header is set on the OUTBOUND request the front sends to a worker, never
+      // on the response handed back, so reading it here yields `null` on every
+      // request and `null === null` passes with affinity deliberately broken.
+      // Measured on this branch: disabling the `sessionWorkers` lookup outright
+      // left that version 12/12 green.
+      //
+      // Reaching the wrong worker is instead observable in the only place it is
+      // real -- the session map is PROCESS-LOCAL, so the other worker has never
+      // heard of this session id and answers a JSON-RPC error rather than a
+      // result. Asserting on the answered payload cannot be satisfied by routing
+      // to the wrong process.
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const followUp = await front(
+          new Request("http://127.0.0.1/mcp", {
+            method: "POST",
+            headers: {
+              authorization: `Bearer ${TEST_TOKEN}`,
+              "content-type": "application/json",
+              accept: "application/json, text/event-stream",
+              "mcp-session-id": sessionId!,
+            },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: attempt + 2,
+              method: "tools/list",
+            }),
+          }),
+        );
+        expect(followUp.status).toBe(200);
+        const answered = await followUp.text();
+        expect(answered).toContain('"result"');
+        expect(answered).toContain("working_set_append");
+        expect(answered).not.toContain("Session not found");
+      }
+      // Still exactly one session in the fleet: affinity routed, it did not
+      // create a second session on the other worker.
+      expect(
+        workerOne.application.sessions.sessionCount() +
+          workerTwo.application.sessions.sessionCount(),
+      ).toBe(1);
+    });
+  },
+);

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -850,44 +850,18 @@ describe("start-equivalence — shared-namespace canonical precedence", () => {
  *
  * L2b-2 rung 5a leaves BOTH paths in force: `sharedNamespaceConfig()` still
  * derives from `process.env`, and `config.sharedNamespaceNames` now carries the
- * same five fields. While that lasts, the only thing that keeps the doubled
- * state honest is a test that drives one input at a time through both and
- * asserts they answer the same. A disagreement here is a real defect in one
- * side, not a test to relax — namespace resolution is a security frontier
- * (`docs/sme/security.md`).
+/**
+ * The composition root is now the ONLY source of shared-namespace names.
+ *
+ * L2b-2 is finished: `server/tools/shared-namespace.ts` reads no environment at
+ * all, so the previous agreement test between the validated group and an
+ * environment reader no longer has two sides to compare. What has to stay true
+ * instead is that a call site which never received the names FAILS rather than
+ * resolving a default — namespace resolution is a security frontier
+ * (`docs/sme/security.md`), and a silent default there would bind an isolation
+ * predicate to the wrong partition.
  */
-describe("sharedNamespaceNames agrees with sharedNamespaceConfig()", () => {
-  const NAMES = [
-    "SHARED_NAMESPACE_PHYSICAL",
-    "SHARED_NAMESPACE_LEGACY",
-    "OPENBRAIN_SHARED_NAMESPACE",
-    "OPENBRAIN_LEGACY_SHARED_NAMESPACE",
-    "OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS",
-  ] as const;
-  const VALUES = [undefined, "", "   ", "7"] as const;
-
-  for (const name of NAMES) {
-    for (const value of VALUES) {
-      it(`agrees for ${name}=${JSON.stringify(value)}`, () => {
-        const saved = process.env[name];
-        try {
-          if (value === undefined) delete process.env[name];
-          else process.env[name] = value;
-          const fromReader = sharedNamespaceConfig();
-          const fromConfig = extendedConfig({
-            [name]: value,
-          }).sharedNamespaceNames;
-          expect(fromConfig).toEqual(fromReader);
-        } finally {
-          if (saved === undefined) delete process.env[name];
-          else process.env[name] = saved;
-        }
-      });
-    }
-  }
-});
-
-describe("shared-namespace helpers honour a passed name set", () => {
+describe("shared-namespace helpers require the validated name set", () => {
   const NAMES = {
     canonicalSharedNamespace: "shared-kb",
     physicalSharedNamespace: "shared-kb-v2",
@@ -896,14 +870,38 @@ describe("shared-namespace helpers honour a passed name set", () => {
     fallbackMinResults: 5,
   };
 
-  it("uses the passed set rather than the environment", () => {
+  it("uses the passed set", () => {
     expect(isSharedNamespace("shared-kb-v2", NAMES)).toBe(true);
     expect(canonicalNamespace("shared-kb-v2", NAMES)).toBe("shared-kb");
     expect(canonicalNamespace("collab", NAMES)).toBe("shared-kb");
     expect(physicalNamespace("shared-kb", NAMES)).toBe("shared-kb-v2");
   });
 
-  it("still reads the environment when no set is passed", () => {
-    expect(physicalNamespace("shared-kb")).toBe("shared-kb");
+  it("throws naming sharedNamespaceNames when the set is missing", () => {
+    expect(() => isSharedNamespace("x", undefined)).toThrow(
+      /sharedNamespaceNames/,
+    );
+    expect(() => isSharedNamespace("x", undefined)).toThrow(
+      /isSharedNamespace/,
+    );
+  });
+
+  it("throws from every helper that resolves a name", () => {
+    expect(() => canonicalNamespace("x", undefined)).toThrow(
+      /sharedNamespaceNames/,
+    );
+    expect(() => physicalNamespace("x", undefined)).toThrow(
+      /sharedNamespaceNames/,
+    );
+    expect(() => sharedNamespaceConfig(undefined)).toThrow(
+      /sharedNamespaceNames/,
+    );
+  });
+
+  it("carries the same five fields as the validated config group", () => {
+    expect(sharedNamespaceConfig(NAMES)).toEqual(NAMES);
+    expect(Object.keys(extendedConfig({}).sharedNamespaceNames).sort()).toEqual(
+      Object.keys(NAMES).sort(),
+    );
   });
 });

--- a/server/tools/agent-context-pack-names.test.ts
+++ b/server/tools/agent-context-pack-names.test.ts
@@ -72,17 +72,13 @@ const args = {
 } as unknown as Parameters<typeof buildAgentContextPackPayload>[0];
 
 describe("agent_context_pack honours injected shared-namespace names", () => {
-  test("the canonical shared name is denied without the injected set", async () => {
-    const result = await buildAgentContextPackPayload(
-      args,
-      identity,
-      dependenciesWith(),
-    );
-
-    expect(result.isError).toBe(true);
-    expect(JSON.stringify(result.payload)).toContain(
-      "cannot read namespace 'lane5-canonical-kb'",
-    );
+  test("the missing set fails loudly rather than reading as a denial", async () => {
+    // Before the names came from config this returned an ordinary permission
+    // refusal, which made an unwired composition root indistinguishable from a
+    // caller asking for a namespace it genuinely may not read.
+    await expect(
+      buildAgentContextPackPayload(args, identity, dependenciesWith()),
+    ).rejects.toThrow(/sharedNamespaceNames/);
   });
 
   test("the same name is authorized once the set arrives via dependencies", async () => {

--- a/server/tools/context-pack.test.ts
+++ b/server/tools/context-pack.test.ts
@@ -21,6 +21,7 @@ import type { Pool } from "pg";
 import type { Role } from "../config.ts";
 import { WorkingSetStore } from "../realtime/working-set.ts";
 import { registerMemoryTools } from "./index.ts";
+import { DEFAULT_SHARED_NAMESPACE_NAMES } from "./shared-namespace-fixture.ts";
 
 interface CapturedQuery {
   readonly sql: string;
@@ -95,6 +96,7 @@ async function harness(
     pool,
     embedFn: async () => Array(768).fill(0.01),
     logger: pino({ level: "silent" }),
+    sharedNamespaceNames: DEFAULT_SHARED_NAMESPACE_NAMES,
     ...(options.workingSetStore
       ? { workingSetStore: options.workingSetStore }
       : {}),

--- a/server/tools/dependency-arrival.test.ts
+++ b/server/tools/dependency-arrival.test.ts
@@ -36,6 +36,7 @@ import { readNatsRuntimeBoundary } from "../../src/nats-runtime.ts";
 import { resetOperatorDoctorCache } from "../../src/operator-doctor.ts";
 import { registerMemoryTools } from "./index.ts";
 import type { MemoryToolDependencies } from "./types.ts";
+import { DEFAULT_SHARED_NAMESPACE_NAMES } from "./shared-namespace-fixture.ts";
 
 interface CapturedQuery {
   readonly sql: string;
@@ -67,6 +68,7 @@ async function clientFor(
   registerMemoryTools(server, {
     embedFn: async () => Array(768).fill(0.01),
     logger: pino({ level: "silent" }),
+    sharedNamespaceNames: DEFAULT_SHARED_NAMESPACE_NAMES,
     ...dependencies,
   });
   const [clientTransport, serverTransport] =

--- a/server/tools/namespace-denial.test.ts
+++ b/server/tools/namespace-denial.test.ts
@@ -5,6 +5,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import pino from "pino";
 import type { Pool } from "pg";
 import { registerMemoryTools } from "./index.ts";
+import { DEFAULT_SHARED_NAMESPACE_NAMES } from "./shared-namespace-fixture.ts";
 
 const closers: Array<() => Promise<void>> = [];
 
@@ -23,8 +24,10 @@ async function clientForAgent(): Promise<Client> {
     pool,
     embedFn: async () => null,
     logger: pino({ level: "silent" }),
+    sharedNamespaceNames: DEFAULT_SHARED_NAMESPACE_NAMES,
   });
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
   const send = clientTransport.send.bind(clientTransport);
   clientTransport.send = (message, options) =>
     send(message, {
@@ -35,7 +38,10 @@ async function clientForAgent(): Promise<Client> {
         namespaceSource: "token",
       },
     } as unknown as Parameters<typeof send>[1]);
-  const client = new Client({ name: "namespace-denial-test", version: "1.0.0" });
+  const client = new Client({
+    name: "namespace-denial-test",
+    version: "1.0.0",
+  });
   await server.connect(serverTransport);
   await client.connect(clientTransport);
   closers.push(async () => {
@@ -45,7 +51,10 @@ async function clientForAgent(): Promise<Client> {
   return client;
 }
 
-async function textFor(tool: string, arguments_: Record<string, unknown>): Promise<string> {
+async function textFor(
+  tool: string,
+  arguments_: Record<string, unknown>,
+): Promise<string> {
   const client = await clientForAgent();
   const result = await client.callTool({ name: tool, arguments: arguments_ });
   expect(result.isError).toBe(true);
@@ -59,7 +68,9 @@ describe("memory tools preserve namespace denial envelopes", () => {
         session_key: "denied",
         namespace: "attacker",
       }),
-    ).toBe("Permission denied: agent role cannot write to namespace 'attacker'");
+    ).toBe(
+      "Permission denied: agent role cannot write to namespace 'attacker'",
+    );
   });
 
   test("session reads preserve the named namespace denial", async () => {

--- a/server/tools/read-scope-names.test.ts
+++ b/server/tools/read-scope-names.test.ts
@@ -37,7 +37,7 @@ const identity: AuthIdentity = {
 
 describe("read-scope helpers honour injected shared-namespace names", () => {
   test("readableNamespaces returns the injected physical shared namespace", () => {
-    expect(readableNamespaces(identity)).toEqual(["rico", "shared-kb"]);
+    expect(() => readableNamespaces(identity)).toThrow(/sharedNamespaceNames/);
     expect(readableNamespaces(identity, {}, injected)).toEqual([
       "rico",
       "lane3-physical-kb",
@@ -45,7 +45,9 @@ describe("read-scope helpers honour injected shared-namespace names", () => {
   });
 
   test("canReadNamespace authorizes the injected canonical name, not the default", () => {
-    expect(canReadNamespace(identity, "lane3-canonical-kb")).toBe(false);
+    expect(() => canReadNamespace(identity, "lane3-canonical-kb")).toThrow(
+      /sharedNamespaceNames/,
+    );
     expect(canReadNamespace(identity, "lane3-canonical-kb", injected)).toBe(
       true,
     );
@@ -53,8 +55,8 @@ describe("read-scope helpers honour injected shared-namespace names", () => {
   });
 
   test("namespaceFilterFor translates through the injected names", () => {
-    expect(namespaceFilterFor(identity, "lane3-canonical-kb")).toBe(
-      "lane3-canonical-kb",
+    expect(() => namespaceFilterFor(identity, "lane3-canonical-kb")).toThrow(
+      /sharedNamespaceNames/,
     );
     expect(
       namespaceFilterFor(identity, "lane3-canonical-kb", {}, injected),

--- a/server/tools/read-scope.ts
+++ b/server/tools/read-scope.ts
@@ -58,8 +58,8 @@ function isGlobalReader(identity: AuthIdentity): boolean {
  *   namespace when the operator has explicitly set one. It is empty by default
  *   (#167 retired `collab`), so this normally changes nothing.
  * @param names When supplied, the already-validated shared-namespace set from
- *   `ServerConfig` is used verbatim instead of the environment. Omitting it
- *   preserves the historical environment-derived behavior exactly.
+ *   `ServerConfig`, the only source for these names. Omitting it
+ *   makes the shared-namespace helpers throw rather than resolve a default.
  * @returns The readable namespaces, or `undefined` when the read is global.
  */
 export function readableNamespaces(
@@ -94,7 +94,7 @@ export function readableNamespaces(
  * @param identity Token-derived identity.
  * @param namespace The caller-supplied namespace argument.
  * @param names When supplied, the already-validated shared-namespace set from
- *   `ServerConfig` is used verbatim instead of the environment.
+ *   `ServerConfig`, the only source for these names.
  * @returns Whether the identity may read that namespace.
  */
 export function canReadNamespace(
@@ -136,7 +136,7 @@ export function canReadNamespace(
  *   it, which is exactly why the gate runs first at every call site.
  * @param options Forwarded to {@link readableNamespaces}.
  * @param names When supplied, the already-validated shared-namespace set from
- *   `ServerConfig` is used verbatim instead of the environment.
+ *   `ServerConfig`, the only source for these names.
  * @returns One namespace, the readable list, or `undefined` for a global read.
  */
 export function namespaceFilterFor(

--- a/server/tools/search-engine.test.ts
+++ b/server/tools/search-engine.test.ts
@@ -164,9 +164,11 @@ describe("shared-namespace name injection on the search path", () => {
     );
   });
 
-  test("no injected names leaves the physical name untranslated", async () => {
-    expect(await namespaceEmittedWith(undefined)).toBe(
-      INJECTED_NAMES.physicalSharedNamespace,
+  test("no injected names fails loudly rather than emitting a raw name", async () => {
+    // An emitted row that silently kept the physical partition name would leak
+    // that partition to a caller; naming the missing wiring is the safe answer.
+    await expect(namespaceEmittedWith(undefined)).rejects.toThrow(
+      /sharedNamespaceNames/,
     );
   });
 });

--- a/server/tools/search-read-scope.test.ts
+++ b/server/tools/search-read-scope.test.ts
@@ -18,6 +18,7 @@ import pino from "pino";
 import type { Pool } from "pg";
 import type { Role } from "../config.ts";
 import { registerMemoryTools } from "./index.ts";
+import { DEFAULT_SHARED_NAMESPACE_NAMES } from "./shared-namespace-fixture.ts";
 
 interface CapturedQuery {
   readonly sql: string;
@@ -66,8 +67,10 @@ async function clientCapturingQueries(
         ? Array(768).fill(0.01)
         : options.embedding,
     logger: pino({ level: "silent" }),
+    sharedNamespaceNames: DEFAULT_SHARED_NAMESPACE_NAMES,
   });
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
   const send = clientTransport.send.bind(clientTransport);
   clientTransport.send = (message, options_) =>
     send(message, {
@@ -103,7 +106,10 @@ describe("search_brain binds an auth-derived namespace predicate", () => {
   });
 
   test("a global role emits no namespace predicate at all", async () => {
-    const { client, queries } = await clientCapturingQueries("ob-admin", "operator");
+    const { client, queries } = await clientCapturingQueries(
+      "ob-admin",
+      "operator",
+    );
 
     await client.callTool({
       name: "search_brain",
@@ -187,7 +193,11 @@ describe("search_brain gates the non-English FTS configuration", () => {
 
     const result = await client.callTool({
       name: "search_brain",
-      arguments: { query: "nadel", search_mode: "keyword", fts_config: "german" },
+      arguments: {
+        query: "nadel",
+        search_mode: "keyword",
+        fts_config: "german",
+      },
     });
 
     expect(result.isError).toBe(true);
@@ -202,7 +212,11 @@ describe("search_brain gates the non-English FTS configuration", () => {
 
     const result = await client.callTool({
       name: "search_brain",
-      arguments: { query: "nadel", search_mode: "vector", fts_config: "german" },
+      arguments: {
+        query: "nadel",
+        search_mode: "vector",
+        fts_config: "german",
+      },
     });
 
     // Vector mode runs no FTS, so the argument cannot influence execution — and
@@ -212,11 +226,18 @@ describe("search_brain gates the non-English FTS configuration", () => {
   });
 
   test("an admin gets the on-the-fly to_tsvector path with the requested config", async () => {
-    const { client, queries } = await clientCapturingQueries("admin", "operator");
+    const { client, queries } = await clientCapturingQueries(
+      "admin",
+      "operator",
+    );
 
     await client.callTool({
       name: "search_brain",
-      arguments: { query: "nadel", search_mode: "keyword", fts_config: "german" },
+      arguments: {
+        query: "nadel",
+        search_mode: "keyword",
+        fts_config: "german",
+      },
     });
 
     const query = onlyQuery(queries);
@@ -228,11 +249,18 @@ describe("search_brain gates the non-English FTS configuration", () => {
   });
 
   test("english reads the stored GIN-indexed column, never a recomputed vector", async () => {
-    const { client, queries } = await clientCapturingQueries("admin", "operator");
+    const { client, queries } = await clientCapturingQueries(
+      "admin",
+      "operator",
+    );
 
     await client.callTool({
       name: "search_brain",
-      arguments: { query: "needle", search_mode: "keyword", fts_config: "english" },
+      arguments: {
+        query: "needle",
+        search_mode: "keyword",
+        fts_config: "english",
+      },
     });
 
     const query = onlyQuery(queries);
@@ -241,11 +269,18 @@ describe("search_brain gates the non-English FTS configuration", () => {
   });
 
   test("an unrecognized language token falls back rather than reaching SQL", async () => {
-    const { client, queries } = await clientCapturingQueries("admin", "operator");
+    const { client, queries } = await clientCapturingQueries(
+      "admin",
+      "operator",
+    );
 
     await client.callTool({
       name: "search_brain",
-      arguments: { query: "needle", search_mode: "keyword", fts_config: "klingon" },
+      arguments: {
+        query: "needle",
+        search_mode: "keyword",
+        fts_config: "klingon",
+      },
     });
 
     const query = onlyQuery(queries);
@@ -267,7 +302,12 @@ describe("brain_answer scopes its retrieval identically", () => {
 
     const query = onlyQuery(queries);
     expect(query.sql).toContain("t.namespace = ANY($4::text[])");
-    expect(query.values).toEqual(["what is known", 5, 0, ["rico", "shared-kb"]]);
+    expect(query.values).toEqual([
+      "what is known",
+      5,
+      0,
+      ["rico", "shared-kb"],
+    ]);
   });
 
   test("an unreadable namespace is refused before any query runs", async () => {
@@ -303,7 +343,10 @@ describe("list_recent scopes both its data and its count query", () => {
   });
 
   test("a global role emits no predicate in either query", async () => {
-    const { client, queries } = await clientCapturingQueries("ob-admin", "operator");
+    const { client, queries } = await clientCapturingQueries(
+      "ob-admin",
+      "operator",
+    );
 
     await client.callTool({ name: "list_recent", arguments: {} });
 

--- a/server/tools/search-tools-shared-names.test.ts
+++ b/server/tools/search-tools-shared-names.test.ts
@@ -98,8 +98,10 @@ describe("search tools take shared-namespace names from dependencies", () => {
       );
     });
 
-    test(`${tool} denies that namespace when no names are injected`, async () => {
-      expect(await textFor(tool, undefined)).toContain(NAMESPACE_DENIED);
+    test(`${tool} fails loudly when no names are injected`, async () => {
+      // Not a denial: an unwired composition root is a defect, and the tool
+      // says so by name rather than looking like an ordinary refusal.
+      expect(await textFor(tool, undefined)).toContain("sharedNamespaceNames");
     });
   }
 });

--- a/server/tools/shared-namespace-fixture.ts
+++ b/server/tools/shared-namespace-fixture.ts
@@ -1,0 +1,20 @@
+/**
+ * The default shared-namespace name set, for tests that wire tool dependencies.
+ *
+ * `server/tools/shared-namespace.ts` reads no environment: every name arrives
+ * from `ServerConfig.sharedNamespaceNames`, and a call site that omits it
+ * throws. A test that registers the memory tools therefore has to supply the
+ * set the same way `server/main.ts` does. This is the set an unconfigured
+ * deployment produces, so a test using it asserts against the same names it
+ * always did — the values are unchanged, only their source is.
+ */
+import type { SharedNamespaceGroup } from "../config/env-groups.ts";
+
+/** The name set an operator who has configured nothing gets. */
+export const DEFAULT_SHARED_NAMESPACE_NAMES: SharedNamespaceGroup = {
+  canonicalSharedNamespace: "shared-kb",
+  physicalSharedNamespace: "shared-kb",
+  legacySharedNamespace: "",
+  legacyFallbackEnabled: false,
+  fallbackMinResults: 5,
+};

--- a/server/tools/shared-namespace.ts
+++ b/server/tools/shared-namespace.ts
@@ -22,40 +22,13 @@
  * operator sets one. An empty legacy name must never match caller input, so every
  * legacy check below tests for non-empty FIRST — otherwise an unset config would
  * make `""` "legacy" and match unnamespaced input.
+ *
+ * Every name here arrives from the validated `ServerConfig`; this module reads no
+ * environment of its own, so a call site that forgets to pass the set gets an
+ * error naming the function rather than a default that quietly mis-binds.
  */
 
 import type { SharedNamespaceGroup } from "../config/env-groups.ts";
-
-/** Public name for shared truth when no operator override is configured. */
-const DEFAULT_SHARED_NAMESPACE = "shared-kb";
-/** No namespace is legacy by default; #167 retired `collab`. */
-const DEFAULT_LEGACY_SHARED_NAMESPACE = "";
-/** Shared hits below this count let the legacy fallback top up a result set. */
-const DEFAULT_FALLBACK_MIN_RESULTS = 5;
-
-/** First non-empty environment value among `names`, else `defaultValue`. */
-function envString(names: readonly string[], defaultValue: string): string {
-  for (const name of names) {
-    const raw = process.env[name]?.trim();
-    if (raw) return raw;
-  }
-  return defaultValue;
-}
-
-/** Parse a permissive boolean environment flag. */
-function envBoolean(name: string, defaultValue: boolean): boolean {
-  const raw = process.env[name];
-  if (raw === undefined || raw.trim() === "") return defaultValue;
-  return ["1", "true", "yes", "on"].includes(raw.trim().toLowerCase());
-}
-
-/** Parse a positive-integer environment value, falling back when unusable. */
-function envPositiveInteger(name: string, defaultValue: number): number {
-  const raw = process.env[name];
-  if (!raw) return defaultValue;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : defaultValue;
-}
 
 /**
  * The shared-namespace name set.
@@ -68,52 +41,53 @@ function envPositiveInteger(name: string, defaultValue: number): number {
 export type { SharedNamespaceGroup as SharedNamespaceConfig };
 
 /**
- * Resolve the shared-namespace configuration from the environment.
+ * Assert that the composition root supplied the validated name set.
  *
- * Read on every call rather than cached at module load: tests and operators
- * both repoint these values at runtime, and a cached copy would silently serve
- * a stale namespace to the predicate that enforces isolation.
+ * The names arrive from `ServerConfig` and nowhere else — this module reads no
+ * environment. A missing set is a wiring defect at the call site, so it fails
+ * loudly here rather than resolving to a default that would silently point an
+ * isolation predicate at the wrong partition.
  *
- * @param names When supplied, the already-validated set from `ServerConfig` is
- * used verbatim and the environment is not consulted. Omitting it preserves the
- * historical environment-derived behavior exactly; the reads below go away in a
- * later rung, once every caller passes the value down.
+ * @param names The set handed down from the composition root, if any.
+ * @param caller Name of the function whose call site is wired wrong.
+ * @returns The same set, now known to be present.
+ */
+function requireNames(
+  names: SharedNamespaceGroup | undefined,
+  caller: string,
+): SharedNamespaceGroup {
+  if (names) return names;
+  throw new Error(
+    `${caller}: shared-namespace names are missing. The composition root must ` +
+      `supply sharedNamespaceNames from the validated ServerConfig.`,
+  );
+}
+
+/**
+ * Pass through the validated shared-namespace name set.
+ *
+ * Kept as a named accessor so existing call sites read the same way; it adds no
+ * resolution of its own and throws when the names were never wired through.
+ *
+ * @param names The set handed down from the composition root.
+ * @returns The same set.
  */
 export function sharedNamespaceConfig(
   names?: SharedNamespaceGroup,
 ): SharedNamespaceGroup {
-  if (names) return names;
-  const canonicalSharedNamespace = envString(
-    ["SHARED_NAMESPACE_CANONICAL", "OPENBRAIN_SHARED_NAMESPACE"],
-    DEFAULT_SHARED_NAMESPACE,
-  );
-  return {
-    canonicalSharedNamespace,
-    physicalSharedNamespace: envString(
-      ["SHARED_NAMESPACE_PHYSICAL", "OPENBRAIN_SHARED_NAMESPACE"],
-      canonicalSharedNamespace,
-    ),
-    legacySharedNamespace: envString(
-      ["SHARED_NAMESPACE_LEGACY", "OPENBRAIN_LEGACY_SHARED_NAMESPACE"],
-      DEFAULT_LEGACY_SHARED_NAMESPACE,
-    ),
-    legacyFallbackEnabled: envBoolean(
-      "OPENBRAIN_LEGACY_SHARED_FALLBACK",
-      false,
-    ),
-    fallbackMinResults: envPositiveInteger(
-      "OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS",
-      DEFAULT_FALLBACK_MIN_RESULTS,
-    ),
-  };
+  return requireNames(names, "sharedNamespaceConfig");
 }
 
-/** @returns Whether the name refers to shared truth, canonical or physical. */
+/**
+ * @param namespace Caller-supplied or stored namespace name.
+ * @param names Validated set from the composition root.
+ * @returns Whether the name refers to shared truth, canonical or physical.
+ */
 export function isSharedNamespace(
   namespace: string,
   names?: SharedNamespaceGroup,
 ): boolean {
-  const config = sharedNamespaceConfig(names);
+  const config = requireNames(names, "isSharedNamespace");
   return (
     namespace === config.canonicalSharedNamespace ||
     namespace === config.physicalSharedNamespace
@@ -125,12 +99,16 @@ export function isSharedNamespace(
  *
  * Applied to emitted rows so a result never exposes the physical partition or
  * the retired legacy name.
+ *
+ * @param namespace Stored namespace name.
+ * @param names Validated set from the composition root.
+ * @returns The canonical name callers should see.
  */
 export function canonicalNamespace(
   namespace: string,
   names?: SharedNamespaceGroup,
 ): string {
-  const config = sharedNamespaceConfig(names);
+  const config = requireNames(names, "canonicalNamespace");
   if (
     config.legacySharedNamespace !== "" &&
     namespace === config.legacySharedNamespace
@@ -147,12 +125,16 @@ export function canonicalNamespace(
  *
  * Applied before building SQL so an authorized canonical name matches the rows
  * that physically carry the partition name.
+ *
+ * @param namespace Caller-supplied namespace name.
+ * @param names Validated set from the composition root.
+ * @returns The physical name a predicate binds.
  */
 export function physicalNamespace(
   namespace: string,
   names?: SharedNamespaceGroup,
 ): string {
-  const config = sharedNamespaceConfig(names);
+  const config = requireNames(names, "physicalNamespace");
   return namespace === config.canonicalSharedNamespace
     ? config.physicalSharedNamespace
     : namespace;


### PR DESCRIPTION
## Summary

- `server/tools/shared-namespace.ts` carried its own environment readers (`envString`, `envBoolean`, `envPositiveInteger`) and re-derived the shared-namespace set from `process.env` on every call. PRs #850-#854 threaded the validated `ServerConfig.sharedNamespaceNames` through every `server/` caller, so that path had no remaining reader — it was a second source of truth for a value that decides which physical partition an isolation predicate binds. This removes it. Final lane of State 5 of #825.
- `isSharedNamespace`, `canonicalNamespace`, `physicalNamespace`, and the `sharedNamespaceConfig` pass-through now take the validated set and THROW when it is absent, naming the function and saying the composition root must supply `sharedNamespaceNames`. The parameter stays optional in the signature so no call site changes; the check is a call-site guard at runtime, never a module-level exit and never a silent default. A default here is the dangerous outcome, not the safe one: it would resolve to `shared-kb` and quietly bind a predicate to the wrong partition instead of failing where the wiring is actually wrong.
- `server/tools/read-scope.ts` delegates to those helpers and needs no guard of its own. Only its parameter docs change, because they described an environment fallback that no longer exists.
- No default value, name precedence, or trim rule moves. `server/config/env-groups.ts` is untouched and still produces exactly the same five fields with the same precedence.
- No legacy-root bridge was needed: `src/index.ts` does not import `server/tools`, and `server/main.ts` is the only place that builds the tool dependencies object. It already passes `sharedNamespaceNames: config.sharedNamespaceNames`.
- Tests: assertions that previously proved an *environment fallback* now prove the *throw*, because that is the behavior they were guarding. `server/config.test.ts` drops the reader-vs-config agreement block (there is no second side left to compare) and gains a throw proof for each helper. Test files that registered the memory tools without the names now pass the default set through one shared fixture (`server/tools/shared-namespace-fixture.ts`) rather than five copies of the same literal.

## Verification

- Done-means: scripts/done-means/750-l2b2-env-readers-take-config.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED at `origin/main` (34304f0) — `bash scripts/done-means/750-l2b2-env-readers-take-config.sh` exited 1, clause 2 naming 3 `process.env` reads at `server/tools/shared-namespace.ts:39,47,54`.

GREEN at this head — same script, exit 0, all four clauses PASS:

```
CLAUSE 1 (all 4 target files exist):                    PASS — all 4 target files present
CLAUSE 2 (no process.env in any of the 4):              PASS — no process.env read in any of the 4 files — each value now arrives from validated config
CLAUSE 3 (scanner proven to match in server/config.ts):   PASS — server/config.ts still contains 4 process.env line(s) — the pattern, tool, and invocation are proven to match
CLAUSE 4 (values arrive from validated config):         PASS — all 4 values are passed exactly once from validated config
```

Other checks, all re-run on the committed tree after the pre-commit hook's prettier pass:

- `bash scripts/done-means/750-l2b2-check-well-formed.sh` -> 0, all four clauses PASS
- `bunx tsc --noEmit` -> 0
- `./node_modules/.bin/oxlint --deny-warnings server/tools/shared-namespace.ts server/tools/read-scope.ts server/tools/shared-namespace-fixture.ts` -> 0
- `./node_modules/.bin/oxlint --deny-warnings --ignore-pattern '**/*.test.ts' server` -> 0
- `bun run test:isolated server/` -> 517 pass, 0 fail, 41 files
- `bun run test:isolated src/tools/__tests__/` -> 941 pass, 0 fail, 83 files
- `rg -n 'process\.env' server --glob '!*.test.ts'` -> real reads only at `server/config.ts:416`, `server/main.ts:386,436,437,536`, and the pre-existing `server/observability/langfuse-tracing.ts:398` (out of scope for #825 State 5). Every other hit is prose in a comment.

The new throw test was proven able to fail: with the guard temporarily replaced by a returned default set, `bun test server/config.test.ts` went to 84 pass / 2 fail; restoring the guard returned 86 pass / 0 fail with a clean tree.

## Critical Self-Review

- Highest-risk behavior: namespace resolution is a security frontier. If a `server/` caller reaches these helpers without the names at runtime, it now throws where it used to return a value. That is the intended trade — a loud failure at the wiring defect beats a predicate silently bound to `shared-kb` — but it means any unexercised code path that omits the names becomes a runtime error rather than a wrong-but-working read.
- Assumptions that could be wrong: that `server/main.ts` is the only composition root for these tools. Checked with `rg -n 'registerMemoryTools\(|MemoryToolDependencies' src server --glob '!*.test.ts'` — the only non-test construction sites are `server/main.ts:170` and `server/contracts/registered-tools.ts:60`, and the latter passes a cast empty object purely to enumerate tool names without invoking them.
- Missing/weak tests: the guard is proven at the helper boundary and through three tool surfaces (`search_brain`, `search_all`, `brain_answer`) plus `agent_context_pack`. It is not proven for every one of the ~20 other tools that transitively reach `physicalNamespace`; those share the same dependencies object, so the coverage is by construction rather than by direct assertion.
- Security/permission risk: reduced. The removed readers were a second, unvalidated source for the names that decide an isolation predicate, and `SHARED_NAMESPACE_PHYSICAL` set in a stray environment could previously diverge from what the validated config had already parsed. Nothing here widens a read: `read-scope.ts` keeps its role gates, its `all`-keyword rule, and its delegated-identity narrowing unchanged.
- Migration/deploy risk: none at the schema layer, no migration. The deployment risk is a hosted process whose environment sets a shared-namespace variable that never reached `ServerConfig` — but `server/config/env-groups.ts` parses all five of the same variables with the same precedence and defaults, and it is untouched, so a deployment that worked before resolves to the same five values.
- Downstream client/runtime risk: none. No MCP tool schema, no transport shape, no Python client surface, and no response envelope changes. `docs/downstream-rollout.md` classifies this as an internal server refactor.
- Rollback/cleanup concern: a single revert restores the readers; nothing persists state and no artifact outlives the process. The one new file, `server/tools/shared-namespace-fixture.ts`, is only imported by tests.
- Fixes made before PR: `server/application/sdk-protocol.pg.test.ts` had three `registerMemoryTools` sites and the first pass only caught two — the third used a deeper indentation and was found by the remaining live-Postgres failures rather than by reading. Also corrected a missing `await` on a `rejects.toThrow` assertion in `server/tools/agent-context-pack-names.test.ts`, which would have passed vacuously.
- Known residual risk: `src/shared-namespace.ts` still reads the environment and still serves the legacy root's own callers. That is deliberate and out of scope here — it is a separate module with a different field shape (`sharedNamespace`, `allowLegacySharedWrites`), and #825 State 5 scopes only the `server/` copy.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new failure pattern surfaced — the test breakage was the expected, intended consequence of removing the fallback, and every failing assertion was one that had been written specifically to prove the fallback behavior this PR removes.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no MCP schema, transport, or client-facing surface changes; this is an internal wiring change inside the server process.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no tool contract changes. `server/contracts/registered-tools.ts` enumerates the same tools with the same schemas, and `bun run test:isolated server/` includes the contract tests at 0 fail.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All four are not applicable: rollout applies to MCP tool, schema, protocol, or client-facing changes, and this PR changes none of them. The tool list, every input schema, and every response envelope are byte-identical; the only behavior difference is confined to a code path that no correctly-wired caller reaches.
