### PR TITLE
refactor(observability): move the tracing env read out of langfuse-tracing into the legacy root (L2b-2, #825)

### DIFF
--- a/scripts/run-nats-worker.ts
+++ b/scripts/run-nats-worker.ts
@@ -16,6 +16,7 @@ import {
 } from "../src/nats-worker.ts";
 import type { AuthInfo } from "../src/types.ts";
 import { createTracingRuntime } from "../server/observability/langfuse-tracing.ts";
+import { readMcpTracingConfig } from "../server/observability/trace-config.ts";
 
 type LoggerLike = Pick<typeof logger, "error" | "info">;
 type HealthServer = { stop(force?: boolean): void };
@@ -323,7 +324,10 @@ export async function startNatsWorkerProcess(
     }
 
     pool = createDbPool();
-    tracing = createTracing();
+    // This worker root has no `ServerConfig`, so it reads its own tracing
+    // configuration from the env record it was handed and passes it down;
+    // the tracing module itself reads no environment (#825, L2b-2).
+    tracing = createTracing({ config: readMcpTracingConfig(env) });
     // NOTHING IS ADJUSTED SILENTLY: read the threshold before composing the
     // observer, so the bound the observer takes its verdict against is the
     // same one announced in the startup summary below.

--- a/server/observability/langfuse-tracing.test.ts
+++ b/server/observability/langfuse-tracing.test.ts
@@ -1573,6 +1573,19 @@ describe("the SDK's own logger cannot bypass the content-free discipline", () =>
     expect(gated.shouldLog(LogLevel.ERROR)).toBe(false);
     expect(gated.shouldLog(LogLevel.WARN)).toBe(false);
   });
