### PR TITLE
feat(shared-namespace): give the server twin the legacy-namespace helpers and two config fields (L5 owner, #864)

### DIFF
--- a/scripts/done-means/750-l5-shared-namespace-owner.sh
+++ b/scripts/done-means/750-l5-shared-namespace-owner.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for rung L5 of the server/ hardening ladder
+# (issue #864, "shared-namespace owner").
+#
+#   bash scripts/done-means/750-l5-shared-namespace-owner.sh
+#
+# ---------------------------------------------------------------------------
+# The defect this gates
+# ---------------------------------------------------------------------------
+# `src/shared-namespace.ts` and `server/tools/shared-namespace.ts` are twins.
+# The src copy already knows two things the server copy does not: whether a
+# name IS the retired `collab` namespace, and whether a write aimed at it must
+# be refused. The server copy knowing only how to TRANSLATE names is the state
+# this rung ends, because a caller on the server path has no way to ask the
+# frozen-namespace question and therefore does not ask it.
+#
+# That failure is silent in the direction that matters. A write into the frozen
+# legacy namespace succeeds and looks ordinary; nothing errors, and the row is
+# indistinguishable afterward from one written before the freeze. So the gate
+# is the presence of the ANSWERING functions on the server twin, not the
+# presence of a caller — a caller can be added later, but it cannot be added at
+# all while there is nothing to call.
+#
+# ---------------------------------------------------------------------------
+# Four clauses, and all four must pass
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — THE SERVER TWIN ANSWERS BOTH QUESTIONS.
+#   `server/tools/shared-namespace.ts` exports `isLegacySharedNamespace` and
+#   `shouldRejectLegacySharedWrite`. Both, because either alone leaves a caller
+#   assembling the policy itself out of the other one, which is how two call
+#   sites end up disagreeing about what "frozen" means.
+#
+# CLAUSE 2 — THE CONFIG GROUP CARRIES THE TWO FIELDS THAT FEED THEM.
+#   `SharedNamespaceGroup` in `server/config/env-groups.ts` declares
+#   `sharedNamespace` and `allowLegacySharedWrites`, and
+#   `extendedEnvironmentFields` declares `OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES`.
+#   The helpers read no environment of their own by design, so an undeclared
+#   field means the operator escape hatch is unreachable however the helper is
+#   written.
+#
+# CLAUSE 3 — THE BEHAVIOR IS DRIVEN, NOT MERELY DECLARED.
+#   `bun run test:isolated` over the three owning test files exits 0. Presence
+#   checks alone are satisfied by a function that returns a constant, so this
+#   clause runs the tests that pin the actual answers: an unconfigured legacy
+#   name matching nothing, both admin roles passing, the escape hatch opening
+#   the write, and the config reader producing both new fields.
+#
+# CLAUSE 4 — THE SCANNER IS PROVEN TO MATCH (positive control).
+#   Clauses 1 and 2 pass either because the state is correct or because the
+#   scan examined nothing — a renamed file, a bad glob, an `rg` missing from
+#   PATH each produce a silent clean sweep. So the same pattern, tool, and
+#   invocation must still find `export function isSharedNamespace`, which has
+#   been in the server twin since before this rung and which no lane here
+#   should ever remove.
+#
+# NO ARGUMENTS.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v rg >/dev/null 2>&1 || fail_hard "rg (ripgrep) not on PATH"
+[ -d "$REPO_ROOT/.git" ] || [ -f "$REPO_ROOT/.git" ] || fail_hard "not a git repo at $REPO_ROOT"
+
+TWIN_FILE="server/tools/shared-namespace.ts"
+GROUPS_FILE="server/config/env-groups.ts"
+TEST_FILES=(
+  "server/config-extended.test.ts"
+  "server/config-equivalence.test.ts"
+  "server/tools/shared-namespace-legacy.test.ts"
+)
+
+[ -f "$REPO_ROOT/$TWIN_FILE" ] || fail_hard "$TWIN_FILE is missing"
+[ -f "$REPO_ROOT/$GROUPS_FILE" ] || fail_hard "$GROUPS_FILE is missing"
+
+CLAUSE1=FAIL; CLAUSE1_EVIDENCE=""
+CLAUSE2=FAIL; CLAUSE2_EVIDENCE=""
+CLAUSE3=FAIL; CLAUSE3_EVIDENCE=""
+CLAUSE4=FAIL; CLAUSE4_EVIDENCE=""
+
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — the server twin exports both legacy-namespace answers.
+# ---------------------------------------------------------------------------
+IS_LEGACY_N="$(cd "$REPO_ROOT" && rg -cF 'export function isLegacySharedNamespace' "$TWIN_FILE" 2>/dev/null)"
+IS_LEGACY_N="${IS_LEGACY_N:-0}"
+REJECT_N="$(cd "$REPO_ROOT" && rg -cF 'export function shouldRejectLegacySharedWrite' "$TWIN_FILE" 2>/dev/null)"
+REJECT_N="${REJECT_N:-0}"
+
+if [ "$IS_LEGACY_N" -lt 1 ] || [ "$REJECT_N" -lt 1 ]; then
+  CLAUSE1_EVIDENCE="$TWIN_FILE exports isLegacySharedNamespace=$IS_LEGACY_N, shouldRejectLegacySharedWrite=$REJECT_N — both must be exported"
+else
+  CLAUSE1=PASS
+  CLAUSE1_EVIDENCE="$TWIN_FILE exports both isLegacySharedNamespace and shouldRejectLegacySharedWrite"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 2 — the config group and the env field set carry the coordinates.
+# ---------------------------------------------------------------------------
+# The interface body is sliced out by line range so a same-named field on some
+# OTHER interface in the file cannot satisfy this clause by accident.
+GROUP_BODY="$(cd "$REPO_ROOT" && sed -n '/^export interface SharedNamespaceGroup {/,/^}/p' "$GROUPS_FILE")"
+SHARED_N="$(printf '%s\n' "$GROUP_BODY" | rg -cF 'sharedNamespace:' 2>/dev/null)"
+SHARED_N="${SHARED_N:-0}"
+ALLOW_N="$(printf '%s\n' "$GROUP_BODY" | rg -cF 'allowLegacySharedWrites:' 2>/dev/null)"
+ALLOW_N="${ALLOW_N:-0}"
+ENV_BODY="$(cd "$REPO_ROOT" && sed -n '/^export const extendedEnvironmentFields = {/,/^} as const;/p' "$GROUPS_FILE")"
+ENV_N="$(printf '%s\n' "$ENV_BODY" | rg -cF 'OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES' 2>/dev/null)"
+ENV_N="${ENV_N:-0}"
+
+if [ "$SHARED_N" -lt 1 ] || [ "$ALLOW_N" -lt 1 ] || [ "$ENV_N" -lt 1 ]; then
+  CLAUSE2_EVIDENCE="in $GROUPS_FILE: SharedNamespaceGroup.sharedNamespace=$SHARED_N, .allowLegacySharedWrites=$ALLOW_N, extendedEnvironmentFields.OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES=$ENV_N — all three required"
+else
+  CLAUSE2=PASS
+  CLAUSE2_EVIDENCE="SharedNamespaceGroup declares both fields and the env field set declares OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 3 — the owning tests pass against a fresh database.
+# ---------------------------------------------------------------------------
+MISSING_TESTS=""
+for f in "${TEST_FILES[@]}"; do
+  [ -f "$REPO_ROOT/$f" ] || MISSING_TESTS="$MISSING_TESTS $f"
+done
+
+if [ -n "$MISSING_TESTS" ]; then
+  CLAUSE3_EVIDENCE="missing test file(s):$MISSING_TESTS"
+elif ! command -v bun >/dev/null 2>&1; then
+  fail_hard "bun not on PATH; clause 3 cannot be judged"
+else
+  TEST_OUT="$(cd "$REPO_ROOT" && bun run test:isolated "${TEST_FILES[@]}" 2>&1)"
+  TEST_STATUS=$?
+  if [ "$TEST_STATUS" -eq 0 ]; then
+    CLAUSE3=PASS
+    CLAUSE3_EVIDENCE="bun run test:isolated over ${#TEST_FILES[@]} owning test file(s) exited 0"
+  else
+    CLAUSE3_EVIDENCE="bun run test:isolated exited $TEST_STATUS over the owning test files:"
+    CLAUSE3_HITS="$(printf '%s\n' "$TEST_OUT" | tail -n 12)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 4 — positive control: the scanner still matches where it must.
+# ---------------------------------------------------------------------------
+CONTROL_N="$(cd "$REPO_ROOT" && rg -cF 'export function isSharedNamespace' "$TWIN_FILE" 2>/dev/null)"
+CONTROL_N="${CONTROL_N:-0}"
+if [ "$CONTROL_N" -lt 1 ]; then
+  CLAUSE4_EVIDENCE="0 isSharedNamespace hits in $TWIN_FILE — the same scan that reported clauses 1 and 2 sees nothing"
+else
+  CLAUSE4=PASS
+  CLAUSE4_EVIDENCE="$CONTROL_N isSharedNamespace hit(s) in $TWIN_FILE — the scanner is proven to match"
+fi
+
+printf 'CLAUSE 1 (server twin answers both legacy questions): %s — %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+printf 'CLAUSE 2 (config group carries the two fields):       %s — %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+printf 'CLAUSE 3 (owning tests drive the behavior):           %s — %s\n' "$CLAUSE3" "$CLAUSE3_EVIDENCE"
+if [ "$CLAUSE3" != PASS ] && [ -n "${CLAUSE3_HITS:-}" ]; then
+  printf '%s\n' "$CLAUSE3_HITS" | sed 's/^/    /'
+fi
+printf 'CLAUSE 4 (scanner proven to match in %s): %s — %s\n' "$TWIN_FILE" "$CLAUSE4" "$CLAUSE4_EVIDENCE"
+
+if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ] \
+  && [ "$CLAUSE4" = PASS ]; then
+  exit 0
+fi
+exit 1

