### PR TITLE
refactor(tools): tier-lane and ingest-conversation-facts take shared-namespace names from their deps instead of src (L5, #864)

### DIFF
--- a/scripts/done-means/750-l5-shared-namespace-importers.sh
+++ b/scripts/done-means/750-l5-shared-namespace-importers.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for rung L5 of the server/ hardening ladder
+# (`_plans/server-hardening-ladder.md`, issue #864).
+#
+#   bash scripts/done-means/750-l5-shared-namespace-importers.sh
+#
+# ---------------------------------------------------------------------------
+# The defect this gates
+# ---------------------------------------------------------------------------
+# `src/shared-namespace.ts` reads the environment to decide what the shared
+# namespace is called. Every server/tools module that imports from it therefore
+# re-derives those names on its own, at whatever moment its call happens to
+# run, from whatever the environment says then. Two modules can disagree about
+# which physical namespace a write lands in, and nothing errors when they do —
+# the row simply goes somewhere else.
+#
+# The server twin `server/tools/shared-namespace.ts` closes that by taking the
+# names as an argument. It throws when the argument is absent, so the migration
+# cannot half-land silently: a call site that forgets to thread the names fails
+# loudly at runtime instead of quietly re-deriving them.
+#
+# L5 is complete for a module when both halves hold — it no longer imports the
+# environment-reading `src/` copy, AND every call it makes to the twin actually
+# passes the names it was handed by the composition root.
+#
+# ---------------------------------------------------------------------------
+# GENERIC BY DESIGN — NO ARGUMENTS
+# ---------------------------------------------------------------------------
+# This check takes no argv. It discovers its own subject: the non-test files
+# under server/tools changed against origin/main. That is what makes it usable
+# by the sibling lanes on this rung without editing it — each lane changes a
+# different pair of modules, and each gets its own subject list for free.
+#
+# `CHANGED_FILES` (space-separated) overrides the discovery, which is how the
+# RED receipt is taken before any edit exists to be discovered.
+#
+# ---------------------------------------------------------------------------
+# Three clauses, and all three must pass
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — NO MODULE IN THE SUBJECT IMPORTS THE src/ COPY.
+#   Zero references to `src/shared-namespace` in each subject file. That import
+#   is the environment read; while it is present the module can still reach the
+#   old names regardless of what it was handed.
+#
+# CLAUSE 2 — EVERY CALL PASSES THE NAMES (arrival, not departure).
+#   Clause 1 alone is satisfiable by deleting the calls, which is worse than
+#   the defect. So clause 2 counts ARRIVALS: for each of the six helpers, the
+#   number of call sites in the file must equal the number of call sites whose
+#   argument list mentions `sharedNamespaceNames` within the following 3 lines
+#   (prettier wraps a two-argument call across lines), and that number must be
+#   greater than zero. Equal-and-zero is a FAIL, not a pass — a subject file on
+#   this rung has calls to thread, and zero means the scan found nothing rather
+#   than that the work is done.
+#
+# CLAUSE 3 — THE TREE TYPECHECKS.
+#   `bunx tsc --noEmit` exits 0. The twin's trailing argument is typed, so a
+#   call threading the wrong shape is caught here rather than at runtime.
+#
+# An EMPTY subject list is exit 1 with a message, never a silent pass: a check
+# that examines nothing and reports success is the failure mode this whole
+# family of scripts exists to avoid.
+#
+# NO ARGUMENTS.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v rg >/dev/null 2>&1 || fail_hard "rg (ripgrep) not on PATH"
+command -v git >/dev/null 2>&1 || fail_hard "git not on PATH"
+[ -d "$REPO_ROOT/.git" ] || [ -f "$REPO_ROOT/.git" ] || fail_hard "not a git repo at $REPO_ROOT"
+
+HELPERS='canonicalNamespace|physicalNamespace|sharedNamespaceConfig|isSharedNamespace|isLegacySharedNamespace|shouldRejectLegacySharedWrite'
+NAMES_ARG='sharedNamespaceNames'
+
+# ---------------------------------------------------------------------------
+# SUBJECT — the non-test server/tools files changed against origin/main.
+# ---------------------------------------------------------------------------
+if [ -n "${CHANGED_FILES:-}" ]; then
+  SUBJECT="$(printf '%s\n' $CHANGED_FILES)"
+  SUBJECT_SOURCE="CHANGED_FILES override"
+else
+  SUBJECT="$(cd "$REPO_ROOT" && git diff --name-only origin/main -- server/tools 2>/dev/null | rg -v '\.test\.ts$')"
+  SUBJECT_SOURCE="git diff --name-only origin/main -- server/tools (non-test)"
+fi
+SUBJECT="$(printf '%s\n' "$SUBJECT" | rg -v '^$' || true)"
+
+if [ -z "$SUBJECT" ]; then
+  printf 'SUBJECT: none — %s produced no files.\n' "$SUBJECT_SOURCE" >&2
+  printf 'A check with nothing to examine is not a pass. Exiting 1.\n' >&2
+  exit 1
+fi
+
+SUBJECT_N="$(printf '%s\n' "$SUBJECT" | rg -c '^')"
+printf 'SUBJECT (%s file(s), from %s):\n' "$SUBJECT_N" "$SUBJECT_SOURCE"
+printf '%s\n' "$SUBJECT" | sed 's/^/    /'
+printf '\n'
+
+CLAUSE1=PASS
+CLAUSE2=PASS
+
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — no src/shared-namespace import survives in any subject file.
+# CLAUSE 2 — helper calls and names-carrying calls arrive at the same count.
+# ---------------------------------------------------------------------------
+while IFS= read -r FILE; do
+  [ -n "$FILE" ] || continue
+  if [ ! -f "$REPO_ROOT/$FILE" ]; then
+    printf 'CLAUSE 1 [%s]: FAIL — file does not exist\n' "$FILE"
+    CLAUSE1=FAIL
+    continue
+  fi
+
+  SRC_HITS="$(cd "$REPO_ROOT" && rg -nF 'src/shared-namespace' "$FILE" 2>/dev/null)"
+  RG_STATUS=$?
+  [ "$RG_STATUS" -ge 2 ] && fail_hard "rg failed with status $RG_STATUS scanning $FILE"
+  if [ -n "$SRC_HITS" ]; then
+    printf 'CLAUSE 1 [%s]: FAIL — still imports the environment-reading src/ copy:\n' "$FILE"
+    printf '%s\n' "$SRC_HITS" | sed 's/^/    /'
+    CLAUSE1=FAIL
+  else
+    printf 'CLAUSE 1 [%s]: PASS — 0 references to src/shared-namespace\n' "$FILE"
+  fi
+
+  # Departures: every call to one of the six helpers. The `\(` anchors on the
+  # call rather than the import line, which carries no parenthesis.
+  CALL_N="$(cd "$REPO_ROOT" && rg -c "\\b($HELPERS)\\(" "$FILE" 2>/dev/null)"
+  CALL_N="${CALL_N:-0}"
+  # Arrivals: calls whose argument list mentions the names within 3 lines.
+  ARRIVE_N="$(cd "$REPO_ROOT" && rg -U -c "\\b($HELPERS)\\((.|\\n){0,3}*?$NAMES_ARG" "$FILE" 2>/dev/null)"
+  ARRIVE_N="${ARRIVE_N:-0}"
+  if [ "$ARRIVE_N" -eq 0 ]; then
+    ARRIVE_N="$(cd "$REPO_ROOT" && rg -A3 "\\b($HELPERS)\\(" "$FILE" 2>/dev/null \
+      | rg -c "$NAMES_ARG" 2>/dev/null)"
+    ARRIVE_N="${ARRIVE_N:-0}"
+  fi
+
+  if [ "$CALL_N" -eq 0 ]; then
+    printf 'CLAUSE 2 [%s]: FAIL — 0 helper call sites found; the scan matched nothing\n' "$FILE"
+    CLAUSE2=FAIL
+  elif [ "$CALL_N" -ne "$ARRIVE_N" ]; then
+    printf 'CLAUSE 2 [%s]: FAIL — %s helper call(s), %s carrying %s\n' \
+      "$FILE" "$CALL_N" "$ARRIVE_N" "$NAMES_ARG"
+    (cd "$REPO_ROOT" && rg -n -A3 "\\b($HELPERS)\\(" "$FILE" 2>/dev/null) | sed 's/^/    /'
+    CLAUSE2=FAIL
+  else
+    printf 'CLAUSE 2 [%s]: PASS — %s helper call(s), all %s carrying %s\n' \
+      "$FILE" "$CALL_N" "$ARRIVE_N" "$NAMES_ARG"
+  fi
+done <<EOF
+$SUBJECT
+EOF
+
+# ---------------------------------------------------------------------------
+# CLAUSE 3 — the tree typechecks.
+# ---------------------------------------------------------------------------
+CLAUSE3=FAIL
+if ! command -v bunx >/dev/null 2>&1; then
+  fail_hard "bunx not on PATH; clause 3 cannot be judged"
+fi
+TSC_OUT="$(cd "$REPO_ROOT" && bunx tsc --noEmit 2>&1)"
+TSC_STATUS=$?
+if [ "$TSC_STATUS" -eq 0 ]; then
+  CLAUSE3=PASS
+  printf '\nCLAUSE 3 (bunx tsc --noEmit): PASS — exited 0\n'
+else
+  printf '\nCLAUSE 3 (bunx tsc --noEmit): FAIL — exited %s\n' "$TSC_STATUS"
+  printf '%s\n' "$TSC_OUT" | tail -n 12 | sed 's/^/    /'
+fi
+
+printf '\nCLAUSE 1 (no src/shared-namespace import):        %s\n' "$CLAUSE1"
+printf 'CLAUSE 2 (every helper call carries the names):   %s\n' "$CLAUSE2"
+printf 'CLAUSE 3 (bunx tsc --noEmit exits 0):            %s\n' "$CLAUSE3"
+
+if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ] && [ "$CLAUSE3" = PASS ]; then
+  exit 0
+fi
+exit 1

--- a/scripts/done-means/750-l5-shared-namespace-importers.sh
+++ b/scripts/done-means/750-l5-shared-namespace-importers.sh
@@ -27,7 +27,17 @@
 # GENERIC BY DESIGN — NO ARGUMENTS
 # ---------------------------------------------------------------------------
 # This check takes no argv. It discovers its own subject: the non-test files
-# under server/tools changed against origin/main. That is what makes it usable
+# under server/tools changed against the MERGE BASE of origin/main and HEAD.
+# Diffing against the moving tip of origin/main instead would drag in files
+# that other branches changed after this one was cut, and judge them as if
+# this lane had touched them. The merge base is the branch's own diff.
+#
+# Two files are always excluded from the subject, however they arrive:
+# `server/tools/shared-namespace.ts`, which DEFINES the six helpers rather
+# than calling them, and anything matching `*-fixture.ts`. Neither is a
+# migration subject, and both fail clause 2 by construction.
+#
+# Self-discovery is what makes this check usable
 # by the sibling lanes on this rung without editing it — each lane changes a
 # different pair of modules, and each gets its own subject list for free.
 #
@@ -84,10 +94,17 @@ if [ -n "${CHANGED_FILES:-}" ]; then
   SUBJECT="$(printf '%s\n' $CHANGED_FILES)"
   SUBJECT_SOURCE="CHANGED_FILES override"
 else
-  SUBJECT="$(cd "$REPO_ROOT" && git diff --name-only origin/main -- server/tools 2>/dev/null | rg -v '\.test\.ts$')"
-  SUBJECT_SOURCE="git diff --name-only origin/main -- server/tools (non-test)"
+  MERGE_BASE="$(cd "$REPO_ROOT" && git merge-base origin/main HEAD 2>/dev/null)"
+  [ -n "$MERGE_BASE" ] || fail_hard "git merge-base origin/main HEAD produced nothing"
+  SUBJECT="$(cd "$REPO_ROOT" && git diff --name-only "$MERGE_BASE" -- server/tools 2>/dev/null | rg -v '\.test\.ts$')"
+  SUBJECT_SOURCE="git diff --name-only \$(git merge-base origin/main HEAD) -- server/tools (non-test)"
 fi
 SUBJECT="$(printf '%s\n' "$SUBJECT" | rg -v '^$' || true)"
+# The twin DEFINES the helpers; a fixture is test scaffolding. Neither is ever
+# a subject, whether discovery or CHANGED_FILES put it there.
+SUBJECT="$(printf '%s\n' "$SUBJECT" \
+  | rg -v '^server/tools/shared-namespace\.ts$' \
+  | rg -v -- '-fixture\.ts$' || true)"
 
 if [ -z "$SUBJECT" ]; then
   printf 'SUBJECT: none — %s produced no files.\n' "$SUBJECT_SOURCE" >&2

--- a/server/tools/ingest-conversation-facts.ts
+++ b/server/tools/ingest-conversation-facts.ts
@@ -33,7 +33,7 @@ import { canWrite } from "../auth/permissions.ts";
 import { canTargetNamespace } from "../auth/namespace-policy.ts";
 import type { AuthIdentity } from "../auth/types.ts";
 import type { AuthInfo } from "../types.ts";
-import { physicalNamespace } from "../../src/shared-namespace.ts";
+import { physicalNamespace } from "./shared-namespace.ts";
 import { contentHash, EMBEDDING_MODEL } from "../../src/embedding.ts";
 import { containsSecret } from "../../src/sharing.ts";
 import { resolveIngestionEligibility } from "../../src/source-registry.ts";
@@ -154,7 +154,9 @@ function resolveWriteTarget(
     };
   }
 
-  return { namespace: physicalNamespace(requested) };
+  return {
+    namespace: physicalNamespace(requested, dependencies.sharedNamespaceNames),
+  };
 }
 
 /**

--- a/server/tools/ported-tools-scope.test.ts
+++ b/server/tools/ported-tools-scope.test.ts
@@ -25,6 +25,7 @@ import pino from "pino";
 import type { Pool, PoolClient } from "pg";
 import type { Role } from "../config.ts";
 import { registerMemoryTools } from "./index.ts";
+import { DEFAULT_SHARED_NAMESPACE_NAMES } from "./shared-namespace-fixture.ts";
 
 interface CapturedQuery {
   readonly sql: string;
@@ -70,8 +71,10 @@ async function clientCapturingQueries(
     pool,
     embedFn: async () => null,
     logger: pino({ level: "silent" }),
+    sharedNamespaceNames: DEFAULT_SHARED_NAMESPACE_NAMES,
   });
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
   const send = clientTransport.send.bind(clientTransport);
   clientTransport.send = (message, options) =>
     send(message, {
@@ -139,7 +142,10 @@ describe("set_tier scopes its write to the caller's own namespace", () => {
   });
 
   test("a role without write permission never reaches the pool", async () => {
-    const { client, queries } = await clientCapturingQueries("readonly", "rico");
+    const { client, queries } = await clientCapturingQueries(
+      "readonly",
+      "rico",
+    );
 
     const result = await client.callTool({
       name: "set_tier",
@@ -186,7 +192,9 @@ describe("bulk_set_tier and bulk_archive scope every statement", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(textOf(result)).toBe("Permission denied: cannot delete from thoughts");
+    expect(textOf(result)).toBe(
+      "Permission denied: cannot delete from thoughts",
+    );
     expect(queries).toHaveLength(0);
   });
 
@@ -212,12 +220,22 @@ describe("bulk_set_tier and bulk_archive scope every statement", () => {
 
 describe("demote_entry does not archive on merely-readable scope", () => {
   test("the UPDATE binds the write scope even though the SELECT read wider", async () => {
-    const { client, queries } = await clientCapturingQueries("admin", "operator", [
-      {
-        match: "SELECT id, namespace, promoted_from",
-        rows: [{ id: UUID_A, namespace: "shared-kb", promoted_from: { source_id: UUID_B } }],
-      },
-    ]);
+    const { client, queries } = await clientCapturingQueries(
+      "admin",
+      "operator",
+      [
+        {
+          match: "SELECT id, namespace, promoted_from",
+          rows: [
+            {
+              id: UUID_A,
+              namespace: "shared-kb",
+              promoted_from: { source_id: UUID_B },
+            },
+          ],
+        },
+      ],
+    );
 
     await client.callTool({
       name: "demote_entry",
@@ -233,7 +251,10 @@ describe("demote_entry does not archive on merely-readable scope", () => {
   });
 
   test("a non-global role is refused before any statement runs", async () => {
-    const { client, queries } = await clientCapturingQueries("promoter", "promo");
+    const { client, queries } = await clientCapturingQueries(
+      "promoter",
+      "promo",
+    );
 
     const result = await client.callTool({
       name: "demote_entry",
@@ -241,7 +262,9 @@ describe("demote_entry does not archive on merely-readable scope", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(textOf(result)).toBe("Permission denied: admin or ob-admin role required");
+    expect(textOf(result)).toBe(
+      "Permission denied: admin or ob-admin role required",
+    );
     expect(queries).toHaveLength(0);
   });
 });
@@ -251,7 +274,10 @@ describe("find_duplicates never emits an unscoped self-join (#485)", () => {
     // This is the #485 regression. Current-src gives admin an empty predicate on
     // both sides, so the join runs over every pair in the table -- measured at a
     // 60s statement_timeout cancellation against 256.7ms for the scoped form.
-    const { client, queries } = await clientCapturingQueries("ob-admin", "operator");
+    const { client, queries } = await clientCapturingQueries(
+      "ob-admin",
+      "operator",
+    );
 
     await client.callTool({
       name: "find_duplicates",
@@ -275,7 +301,9 @@ describe("find_duplicates never emits an unscoped self-join (#485)", () => {
     const timeoutIndex = queries.findIndex((query) =>
       query.sql.includes("statement_timeout"),
     );
-    const joinIndex = queries.findIndex((query) => query.sql.includes("JOIN thoughts b"));
+    const joinIndex = queries.findIndex((query) =>
+      query.sql.includes("JOIN thoughts b"),
+    );
     expect(queries[0]?.sql).toBe("BEGIN READ ONLY");
     expect(timeoutIndex).toBeGreaterThanOrEqual(0);
     // Arming the bound after the join is the same as not arming it: the
@@ -334,7 +362,10 @@ describe("citation_recall scopes on the lane's namespace", () => {
 
 describe("scan_namespace binds the scanned namespace as a parameter", () => {
   test("every table scan is bound to the requested namespace", async () => {
-    const { client, queries } = await clientCapturingQueries("ob-admin", "operator");
+    const { client, queries } = await clientCapturingQueries(
+      "ob-admin",
+      "operator",
+    );
 
     await client.callTool({
       name: "scan_namespace",
@@ -393,9 +424,9 @@ describe("tier_lane defaults to dry-run and writes nothing", () => {
     // Reading the default as `?? false` would make every exploratory call write
     // durable memory. This assertion is what fails if it is ever inverted.
     expect(JSON.parse(textOf(result)).dry_run).toBe(true);
-    expect(queries.some((query) => query.sql.includes("INSERT INTO thoughts"))).toBe(
-      false,
-    );
+    expect(
+      queries.some((query) => query.sql.includes("INSERT INTO thoughts")),
+    ).toBe(false);
   });
 
   test("the lane read binds the caller's own namespace", async () => {
@@ -429,9 +460,16 @@ describe("tier_lane defaults to dry-run and writes nothing", () => {
 
 describe("promote_entry defaults to dry-run", () => {
   test("an unqualified call reports dry_run true and inserts nothing", async () => {
-    const { client, queries } = await clientCapturingQueries("promoter", "promo", [
-      { match: "FROM thoughts", rows: [{ id: UUID_A, content: "shareable", tags: null }] },
-    ]);
+    const { client, queries } = await clientCapturingQueries(
+      "promoter",
+      "promo",
+      [
+        {
+          match: "FROM thoughts",
+          rows: [{ id: UUID_A, content: "shareable", tags: null }],
+        },
+      ],
+    );
 
     const result = await client.callTool({
       name: "promote_entry",
@@ -444,13 +482,16 @@ describe("promote_entry defaults to dry-run", () => {
     if (!result.isError) {
       expect(JSON.parse(textOf(result)).dry_run).toBe(true);
     }
-    expect(queries.some((query) => query.sql.startsWith("INSERT INTO thoughts"))).toBe(
-      false,
-    );
+    expect(
+      queries.some((query) => query.sql.startsWith("INSERT INTO thoughts")),
+    ).toBe(false);
   });
 
   test("the legacy shared name is refused as a target before any statement", async () => {
-    const { client, queries } = await clientCapturingQueries("promoter", "promo");
+    const { client, queries } = await clientCapturingQueries(
+      "promoter",
+      "promo",
+    );
 
     const result = await client.callTool({
       name: "promote_entry",
@@ -488,7 +529,9 @@ describe("ingest_conversation_facts refuses before it writes", () => {
     session_key: "lane-1",
   };
   const sourceRef = { source_kind: "conversation", external_id: "conv-1" };
-  const facts = [{ event_type: "fact", content: "a distilled durable statement" }];
+  const facts = [
+    { event_type: "fact", content: "a distilled durable statement" },
+  ];
 
   test("a role without sessions write permission never reaches the pool", async () => {
     const { client, queries } = await clientCapturingQueries("discord", "bot");
@@ -563,7 +606,9 @@ describe("ingest_conversation_facts refuses before it writes", () => {
       arguments: { scope, source_ref: sourceRef, facts },
     });
 
-    const lane = queries.find((query) => query.sql.includes("FROM ob_session_lanes"));
+    const lane = queries.find((query) =>
+      query.sql.includes("FROM ob_session_lanes"),
+    );
     if (lane) {
       // The namespace is the first coordinate and is a bound parameter, never
       // interpolated: it is the isolation boundary for the whole call.
@@ -574,7 +619,9 @@ describe("ingest_conversation_facts refuses before it writes", () => {
     // Whatever the source registry answered, no durable row may be written when
     // the lane does not resolve.
     expect(
-      queries.some((query) => query.sql.includes("INSERT INTO ob_session_events")),
+      queries.some((query) =>
+        query.sql.includes("INSERT INTO ob_session_events"),
+      ),
     ).toBe(false);
   });
 });

--- a/server/tools/tier-lane.ts
+++ b/server/tools/tier-lane.ts
@@ -36,10 +36,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { AuthIdentity } from "../auth/types.ts";
 import { canWrite } from "../auth/permissions.ts";
 import { canTargetNamespace } from "../auth/namespace-policy.ts";
-import {
-  canonicalNamespace,
-  physicalNamespace,
-} from "../../src/shared-namespace.ts";
+import { canonicalNamespace, physicalNamespace } from "./shared-namespace.ts";
 import {
   newTierReceipt,
   tierLaneEvent,
@@ -156,7 +153,10 @@ function authorizeTierLane(
     );
   }
 
-  return { identity, namespace: physicalNamespace(requested) };
+  return {
+    identity,
+    namespace: physicalNamespace(requested, dependencies.sharedNamespaceNames),
+  };
 }
 
 /** @returns True when authorization returned a refusal rather than a target. */
@@ -293,7 +293,10 @@ async function handleTierLane(
     );
     return textResult({
       session_key: args.session_key,
-      namespace: canonicalNamespace(namespace),
+      namespace: canonicalNamespace(
+        namespace,
+        dependencies.sharedNamespaceNames,
+      ),
       ...receipt,
     });
   } catch (error) {


### PR DESCRIPTION
## Summary

- Closes part of #864 (L5 importer switch, lane 1 of 4): `server/tools/tier-lane.ts` and `server/tools/ingest-conversation-facts.ts` now take the shared-namespace names from their injected dependencies instead of importing the environment-reading `src/shared-namespace.ts`.
- `src/shared-namespace.ts` derives the shared namespace names from the environment, so every module importing it re-derived them independently, at whatever moment its call ran. Two modules could disagree about which physical namespace a write landed in, and nothing errored when they did — the row simply went somewhere else.
- Both modules now import the server twin `server/tools/shared-namespace.ts` and pass `dependencies.sharedNamespaceNames`, which the composition root (`server/main.ts:191`) already parses once and threads through `MemoryToolDependencies` (`server/tools/types.ts:11-22`). The twin throws when the argument is absent, so a call site that forgets to thread the names fails loudly instead of quietly re-deriving them. No default, no fallback, and no `process.env` read is introduced.
- Three call sites move, all of which already had `dependencies` in scope, so no signature changed: `physicalNamespace` in `authorizeTierLane` (tier-lane) and `resolveWriteTarget` (ingest-conversation-facts), and `canonicalNamespace` in `handleTierLane` (tier-lane).
- `server/tools/ported-tools-scope.test.ts` composes its own dependencies and now supplies `DEFAULT_SHARED_NAMESPACE_NAMES` from the existing `server/tools/shared-namespace-fixture.ts`. Without it the twin throws and two `tier_lane` cases fail — that is the intended loud failure working, not a regression.
- Adds `scripts/done-means/750-l5-shared-namespace-importers.sh`, which is generic and takes no argv: it discovers the non-test `server/tools` files changed against `origin/main`, so the three sibling lanes on this rung can use it unmodified.

## Verification

- Done-means: scripts/done-means/750-l5-shared-namespace-importers.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts, all re-run against the committed tree after the pre-commit hook reformatted files:

- RED, at `origin/main` before any edit: `CHANGED_FILES='server/tools/tier-lane.ts server/tools/ingest-conversation-facts.ts' bash scripts/done-means/750-l5-shared-namespace-importers.sh` exited 1 — clause 1 failed on both files (`src/shared-namespace` import still present at `tier-lane.ts:42` and `ingest-conversation-facts.ts:36`) and clause 2 reported 2 and 1 helper calls respectively, none carrying the names.
- GREEN, after the change, via the script's own git-diff discovery with no override: exit 0 — clause 1 clean on both, clause 2 counted 2/2 and 1/1 calls carrying `sharedNamespaceNames`, clause 3 typecheck 0.
- `bunx tsc --noEmit` exited 0.
- `./node_modules/.bin/oxlint --deny-warnings` exited 0 on all three touched TypeScript files.
- `bun run test:isolated server/tools`: 182 pass / 0 fail across 21 files. The pre-change baseline on the same tree was also 182 pass / 0 fail, measured by stashing the change, so this matches rather than merely being green.
- `bun run test:isolated` (whole suite, no path): 3933 pass / 0 fail across 260 files. Run because `server/contracts/registered-tools.ts:60-64` composes dependencies itself and might have needed the field; it did not.

Python package checks are not applicable — nothing under `python/openbrain-memory/` is touched. Live smoke is not applicable — this is an internal dependency-threading change with no protocol, schema, or client-facing surface.

## Critical Self-Review

- Highest-risk behavior: namespace resolution on the write path. `physicalNamespace` decides which physical namespace a `tier_lane` or `ingest_conversation_facts` write lands in; if the threaded names differed from what the module previously derived from the environment, rows would silently move. They cannot differ here, because the composition root parses the same names the `src/` copy read, and the twin throws rather than defaulting when nothing is passed.
- Assumptions that could be wrong: that `dependencies.sharedNamespaceNames` is always populated in production. It is optional on `MemoryToolDependencies`, so the type does not enforce it; the guarantee is the composition root at `server/main.ts:191` plus the twin's throw. If some other composition path registers these tools without the field, those two tools throw at call time instead of silently using stale names — loud, but still a runtime failure rather than a compile-time one. The whole-suite run is what checks for such a path, and found only the one test fixture.
- Missing/weak tests: neither module has a direct unit test file, so the coverage here is indirect — `ported-tools-scope.test.ts` exercises `tier_lane` end to end through the MCP client and is what caught the missing fixture field. No new test asserts that the *specific* names threaded from the root are the ones used; the done-means clause 2 covers that structurally by counting call arrivals rather than by behavior.
- Security/permission risk: low, and the namespace predicate is the reason to look. Namespace isolation is a security boundary in this repo, so a change to namespace resolution deserves scrutiny — but the authorization order is untouched. `canWrite` and `canTargetNamespace` still run before `physicalNamespace` in both modules; only the argument list of the resolution call changed, not what is checked or when.
- Migration/deploy risk: none. No schema change, no migration, no config key added or removed. The names come from a parse that already happens at startup.
- Downstream client/runtime risk: none identified. No MCP tool schema, transport, contract fixture, or Python client surface changes — the tool signatures and their responses are byte-identical. `docs/downstream-rollout.md` classification is therefore not-applicable, recorded below.
- Rollback/cleanup concern: revertible as a single commit with no state to unwind. The done-means script is additive and would simply have no changed files to examine after a revert, in which case it exits 1 with a message rather than passing silently.
- Fixes made before PR: added `DEFAULT_SHARED_NAMESPACE_NAMES` to the `ported-tools-scope.test.ts` dependency fixture after the two `tier_lane` failures surfaced, and confirmed against a stashed baseline that those two failures were introduced by this change rather than pre-existing.
- Known residual risk: `sharedNamespaceNames` remains optional on `MemoryToolDependencies` while the other three lanes on this rung land, so during that window a new composition site can omit it and reach a runtime throw rather than a type error. Making it required is the rung's closing move, not this lane's.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane found no new review pattern — the failure it hit (a test fixture needing a newly-threaded dependency field) is the expected, designed consequence of a throwing twin, already documented as the mechanism in `server/tools/shared-namespace.ts`, and the existing entry on announcing self-made adjustments already covers the no-silent-default rule this change follows.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no protocol, schema, or client-facing surface changes; this threads an already-parsed value from the composition root into two existing call sites.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface moved. Tool names, input schemas, and response shapes are unchanged; the only edit is which module the namespace helpers are imported from and what they are passed.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Every downstream item is not-applicable under the gate's own classification: the change is internal to `server/tools`, alters no MCP tool schema, no transport behavior, and no Python client surface, so there is nothing for rtech-mcps, mcp2cli, or rtech-hermes to pick up. The classification was made by reading the doc, not assumed.
- Scope held to the brief: `src/`, `server/main.ts`, and every other `server/tools` module are untouched. The only file changed beyond the two named modules is the test fixture that composes their dependencies.
