### PR TITLE
feat(server): wrap every registered tool handler with the logging decorator once, at the composition root (L3 State 6, #860)

### DIFF
--- a/server/main.tool-logging.test.ts
+++ b/server/main.tool-logging.test.ts
@@ -1,0 +1,161 @@
+/**
+ * The composition root wraps every registered tool handler exactly once.
+ *
+ * These read the REAL emitted envelope through an in-memory destination, the
+ * same way `server/logging/decorate.test.ts` does, rather than asserting
+ * against a mock's record of a call. What is under test is the seam in
+ * `server/main.ts` — that a handler registered through `registerTool` after
+ * `installToolLogging` runs comes back decorated, that its return value is
+ * untouched, and that a throw still reaches the caller.
+ */
+import { describe, expect, it } from "bun:test";
+import { Writable } from "node:stream";
+import type { DestinationStream } from "pino";
+import { createLogger } from "./logging/logger.ts";
+import { installToolLogging } from "./main.ts";
+
+const CONFIG = {
+  level: "debug" as const,
+  file: "logs/open-brain.log",
+  service: "open-brain-server",
+  workerName: "worker-1",
+};
+
+function captureLogger(): {
+  logger: ReturnType<typeof createLogger>;
+  entries(): Record<string, unknown>[];
+} {
+  const lines: string[] = [];
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      lines.push(String(chunk));
+      callback();
+    },
+  });
+  return {
+    logger: createLogger(CONFIG, stream as DestinationStream),
+    entries: () =>
+      lines.flatMap((line) =>
+        line
+          .split("\n")
+          .filter(Boolean)
+          .map((item) => JSON.parse(item) as Record<string, unknown>),
+      ),
+  };
+}
+
+/**
+ * The smallest stand-in that exercises the seam: a `registerTool` that keeps
+ * whatever callback it is handed. A real `McpServer` would add a transport,
+ * schema validation, and a session, none of which the wrap depends on.
+ */
+function fakeServer(): {
+  server: { registerTool: (...args: unknown[]) => unknown };
+  handlerFor(name: string): (...args: never[]) => unknown;
+} {
+  const registered = new Map<string, (...args: never[]) => unknown>();
+  return {
+    server: {
+      registerTool: (...args: unknown[]) => {
+        const [name, , cb] = args;
+        if (typeof cb === "function") {
+          registered.set(String(name), cb as (...args: never[]) => unknown);
+        }
+        return undefined;
+      },
+    },
+    handlerFor: (name: string) => {
+      const found = registered.get(name);
+      if (!found) throw new Error(`no handler registered for ${name}`);
+      return found;
+    },
+  };
+}
+
+function install(capture: ReturnType<typeof captureLogger>) {
+  const fake = fakeServer();
+  installToolLogging(
+    fake.server as unknown as Parameters<typeof installToolLogging>[0],
+    capture.logger,
+  );
+  return fake;
+}
+
+function messages(entries: Record<string, unknown>[]): string[] {
+  return entries.map((entry) => String(entry.message));
+}
+
+describe("installToolLogging", () => {
+  it("emits entry and exit lines around a registered handler", async () => {
+    const capture = captureLogger();
+    const fake = install(capture);
+    fake.server.registerTool("search_brain", {}, async () => ({
+      content: [{ type: "text", text: "ok" }],
+    }));
+
+    const result = await (
+      fake.handlerFor("search_brain") as () => Promise<unknown>
+    )();
+
+    expect(result).toEqual({ content: [{ type: "text", text: "ok" }] });
+    const emitted = messages(capture.entries());
+    expect(emitted).toContain("operation_entry");
+    expect(emitted).toContain("operation_result");
+    expect(emitted).not.toContain("operation_failure");
+    expect(
+      capture
+        .entries()
+        .every((entry) => entry.operation === "tool.search_brain"),
+    ).toBe(true);
+  });
+
+  it("emits a failure line with a stack when the handler throws", async () => {
+    const capture = captureLogger();
+    const fake = install(capture);
+    fake.server.registerTool("get_entity", {}, async () => {
+      throw new Error("entity lookup exploded");
+    });
+
+    await expect(
+      (fake.handlerFor("get_entity") as () => Promise<unknown>)(),
+    ).rejects.toThrow("entity lookup exploded");
+
+    const failure = capture
+      .entries()
+      .find((entry) => entry.message === "operation_failure");
+    expect(failure).toBeDefined();
+    const error = failure?.error as Record<string, unknown> | undefined;
+    expect(error?.message).toBe("entity lookup exploded");
+    expect(String(error?.stack)).toContain("entity lookup exploded");
+    expect(failure?.operation).toBe("tool.get_entity");
+    expect(failure).toHaveProperty("correlation_id");
+  });
+
+  it("returns an isError result unchanged and records it as an ordinary exit", async () => {
+    const capture = captureLogger();
+    const fake = install(capture);
+    const errorResult = {
+      content: [{ type: "text", text: "namespace denied" }],
+      isError: true,
+    };
+    fake.server.registerTool("set_tier", {}, async () => errorResult);
+
+    const result = await (
+      fake.handlerFor("set_tier") as () => Promise<unknown>
+    )();
+
+    expect(result).toEqual(errorResult);
+    const emitted = messages(capture.entries());
+    expect(emitted).toContain("operation_result");
+    expect(emitted).not.toContain("operation_failure");
+  });
+
+  it("passes a non-function third argument straight through", () => {
+    const capture = captureLogger();
+    const fake = install(capture);
+    expect(() =>
+      fake.server.registerTool("no_callback", {}, undefined),
+    ).not.toThrow();
+    expect(capture.entries()).toHaveLength(0);
+  });
+});