--- a/server/config-equivalence.test.ts
+++ b/server/config-equivalence.test.ts
@@ -38,7 +38,6 @@ function extendedConfig(overrides: Record<string, string | undefined> = {}) {
   return result.config;
 }
 
-
 /**
  * START-EQUIVALENCE: the schema must answer what the READER answers.
  *
@@ -266,6 +265,8 @@ describe("shared-namespace helpers require the validated name set", () => {
     legacySharedNamespace: "collab",
     legacyFallbackEnabled: false,
     fallbackMinResults: 5,
+    sharedNamespace: "shared-kb-v2",
+    allowLegacySharedWrites: false,
   };
 
   it("uses the passed set", () => {
@@ -296,7 +297,7 @@ describe("shared-namespace helpers require the validated name set", () => {
     );
   });
 
-  it("carries the same five fields as the validated config group", () => {
+  it("carries the same fields as the validated config group", () => {
     expect(sharedNamespaceConfig(NAMES)).toEqual(NAMES);
     expect(Object.keys(extendedConfig({}).sharedNamespaceNames).sort()).toEqual(
       Object.keys(NAMES).sort(),

--- a/server/config-extended.test.ts
+++ b/server/config-extended.test.ts
@@ -186,6 +186,29 @@ describe("extended env — sharedNamespaceNames", () => {
       ).toBe(5);
     }
   });
+
+  it("leaves legacy shared writes refused when no escape hatch is set", () => {
+    expect(extendedConfig().sharedNamespaceNames.allowLegacySharedWrites).toBe(
+      false,
+    );
+  });
+
+  it("opens legacy shared writes when the escape hatch is set", () => {
+    expect(
+      extendedConfig({ OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES: "true" })
+        .sharedNamespaceNames.allowLegacySharedWrites,
+    ).toBe(true);
+  });
+
+  it("resolves sharedNamespace from the physical override", () => {
+    expect(extendedConfig().sharedNamespaceNames.sharedNamespace).toBe(
+      extendedConfig().sharedNamespaceNames.canonicalSharedNamespace,
+    );
+    expect(
+      extendedConfig({ SHARED_NAMESPACE_PHYSICAL: "shared-kb-v9" })
+        .sharedNamespaceNames.sharedNamespace,
+    ).toBe("shared-kb-v9");
+  });
 });
 
 describe("extended env — tracing", () => {

--- a/server/config/env-groups.ts
+++ b/server/config/env-groups.ts
@@ -199,6 +199,7 @@ export const extendedEnvironmentFields = {
   OPENBRAIN_LEGACY_SHARED_NAMESPACE: blankAsAbsent,
   OPENBRAIN_LEGACY_SHARED_FALLBACK: permissiveBoolean,
   OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS: fallbackInteger(1, 5),
+  OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES: permissiveBoolean,
   // tracing — `server/observability/langfuse-tracing.ts:599-604`.
   OPENBRAIN_TRACING_ENDPOINT: blankAsAbsent,
   OPENBRAIN_TRACING_PUBLIC_KEY: blankAsAbsent,
@@ -266,6 +267,10 @@ export interface SharedNamespaceGroup {
   readonly legacyFallbackEnabled: boolean;
   /** Shared-hit count at or above which the legacy fallback is skipped. */
   readonly fallbackMinResults: number;
