### PR TITLE
fix(contracts): pass shared-namespace names to every tool-dependency composition the parity harness builds (L2b-2, #825)

### DIFF
--- a/contracts/server-tool-parity.test.ts
+++ b/contracts/server-tool-parity.test.ts
@@ -7,6 +7,7 @@ import { createBrainServer } from "../src/server.ts";
 import { registerAllTools } from "../src/tools/index.ts";
 import type { AuthInfo } from "../src/types.ts";
 import { registerMemoryTools } from "../server/tools/index.ts";
+import { DEFAULT_SHARED_NAMESPACE_NAMES } from "../server/tools/shared-namespace-fixture.ts";
 
 interface FixtureStep {
   tool: string;
@@ -58,18 +59,29 @@ for await (const name of fixtureGlob.scan({
   cwd: fixtureDir.pathname,
   onlyFiles: true,
 })) {
-  fixtures.push((await Bun.file(new URL(name, fixtureDir)).json()) as ServerFixture);
+  fixtures.push(
+    (await Bun.file(new URL(name, fixtureDir)).json()) as ServerFixture,
+  );
 }
 fixtures.sort((a, b) => a.id.localeCompare(b.id));
-const parityManifest = (await Bun.file(new URL("./server/parity-manifest.json", import.meta.url)).json()) as {
-  provider_capability_status: Record<ProviderId, Record<string, CapabilityStatus>>;
+const parityManifest = (await Bun.file(
+  new URL("./server/parity-manifest.json", import.meta.url),
+).json()) as {
+  provider_capability_status: Record<
+    ProviderId,
+    Record<string, CapabilityStatus>
+  >;
 };
 const providers: ProviderId[] = ["current-src", "server-rewrite-scaffold"];
 
-function replacePlaceholders(value: unknown, replacements: Record<string, string>): unknown {
+function replacePlaceholders(
+  value: unknown,
+  replacements: Record<string, string>,
+): unknown {
   if (typeof value === "string") {
     return Object.entries(replacements).reduce(
-      (result, [placeholder, replacement]) => result.replaceAll(placeholder, replacement),
+      (result, [placeholder, replacement]) =>
+        result.replaceAll(placeholder, replacement),
       value,
     );
   }
@@ -102,7 +114,9 @@ function valueAtPath(source: unknown, path: string): unknown {
 function expectObserved(actual: unknown, expected: unknown): void {
   if (expected === "<uuid>") {
     expect(actual).toBeString();
-    expect(actual as string).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+    expect(actual as string).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
     return;
   }
   if (expected === "<iso-date>") {
@@ -118,7 +132,9 @@ function expectObserved(actual: unknown, expected: unknown): void {
   if (Array.isArray(expected)) {
     expect(actual).toBeArray();
     expect((actual as unknown[]).length).toBe(expected.length);
-    expected.forEach((item, index) => expectObserved((actual as unknown[])[index], item));
+    expected.forEach((item, index) =>
+      expectObserved((actual as unknown[])[index], item),
+    );
     return;
   }
   if (expected && typeof expected === "object") {
@@ -131,7 +147,10 @@ function expectObserved(actual: unknown, expected: unknown): void {
   expect(actual).toEqual(expected);
 }
 
-async function createClient(provider: ProviderId, auth: AuthInfo): Promise<{
+async function createClient(
+  provider: ProviderId,
+  auth: AuthInfo,
+): Promise<{
   client: Client;
   close: () => Promise<void>;
 }> {
@@ -155,17 +174,17 @@ async function createClient(provider: ProviderId, auth: AuthInfo): Promise<{
       embedFn: async () => Array(768).fill(0.01),
       logger: pino({ level: "silent" }),
       embeddingModel: "parity-fixture",
+      sharedNamespaceNames: isolatedSharedNamespaceNames(),
     });
   }
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
   const originalSend = clientTransport.send.bind(clientTransport);
   clientTransport.send = (message, options) =>
-    originalSend(
-      message,
-      { ...options, authInfo: auth } as unknown as Parameters<
-        typeof originalSend
-      >[1],
-    );
+    originalSend(message, {
+      ...options,
+      authInfo: auth,
+    } as unknown as Parameters<typeof originalSend>[1]);
   const client = new Client({ name: "server-parity", version: "1.0.0" });
   await server.connect(serverTransport);
   await client.connect(clientTransport);
@@ -207,6 +226,25 @@ const priorSharedNamespaceEnv = {
   canonical: process.env.SHARED_NAMESPACE_CANONICAL,
   physical: process.env.SHARED_NAMESPACE_PHYSICAL,
 };
+
+/**
+ * The shared-namespace name set the `server-rewrite-scaffold` provider is wired
+ * with.
+ *
+ * `server/tools/shared-namespace.ts` reads no environment (#857): every name
+ * arrives through `MemoryToolDependencies.sharedNamespaceNames`, exactly as
+ * `server/main.ts` supplies it from `ServerConfig`. The env assignments above
+ * still isolate the `current-src` provider, which resolves those names itself;
+ * this returns the same isolated pair as an explicit dependency so BOTH
+ * providers observe the identical premise.
+ */
+function isolatedSharedNamespaceNames(): typeof DEFAULT_SHARED_NAMESPACE_NAMES {
+  return {
+    ...DEFAULT_SHARED_NAMESPACE_NAMES,
+    canonicalSharedNamespace: SHARED_NAMESPACE_ISOLATION,
+    physicalSharedNamespace: SHARED_NAMESPACE_ISOLATION,
+  };
+}
 
 /** Restore an env var to its pre-suite value, unsetting it when it was absent. */
 function restoreEnv(key: string, value: string | undefined): void {
@@ -267,85 +305,111 @@ async function deleteSeededRows(): Promise<void> {
   if (!pool || seededNamespaces.size === 0) return;
   const namespaces = [...seededNamespaces];
   for (const table of SEEDED_TABLES) {
-    await pool.query(`DELETE FROM ${table} WHERE namespace = ANY($1)`, [namespaces]);
+    await pool.query(`DELETE FROM ${table} WHERE namespace = ANY($1)`, [
+      namespaces,
+    ]);
   }
 }
 
-dbDescribe("server parity fixtures by implemented provider capability (live Postgres)", () => {
-  beforeAll(() => {
-    process.env.SHARED_NAMESPACE_CANONICAL = SHARED_NAMESPACE_ISOLATION;
-    process.env.SHARED_NAMESPACE_PHYSICAL = SHARED_NAMESPACE_ISOLATION;
-  });
+dbDescribe(
+  "server parity fixtures by implemented provider capability (live Postgres)",
+  () => {
+    beforeAll(() => {
+      process.env.SHARED_NAMESPACE_CANONICAL = SHARED_NAMESPACE_ISOLATION;
+      process.env.SHARED_NAMESPACE_PHYSICAL = SHARED_NAMESPACE_ISOLATION;
+    });
 
-  afterAll(async () => {
-    // Delete BEFORE restoring the shared-namespace override. The deletes are
-    // plain namespace-predicated SQL and do not read that config, so the order
-    // is not load-bearing today — but keeping cleanup inside the isolated
-    // window means it stays correct if a future teardown ever routes through
-    // application code that resolves the shared namespace.
-    await deleteSeededRows();
-    restoreEnv("SHARED_NAMESPACE_CANONICAL", priorSharedNamespaceEnv.canonical);
-    restoreEnv("SHARED_NAMESPACE_PHYSICAL", priorSharedNamespaceEnv.physical);
-  });
+    afterAll(async () => {
+      // Delete BEFORE restoring the shared-namespace override. The deletes are
+      // plain namespace-predicated SQL and do not read that config, so the order
+      // is not load-bearing today — but keeping cleanup inside the isolated
+      // window means it stays correct if a future teardown ever routes through
+      // application code that resolves the shared namespace.
+      await deleteSeededRows();
+      restoreEnv(
+        "SHARED_NAMESPACE_CANONICAL",
+        priorSharedNamespaceEnv.canonical,
+      );
+      restoreEnv("SHARED_NAMESPACE_PHYSICAL", priorSharedNamespaceEnv.physical);
+    });
 
-  for (const provider of providers) {
-    for (const fixture of fixtures) {
-      if (parityManifest.provider_capability_status[provider][fixture.capability] !== "implemented") continue;
-      test(`${provider}: ${fixture.id}`, async () => {
-        const providerSlug = provider.replaceAll("-", "_");
-        const namespace = `${fixture.auth.client_id}-${providerSlug}-${process.pid}`;
-        const otherNamespace = `${namespace}-other`;
-        // Recorded BEFORE the steps run, not after. A fixture that throws
-        // partway has still written rows, and those are exactly the ones most
-        // worth cleaning up; registering on the way in makes teardown cover the
-        // failure path too.
-        seededNamespaces.add(namespace);
-        seededNamespaces.add(otherNamespace);
-        // Captured ids are added to this same map as steps run, so a fixture
-        // substitutes namespace tokens and prior-step ids through one mechanism.
-        const replacements: Record<string, string> = {
-          "{{namespace}}": namespace,
-          "{{other_namespace}}": otherNamespace,
-        };
-        const auth: AuthInfo = {
-          role: fixture.auth.role,
-          clientId: namespace,
-          namespaceSource: fixture.auth.namespace_source ?? "token",
-        };
-        const { client, close } = await createClient(provider, auth);
-        try {
-          for (const step of fixture.steps) {
-            const args = replacePlaceholders(step.arguments, replacements) as Record<string, unknown>;
-            const expected = replacePlaceholders(step.expectation, replacements) as FixtureStep["expectation"];
-            const result = await client.callTool({ name: step.tool, arguments: args });
-            const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
-            if (process.env.PARITY_OBSERVE === "1") {
-              process.stdout.write(`${provider} ${fixture.id} ${step.tool}: ${JSON.stringify({ is_error: result.isError === true, text })}\n`);
+    for (const provider of providers) {
+      for (const fixture of fixtures) {
+        if (
+          parityManifest.provider_capability_status[provider][
+            fixture.capability
+          ] !== "implemented"
+        )
+          continue;
+        test(`${provider}: ${fixture.id}`, async () => {
+          const providerSlug = provider.replaceAll("-", "_");
+          const namespace = `${fixture.auth.client_id}-${providerSlug}-${process.pid}`;
+          const otherNamespace = `${namespace}-other`;
+          // Recorded BEFORE the steps run, not after. A fixture that throws
+          // partway has still written rows, and those are exactly the ones most
+          // worth cleaning up; registering on the way in makes teardown cover the
+          // failure path too.
+          seededNamespaces.add(namespace);
+          seededNamespaces.add(otherNamespace);
+          // Captured ids are added to this same map as steps run, so a fixture
+          // substitutes namespace tokens and prior-step ids through one mechanism.
+          const replacements: Record<string, string> = {
+            "{{namespace}}": namespace,
+            "{{other_namespace}}": otherNamespace,
+          };
+          const auth: AuthInfo = {
+            role: fixture.auth.role,
+            clientId: namespace,
+            namespaceSource: fixture.auth.namespace_source ?? "token",
+          };
+          const { client, close } = await createClient(provider, auth);
+          try {
+            for (const step of fixture.steps) {
+              const args = replacePlaceholders(
+                step.arguments,
+                replacements,
+              ) as Record<string, unknown>;
+              const expected = replacePlaceholders(
+                step.expectation,
+                replacements,
+              ) as FixtureStep["expectation"];
+              const result = await client.callTool({
+                name: step.tool,
+                arguments: args,
+              });
+              const text =
+                (result.content as Array<{ text: string }>)[0]?.text ?? "";
+              if (process.env.PARITY_OBSERVE === "1") {
+                process.stdout.write(
+                  `${provider} ${fixture.id} ${step.tool}: ${JSON.stringify({ is_error: result.isError === true, text })}\n`,
+                );
+              }
+              expect(result.isError === true).toBe(expected.is_error);
+              if (expected.text !== undefined) expect(text).toBe(expected.text);
+              if (expected.json !== undefined)
+                expectObserved(JSON.parse(text), expected.json);
+
+              for (const [name, path] of Object.entries(step.capture ?? {})) {
+                const captured = valueAtPath(JSON.parse(text), path);
+                // A capture that silently resolved to undefined would substitute
+                // the literal string "undefined" into the next step's arguments,
+                // turning a broken fixture into a confusing validation error
+                // several steps later. Fail here, where the cause is visible.
+                expect(
+                  typeof captured === "string" && captured.length > 0,
+                  `${fixture.id} step ${step.tool}: capture '${name}' found nothing at '${path}'`,
+                ).toBe(true);
+                replacements[`{{${name}}}`] = captured as string;
+              }
             }
-            expect(result.isError === true).toBe(expected.is_error);
-            if (expected.text !== undefined) expect(text).toBe(expected.text);
-            if (expected.json !== undefined) expectObserved(JSON.parse(text), expected.json);
-
-            for (const [name, path] of Object.entries(step.capture ?? {})) {
-              const captured = valueAtPath(JSON.parse(text), path);
-              // A capture that silently resolved to undefined would substitute
-              // the literal string "undefined" into the next step's arguments,
-              // turning a broken fixture into a confusing validation error
-              // several steps later. Fail here, where the cause is visible.
-              expect(
-                typeof captured === "string" && captured.length > 0,
-                `${fixture.id} step ${step.tool}: capture '${name}' found nothing at '${path}'`,
-              ).toBe(true);
-              replacements[`{{${name}}}`] = captured as string;
-            }
+          } finally {
+            await close();
           }
-        } finally {
-          await close();
-        }
-      });
+        });
+      }
     }
-  }
-});
+  },
+);
 
 afterAll(async () => {
   await pool?.end();


### PR DESCRIPTION
## Summary

- `main` is currently red. #857 (commit 49a8ae6) removed the `process.env` fallback from `server/tools/shared-namespace.ts` and added a `requireNames` guard that throws when the optional `names` are absent. `server/main.ts` was updated to pass `sharedNamespaceNames: config.sharedNamespaceNames`, but the parity fixture harness composes its own `MemoryToolDependencies` and was not updated, so every `server-rewrite-scaffold` fixture threw and returned `isError: true`. CI run 33022617001 failed with exactly six cases: `server-brain-answer-empty`, `server-context-pack-sections`, `server-namespace-denial`, `server-recall-family`, `server-reflex-pointers-empty`, `server-search-brain-arms`, all at `contracts/server-tool-parity.test.ts:325`. That lane ran the `server/tools` tests but not `contracts/`, which is why it merged green.
- This PR is the fix, and it is made at the composition site, which is the only place that can know the names. `contracts/server-tool-parity.test.ts` now hands the scaffold provider an explicit name set built from the same per-run isolation value the suite already assigns to `SHARED_NAMESPACE_CANONICAL`/`SHARED_NAMESPACE_PHYSICAL` for the `current-src` provider. Both providers observe the identical premise, and the scaffold path now depends on no environment at all.
- The set is derived from the existing `DEFAULT_SHARED_NAMESPACE_NAMES` fixture (`server/tools/shared-namespace-fixture.ts`) that the sibling `server/` suites already use, rather than a second hand-written literal.
- `server/tools/shared-namespace.ts`, `server/tools/read-scope.ts`, `.oxlintrc.json`, and `server/observability/*` are untouched. The guard was not made lenient and no environment read was restored. An `rg` over `server src scripts contracts` for `registerMemoryTools\(|sharedNamespaceNames|MemoryToolDependencies|SearchDependencies` found no other composition site missing the names: `server/main.ts` already passes them, `server/application/sdk-protocol.pg.test.ts` and the `server/tools/*.test.ts` suites already use the fixture, and `server/contracts/registered-tools.ts` casts an empty object purely for schema introspection and never resolves a namespace. No non-test production entrypoint needed a change.

## Verification

- Done-means: scripts/done-means/750-l2b2-check-well-formed.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Evidence, all run in this lane's own clone:

- RED at `origin/main`: `bun run test:isolated contracts/server-tool-parity.test.ts` -> `69 pass / 6 fail`, exit 1.
- GREEN after the change: `bun run test:isolated contracts/server-tool-parity.test.ts` -> `75 pass / 0 fail`, exit 0. Re-run against the committed (prettier-reformatted) tree: same result.
- Whole suite: `bun run test:isolated` -> `3907 pass / 0 fail`, 3942 tests across 254 files.
- `bunx tsc --noEmit` -> exit 0, on the committed tree.
- `bash scripts/done-means/750-l2b2-check-well-formed.sh` -> exit 0.
- `bash scripts/done-means/750-l2b2-env-readers-take-config.sh` -> exit 0.
- `./node_modules/.bin/oxlint --deny-warnings contracts/server-tool-parity.test.ts` reports one pre-existing `eslint(complexity)` error on the per-fixture `test()` body, which is present unchanged at `origin/main` (verified by stashing: baseline `:294`, this branch `:315`, same rule and same function). No new lint finding is introduced and no disable comment was added.

## Critical Self-Review

- Highest-risk behavior: shared-namespace resolution inside the parity suite. If the explicit set and the env assignments ever disagree, the two providers would silently assert against different shared namespaces and parity would stop meaning anything. Both are derived from the single `SHARED_NAMESPACE_ISOLATION` constant, so they cannot drift.
- Assumptions that could be wrong: that `current-src` still resolves the shared namespace from the environment. It does today — that path is the pre-#857 `src/` implementation, which is exactly why the env assignments have to stay. When `src/` is retired, the env block goes with it and only the explicit set remains.
- Missing/weak tests: none added. The six failing fixtures are the test, they failed red before this change and pass after it, and the whole suite proves nothing else moved. Adding a test that the harness wires its own dependencies correctly would be a test of the test.
- Security/permission risk: none. The change is confined to a test file. Namespace isolation is still enforced server-side by the same predicates; the fixture set only names a per-run namespace no production row can belong to.
- Migration/deploy risk: none. No schema, no migration, no runtime file changed.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python-client surface changed, so `docs/downstream-rollout.md` does not apply.
- Rollback/cleanup concern: a plain revert restores the six failures; it does not leave partial state. The suite's own `afterAll` still deletes the seeded rows before restoring the env, unchanged.
- Fixes made before PR: the first draft added a second literal name set inline. It was replaced with a spread of the existing `DEFAULT_SHARED_NAMESPACE_NAMES` fixture so `legacySharedNamespace`, `legacyFallbackEnabled`, and `fallbackMinResults` cannot drift from what the sibling suites assert against.
- Known residual risk: the pre-existing `oxlint` complexity error on the fixture `test()` body remains. It is unrelated to this fix, predates the branch, and widening scope to refactor it would obscure a red-main repair.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the lesson is a process one about which tests a lane runs, not a code pattern a reviewer lane would grep for, and it is recorded as a `harvested:` comment on this PR instead.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this is a test-harness wiring fix with no runtime, transport, or tool-surface change.

## Contract Parity

- Contract parity: [x] fixtures updated
- Contract parity: [ ] runtime-specific because:

No fixture JSON changed. The harness that drives the recorded fixtures is what was repaired, and all six previously-failing fixtures now pass for both providers against the same recorded expectations.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: the only changed file is `contracts/server-tool-parity.test.ts`. No MCP tool, schema, protocol, or client-facing surface is touched, so no downstream consumer can observe this change.
