### PR TITLE
docs(ladder): mark L3 MERGED on the server hardening ladder (#860)

### DIFF
--- a/_plans/server-hardening-ladder.md
+++ b/_plans/server-hardening-ladder.md
@@ -1,7 +1,7 @@
 # server/ hardening ladder — L1 through L6
 
-**Status: L1 MERGED, L2 MERGED, L4 MET, L3 IN PROGRESS — 2026-08-26.** Ordering
-approved by the operator. L1 and both halves of L2 are on `origin/main`, and L4
+**Status: L1 MERGED, L2 MERGED, L3 MERGED (#863, #865, #867, #869), L4 MET — 2026-08-27.** Ordering
+approved by the operator. L1, both halves of L2, and L3 are on `origin/main`, and L4
 is already met on `origin/main` as a side effect of the #780 lint sweep. L5 and
 L6 are not started.
 


### PR DESCRIPTION
## Summary

- Closes the documentation half of #860: the `server/` hardening ladder's status line still read `L3 IN PROGRESS` while L3 ("one logger, threaded") had already merged to `origin/main` across #863, #865, #867, and #869. A reader arriving at `_plans/server-hardening-ladder.md` saw an open rung that origin/main had closed, which is the exact way a ladder file stops being usable as a status source.
- The change is two lines in `_plans/server-hardening-ladder.md`: the bold status line now reads `L1 MERGED, L2 MERGED, L3 MERGED (#863, #865, #867, #869), L4 MET — 2026-08-27`, and the following sentence names L3 alongside L1 and L2 as being on `origin/main`. `L5 and L6 are not started` is unchanged.
- Markdown only. No source file, test, config, or migration is touched.

## Verification

- Done-means: scripts/done-means/750-l3-logger-threaded.sh
- The check was run on a branch identical to `origin/main` (before the edit) and again on the committed tree (after). Both runs exit `0` with all five clauses PASS, verbatim:

```
CLAUSE 1 (one createLogger call site, at the root):  PASS — exactly 1 createLogger( call site, in server/main.ts
CLAUSE 2 (no logger imports outside the root):       PASS — 0 references to logging/logger outside server/main.ts and server/logging/
CLAUSE 3 (decoration seam exports both spellings):   PASS — server/logging/decorate.ts exports both withLogging (wrapper) and logged (method decorator)
CLAUSE 4 (driver test proves the failure is logged): PASS — bun test server/logging/decorate.driver.test.ts exited 0 — a thrown error logs stack and correlation id
CLAUSE 5 (scanner proven to match in server/logging/logger.ts): PASS — 1 createLogger hit(s) in server/logging/logger.ts — the scanner is proven to match
EXIT=0
```

- `oxlint`, `bunx tsc --noEmit`, and `bun run test:isolated` do not apply to this change and were not run: the only touched file is a markdown document under `_plans/`, which none of those three tools reads. Asserting a green typecheck or test count here would be a receipt for something this diff cannot affect.
- [x] Relevant Open Brain tests/typecheck/migrations passed — not applicable, markdown-only diff; the done-means check above (which itself runs `bun test server/logging/decorate.driver.test.ts`) is the evidence that the state the doc now claims is real.
- [x] Python package checks passed or are not applicable — not applicable, nothing under `python/openbrain-memory/` is touched.
- [x] Live Open Brain smoke passed or is not applicable — not applicable, no runtime behavior changes.

## Critical Self-Review

- Highest-risk behavior: the risk is a documentation claim outrunning the code — writing `L3 MERGED` when L3 is not actually on `origin/main`. That is why the branch was cut from `origin/main` and the done-means check run there before the edit rather than after; the receipt is about the tree, not about this diff.
- Assumptions that could be wrong: that #863, #865, #867, and #869 are the complete set of PRs constituting L3. The PR numbers came from the issue brief, not from an independent traversal of `origin/main`'s history, so a fifth L3 PR would leave the parenthetical incomplete. The MERGED verdict itself does not depend on that list — the check does.
- Missing/weak tests: none added and none warranted. `scripts/done-means/750-l3-logger-threaded.sh` is the executable assertion for this rung and it already exists on `origin/main`; a test asserting the wording of a markdown status line would encode the prose, not the property.
- Security/permission risk: none. No auth path, namespace predicate, SQL, or token handling is in the diff.
- Migration/deploy risk: none. No migration, no schema, no deployed artifact changes.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classification is not applicable — no MCP tool, schema, transport, protocol, or client-facing surface is touched, so there is nothing for rtech-mcps, mcp2cli, or rtech-hermes to pick up.
- Rollback/cleanup concern: a single two-line markdown revert. No scratch files, backup files, or generated artifacts are left in the repo; the commit message file and this body live under the temp workspace, not the repo.
- Fixes made before PR: the initial edit was scoped to the bold status line only; on reading the following sentence it still asserted that only L1 and both halves of L2 were on `origin/main`, which the new status line contradicts. That sentence was adjusted in the same commit so the paragraph does not disagree with its own heading.
- Known residual risk: the date in the status line is `2026-08-27` per the brief while the commit lands on 2026-08-26. That is a deliberate forward-dating carried from the brief, not a drift, and it is the only factual claim in the diff not backed by a command run this session.
- SME review-memory update: [x] not applicable because: this lane produced no new review finding — the change is a status-line correction with an existing done-means check as its evidence, and no missed pattern, failed gate, or post-merge surprise arose that `docs/sme/` does not already cover.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] not applicable because: markdown-only change with no runtime surface.

## Contract Parity

- Contract parity: [x] runtime-specific because: no contract, fixture, or tool schema is touched by a markdown status-line edit.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Classification: not applicable. `docs/downstream-rollout.md` scopes the gate to MCP tool, schema, protocol, and client-facing changes. This diff changes one bold line and one sentence in `_plans/server-hardening-ladder.md` and nothing else, so no downstream consumer can observe it.
