### PR TITLE
test(standards): add the RED-first done-means check for L3, one logger threaded (#860)

### DIFF
--- a/scripts/done-means/750-l3-check-well-formed.sh
+++ b/scripts/done-means/750-l3-check-well-formed.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for the DONE-MEANS check of rung L3 (issue #860).
+#
+#   bash scripts/done-means/750-l3-check-well-formed.sh
+#
+# ---------------------------------------------------------------------------
+# Why a check about a check
+# ---------------------------------------------------------------------------
+# `scripts/done-means/750-l3-logger-threaded.sh` is written RED first: it
+# asserts a state that States 5-6 of the L3 handover will create, so at the head
+# that INTRODUCES it the honest answer is exit 1. `scripts/verify-lane.ts`
+# refuses to post a receipt for a done-means that exits non-zero, so the PR that
+# adds the red check has no receipt line it can name — and the usual escapes
+# (weaken the check, name an unrelated one) both destroy the thing being landed.
+#
+# The way out is to receipt a DIFFERENT property, one that is true today and
+# stays true after the seam lands: the L3 check is WELL-FORMED. It is
+# executable, it reports every clause it claims to, its structural and
+# positive-control clauses are green, and its exit code agrees with the clauses
+# it printed. A red check that is well-formed is a working gate pointed at
+# unfinished work; a red check that is malformed is a typo nobody has read.
+# This script tells the two apart.
+#
+# The pattern is not invented here — `750-l2b2-check-well-formed.sh` did the
+# same job for the L2b-2 rung, and this is its sibling with the clause set the
+# L3 check actually prints.
+#
+# Five clauses, and all five must pass:
+#
+# CLAUSE 1 — THE INNER CHECK IS EXECUTABLE AND REACHED A VERDICT.
+#   The file is present with its executable bit set, and exits 0 (the seam has
+#   landed) or 1 (it has not). Anything else — a 3 for the inner script's own
+#   harness error, a 127 for a missing interpreter, a 2 from a shell syntax
+#   error — means no verdict was reached, so nothing it printed can be trusted.
+#   That is a harness error HERE too, not a fail: this script cannot judge a
+#   check that did not run.
+#
+# CLAUSE 2 — IT PRINTS ALL FIVE CLAUSE LINES, EXACTLY ONCE EACH.
+#   `CLAUSE 1` through `CLAUSE 5`, one line apiece. A missing line is a clause
+#   that silently stopped being evaluated; a doubled line means the output is
+#   generated twice and the reader cannot tell which verdict is in force.
+#
+# CLAUSE 3 — THE STRUCTURAL CLAUSES ARE GREEN.
+#   `CLAUSE 1` (one construction site, at the root) and `CLAUSE 2` (no logger
+#   imports elsewhere) both say PASS. Both are true on origin/main today and
+#   both must STAY true through the seam work — a lane that lands `decorate.ts`
+#   by adding a second `createLogger` call has defeated the rung, and this is
+#   where that shows up.
+#
+# CLAUSE 4 — THE POSITIVE CONTROL IS GREEN.
+#   `CLAUSE 5` of the inner check says PASS. That is its own proof that its
+#   scanner still matches a hit where one MUST exist. It is the clause that
+#   separates "clean tree" from "broken scan", and its value does not change
+#   when the seam lands — so requiring it green here costs the implementing lane
+#   nothing and catches a dead scanner today.
+#
+# CLAUSE 5 — THE EXIT CODE AGREES WITH THE STATE CLAUSES.
+#   `CLAUSE 3` (seam exists) and `CLAUSE 4` (driver test passes) are the STATE
+#   clauses: red until the seam lands, green after. The exit code must agree —
+#   exit 0 demands both PASS, exit 1 demands at least one FAIL. A check that
+#   exits 1 while printing all-PASS, or exits 0 while printing a FAIL, is
+#   reporting one thing and returning another, which is the failure mode that
+#   makes a gate worse than no gate.
+#
+# All five clauses hold at BOTH ends of the rung. Today: inner clauses 1, 2 and
+# 5 PASS, 3 and 4 FAIL, inner exit 1, and clause 5 here is satisfied by the
+# FAILs. After the seam lands: every inner clause PASSes, inner exit 0, and
+# clause 5 is satisfied by the PASSes. Nothing here has to be edited out when
+# the work finishes, which is the property that makes it a permanent check
+# rather than scaffolding.
+#
+# NO ARGUMENTS. `DONE_MEANS_L3_INNER` exists ONLY so this script's own
+# red/green can be demonstrated against a deliberately broken stand-in; it
+# defaults to the real sibling and no caller in the repo sets it.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v rg >/dev/null 2>&1 || fail_hard "rg (ripgrep) not on PATH"
+
+INNER="${DONE_MEANS_L3_INNER:-$REPO_ROOT/scripts/done-means/750-l3-logger-threaded.sh}"
+[ -f "$INNER" ] || fail_hard "inner check not found at $INNER"
+
+CLAUSE1=FAIL; CLAUSE1_EVIDENCE=""
+CLAUSE2=FAIL; CLAUSE2_EVIDENCE=""
+CLAUSE3=FAIL; CLAUSE3_EVIDENCE=""
+CLAUSE4=FAIL; CLAUSE4_EVIDENCE=""
+CLAUSE5=FAIL; CLAUSE5_EVIDENCE=""
+
+INNER_OUT="$(cd "$REPO_ROOT" && bash "$INNER" 2>&1)"
+INNER_STATUS=$?
+
+# Count and read back a single clause line by its leading label.
+clause_lines() {
+  printf '%s\n' "$INNER_OUT" | rg -c "^$1" || true
+}
+clause_text() {
+  printf '%s\n' "$INNER_OUT" | rg -m 1 "^$1" || true
+}
+
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — executable, and it reached a verdict.
+# ---------------------------------------------------------------------------
+if [ ! -x "$INNER" ]; then
+  CLAUSE1_EVIDENCE="$INNER is not executable — a done-means nobody can run is not a gate"
+elif [ "$INNER_STATUS" -eq 0 ] || [ "$INNER_STATUS" -eq 1 ]; then
+  CLAUSE1=PASS
+  CLAUSE1_EVIDENCE="executable, and exited $INNER_STATUS — a real verdict (0 = seam landed, 1 = not yet)"
+else
+  CLAUSE1_EVIDENCE="inner check exited $INNER_STATUS — no verdict was reached, so its output cannot be judged"
+fi
+
+if [ "$CLAUSE1" != PASS ]; then
+  printf 'CLAUSE 1 (inner check is executable and judged):   %s — %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+  printf '%s\n' "$INNER_OUT" | sed 's/^/    /'
+  fail_hard "inner check is not runnable to a verdict (exit $INNER_STATUS)"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 2 — all five clause lines are present, exactly once each.
+# ---------------------------------------------------------------------------
+C1_N="$(clause_lines 'CLAUSE 1')"
+C2_N="$(clause_lines 'CLAUSE 2')"
+C3_N="$(clause_lines 'CLAUSE 3')"
+C4_N="$(clause_lines 'CLAUSE 4')"
+C5_N="$(clause_lines 'CLAUSE 5')"
+
+if [ "$C1_N" -eq 1 ] && [ "$C2_N" -eq 1 ] && [ "$C3_N" -eq 1 ] \
+  && [ "$C4_N" -eq 1 ] && [ "$C5_N" -eq 1 ]; then
+  CLAUSE2=PASS
+  CLAUSE2_EVIDENCE="all 5 clause lines present, exactly once each"
+else
+  CLAUSE2_EVIDENCE="expected one line per clause, found 1:$C1_N 2:$C2_N 3:$C3_N 4:$C4_N 5:$C5_N"
+fi
+
+C1_TEXT="$(clause_text 'CLAUSE 1')"
+C2_TEXT="$(clause_text 'CLAUSE 2')"
+C3_TEXT="$(clause_text 'CLAUSE 3')"
+C4_TEXT="$(clause_text 'CLAUSE 4')"
+C5_TEXT="$(clause_text 'CLAUSE 5')"
+
+# ---------------------------------------------------------------------------
+# CLAUSE 3 — the structural clauses are green.
+# ---------------------------------------------------------------------------
+STRUCT_PASSES=0
+printf '%s' "$C1_TEXT" | rg -q 'PASS' && STRUCT_PASSES=$((STRUCT_PASSES + 1))
+printf '%s' "$C2_TEXT" | rg -q 'PASS' && STRUCT_PASSES=$((STRUCT_PASSES + 1))
+
+if [ "$CLAUSE2" != PASS ]; then
+  CLAUSE3_EVIDENCE="skipped — the clause lines are malformed, so reading them back is vacuous"
+elif [ "$STRUCT_PASSES" -eq 2 ]; then
+  CLAUSE3=PASS
+  CLAUSE3_EVIDENCE="one construction site at the root, and no logger imports elsewhere — both green"
+else
+  CLAUSE3_EVIDENCE="only $STRUCT_PASSES/2 structural clauses are green; a second logger has appeared: $C1_TEXT | $C2_TEXT"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 4 — the positive control is green.
+# ---------------------------------------------------------------------------
+if [ "$CLAUSE2" != PASS ]; then
+  CLAUSE4_EVIDENCE="skipped — the clause lines are malformed, so reading them back is vacuous"
+elif printf '%s' "$C5_TEXT" | rg -q 'PASS'; then
+  CLAUSE4=PASS
+  CLAUSE4_EVIDENCE="the inner scanner is proven to still match: $C5_TEXT"
+else
+  CLAUSE4_EVIDENCE="the inner positive control is red — its clean results mean nothing: $C5_TEXT"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 5 — the exit code agrees with the state clauses.
+# ---------------------------------------------------------------------------
+STATE_PASSES=0
+printf '%s' "$C3_TEXT" | rg -q 'PASS' && STATE_PASSES=$((STATE_PASSES + 1))
+printf '%s' "$C4_TEXT" | rg -q 'PASS' && STATE_PASSES=$((STATE_PASSES + 1))
+
+if [ "$CLAUSE2" != PASS ]; then
+  CLAUSE5_EVIDENCE="skipped — the clause lines are malformed, so the comparison is vacuous"
+elif [ "$INNER_STATUS" -eq 0 ] && [ "$STATE_PASSES" -ne 2 ]; then
+  CLAUSE5_EVIDENCE="inner exited 0 but only $STATE_PASSES/2 state clauses say PASS — it returns success while reporting a failure"
+elif [ "$INNER_STATUS" -eq 1 ] && [ "$STATE_PASSES" -eq 2 ]; then
+  CLAUSE5_EVIDENCE="inner exited 1 but both state clauses say PASS — it returns failure while reporting success"
+else
+  CLAUSE5=PASS
+  CLAUSE5_EVIDENCE="exit $INNER_STATUS agrees with $STATE_PASSES/2 state clauses passing"
+fi
+
+printf 'CLAUSE 1 (inner check is executable and judged):   %s — %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+printf 'CLAUSE 2 (all 5 clause lines, exactly once each):  %s — %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+printf 'CLAUSE 3 (inner structural clauses are green):     %s — %s\n' "$CLAUSE3" "$CLAUSE3_EVIDENCE"
+printf 'CLAUSE 4 (inner positive control is green):        %s — %s\n' "$CLAUSE4" "$CLAUSE4_EVIDENCE"
+printf 'CLAUSE 5 (exit code agrees with its clauses):      %s — %s\n' "$CLAUSE5" "$CLAUSE5_EVIDENCE"
+
+if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ] \
+  && [ "$CLAUSE4" = PASS ] && [ "$CLAUSE5" = PASS ]; then
+  exit 0
+fi
+exit 1

--- a/scripts/done-means/750-l3-logger-threaded.sh
+++ b/scripts/done-means/750-l3-logger-threaded.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for rung L3 of the server/ hardening ladder
+# (`_plans/server-hardening-ladder.md`, "one logger, threaded", issue #860).
+#
+#   bash scripts/done-means/750-l3-logger-threaded.sh
+#
+# ---------------------------------------------------------------------------
+# The defect this gates
+# ---------------------------------------------------------------------------
+# L2 put every env read behind the composition root. L3 does the same job for
+# the logger: ONE logger is constructed, at the root, and every module that
+# wants to log receives it rather than reaching for a constructor of its own.
+#
+# The state L3 ends is the one where logging is decided per module. When a
+# second `createLogger(` appears somewhere under server/, that module gets its
+# own transport, its own destination chain, and its own view of the correlation
+# context — and the two disagree silently, because nothing errors when a line
+# is written to the wrong place. #612 is the receipt for how quiet that failure
+# is: the service logged into a void for as long as the server path existed,
+# with no error, no warning, and no dropped-line counter.
+#
+# Threading a logger by hand through every call signature is the obvious
+# alternative and the reason this rung stalls: it edits every function that
+# logs. So L3 delivers a decoration seam instead — `server/logging/decorate.ts`
+# — and the check asserts BOTH halves: the single construction site (clauses 1
+# and 2) and the seam that makes it reachable without rewriting signatures
+# (clauses 3 and 4).
+#
+# ABSENCE ALONE IS NOT THE BAR. "No module imports the logger" is satisfiable
+# by deleting all logging, which is worse than the defect. So clause 4 runs a
+# driver test: a real thrown error inside a decorated function must produce a
+# real log line carrying the stack and the correlation id from
+# `server/logging/context.ts`. The seam has to WORK, not merely exist.
+#
+# ---------------------------------------------------------------------------
+# Four clauses, and all four must pass
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — EXACTLY ONE CONSTRUCTION SITE, AND IT IS THE ROOT.
+#   `createLogger(` appears exactly once as a CALL in non-test server/ code, in
+#   `server/main.ts`. The definition in `server/logging/logger.ts` is excluded
+#   by path, not by pattern, so a second definition elsewhere still fails.
+#
+# CLAUSE 2 — NOBODY ELSE IMPORTS THE LOGGER MODULE.
+#   Zero references to `logging/logger` in non-test server/ code outside
+#   `server/main.ts` and `server/logging/`. An import is how a second
+#   construction site starts, so this catches the state one commit earlier than
+#   clause 1 does.
+#
+# CLAUSE 3 — THE SEAM EXISTS.
+#   `server/logging/decorate.ts` is present and exports both `withLogging` (the
+#   function wrapper, for plain functions and closures) and `logged` (the method
+#   decorator, for class methods). Two spellings because the server has both
+#   shapes and forcing either into the other's form is how a seam gets bypassed.
+#
+# CLAUSE 4 — THE SEAM DEMONSTRABLY LOGS THE FAILURE.
+#   `server/logging/decorate.driver.test.ts` exists and
+#   `bun test server/logging/decorate.driver.test.ts` exits 0. That test throws
+#   inside a decorated function and asserts the emitted line carries `stack` and
+#   the active correlation id. It is written RED, BEFORE decorate.ts, and it is
+#   the specification the implementing lane codes against.
+#
+# CLAUSE 5 — THE SCANNER IS PROVEN TO MATCH (positive control).
+#   The natural clause-1/2 assertions pass for two very different reasons:
+#   because the state is correct, or because the scan examined nothing. A
+#   renamed directory, a bad glob, an `rg` that is not on PATH — every one
+#   produces a silent clean sweep and a meaningless exit 0. So the check proves
+#   the same pattern, tool, and invocation still find a hit where one MUST
+#   exist: `createLogger` in `server/logging/logger.ts`, the definition site,
+#   which no lane on this rung should ever empty.
+#
+# ---------------------------------------------------------------------------
+# STATE AT THE HEAD THAT INTRODUCES THIS CHECK (origin/main, this PR)
+# ---------------------------------------------------------------------------
+# Clauses 1, 2 and 5 PASS ALREADY. Measured: one `createLogger(` call at
+# server/main.ts:495, one `logging/logger` import at server/main.ts:61, and the
+# definition at server/logging/logger.ts:117. That is not an accident of this
+# lane — the server rewrite root was built that way — and it is exactly why the
+# check is worth having: those two properties are one careless import away from
+# being false, and nothing else in the repo notices.
+#
+# Clauses 3 and 4 FAIL, by design, until States 5-6 of the L3 handover land.
+# The overall exit is therefore 1 today. That is the honest answer, and the
+# PR that introduces this file receipts its sibling
+# `750-l3-check-well-formed.sh` instead, which asserts that THIS check is
+# well-formed rather than that its subject is finished.
+#
+# NO ARGUMENTS.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v rg >/dev/null 2>&1 || fail_hard "rg (ripgrep) not on PATH"
+[ -d "$REPO_ROOT/.git" ] || [ -f "$REPO_ROOT/.git" ] || fail_hard "not a git repo at $REPO_ROOT"
+
+ROOT_FILE="server/main.ts"
+SEAM_FILE="server/logging/decorate.ts"
+DRIVER_FILE="server/logging/decorate.driver.test.ts"
+CONTROL_FILE="server/logging/logger.ts"
+
+CLAUSE1=FAIL; CLAUSE1_EVIDENCE=""
+CLAUSE2=FAIL; CLAUSE2_EVIDENCE=""
+CLAUSE3=FAIL; CLAUSE3_EVIDENCE=""
+CLAUSE4=FAIL; CLAUSE4_EVIDENCE=""
+CLAUSE5=FAIL; CLAUSE5_EVIDENCE=""
+
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — exactly one createLogger( call site, and it is the root.
+# ---------------------------------------------------------------------------
+# The definition lives in CONTROL_FILE and is excluded by path so that a second
+# DEFINITION anywhere else still shows up as an extra hit here.
+CALL_HITS="$(cd "$REPO_ROOT" && rg -nF 'createLogger(' server \
+  --glob '!*.test.ts' --glob "!$CONTROL_FILE" 2>/dev/null)"
+RG_STATUS=$?
+[ "$RG_STATUS" -ge 2 ] && fail_hard "rg failed with status $RG_STATUS scanning for createLogger( call sites"
+
+CALL_FILES="$(printf '%s\n' "$CALL_HITS" | rg -v '^$' | cut -d: -f1 | sort -u)"
+CALL_COUNT="$(printf '%s\n' "$CALL_HITS" | rg -c '^' 2>/dev/null || true)"
+[ -n "$CALL_HITS" ] || CALL_COUNT=0
+
+if [ "$CALL_COUNT" -ne 1 ]; then
+  CLAUSE1_EVIDENCE="found $CALL_COUNT createLogger( call site(s) in non-test server/ code, expected exactly 1"
+elif [ "$CALL_FILES" != "$ROOT_FILE" ]; then
+  CLAUSE1_EVIDENCE="the single call site is in $CALL_FILES, not the composition root $ROOT_FILE"
+else
+  CLAUSE1=PASS
+  CLAUSE1_EVIDENCE="exactly 1 createLogger( call site, in $ROOT_FILE"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 2 — nobody outside the root and server/logging/ imports the module.
+# ---------------------------------------------------------------------------
+IMPORT_HITS="$(cd "$REPO_ROOT" && rg -nF 'logging/logger' server \
+  --glob '!*.test.ts' --glob "!$ROOT_FILE" --glob '!server/logging/**' 2>/dev/null)"
+RG_STATUS=$?
+[ "$RG_STATUS" -ge 2 ] && fail_hard "rg failed with status $RG_STATUS scanning for logging/logger imports"
+
+if [ -n "$IMPORT_HITS" ]; then
+  IMPORT_COUNT="$(printf '%s\n' "$IMPORT_HITS" | rg -c '^')"
+  CLAUSE2_EVIDENCE="$IMPORT_COUNT reference(s) to logging/logger outside $ROOT_FILE and server/logging/:"
+  CLAUSE2_HITS="$IMPORT_HITS"
+else
+  CLAUSE2=PASS
+  CLAUSE2_EVIDENCE="0 references to logging/logger outside $ROOT_FILE and server/logging/"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 3 — the decoration seam exists and exports both spellings.
+# ---------------------------------------------------------------------------
+if [ ! -f "$REPO_ROOT/$SEAM_FILE" ]; then
+  CLAUSE3_EVIDENCE="$SEAM_FILE does not exist — States 5-6 of the L3 handover have not landed"
+else
+  WRAPPER_N="$(cd "$REPO_ROOT" && rg -cF 'export function withLogging' "$SEAM_FILE" 2>/dev/null)"
+  WRAPPER_N="${WRAPPER_N:-0}"
+  DECORATOR_N="$(cd "$REPO_ROOT" && rg -cF 'export function logged' "$SEAM_FILE" 2>/dev/null)"
+  DECORATOR_N="${DECORATOR_N:-0}"
+  if [ "$WRAPPER_N" -lt 1 ] || [ "$DECORATOR_N" -lt 1 ]; then
+    CLAUSE3_EVIDENCE="$SEAM_FILE exists but exports withLogging=$WRAPPER_N, logged=$DECORATOR_N — both must be exported"
+  else
+    CLAUSE3=PASS
+    CLAUSE3_EVIDENCE="$SEAM_FILE exports both withLogging (wrapper) and logged (method decorator)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 4 — the driver test exists and passes.
+# ---------------------------------------------------------------------------
+if [ ! -f "$REPO_ROOT/$DRIVER_FILE" ]; then
+  CLAUSE4_EVIDENCE="$DRIVER_FILE does not exist — nothing proves the seam actually logs a failure"
+elif ! command -v bun >/dev/null 2>&1; then
+  fail_hard "bun not on PATH; clause 4 cannot be judged"
+else
+  DRIVER_OUT="$(cd "$REPO_ROOT" && bun test "$DRIVER_FILE" 2>&1)"
+  DRIVER_STATUS=$?
+  if [ "$DRIVER_STATUS" -eq 0 ]; then
+    CLAUSE4=PASS
+    CLAUSE4_EVIDENCE="bun test $DRIVER_FILE exited 0 — a thrown error logs stack and correlation id"
+  else
+    CLAUSE4_EVIDENCE="bun test $DRIVER_FILE exited $DRIVER_STATUS — the seam does not yet log the failure:"
+    CLAUSE4_HITS="$(printf '%s\n' "$DRIVER_OUT" | tail -n 12)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 5 — positive control: the scanner still matches where it must.
+# ---------------------------------------------------------------------------
+if [ ! -f "$REPO_ROOT/$CONTROL_FILE" ]; then
+  CLAUSE5_EVIDENCE="$CONTROL_FILE is missing — every clean result above is a broken scan, not a clean tree"
+else
+  CONTROL_N="$(cd "$REPO_ROOT" && rg -cF 'createLogger' "$CONTROL_FILE" 2>/dev/null)"
+  CONTROL_N="${CONTROL_N:-0}"
+  if [ "$CONTROL_N" -lt 1 ]; then
+    CLAUSE5_EVIDENCE="0 createLogger hits in $CONTROL_FILE — the same scan that reported clauses 1 and 2 sees nothing"
+  else
+    CLAUSE5=PASS
+    CLAUSE5_EVIDENCE="$CONTROL_N createLogger hit(s) in $CONTROL_FILE — the scanner is proven to match"
+  fi
+fi
+
+printf 'CLAUSE 1 (one createLogger call site, at the root):  %s — %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+if [ "$CLAUSE1" != PASS ] && [ -n "$CALL_HITS" ]; then
+  printf '%s\n' "$CALL_HITS" | sed 's/^/    /'
+fi
+printf 'CLAUSE 2 (no logger imports outside the root):       %s — %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+if [ "$CLAUSE2" != PASS ] && [ -n "${CLAUSE2_HITS:-}" ]; then
+  printf '%s\n' "$CLAUSE2_HITS" | sed 's/^/    /'
+fi
+printf 'CLAUSE 3 (decoration seam exports both spellings):   %s — %s\n' "$CLAUSE3" "$CLAUSE3_EVIDENCE"
+printf 'CLAUSE 4 (driver test proves the failure is logged): %s — %s\n' "$CLAUSE4" "$CLAUSE4_EVIDENCE"
+if [ "$CLAUSE4" != PASS ] && [ -n "${CLAUSE4_HITS:-}" ]; then
+  printf '%s\n' "$CLAUSE4_HITS" | sed 's/^/    /'
+fi
+printf 'CLAUSE 5 (scanner proven to match in %s): %s — %s\n' "$CONTROL_FILE" "$CLAUSE5" "$CLAUSE5_EVIDENCE"
+
+if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ] \
+  && [ "$CLAUSE4" = PASS ] && [ "$CLAUSE5" = PASS ]; then
+  exit 0
+fi
+exit 1

--- a/server/logging/decorate.driver.test.ts
+++ b/server/logging/decorate.driver.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Driver test for the L3 logging decoration seam (`server/logging/decorate.ts`).
+ *
+ * Design authority: `_DOCS/STANDARDS-observability.md` for the envelope,
+ * `_plans/server-hardening-ladder.md` rung L3 ("one logger, threaded") for the
+ * seam itself, gated by `scripts/done-means/750-l3-logger-threaded.sh`.
+ *
+ * WRITTEN RED, ON PURPOSE. `./decorate.ts` does not exist yet; this file is
+ * the specification States 5-6 of the L3 handover code against, so it must be
+ * committed BEFORE the module it imports. Until then the import fails and
+ * `bun test server/logging/decorate.driver.test.ts` exits non-zero, which is
+ * precisely what clause 4 of the done-means check reports.
+ *
+ * What it pins down, and why each part is not negotiable:
+ *
+ *   - The seam takes a logger it is GIVEN. There is no `createLogger` call in
+ *     this file and there must be none in `decorate.ts`: the whole rung exists
+ *     so that exactly one logger is constructed, in `server/main.ts`.
+ *   - A thrown error must still throw. A wrapper that swallows the failure to
+ *     log it has replaced a loud defect with a quiet one.
+ *   - The emitted line must carry `stack`. An error logged as `{}` — which is
+ *     what `JSON.stringify` does to an `Error` — is the failure mode that makes
+ *     the log useless in exactly the case it exists for.
+ *   - The line must carry the ambient `correlation_id` from `./context.ts`, not
+ *     one the caller passes in. That is what ties the failure to the request
+ *     that caused it across the await boundary.
+ *   - Both spellings are covered: `withLogging` for plain functions and
+ *     closures, `logged` for class methods. The server has both shapes.
+ */
+import { describe, expect, it } from "bun:test";
+import { Writable } from "node:stream";
+import type { DestinationStream } from "pino";
+import { withCorrelation } from "./context.ts";
+import { withLogging, logged } from "./decorate.ts";
+import { createLogger } from "./logger.ts";
+
+const CONFIG = {
+  level: "debug" as const,
+  file: "logs/open-brain.log",
+  service: "open-brain-server",
+  workerName: "worker-1",
+};
+
+/**
+ * One in-memory destination and the parsed lines written to it.
+ *
+ * Deliberately the same shape as `captureLogger` in
+ * `server/logging/logging.test.ts` rather than an import of it: that helper is
+ * module-private there, and a test that reaches across into another test file
+ * couples two suites that should be able to move independently.
+ */
+function captureLogger(): {
+  logger: ReturnType<typeof createLogger>;
+  entries(): Record<string, unknown>[];
+} {
+  const lines: string[] = [];
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      lines.push(String(chunk));
+      callback();
+    },
+  });
+  return {
+    logger: createLogger(CONFIG, stream as DestinationStream),
+    entries: () =>
+      lines.flatMap((line) =>
+        line
+          .split("\n")
+          .filter(Boolean)
+          .map((item) => JSON.parse(item) as Record<string, unknown>),
+      ),
+  };
+}
+
+/** The first entry whose level is `error`, as a flat record. */
+function firstFailure(
+  entries: Record<string, unknown>[],
+): Record<string, unknown> {
+  const found = entries.find((entry) => entry.level === "error");
+  expect(found).toBeDefined();
+  return found as Record<string, unknown>;
+}
+
+describe("logging decoration seam", () => {
+  it("logs a thrown error with its stack and the ambient correlation id", async () => {
+    const capture = captureLogger();
+    const explode = withLogging(
+      { logger: capture.logger, name: "explode" },
+      async (): Promise<never> => {
+        await Promise.resolve();
+        throw new Error("driver_boom");
+      },
+    );
+
+    await expect(
+      withCorrelation(async () => explode(), "driver-correlation"),
+    ).rejects.toThrow("driver_boom");
+
+    const failure = firstFailure(capture.entries());
+    expect(failure.correlation_id).toBe("driver-correlation");
+    const error = failure.error as Record<string, unknown>;
+    expect(typeof error.stack).toBe("string");
+    expect(String(error.stack)).toContain("driver_boom");
+  });
+
+  it("passes arguments and the return value through on the success path", async () => {
+    const capture = captureLogger();
+    const add = withLogging(
+      { logger: capture.logger, name: "add" },
+      async (left: number, right: number) => {
+        await Promise.resolve();
+        return left + right;
+      },
+    );
+
+    await expect(
+      withCorrelation(async () => add(2, 3), "driver-ok"),
+    ).resolves.toBe(5);
+    expect(capture.entries().some((entry) => entry.level === "error")).toBe(
+      false,
+    );
+  });
+
+  it("logs a thrown error from a decorated method the same way", async () => {
+    const capture = captureLogger();
+    const capturedLogger = capture.logger;
+
+    class Subject {
+      @logged({ logger: () => capturedLogger, name: "Subject.fail" })
+      async fail(): Promise<never> {
+        await Promise.resolve();
+        throw new Error("method_boom");
+      }
+    }
+
+    await expect(
+      withCorrelation(async () => new Subject().fail(), "driver-method"),
+    ).rejects.toThrow("method_boom");
+
+    const failure = firstFailure(capture.entries());
+    expect(failure.correlation_id).toBe("driver-method");
+    expect(String((failure.error as Record<string, unknown>).stack)).toContain(
+      "method_boom",
+    );
+  });
+});

