### PR TITLE
refactor(server): merge the src/types.ts type set into server/ so no server module imports src/types.ts (L5, #864)

### DIFF
--- a/server/application/nats.ts
+++ b/server/application/nats.ts
@@ -30,7 +30,7 @@ import {
 } from "../../src/nats-bridge.ts";
 import type { NatsRuntimeBoundary } from "../../src/nats-runtime.ts";
 import type { ToolDeps } from "../../src/tools/index.ts";
-import type { AuthInfo } from "../../src/types.ts";
+import type { AuthInfo } from "../types.ts";
 import type { BackgroundTraceEmitter } from "../../src/background-tracing.ts";
 import type { BackgroundRuntime } from "./index.ts";
 

--- a/server/main.ts
+++ b/server/main.ts
@@ -82,7 +82,7 @@ import {
 } from "../src/maintenance-bootstrap.ts";
 import { getOperatorDoctorStatus } from "../src/operator-doctor.ts";
 import type { ToolDeps } from "../src/tools/index.ts";
-import type { AuthInfo } from "../src/types.ts";
+import type { AuthInfo } from "./types.ts";
 
 /** Default listening port, unchanged from `src/index.ts:349`. */
 const DEFAULT_PORT = 3100;

--- a/server/observability/langfuse-tracing.ts
+++ b/server/observability/langfuse-tracing.ts
@@ -126,7 +126,7 @@ import type {
   BackgroundTraceBody,
   BackgroundTraceEmitter,
 } from "../../src/background-tracing.ts";
-import type { AuthInfo } from "../../src/types.ts";
+import type { AuthInfo } from "../types.ts";
 
 /**
  * Re-exported so this module stays the single import surface for the tracing

--- a/server/observability/trace-body.ts
+++ b/server/observability/trace-body.ts
@@ -11,7 +11,7 @@
  * arguments, a result, and an identity it returns a plain object, with no SDK,
  * server, socket, or async-local state involved.
  */
-import type { AuthInfo } from "../../src/types.ts";
+import type { AuthInfo } from "../types.ts";
 import { maskTraceValue } from "./trace-masking.ts";
 import type {
   McpTraceStatus,

--- a/server/tools/ingest-conversation-facts.ts
+++ b/server/tools/ingest-conversation-facts.ts
@@ -32,7 +32,7 @@ import { toSql } from "pgvector/pg";
 import { canWrite } from "../auth/permissions.ts";
 import { canTargetNamespace } from "../auth/namespace-policy.ts";
 import type { AuthIdentity } from "../auth/types.ts";
-import type { AuthInfo } from "../../src/types.ts";
+import type { AuthInfo } from "../types.ts";
 import { physicalNamespace } from "../../src/shared-namespace.ts";
 import { contentHash, EMBEDDING_MODEL } from "../../src/embedding.ts";
 import { containsSecret } from "../../src/sharing.ts";

--- a/server/tools/promote-entry.ts
+++ b/server/tools/promote-entry.ts
@@ -34,7 +34,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { AuthIdentity, ResourceTable } from "../auth/types.ts";
-import type { AuthInfo } from "../../src/types.ts";
+import type { AuthInfo } from "../types.ts";
 import { sharedNamespaceConfig } from "../../src/shared-namespace.ts";
 import { promoteEntry } from "../../src/promotion-service.ts";
 import {

--- a/server/tools/promotion.ts
+++ b/server/tools/promotion.ts
@@ -23,7 +23,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { canRead } from "../auth/permissions.ts";
 import { namespacePredicate } from "../auth/namespace-policy.ts";
 import type { AuthIdentity, ResourceTable } from "../auth/types.ts";
-import type { AuthInfo } from "../../src/types.ts";
+import type { AuthInfo } from "../types.ts";
 import {
   canonicalNamespace,
   sharedNamespaceConfig,

--- a/server/tools/source-registry.ts
+++ b/server/tools/source-registry.ts
@@ -17,7 +17,7 @@
  */
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { AuthInfo } from "../../src/types.ts";
+import type { AuthInfo } from "../types.ts";
 import {
   APPROVAL_STATES,
   LIFECYCLE_STATES,

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,0 +1,59 @@
+// Origin: src/types.ts. Copied here so no server module imports from src/ (L5, #864).
+export type Role =
+  "admin" | "agent" | "discord" | "ob-admin" | "promoter" | "readonly";
+export type Table =
+  "thoughts" | "decisions" | "relationships" | "projects" | "sessions";
+// Keep in sync with CHECK (relation IN (...)) in 010_entity_links.sql
+export type LinkRelation =
+  | "artifact"
+  | "depends_on"
+  | "supersedes"
+  | "caused_by"
+  | "same_lane"
+  | "adjacent"
+  | "mentions"
+  | "implemented_by"
+  | "blocked_by"
+  | "decided_by"
+  | "relates_to"
+  | "contradicts"
+  | "duplicates"
+  | "supplements";
+export type Tier = "hot" | "warm" | "cold";
+export type Permission = "read" | "write" | "delete";
+
+export interface AuthInfo {
+  role: Role;
+  clientId: string;
+  tokenClientId?: string;
+  agentId?: string;
+  namespaceSource?: "token" | "header";
+}
+
+export interface PoolHealth {
+  connected: boolean;
+  total: number;
+  idle: number;
+  waiting: number;
+}
+
+export interface HealthStatus {
+  status: "healthy" | "degraded";
+  /** Machine hostname — the human half of "which brain did I reach?". */
+  hostname: string;
+  server_ip: string;
+  server_ips: string[];
+  /** Deploy stamp short sha; absent on a tree that was never deployed. */
+  revision?: string;
+  database: PoolHealth;
+  embedding: { configured: boolean; connected: boolean };
+  nats: {
+    requested_transport: "http" | "nats";
+    availability: "available" | "not_runtime_available";
+    context_pack_subject: string;
+    fallback_http: boolean;
+    consecutive_failures: number;
+    last_error: string | null;
+  };
+  timestamp: string;
+}


### PR DESCRIPTION
## Summary

- This is the first L5 MERGE row from #864: eight `server/` modules imported `AuthInfo` from `src/types.ts`, keeping the server half of the tree structurally dependent on the legacy root for a type set and nothing else.
- Adds `server/types.ts` carrying that type set verbatim — `Role`, `Table`, `LinkRelation`, `Tier`, `Permission`, `AuthInfo`, `PoolHealth`, `HealthStatus` — with a header comment naming `src/types.ts` as the origin.
- Repoints the eight importers (`server/application/nats.ts`, `server/main.ts`, `server/observability/trace-body.ts`, `server/observability/langfuse-tracing.ts`, `server/tools/source-registry.ts`, `server/tools/promotion.ts`, `server/tools/promote-entry.ts`, `server/tools/ingest-conversation-facts.ts`) at the local copy. Import paths only; every symbol keeps its name and its shape.
- `AuthInfo` is copied rather than aliased to `server/tools/types.ts`'s `McpAuthInfo`, because the two are not structurally identical: `McpAuthInfo` is `readonly` throughout, sources `role` from `AuthIdentity`, and admits a `"delegated"` `namespaceSource` that `AuthInfo` does not. `server/tools/types.ts` is untouched.
- `src/types.ts` keeps its own copy and its own callers; the two are identical at creation and `src/` retires at L6.

## Verification

- Done-means: scripts/done-means/750-l2b2-check-well-formed.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Measured on the committed, rebased tree:

- `rg -c "src/types" server --glob '!*.test.ts'` → 8 files at `origin/main`; after the change the only hit is the origin-naming comment on line 1 of `server/types.ts`, zero imports.
- `bunx tsc --noEmit` → exit 0
- `./node_modules/.bin/oxlint --deny-warnings` on all 9 touched files → exit 0
- `bun run test:isolated` (whole suite) → 3908 pass, 35 skip, 0 fail, 15867 expect() calls, 254 files
- `bash scripts/done-means/750-l2b2-check-well-formed.sh` → exit 0
- `bash scripts/done-means/750-l2b2-env-readers-take-config.sh` → exit 0

Python package: no files under `python/openbrain-memory/` are touched. Live smoke: no runtime behavior, wire format, tool schema, or SQL changes — the diff is one new type-only module plus eight import lines.

## Critical Self-Review

- Highest-risk behavior: authorization. `AuthInfo` carries `role` and `clientId`, so a silently widened or narrowed shape here would change what the permission checks in the eight consumers accept. The mitigation is that the declaration is byte-identical to the one it replaced, and `tsc --noEmit` is clean across the tree, so no consumer's inference moved.
- Assumptions that could be wrong: that no consumer relied on `AuthInfo` and `src/types.ts`'s other exports being nominally the same declaration as the ones `src/` uses. TypeScript's structural typing means two identical declarations are interchangeable, and the clean typecheck across both halves of the tree is the evidence; there is no `declare unique` or branded type in the set.
- Missing/weak tests: no new test ships, and that is deliberate — a type-only move has no runtime behavior to assert, and a test that only re-states the shape would pass on a wrong shape too. The real gate is `tsc --noEmit` plus the unchanged suite, which exercises the eight consumers' real call paths.
- Security/permission risk: none introduced. Namespace predicates, role checks, and token binding all live in `server/auth/` and `server/tools/memory-helpers.ts` and are untouched. Notably, `McpAuthInfo` was NOT merged into `AuthInfo`: aliasing them would have widened `namespaceSource` to admit `"delegated"` at seven call sites as a side effect of a file move, which is exactly the kind of quiet permission-surface change this repo's standards forbid.
- Migration/deploy risk: none. No migration, no schema change, no config key, no environment read.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` applies to MCP tool/schema/protocol/client-facing changes; this changes no tool declaration, no contract fixture, and no wire shape. `server/tools/types.ts`, which owns the MCP-facing types, is not in the diff.
- Rollback/cleanup concern: the type set now exists in two places until `src/` retires at L6. That duplication is the intended L5 shape, not drift, but it will read as drift to anyone who finds one copy without the other — which is why `server/types.ts` opens with a comment naming `src/types.ts` and the L5 issue. Rollback is reverting one commit.
- Fixes made before PR: initial `sed` edits were re-verified after the pre-commit prettier pass reformatted `server/types.ts`; every check above was re-run on the committed tree rather than the pre-commit working tree, and again after rebasing onto `origin/main` at 3f3e122.
- Known residual risk: `server/types.ts` exports six symbols no `server/` module imports yet (`Role`, `Table`, `LinkRelation`, `Tier`, `Permission`, `PoolHealth`, `HealthStatus`). They were copied whole rather than cherry-picked so the file is a faithful mirror for the L6 retirement, at the cost of being briefly wider than its current use.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical import-path move with no new failure pattern — the one judgment call, declining to alias two near-identical auth types, is already covered by the repo's existing rule that permission checks are server-side and shapes are not widened incidentally.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or tool-schema surface changes; the diff is a type-only module plus eight import lines.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no tool declaration, input schema, or output shape changes, so no contract fixture moves.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All four are not applicable: downstream rollout is gated on MCP tool/schema/protocol/client-facing changes, and this PR changes none of them. The MCP-facing type module `server/tools/types.ts` is deliberately untouched, and `bun run test:isolated` covering the contract tests is green at 0 fail.
