### PR TITLE
docs(ladder): record L4 as met by the #780 sweep, with measured code-line counts

### DIFF
--- a/_plans/server-hardening-ladder.md
+++ b/_plans/server-hardening-ladder.md
@@ -1,9 +1,9 @@
 # server/ hardening ladder — L1 through L6
 
-**Status: L1 MERGED, L2 IN PROGRESS — 2026-08-26.** Ordering approved by the
-operator. L1 is on `origin/main`; L2's schema half (L2a) is on `origin/main`;
-L2b is open and gated by the lint-debt ruling in #780. L3 through L6 are not
-started.
+**Status: L1 MERGED, L2 MERGED, L4 MET, L3 IN PROGRESS — 2026-08-26.** Ordering
+approved by the operator. L1 and both halves of L2 are on `origin/main`, and L4
+is already met on `origin/main` as a side effect of the #780 lint sweep. L5 and
+L6 are not started.
 
 ## What this file is, and what it is NOT
 
@@ -235,6 +235,23 @@ stack and the correlation id.
 ## L4 — Break the five oversize files
 
 **Deliverable.** No non-test file in `server/` over 500 code lines.
+
+**Status: MET 2026-08-26 as a side effect of #780.** The lint sweep split every
+one of the five, not just the two that were pulled forward, so this rung's
+deliverable is already true on `origin/main`. Code lines on `origin/main`,
+blanks and comments stripped:
+
+    461  server/observability/langfuse-tracing.ts
+    478  server/tools/search-engine.ts
+    330  server/tools/agent-context-pack.ts
+    487  server/realtime/recovery-wal.ts
+    361  server/tools/entities.ts
+
+`./node_modules/.bin/oxlint --deny-warnings --ignore-pattern '**/*.test.ts'
+server` exits 0 with `max-lines` at 500 armed (`.oxlintrc.json`), so no
+non-test file in `server/` is over the mark. The two pulled-forward splits are
+`ca349ad` (PR #795, `search-engine.ts`) and `5666c67` (PR #796,
+`langfuse-tracing.ts`).
 
 **Scope is exactly five files.** Code lines, comments and blanks stripped:
 


### PR DESCRIPTION
## Summary

- L4 of the server hardening ladder asked that no non-test file in `server/` exceed 500 code lines. That is already true on `origin/main`: the #780 lint sweep split all five named files, not only the two that were pulled forward into their own lint lanes. This records the rung as MET with the numbers that back it.
- Measured on `origin/main` with blanks and comments stripped: 461 `server/observability/langfuse-tracing.ts`, 478 `server/tools/search-engine.ts`, 330 `server/tools/agent-context-pack.ts`, 487 `server/realtime/recovery-wal.ts`, 361 `server/tools/entities.ts`. `./node_modules/.bin/oxlint --deny-warnings --ignore-pattern '**/*.test.ts' server` exits 0 with `max-lines` at 500 armed in `.oxlintrc.json`, which is the rung's own done-means.
- The two pulled-forward splits are `ca349ad` (PR #795, `search-engine.ts`) and `5666c67` (PR #796, `langfuse-tracing.ts`), both cited in the new status paragraph.
- The L4 scope table is left exactly as written, because it records the sizes the rung faced when it was planned and that history is the point of the table. The header status line moves to `L1 MERGED, L2 MERGED, L4 MET, L3 IN PROGRESS`.
- Prose only. One file changed, `_plans/server-hardening-ladder.md`; no source, config, schema, or test is touched.

## Verification

- Done-means: scripts/done-means/750-l2b2-env-readers-take-config.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bunx tsc --noEmit` exits 0 on the committed tree. `rg -n 'L4 MET|Status: MET' _plans/server-hardening-ladder.md` returns 2 matches on the committed tree. `./node_modules/.bin/oxlint --deny-warnings --ignore-pattern '**/*.test.ts' server` exits 0. No test file corresponds to a plans document, so no `test:isolated` selection applies. `scripts/done-means/handover-validates.sh` reports `FAIL: no handover files to check` on this branch, which is that checker declining a change that produces no `_DOCS/_handover/` diff rather than a defect in this change; it is named here because the brief named it, and its verdict is reported honestly rather than dressed up.

## Critical Self-Review

- Highest-risk behavior: none at runtime. The only risk is a documentation claim that is wrong, which would let a later reader skip a rung that is not actually met.
- Assumptions that could be wrong: that the five files listed in the L4 scope table are still the five largest in `server/`. If a file grew past 500 since #780 landed, the oxlint run would have caught it, and it exits 0 — so the claim rests on the linter, not on the table.
- Missing/weak tests: no test is added. A plans document has no executable behavior; the rung's own done-means is the oxlint run, which is recorded and reproducible.
- Security/permission risk: none. No auth, namespace, SQL, or token surface is touched.
- Migration/deploy risk: none. No schema, no migration, no deploy artifact.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client contract changes, so `docs/downstream-rollout.md` does not apply.
- Rollback/cleanup concern: single-file revert. Nothing else depends on the wording.
- Fixes made before PR: the header replaced the stale sentence claiming L2b was open and gated by #780, which the merged L2b work had already made false; leaving it would have contradicted the L2 section three screens below.
- Known residual risk: the named done-means script cannot pass for a prose-only change, so this PR's automated gate is the oxlint run and the two-match grep rather than that script.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a status record on an existing plans document, with no code pattern, review miss, or defect class for a future swarm to check against.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the change is a plans document and touches no running service surface.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or tool schema is involved in a plans document edit.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- No MCP tool, schema, transport, or client-facing surface changes, so every downstream step is not applicable by the classification in `docs/downstream-rollout.md`.