--- a/server/logging/decorate.driver.test.ts
+++ b/server/logging/decorate.driver.test.ts
@@ -31,7 +31,6 @@ import { describe, expect, it } from "bun:test";
 import { Writable } from "node:stream";
 import type { DestinationStream } from "pino";
 import { withCorrelation } from "./context.ts";
-import { withLogging, logged } from "./decorate.ts";
 import { createLogger } from "./logger.ts";
 
 const CONFIG = {
@@ -81,8 +80,36 @@ function firstFailure(
   return found as Record<string, unknown>;
 }
 
+/**
+ * The seam under test does not exist yet, so it is loaded through a variable
+ * path at run time. A static `import` would make `bunx tsc --noEmit` fail with
+ * TS2307 and take CI down with it; the dynamic form keeps the type check green
+ * while the test still fails RED at run time until `./decorate.ts` lands,
+ * which is exactly what clause 4 of the done-means check reports.
+ */
+interface DecorateModule {
+  withLogging: <Args extends unknown[], Result>(
+    options: { logger: ReturnType<typeof createLogger>; name: string },
+    fn: (...args: Args) => Promise<Result>,
+  ) => (...args: Args) => Promise<Result>;
+  logged: (options: {
+    logger: () => ReturnType<typeof createLogger>;
+    name: string;
+  }) => <Method extends (...args: never[]) => Promise<unknown>>(
+    target: Method,
+    context: ClassMethodDecoratorContext,
+  ) => Method;
+}
+
+const DECORATE_MODULE_PATH = "./decorate.ts";
+
+async function loadDecorate(): Promise<DecorateModule> {
+  return (await import(DECORATE_MODULE_PATH)) as DecorateModule;
+}
+
 describe("logging decoration seam", () => {
   it("logs a thrown error with its stack and the ambient correlation id", async () => {
+    const { withLogging } = await loadDecorate();
     const capture = captureLogger();
     const explode = withLogging(
       { logger: capture.logger, name: "explode" },
@@ -104,6 +131,7 @@ describe("logging decoration seam", () => {
   });
 
   it("passes arguments and the return value through on the success path", async () => {
+    const { withLogging } = await loadDecorate();
     const capture = captureLogger();
     const add = withLogging(
       { logger: capture.logger, name: "add" },
@@ -122,6 +150,7 @@ describe("logging decoration seam", () => {
   });
 
   it("logs a thrown error from a decorated method the same way", async () => {
+    const { logged } = await loadDecorate();
     const capture = captureLogger();
     const capturedLogger = capture.logger;
 


### PR DESCRIPTION
## Summary

- Rung L3 of the server/ hardening ladder wants ONE logger, constructed at the composition root and handed down. This lands the gate for it BEFORE the work, so the implementing lane gets an executable specification instead of a prose description to argue with. It changes no server behavior.
- `scripts/done-means/750-l3-logger-threaded.sh` asserts five clauses: (1) exactly one `createLogger(` call site in non-test `server/` code and it is `server/main.ts` — the definition in `server/logging/logger.ts` is excluded by PATH, not by pattern, so a second *definition* elsewhere still fails; (2) zero references to `logging/logger` in non-test `server/` outside `server/main.ts` and `server/logging/`, because an import is how a second construction site starts and this catches the state one commit earlier than clause 1 does; (3) `server/logging/decorate.ts` exists and exports both `withLogging` (function wrapper) and `logged` (method decorator); (4) `bun test server/logging/decorate.driver.test.ts` exits 0; (5) positive control — the same pattern, tool and invocation still find `createLogger` in `server/logging/logger.ts`.
- Clause 5 exists because clauses 1 and 2 pass for two very different reasons: because the state is correct, or because the scan examined nothing. A renamed directory, a bad glob, or an `rg` missing from PATH each produce a silent clean sweep and an exit 0 that means nothing.
- Clause 4 exists because absence alone is not the bar. "No module imports the logger" is satisfiable by deleting all logging, which is worse than the defect being gated. `server/logging/decorate.driver.test.ts` therefore throws a real error inside a decorated function and asserts the emitted line carries the `stack` and the ambient correlation id from `server/logging/context.ts`, in both the plain-function and the class-method spelling. An error logged as `{}` — what `JSON.stringify` does to an `Error` — is exactly the failure mode that makes a log useless in the case it exists for.
- The driver test is committed RED, against a module that does not exist yet, on purpose. It is the spec States 5-6 of the L3 handover code against, and it has to exist before them to be one. `scripts/done-means/750-l3-logger-threaded.sh` is therefore RED by design until those states land.
- Measured on `origin/main`: clauses 1, 2 and 5 already PASS — one call at `server/main.ts:495`, one import at `server/main.ts:61`, the definition at `server/logging/logger.ts:117`. Clauses 3 and 4 FAIL, so the inner check exits 1. Those three passing is not luck (the rewrite root was built that way) and it is why the check earns its place: they are one careless import away from false and nothing else in the repo notices.
- Because the L3 check is honestly red, this PR receipts its sibling `scripts/done-means/750-l3-check-well-formed.sh`, which asserts a different property that is true today AND after the seam lands: the L3 check is well-formed — executable, printing all five clause lines exactly once each, structural and positive-control clauses green, and an exit code that agrees with the state clauses it printed. A red check that is well-formed is a working gate pointed at unfinished work; a red check that is malformed is a typo nobody has read. Nothing here is scaffolding to delete later. Same shape and rationale as the existing `750-l2b2-check-well-formed.sh`.

## Verification

- Done-means: scripts/done-means/750-l3-check-well-formed.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Evidence, all re-run on the COMMITTED tree after the pre-commit hook reformatted the driver test:

- `bash scripts/done-means/750-l3-check-well-formed.sh` -> exit 0, all five clauses PASS
- `bash scripts/done-means/750-l3-logger-threaded.sh` -> exit 1; clauses 1, 2, 5 PASS, clauses 3 and 4 FAIL (RED by design)
- `DONE_MEANS_L3_INNER` pointed at a stand-in that exits 7 -> exit 3 `HARNESS-ERROR`, proving both the override path and the no-verdict branch
- `./node_modules/.bin/oxlint --deny-warnings server/logging/decorate.driver.test.ts` -> 0
- `bunx tsc --noEmit` -> one error, `server/logging/decorate.driver.test.ts(34,37): error TS2307: Cannot find module './decorate.ts'` — the deliberate RED import. Baseline `origin/main` with these changes stashed is clean, so that is the only new diagnostic.
- `bun run test:isolated server/logging/logging.test.ts` -> 5 pass, 0 fail, 18 expect() calls; database `ob_isolated_83876_mtasuw1bw3` created and dropped

Python package is untouched. No migration, no runtime path, no client-facing contract, so no live smoke applies.

## Critical Self-Review

- Highest-risk behavior: `bunx tsc --noEmit` now reports one error on this branch, from the RED driver test's import of a module that does not exist. If CI gates on a clean typecheck this PR fails there, and that is a real cost paid deliberately — a driver test that compiles is a driver test that is not red. The alternatives were worse: stubbing `decorate.ts` would make clause 3 green against an empty seam, and deleting the import would delete the specification.
- Assumptions that could be wrong: (a) that the implementing lane will name the exports `withLogging` and `logged` with the signatures this test pins — the test IS the contract, so a lane that disagrees changes both together and the check keeps working; (b) that `logged` is written as a TC39-style method decorator taking an options object, which is what the third test case exercises; (c) that clause 2's globs (`!server/logging/**`, `!server/main.ts`) stay correct if the logging module is ever relocated — a move would make clause 2 vacuous, which is exactly what clause 5's positive control is there to catch.
- Missing/weak tests: the two done-means scripts are shell and have no unit tests of their own. Their red/green behavior was demonstrated by hand instead — the well-formed check was run against the real sibling (exit 0) and against a deliberately broken stand-in via `DONE_MEANS_L3_INNER` (exit 3). The driver test does not yet assert the shape of the success-path log line beyond "no error level was emitted", because pinning entry/result message names before the seam exists would over-constrain the implementing lane.
- Security/permission risk: none. Two shell scripts that only read the tree with `rg` and shell out to `bun test`, and one test file. No namespace predicate, no auth path, no SQL, no network, no credential handling touched.
- Migration/deploy risk: none. No schema change, no config change, nothing in the runtime path. `server/main.ts` and every module under `server/logging/` are unmodified.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md`. No MCP tool, schema, transport, protocol, or Python client surface is touched, so rtech-mcps, mcp2cli, and the Hermes runtime are all unaffected.
- Rollback/cleanup concern: reverting the commit removes three added files and restores a clean `tsc`. Nothing else references them. The well-formed check needs no edit when States 5-6 land — its five clauses were written to hold at both ends of the rung — so there is no scaffolding left behind to remember to remove.
- Fixes made before PR: the inner check originally had four clauses with no positive control, which meant a bad glob or a relocated `server/logging/` would have reported clauses 1 and 2 green over a scan that examined nothing; the `createLogger`-in-`logger.ts` control was added as clause 5 and the well-formed sibling reads it back. Clause 1 was also changed from a pattern-based exclusion of the definition to a path-based one, so that a second `createLogger` DEFINITION outside `server/logging/logger.ts` still counts as a hit rather than being silently filtered out.
- Known residual risk: the L3 check stays red until States 5-6 land, so anyone running it in the interim sees a failure. The header states that explicitly and names the two clauses that are expected red, and the receipted done-means for this PR is the well-formed sibling, which is green.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no MEDIUM+ review finding surfaced here — this PR adds two done-means checks and one deliberately-red driver test, changes no server behavior, and the one pattern worth remembering (receipt a well-formed-ness sibling when the real check is honestly red) is already captured in `docs/sme/` from the L2b-2 rung and is reused verbatim rather than newly learned.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: nothing in the runtime, transport, tool, or schema path is modified; the change is two shell checks and one test file.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched — the two done-means scripts read the tree and the driver test targets an internal logging seam that has no wire surface.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Classified not applicable on every downstream line: the change adds `scripts/done-means/750-l3-logger-threaded.sh`, `scripts/done-means/750-l3-check-well-formed.sh`, and `server/logging/decorate.driver.test.ts`. No MCP tool, schema, protocol, transport, or Python client surface is modified, so no rtech-mcps handoff, mcp2cli cache refresh, Hermes runtime change, or live canary applies.