+
+  // #825 (L2b-2): this module reads no environment. A caller that omits
+  // `config` used to get a second, module-private parse of `process.env` that
+  // could disagree with the one the composition root made; now it gets a
+  // wiring error at the call site instead of a silently different runtime.
+  test("throws when constructed without config from the composition root", () => {
+    expect(() => createTracingRuntime()).toThrow(
+      /requires config from the composition root/,
+    );
+    expect(() => createTracingRuntime({})).toThrow(
+      /requires config from the composition root/,
+    );
+  });
 });
 
 const REAL_SINK_PROBE_SCRIPT = String.raw`

--- a/server/observability/langfuse-tracing.ts
+++ b/server/observability/langfuse-tracing.ts
@@ -91,7 +91,7 @@ import { logger } from "../../src/logger.ts";
 import { maskTraceValue } from "./trace-masking.ts";
 import { buildToolTraceBody, errorOutput } from "./trace-body.ts";
 export { readMcpTracingConfig, resolveSessionId } from "./trace-config.ts";
-import { readMcpTracingConfig, resolveSessionId } from "./trace-config.ts";
+import { resolveSessionId } from "./trace-config.ts";
 import { tracingErrorLabel } from "./trace-error-label.ts";
 import {
   DEFAULT_FLAP_COOLDOWN_MS,
@@ -389,13 +389,22 @@ type RegisterTool = McpServer["registerTool"];
  * disagree. The composition root (`server/main.ts`) passes `config.tracing`
  * from the single validated parse, so `deps.config` is the normal path there.
  *
- * The fallback exists only for the legacy root `src/index.ts:318`, which has no
- * `ServerConfig` and still calls with no arguments. `readMcpTracingConfig` no
- * longer defaults its parameter (#825, L2b-2), so the environment is named
- * HERE, once, instead of hiding inside the reader's signature.
+ * There is no environment fallback here (#825, L2b-2). This module reads no
+ * environment at all; a caller without a `ServerConfig` — the legacy root
+ * `src/index.ts` and `scripts/run-nats-worker.ts` — calls
+ * `readMcpTracingConfig` on its own environment record and passes the result,
+ * so the one place the environment is named is the root that owns it. A
+ * missing `deps.config` is a wiring mistake, so it fails at the call site
+ * rather than silently resolving to a different configuration than the root
+ * parsed.
  */
 function resolveTracingConfig(deps: McpTracingDeps): McpTracingConfig {
-  return deps.config ?? readMcpTracingConfig(process.env);
+  if (!deps.config) {
+    throw new Error(
+      "createTracingRuntime requires config from the composition root: pass { config } (server/main.ts uses config.tracing; a root without a ServerConfig passes readMcpTracingConfig on its own environment record)",
+    );
+  }
+  return deps.config;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import {
   createTracingRuntime,
   installMcpTracing,
 } from "../server/observability/langfuse-tracing.ts";
+import { readMcpTracingConfig } from "../server/observability/trace-config.ts";
 
 const EMBEDDING_BASE_URL = process.env.EMBEDDING_BASE_URL;
 
@@ -315,7 +316,12 @@ if (import.meta.main) {
   }
 
   const pool = createPool();
-  const tracing = createTracingRuntime();
+  // This legacy root has no `ServerConfig`, so it is the env door for its own
+  // tracing configuration: it reads the environment here and hands the result
+  // down, the same values `server/main.ts` hands down from its validated parse.
+  const tracing = createTracingRuntime({
+    config: readMcpTracingConfig(process.env),
+  });
 
   if (process.env.OPEN_BRAIN_RUN_MIGRATIONS !== "0") {
     try {


### PR DESCRIPTION
## Summary

- `resolveTracingConfig` (server/observability/langfuse-tracing.ts) fell back to reading the environment itself when a caller omitted `deps.config`. That made the tracing module a second place tracing configuration could be parsed — a root that had already parsed one could silently receive a different one — and it was the last direct environment read in non-test `server/` outside `server/config.ts` and `server/main.ts`, which is exactly what State 7's `node/no-process-env` rule (#856) needs gone to go green.
- The fallback is removed. `resolveTracingConfig` uses `deps.config` and, when it is absent, throws an error naming the composition root. That is a call-site guard for a wiring mistake, not a module-level exit and not a silently different runtime.
- `server/main.ts` already passed `{ config: config.tracing }` (#849) and is unchanged. The two roots with no `ServerConfig` now read the environment themselves and pass the result down, so the resolved values are identical on every path:
  - `src/index.ts:318` — `createTracingRuntime({ config: readMcpTracingConfig(process.env) })`, with a comment saying this legacy root is the env door for its own tracing configuration.
  - `scripts/run-nats-worker.ts:325` — `createTracing({ config: readMcpTracingConfig(env) })`, reusing the env record the function was already handed rather than reaching for the global. This call site was not in the original brief; it called `createTracing()` with no arguments and would have thrown at worker startup without this line.
- `readMcpTracingConfig` (server/observability/trace-config.ts) is unchanged. Its now-unused value import inside langfuse-tracing.ts is dropped; the re-export on the line above stays, so the module's import surface is unchanged for callers.
- No oxlint disable comments, and no behavior change beyond the above.

## Verification

- Done-means: scripts/done-means/750-l2b2-check-well-formed.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED at `origin/main` (34304f0): `rg -n 'process\.env' server/observability/langfuse-tracing.ts` -> 1 hit at `:398`.
GREEN on the committed, rebased tree:

- `rg -n 'process\.env' server/observability/langfuse-tracing.ts` -> 0 hits
- `bunx tsc --noEmit` -> exit 0
- `./node_modules/.bin/oxlint --deny-warnings server/observability/langfuse-tracing.ts` -> exit 0
- `bun run test:isolated server/observability/langfuse-tracing.test.ts scripts/run-nats-worker.test.ts` -> 76 pass, 0 fail
- `bun run test:isolated src/tools/__tests__/` -> 941 pass, 0 fail (the legacy root path)
- `bash scripts/done-means/750-l2b2-check-well-formed.sh` -> exit 0, all four clauses PASS

The new test was proven able to fail: neutralizing the guard produced 1 fail ("did not throw"), and restoring it produced 1 pass.

Python package checks are not applicable — nothing under `python/openbrain-memory/` is touched. A live smoke is not applicable — this is an internal composition change with no protocol, schema, or client-facing surface.

## Critical Self-Review

- Highest-risk behavior: a root that constructs the tracing runtime without a config now throws at startup instead of quietly tracing with environment-derived settings. `rg -n 'createTracingRuntime' src server scripts --glob '!*.test.ts'` found exactly three construction sites — `server/main.ts:512` (already wired), `src/index.ts:318`, and `scripts/run-nats-worker.ts:326` — and all three are wired here. Every `installMcpTracing` call site in the repo (25 in the test file, `server/main.ts:165`, `src/index.ts:260`) already passes `config`.
- Assumptions that could be wrong: that `readMcpTracingConfig(process.env)` at the legacy root produces the same value the old in-module fallback produced. It is the same function on the same input — the fallback line was literally `readMcpTracingConfig(process.env)` — so this holds unless a caller relied on the read happening later than construction, which none does.
- Missing/weak tests: the throw is covered directly; the two rewired roots are not covered by a test that asserts the config reaches the runtime, because neither root is under test as a whole. `scripts/run-nats-worker.test.ts` injects its own `createTracing`, so it exercises the seam but not the new default expression. `src/tools/__tests__/` (941 tests) exercises the legacy root's tools and stays green.
- Security/permission risk: none. No namespace predicate, auth path, token handling, or SQL is touched. Tracing configuration carries a Langfuse public/secret key pair, and the change moves where that pair is read, never what is done with it or where it is logged — the content-free error logging in this module is untouched.
- Migration/deploy risk: no migration. Deploy risk is the startup-throw above: a deployed root that somehow constructs the runtime with no config fails loudly at boot rather than starting with tracing silently misconfigured. All three in-repo roots are wired, so this is the intended failure mode for a future unwired one, not a live regression.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md`. No MCP tool, schema, transport, protocol, or Python client surface changes; `createTracingRuntime` is an internal composition function with no consumers outside this repo.
- Rollback/cleanup concern: a single revert restores the fallback and both call sites together; there is no partial state, no data written, and nothing to clean up.
- Fixes made before PR: found and fixed `scripts/run-nats-worker.ts:326`, which the brief's scope did not name and which would have thrown at worker startup once the fallback was removed. Also removed the value import of `readMcpTracingConfig` that oxlint flagged as unused after the change, and corrected the new test from `it` to `test` to match this suite's `bun:test` imports.
- Known residual risk: the throw message and the module comment name `readMcpTracingConfig` in prose rather than as an expression, so a future reader has one indirection to follow to find the two roots. Accepted deliberately: writing the expression would reintroduce the literal string this rung exists to remove from the file.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical composition-root rewiring inside an established L2b-2 pattern (#849 did the same for `server/main.ts`), and it surfaced no new review-missable pattern — the one thing worth remembering, that removing an env fallback requires finding EVERY zero-argument construction site and not just the one the brief names, is already the exact-1 arrival discipline `scripts/done-means/750-l2b2-env-readers-take-config.sh` encodes and checks.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no protocol, schema, tool, or client-facing surface changes; the change is internal to how one process resolves its own tracing configuration.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or wire shape is touched — `readMcpTracingConfig` and `McpTracingConfig` are unchanged, and only the call sites that supply the value moved.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All five are not applicable: `docs/downstream-rollout.md` scopes rollout to MCP tool, schema, protocol, and client-facing changes. This PR touches none of those — it moves an environment read from a shared observability module into the two process roots that own it, with the resolved configuration values unchanged on every path.