+  /** Physical shared namespace used by existing read/write call sites. */
+  readonly sharedNamespace: string;
+  /** Whether a non-admin may write into the configured legacy namespace. */
+  readonly allowLegacySharedWrites: boolean;
 }
 
 export interface TracingConfigGroup {
@@ -366,6 +371,8 @@ export function sharedNamespaceGroup(
       DEFAULT_LEGACY_SHARED_NAMESPACE,
     legacyFallbackEnabled: parsed.OPENBRAIN_LEGACY_SHARED_FALLBACK,
     fallbackMinResults: parsed.OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS,
+    sharedNamespace: parsed.SHARED_NAMESPACE_PHYSICAL ?? resolvedCanonical,
+    allowLegacySharedWrites: parsed.OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES,
   };
 }
 

--- a/server/tools/agent-context-pack-names.test.ts
+++ b/server/tools/agent-context-pack-names.test.ts
@@ -23,6 +23,8 @@ const injected: SharedNamespaceConfig = {
   legacySharedNamespace: "",
   legacyFallbackEnabled: false,
   fallbackMinResults: 5,
+  sharedNamespace: "lane5-physical-kb",
+  allowLegacySharedWrites: false,
 };
 
 const identity: AuthIdentity = {

--- a/server/tools/read-scope-names.test.ts
+++ b/server/tools/read-scope-names.test.ts
@@ -26,6 +26,8 @@ const injected: SharedNamespaceConfig = {
   legacySharedNamespace: "",
   legacyFallbackEnabled: false,
   fallbackMinResults: 5,
+  sharedNamespace: "lane3-physical-kb",
+  allowLegacySharedWrites: false,
 };
 
 const identity: AuthIdentity = {

--- a/server/tools/search-engine.test.ts
+++ b/server/tools/search-engine.test.ts
@@ -67,7 +67,9 @@ async function timeoutObservedFor(
     executeSearch(dependencies, ["thoughts"], "anything", 5, "vector"),
   ).rejects.toThrow();
   expect(warnings).toHaveLength(1);
-  return warnings[0]!.timeout_ms;
+  const [first] = warnings;
+  if (!first) throw new Error("expected one recorded warning");
+  return first.timeout_ms;
 }
 
 describe("search embedding timeout injection", () => {
@@ -112,6 +114,8 @@ const INJECTED_NAMES = {
   legacySharedNamespace: "",
   legacyFallbackEnabled: false,
   fallbackMinResults: 5,
+  sharedNamespace: "lane5-physical-shared",
+  allowLegacySharedWrites: false,
 } as const;
 
 function poolReturningPhysicalRow(): Pool {

--- a/server/tools/search-tools-shared-names.test.ts
+++ b/server/tools/search-tools-shared-names.test.ts
@@ -27,6 +27,8 @@ const INJECTED_NAMES: SharedNamespaceConfig = {
   legacySharedNamespace: "",
   legacyFallbackEnabled: false,
   fallbackMinResults: 5,
+  sharedNamespace: "lane3-physical-shared",
+  allowLegacySharedWrites: false,
 };
 
 const REACHED_POOL = "reached-the-pool";

--- a/server/tools/shared-namespace-fixture.ts
+++ b/server/tools/shared-namespace-fixture.ts
@@ -17,4 +17,6 @@ export const DEFAULT_SHARED_NAMESPACE_NAMES: SharedNamespaceGroup = {
   legacySharedNamespace: "",
   legacyFallbackEnabled: false,
   fallbackMinResults: 5,
+  sharedNamespace: "shared-kb",
+  allowLegacySharedWrites: false,
 };

--- a/server/tools/shared-namespace-legacy.test.ts
+++ b/server/tools/shared-namespace-legacy.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Legacy shared-namespace helper tests (L5 owner, #864).
+ *
+ * Two properties are asserted here that nothing else in the suite covers.
+ * First, an UNCONFIGURED legacy name never matches: `legacySharedNamespace` is
+ * `""` by default, so a helper that tested equality alone would report every
+ * unnamespaced input as legacy. Second, the frozen-namespace refusal (#167)
+ * has three separate off-switches — the operator escape hatch, an unconfigured
+ * legacy name, and a write aimed somewhere else — and each is exercised so a
+ * later edit cannot collapse them into one.
+ */
+import { describe, expect, it } from "bun:test";
+import type { AuthInfo } from "../types.ts";
+import type { SharedNamespaceGroup } from "../config/env-groups.ts";
+import {
+  isLegacySharedNamespace,
+  shouldRejectLegacySharedWrite,
+} from "./shared-namespace.ts";
+
+const CONFIGURED: SharedNamespaceGroup = {
+  canonicalSharedNamespace: "shared-kb",
+  physicalSharedNamespace: "shared-kb-v2",
+  legacySharedNamespace: "collab",
+  legacyFallbackEnabled: false,
+  fallbackMinResults: 5,
+  sharedNamespace: "shared-kb-v2",
+  allowLegacySharedWrites: false,
+};
+
+const UNCONFIGURED: SharedNamespaceGroup = {
+  ...CONFIGURED,
+  legacySharedNamespace: "",
+};
+
+function authAs(role: AuthInfo["role"]): AuthInfo {
+  return { role, clientId: "lane5-client" };
+}
+
+describe("isLegacySharedNamespace", () => {
+  it("matches the configured legacy name", () => {
+    expect(isLegacySharedNamespace("collab", CONFIGURED)).toBe(true);
+  });
+
+  it("never matches when no legacy name is configured", () => {
+    expect(isLegacySharedNamespace("", UNCONFIGURED)).toBe(false);
+    expect(isLegacySharedNamespace("collab", UNCONFIGURED)).toBe(false);
+  });
+
+  it("does not treat the canonical name as legacy", () => {
+    expect(isLegacySharedNamespace("shared-kb", CONFIGURED)).toBe(false);
+  });
+});
+
+describe("shouldRejectLegacySharedWrite", () => {
+  it("refuses a non-admin write into the frozen legacy namespace", () => {
+    expect(
+      shouldRejectLegacySharedWrite(authAs("agent"), "collab", CONFIGURED),
+    ).toBe(true);
+  });
+
+  it("allows both admin roles through", () => {
+    expect(
+      shouldRejectLegacySharedWrite(authAs("admin"), "collab", CONFIGURED),
+    ).toBe(false);
+    expect(
+      shouldRejectLegacySharedWrite(authAs("ob-admin"), "collab", CONFIGURED),
+    ).toBe(false);
+  });
+
+  it("allows the write once the operator opens the escape hatch", () => {
+    expect(
+      shouldRejectLegacySharedWrite(authAs("agent"), "collab", {
+        ...CONFIGURED,
+        allowLegacySharedWrites: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores writes aimed at any other namespace", () => {
+    expect(
+      shouldRejectLegacySharedWrite(authAs("agent"), "shared-kb", CONFIGURED),
+    ).toBe(false);
+  });
+
+  it("refuses nothing when no legacy name is configured", () => {
+    expect(
+      shouldRejectLegacySharedWrite(authAs("agent"), "", UNCONFIGURED),
+    ).toBe(false);
+  });
+});

--- a/server/tools/shared-namespace.ts
+++ b/server/tools/shared-namespace.ts
@@ -29,6 +29,7 @@
  */
 
 import type { SharedNamespaceGroup } from "../config/env-groups.ts";
+import type { AuthInfo } from "../types.ts";
 
 /**
  * The shared-namespace name set.
@@ -92,6 +93,54 @@ export function isSharedNamespace(
     namespace === config.canonicalSharedNamespace ||
     namespace === config.physicalSharedNamespace
   );
+}
+
+/**
+ * Whether the name is the configured legacy shared namespace.
+ *
+ * True only when a non-empty legacy namespace is configured AND matches. With
+ * the default (empty) legacy name, no input is ever legacy — that non-empty
+ * test is what stops an unconfigured deployment treating unnamespaced input as
+ * legacy.
+ *
+ * @param namespace Caller-supplied or stored namespace name.
+ * @param names Validated set from the composition root.
+ * @returns Whether the name is the configured legacy shared namespace.
+ */
+export function isLegacySharedNamespace(
+  namespace: string,
+  names?: SharedNamespaceGroup,
+): boolean {
+  const legacy = requireNames(
+    names,
+    "isLegacySharedNamespace",
+  ).legacySharedNamespace;
+  return legacy !== "" && namespace === legacy;
+}
+
+/**
+ * Whether a write into the legacy shared namespace must be refused.
+ *
+ * The legacy namespace is frozen (#167): only an admin role may still write
+ * into it, and only while an operator has both configured a legacy name and
+ * left the escape hatch off. Every earlier test is a "not applicable" case, so
+ * the role check is reached only for a genuine legacy-target write.
+ *
+ * @param auth The caller's authenticated identity.
+ * @param targetNamespace The namespace the write is aimed at.
+ * @param names Validated set from the composition root.
+ * @returns Whether the write must be refused.
+ */
+export function shouldRejectLegacySharedWrite(
+  auth: AuthInfo,
+  targetNamespace: string,
+  names?: SharedNamespaceGroup,
+): boolean {
+  const config = requireNames(names, "shouldRejectLegacySharedWrite");
+  if (config.allowLegacySharedWrites) return false;
+  if (config.legacySharedNamespace === "") return false;
+  if (targetNamespace !== config.legacySharedNamespace) return false;
+  return auth.role !== "admin" && auth.role !== "ob-admin";
 }
 
 /**


### PR DESCRIPTION
## Summary

- Issue #864, the **L5 shared-namespace owner** row of the server/ hardening ladder. `src/shared-namespace.ts` and `server/tools/shared-namespace.ts` are twins, and the server copy could only TRANSLATE names between the canonical and physical forms — it could not answer either question a caller needs before writing: is this name the retired `collab` namespace, and may this caller write into it.
- A caller with no way to ask does not ask. A write into the frozen legacy namespace (#167) then succeeds looking entirely ordinary: nothing errors, and the row is afterward indistinguishable from one written before the freeze. That is the state this rung ends.
- Adds `isLegacySharedNamespace(namespace, names?)`, which tests non-empty FIRST so the default unset legacy name (`""`) never matches unnamespaced caller input; and `shouldRejectLegacySharedWrite(auth, targetNamespace, names?)`, which refuses a non-admin write aimed at a configured legacy namespace and has three separate off-switches — the operator escape hatch, an unconfigured legacy name, and a write aimed anywhere else.
- The helpers read no environment of their own, matching the rest of the module, so `SharedNamespaceGroup` gains `sharedNamespace` and `allowLegacySharedWrites`, and `extendedEnvironmentFields` gains `OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES`. **`SHARED_NAMESPACE_PHYSICAL` is a real field of `extendedEnvironmentFields`**, already read by `sharedNamespaceGroup()` for its canonical resolution, so `sharedNamespace` resolves as `parsed.SHARED_NAMESPACE_PHYSICAL ?? resolvedCanonical` — no fallback-only path was needed.
- **No caller is rewired and `src/shared-namespace.ts` is untouched.** This rung puts the answers within reach; a later rung asks them.
- The prepared patch was written against an older main and applied cleanly at f79a405 with `git apply --3way` (all 7 files, no conflicts). `server/config.test.ts` was split by #872, so the group-shape assertion now lives in `server/config-equivalence.test.ts` — it compares key sets against its own `NAMES` constant rather than asserting a literal field count, so the fix was to add the two fields to `NAMES` and drop the now-stale word "five" from the test title.

## Verification

- Done-means: scripts/done-means/750-l5-shared-namespace-owner.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bun run test:isolated` (whole suite, fresh database) -> **3944 pass / 35 skip / 0 fail across 261 files**, exit 0. `bunx tsc --noEmit` -> exit 0. `oxlint --deny-warnings` over all 10 touched TypeScript files -> exit 0, no output. The done-means script -> exit 0, all four clauses PASS. Every check was re-run on the COMMITTED tree after the pre-commit hook's prettier reformatted two files; the working tree is clean.

RED receipt at pristine `origin/main` f79a405: `git show origin/main:server/tools/shared-namespace.ts | rg -cF 'export function isLegacySharedNamespace'` -> 0 hits, exit 1; the same for `shouldRejectLegacySharedWrite` -> 0 hits, exit 1; `git show origin/main:server/config/env-groups.ts | rg -cF 'OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES'` -> 0 hits, exit 1. Clauses 1 and 2 therefore both fail at that head and the script exits 1.

The check carries a positive control (clause 4) asserting the same pattern, tool, and invocation still find `export function isSharedNamespace` in the twin — because clauses 1 and 2 pass either when the state is correct or when the scan examined nothing, and a renamed file or a missing `rg` produces a silent clean sweep. Clause 2 slices the `SharedNamespaceGroup` interface body out by line range before scanning, so a same-named field on some other interface in the file cannot satisfy it by accident. Clause 3 runs the owning tests, because presence checks alone are satisfied by a function that returns a constant.

Python package: not applicable, no files under `python/openbrain-memory/` are touched. Live smoke: not applicable, nothing here changes a running surface — no caller is wired to the new helpers and the two config fields are additive with defaults that preserve current behavior (`allowLegacySharedWrites: false`, `sharedNamespace` resolving to the canonical name absent an override).

## Critical Self-Review

- Highest-risk behavior: `shouldRejectLegacySharedWrite` is a security-shaped predicate — it returns "refuse this write" — and its default answer is `false`. Every one of its three early returns is a "not applicable" case, so a wrong ordering would silently permit rather than silently refuse, which is the dangerous direction for a frozen namespace. Mitigated by driving all three off-switches plus both admin roles in separate assertions rather than one composite test.
- Assumptions that could be wrong: that `admin` and `ob-admin` are the correct and complete set of roles still permitted to write into the frozen namespace. I read the `Role` union at `server/types.ts:2-3` and confirmed those two are the only admin-class members of the six, but the *policy* choice came from the prepared patch, not from a design document I verified this session. If shared-truth writes are also meant to be open to `promoter`, this predicate is wrong and the test pins the wrong answer.
- Missing/weak tests: no test drives a real write path through the predicate, because no caller is wired to it yet — the tests are unit-level over the pure function. The `sharedNamespace` field is asserted input-by-input against the reader, but nothing yet consumes it, so its correctness is only as good as the expression it was given. There is also no test for a legacy namespace configured to the *same* string as the canonical one, which an operator could do during a migration.
- Security/permission risk: the two new config fields widen what an operator can turn on. `OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES` is an escape hatch that disables a refusal, and `permissiveBoolean` parsing means a range of truthy spellings enable it. It defaults off and requires a deliberate environment setting, and the predicate it feeds is not yet called by anything, so today it changes no live behavior.
- Migration/deploy risk: none identified. No migration, no schema change, no new required environment variable. `SharedNamespaceGroup` gains two fields, which is a compile-time break for any external construction of that type — all in-repo constructors were updated (five test fixtures plus the reader) and `bunx tsc --noEmit` exits 0, but a consumer outside this repo constructing the interface literally would need the two fields.
- Downstream client/runtime risk: none. I read `docs/downstream-rollout.md`'s applicability criteria — no MCP tool, schema, protocol, transport, or client-facing contract is touched. The change is internal to the server composition root and one server-side module; nothing in `server/contracts/` was modified and the whole suite (which covers those composers) is green.
- Rollback/cleanup concern: revert is a single clean commit with no state left behind — no migration to unwind, no config that must be removed first. If an operator has set `OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES` and the commit is reverted, the variable becomes unrecognized rather than harmful.
- Fixes made before PR: my first `AuthInfo` test literal used a `namespace` field and an `as AuthInfo` cast; reading `server/types.ts:25-31` showed `AuthInfo` has no `namespace` field at all, so the cast would have hidden the mismatch — replaced with a real literal (`role`, `clientId`) and no cast. A `sed` edit also duplicated the two new fields in `server/config-equivalence.test.ts`; caught by re-reading the block and fixed forward by deleting the duplicate pair rather than by discarding work.
- Known residual risk: the role policy noted above is the real one — I am confident the code does what the patch intended, and less confident that the intended policy is the ratified one, because I verified the role *union* this session but not a design document naming which roles may write to the frozen namespace. Flagging rather than asserting it is settled.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no MEDIUM+ review finding surfaced in this lane — the two defects I hit were my own in-progress errors (a guessed `AuthInfo` field caught by reading the type, and a duplicated `sed` insertion caught by re-reading the block), both fixed before commit, and both are instances of patterns `docs/sme/correctness.md` already carries rather than new ones.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no caller is wired to the new helpers and both config fields default to current behavior, so there is no running surface whose behavior this commit changes.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: `SharedNamespaceGroup` is a server-internal config group, not part of any cross-runtime contract. The Python client does not model it and no fixture under `server/contracts/` references it. The five test fixtures that DO construct it were all updated with the two new fields.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All four are **not applicable**: no MCP tool, schema, protocol, or client-facing shape changes. The touched surface is `server/config/env-groups.ts`, `server/tools/shared-namespace.ts`, and test fixtures. No tool registration, no response shape, no transport behavior.
- Whole-suite run against a fresh isolated database: `bun run test:isolated` -> 3944 pass / 35 skip / 0 fail, 261 files, exit 0. Per the brief's rule, a failure in `server/contracts/*.ts` would have been this lane's to fix, since those compose tool deps themselves and this change touches a config group — none occurred.