--- a/server/main.ts
+++ b/server/main.ts
@@ -58,6 +58,7 @@ import {
 } from "./config.ts";
 import { runMigrations } from "./db/migrations.ts";
 import { createDatabase, type Database } from "./db/pool.ts";
+import { withLogging } from "./logging/decorate.ts";
 import { createLogger } from "./logging/logger.ts";
 import {
   createTracingRuntime,
@@ -117,6 +118,44 @@ export interface StartServerOptions {
 }
 
 /**
+ * Wrap every tool handler this server registers with the logging seam.
+ *
+ * Installed at the composition root and NOWHERE else. A per-tool application
+ * would put the same three lines in thirty files and go stale the first time
+ * someone adds the thirty-first, so the wrap happens once, where registration
+ * itself passes through: `server.registerTool`. `installMcpAudit` and
+ * `installMcpTracing` earn their guarantee the same way and for the same
+ * reason, which is why this runs beside them and BEFORE `registerMemoryTools`
+ * — a tool registered before the wrapper is installed is a tool whose calls
+ * are never logged.
+ *
+ * `withLogging` rethrows, so nothing about a handler's contract moves. The
+ * errors tools convert into `isError` results are RETURNED, not thrown, so
+ * they travel back to the caller byte-for-byte as before and are recorded as
+ * an ordinary exit; only a genuine throw produces the failure line.
+ */
+export function installToolLogging(server: McpServer, logger: Logger): void {
+  const original = server.registerTool.bind(server) as (
+    ...args: unknown[]
+  ) => unknown;
+  server.registerTool = ((
+    name: string,
+    configOrDescription: unknown,
+    cb?: unknown,
+  ) => {
+    if (typeof cb !== "function") {
+      return original(name, configOrDescription, cb);
+    }
+    const callback = cb as (...args: never[]) => unknown;
+    return original(
+      name,
+      configOrDescription,
+      withLogging({ logger, name: `tool.${name}` }, callback),
+    );
+  }) as typeof server.registerTool;
+}
+
+/**
  * Build the per-session MCP server factory.
  *
  * A FRESH `McpServer` per session, not one shared instance: the SDK binds a
@@ -158,6 +197,7 @@ function createServerFactory(input: {
   const toolLogger = logger.child({ component: "tools" });
   return () => {
     const server = new McpServer({ name: "open-brain", version: "1.0.0" });
+    installToolLogging(server, toolLogger);
     installMcpAudit(server, { pool });
     // `sink` undefined means tracing is off for this process; the install then
     // never wraps `registerTool` and costs nothing.


### PR DESCRIPTION
## Summary

- L3 State 6 (#860, refs #825): every MCP tool handler registered by `server/main.ts` now runs inside `withLogging` from `server/logging/decorate.ts`, so each call emits an entry line, an exit line with its duration, and — on a throw — a failure line carrying the stack and the ambient correlation id.
- **Seam chosen: `server/main.ts:137` `installToolLogging`, rebinding `server.registerTool`, called from `server/main.ts:200` inside `createServerFactory` before `registerMemoryTools`.** That is the one place every registration already passes through, and it is the same mechanism and the same ordering rule `installMcpAudit` and `installMcpTracing` already rely on: a tool registered before the wrapper is installed is a tool whose calls are never logged.
- Applied ONCE, at the composition root. No tool file is touched. A per-tool application would repeat the same three lines in thirty files and go stale the first time someone adds the thirty-first.
- No handler's return value or error shape changes. `withLogging` rethrows rather than swallowing, so a genuine throw still reaches the caller unchanged; the errors tools convert into `isError` results are RETURNED, not thrown, so they travel back byte-for-byte as before and are recorded as an ordinary exit. A `registerTool` call whose third argument is not a function is passed through untouched.
- The four `src/logger.ts` imports in `server/observability` are deliberately NOT retired here — see Known residual risk.

## Verification

- Done-means: scripts/done-means/750-l2b2-check-well-formed.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Evidence, all on the committed and rebased tree:

- RED at `origin/main`: `rg -c 'withLogging' server/main.ts` -> exit 1, 0 matches. GREEN after: -> 3.
- `bunx tsc --noEmit` -> exit 0.
- `./node_modules/.bin/oxlint --deny-warnings server/main.ts server/main.tool-logging.test.ts` -> exit 0.
- `bun run test:isolated` (whole suite) -> 3922 pass, 0 fail, 3957 tests across 256 files, exited 0.
- `bash scripts/done-means/750-l2b2-check-well-formed.sh` -> exit 0, 4/4 clauses PASS.
- `bash scripts/done-means/750-l2b2-env-readers-take-config.sh` -> exit 0, 4/4 clauses PASS; the four ARRIVALS in `server/main.ts` are untouched by this change.

Python package is untouched, so its checks are not applicable. No migration and no schema or contract change, so no live smoke applies.

## Critical Self-Review

- Highest-risk behavior: rebinding `server.registerTool` on a per-session `McpServer`. If the wrap altered what the SDK receives, every tool would break at once rather than one at a time. It is mitigated by passing `name` and the config argument straight through and handing the SDK a function of identical arity and identical return type — `withLogging` returns `F`, and the synchronous path in `decorate.ts` deliberately does not await, so a synchronous handler stays synchronous.
- Assumptions that could be wrong: that `registerTool` is the only registration entry point in use. The audit and tracing installers both stake their guarantee on the same assumption, so if it were false those two would already be blind, and `rg 'server\.tool\('` finds no other path in `server/`. Second assumption: that ordering relative to `installMcpAudit` does not matter. Both wrap the same method, so they compose either way; logging is installed first so its lines surround the audit work as well.
- Missing/weak tests: the tests drive a stand-in `registerTool` rather than a live `McpServer` over a transport, so they prove the wrap's behavior but not the SDK's acceptance of the wrapped function. `bunx tsc --noEmit` covers the shape, and `server/main.pg.test.ts` starts a real process stack and still passes. There is no test asserting the wrap survives a second installer rebinding on top of it.
- Security/permission risk: the emitted lines pass through `sanitizeValue` in `decorate.ts` before serialization, and this change adds no new field of its own beyond the tool name, which is not user-supplied. Handler arguments are not logged. No auth, namespace, or permission predicate is touched.
- Migration/deploy risk: none. No schema change, no migration, no config key, no environment contract. The change is additive within one process and reverts by dropping one call.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md`. No MCP tool, schema, protocol, or client-facing surface changes — tool names, input schemas, and result payloads are byte-identical. rtech-mcps, mcp2cli, and the rtech-hermes runtime see nothing different. The only observable change is additional server-side log lines at debug and info.
- Rollback/cleanup concern: revert the commit. The seam is one function and one call site, and nothing else was made to depend on it.
- Fixes made before PR: exported `installToolLogging` so the test drives the real function rather than a copy of it; added the non-function third-argument passthrough case after reading how `installMcpTracing` handles the same shape, since without it an overload the SDK supports would have thrown.
- Known residual risk: the four `src/logger.ts` imports in `server/observability` (`trace-sink.ts:23`, `trace-config.ts:8`, `trace-sink-health.ts:17`, `langfuse-tracing.ts:90`) are NOT retired here. Each reaches a module-level logger from inside a function with no deps object in scope — `trace-sink.ts:377`, `trace-config.ts:50`, `trace-sink-health.ts:196`, `langfuse-tracing.ts:279` — so injecting the threaded logger requires a signature change, which this change is not scoped to. They remain L5 #864 rows.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no MEDIUM+ review finding surfaced; this is an additive seam with no defect behind it, and the harvest comment records the one reusable observation instead.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no MCP contract, schema, transport, or client-facing surface changes; the change adds server-side log lines only.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface is touched. Tool names, input schemas, and result payloads are unchanged, so no fixture describes anything different.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Classified not applicable across all four: the rollout gate applies to MCP tool, schema, protocol, and client-facing changes. This change registers the same tools with the same names, schemas, and result shapes, and only adds log emission around each invocation. No downstream client can observe it.
