### PR TITLE
fix(githooks): pre-push runs the isolated test runner so Postgres tests get a real database (#880)

### DIFF
--- a/_githooks/pre-push
+++ b/_githooks/pre-push
@@ -485,12 +485,34 @@ if ! mkdir -p "$TEST_LOG_DIR" 2>/dev/null; then
   exit 1
 fi
 
-echo "  bun test ... (stdout+stderr -> $TEST_LOG, replayed below; #712)"
+# THE RUNNER IS `test:isolated`, NOT BARE `bun test` (issues #878, #880)
+#
+# Under the #878 ruling a Postgres test no longer skips itself when no database
+# is configured: `scripts/test-support/require-test-database.ts` throws
+# `test_database_required` when OPENBRAIN_TEST_DATABASE_URL is unset or empty.
+# A bare `bun test` here sets nothing, so from the moment the first converted
+# Postgres test landed on main — `server/tools/reporting.pg.test.ts` at
+# 3468bdf8 — this hook refused EVERY push, including pushes whose diff was
+# markdown. Measured at that head: exit 1, `error: test_database_required:
+# OPENBRAIN_TEST_DATABASE_URL is unset; run bun run test:isolated`.
+#
+# That is the #705/#712 family again: a gate failing for a reason unrelated to
+# the change in hand, with text identical to a genuinely broken branch, which is
+# the condition that makes `--no-verify` habitual.
+#
+# `bun run test:isolated` (scripts/test-isolated.ts) is the repo's own answer and
+# is not a new mechanism: it creates a uniquely-named database, migrates it,
+# exports OPENBRAIN_TEST_DATABASE_URL, runs `bun test` with the arguments passed
+# through, and drops the database on the way out including on SIGINT/SIGTERM.
+# The working-tree semantics of this step are unchanged — it still judges the
+# tree as it sits on disk, not the pushed commits (#761 is that separate issue
+# and is deliberately not widened here).
+echo "  bun run test:isolated ... (stdout+stderr -> $TEST_LOG, replayed below; #712, #878, #880)"
 
 # `set -e` is on, so the exit code is captured explicitly rather than letting a
 # non-zero status kill the hook before the log can be replayed and classified.
 TEST_EXIT=0
-bun test > "$TEST_LOG" 2>&1 || TEST_EXIT=$?
+bun run test:isolated > "$TEST_LOG" 2>&1 || TEST_EXIT=$?
 
 # Replay what the operator would have seen. `cat` writes to the hook's OWN
 # stdout, which may still be git's pipe -- but a truncated REPLAY cannot change

--- a/scripts/done-means/880-pre-push-provides-database.sh
+++ b/scripts/done-means/880-pre-push-provides-database.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #880 — the pre-push hook provides a database to the
+# test suite instead of running it bare.
+#
+#   bash scripts/done-means/880-pre-push-provides-database.sh
+#
+# ---------------------------------------------------------------------------
+# The defect this gates
+# ---------------------------------------------------------------------------
+# `_githooks/pre-push` ran a bare `bun test` on the working tree with no
+# OPENBRAIN_TEST_DATABASE_URL set. Under the #878 ruling a Postgres test no
+# longer skips itself when no database is configured —
+# `scripts/test-support/require-test-database.ts` throws
+# `test_database_required` — so from the moment the first converted Postgres
+# test landed on main (`server/tools/reporting.pg.test.ts`, 3468bdf8) this hook
+# refused EVERY push, including ones whose diff contained no TypeScript at all.
+#
+# A gate that refuses for a reason unrelated to the change in hand is the same
+# family as #705 and #712, and it is the condition that trains everyone to reach
+# for `--no-verify`. `bun run test:isolated` (scripts/test-isolated.ts) is the
+# repo's own answer: it creates a uniquely-named database, migrates it, exports
+# the variable, passes its arguments through to `bun test`, and drops the
+# database on the way out.
+#
+# ---------------------------------------------------------------------------
+# Two clauses, and both must pass
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — THE HOOK CALLS THE ISOLATED RUNNER, AND NOTHING CALLS `bun test`
+#   BARE. At least one `bun run test:isolated` in the hook, and zero lines whose
+#   first word is `bun test`. Both halves matter: adding the isolated runner
+#   while leaving the bare call in place fixes nothing, and the bare call is what
+#   actually produced the refusal.
+#
+# CLAUSE 2 — THE HOOK ACTUALLY PASSES ON THE CURRENT TREE. The hook is driven
+#   the way git drives it — an empty line on stdin, `origin` and a URL as
+#   arguments — and must exit 0. Clause 1 is a text assertion and could be
+#   satisfied by a hook that is broken for some other reason; this clause is the
+#   behavioural one, and it is the receipt the issue is actually about.
+#
+# A MISSING OR EMPTY HOOK IS A FAILURE, NOT A PASS. Deleting the file would make
+# every text assertion above vacuously clean, which is the classic way a check
+# reports success for having examined nothing.
+#
+# NO ARGUMENTS.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HOOK_FILE="_githooks/pre-push"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v rg >/dev/null 2>&1 || fail_hard "rg (ripgrep) not on PATH"
+
+if [ ! -s "$REPO_ROOT/$HOOK_FILE" ]; then
+  printf 'CLAUSE 1 (hook calls the isolated runner): FAIL — %s is missing or empty\n' "$HOOK_FILE"
+  printf 'CLAUSE 2 (hook exits 0 on the current tree): FAIL — no hook to run\n'
+  exit 1
+fi
+
+CLAUSE1=FAIL; CLAUSE1_EVIDENCE=""
+CLAUSE2=FAIL; CLAUSE2_EVIDENCE=""
+
+# ---------------------------------------------------------------------------
+# CLAUSE 1 — the isolated runner is present and the bare call is gone.
+# ---------------------------------------------------------------------------
+ISOLATED_HITS="$(cd "$REPO_ROOT" && rg -n 'bun run test:isolated' "$HOOK_FILE" 2>/dev/null)"
+RG_STATUS=$?
+[ "$RG_STATUS" -ge 2 ] && fail_hard "rg failed with status $RG_STATUS scanning for the isolated runner"
+ISOLATED_N=0
+[ -n "$ISOLATED_HITS" ] && ISOLATED_N="$(printf '%s\n' "$ISOLATED_HITS" | rg -c '^')"
+
+BARE_HITS="$(cd "$REPO_ROOT" && rg -n '^\s*bun test' "$HOOK_FILE" 2>/dev/null)"
+RG_STATUS=$?
+[ "$RG_STATUS" -ge 2 ] && fail_hard "rg failed with status $RG_STATUS scanning for a bare bun test call"
+BARE_N=0
+[ -n "$BARE_HITS" ] && BARE_N="$(printf '%s\n' "$BARE_HITS" | rg -c '^')"
+
+if [ "$ISOLATED_N" -lt 1 ]; then
+  CLAUSE1_EVIDENCE="0 'bun run test:isolated' invocations in $HOOK_FILE — the suite still gets no database"
+elif [ "$BARE_N" -ne 0 ]; then
+  CLAUSE1_EVIDENCE="$BARE_N bare 'bun test' invocation(s) remain in $HOOK_FILE alongside the isolated runner"
+else
+  CLAUSE1=PASS
+  CLAUSE1_EVIDENCE="$ISOLATED_N 'bun run test:isolated' invocation(s), 0 bare 'bun test' invocations"
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 2 — the hook exits 0 when driven the way git drives it.
+# ---------------------------------------------------------------------------
+command -v zsh >/dev/null 2>&1 || fail_hard "zsh not on PATH; the hook's shebang cannot be honoured"
+
+HOOK_OUT="$(cd "$REPO_ROOT" && echo | zsh "$HOOK_FILE" origin git@github.com:rodaddy/open-brain.git 2>&1)"
+HOOK_STATUS=$?
+if [ "$HOOK_STATUS" -eq 0 ]; then
+  CLAUSE2=PASS
+  CLAUSE2_EVIDENCE="the hook exited 0 on the current working tree"
+else
+  CLAUSE2_EVIDENCE="the hook exited $HOOK_STATUS on the current working tree:"
+  CLAUSE2_HITS="$(printf '%s\n' "$HOOK_OUT" | tail -n 12)"
+fi
+
+printf 'CLAUSE 1 (isolated runner in, bare bun test out):  %s — %s\n' "$CLAUSE1" "$CLAUSE1_EVIDENCE"
+if [ "$CLAUSE1" != PASS ] && [ -n "$BARE_HITS" ]; then
+  printf '%s\n' "$BARE_HITS" | sed 's/^/    /'
+fi
+printf 'CLAUSE 2 (hook exits 0 on the current tree):       %s — %s\n' "$CLAUSE2" "$CLAUSE2_EVIDENCE"
+if [ "$CLAUSE2" != PASS ] && [ -n "${CLAUSE2_HITS:-}" ]; then
+  printf '%s\n' "$CLAUSE2_HITS" | sed 's/^/    /'
+fi
+
+if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ]; then
+  exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary

- Closes #880. `_githooks/pre-push` ran a bare `bun test` on the working tree with no `OPENBRAIN_TEST_DATABASE_URL` set. Under the #878 ruling a Postgres test no longer skips itself when no database is configured — `scripts/test-support/require-test-database.ts` throws `test_database_required` — so from the moment the first converted Postgres test landed on `main` (`server/tools/reporting.pg.test.ts` at 3468bdf8) the hook refused **every** push, including pushes whose diff contained no TypeScript at all.
- That is the #705/#712 family again: a gate failing for a reason unrelated to the change in hand, with text identical to a genuinely broken branch — the condition that trains everyone to reach for `--no-verify`.
- The fix changes **only the test invocation**: `bun test` becomes `bun run test:isolated`. `scripts/test-isolated.ts` is the repo's own answer and introduces no new mechanism — it creates a uniquely-named database, migrates it through the existing `bun run migrate` path, exports `OPENBRAIN_TEST_DATABASE_URL`, passes its arguments through to `bun test`, and drops the database on the way out including on SIGINT/SIGTERM.
- Working-tree semantics are unchanged: the step still judges the tree as it sits on disk rather than the pushed commits. #761 is that separate issue and is deliberately not widened here.
- The hook comment now records why, naming #878 and #880 alongside the existing #712 note on the same block.
- New: `scripts/done-means/880-pre-push-provides-database.sh`.

## Verification

- Done-means: scripts/done-means/880-pre-push-provides-database.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Driven the way git drives it, `echo | zsh _githooks/pre-push origin git@github.com:rodaddy/open-brain.git`:

- **RED** at `origin/main` 3468bdf8 → **exit 1**, `error: test_database_required: OPENBRAIN_TEST_DATABASE_URL is unset; run bun run test:isolated`; suite reported `3545 pass / 520 skip / 1 fail / 1 error`.
- **GREEN** on this branch → **exit 0**, `✓ Bun tests passed`, `pre-push: all checks passed ✓`; isolated database `ob_isolated_22184_mtaz50sfic` created, migrated, and dropped by the runner's own teardown.
- **BITE** — `expect(result.ok).toBe(false)` at `server/config.test.ts:23` temporarily flipped to `toBe(true)` → **exit 1**, `1 fail`, output naming `server/config.test.ts:23`. `git restore server/config.test.ts`; `git status --short` then showed only the two intended paths.
- Done-means **RED** at `origin/main`: clause 1 measured against `git show origin/main:_githooks/pre-push` → 0 `bun run test:isolated` hits, 1 bare `bun test` hit → FAIL. **GREEN** on this branch: `bash scripts/done-means/880-pre-push-provides-database.sh` → exit 0, `CLAUSE 1 ... PASS — 4 'bun run test:isolated' invocation(s), 0 bare 'bun test' invocations` / `CLAUSE 2 ... PASS — the hook exited 0 on the current working tree`.
- `bunx tsc --noEmit` → exit 0. Not affected by this change: both touched files are shell, not TypeScript, and the run is reported to show the tree is otherwise clean.
- `./node_modules/.bin/oxlint --deny-warnings` on both touched files → `No files found to lint`, i.e. **not applicable**: oxlint lints TS/JS, and this change touches a zsh hook and a bash script.
- **Push receipt — this branch was pushed through the fixed hook itself, no `--no-verify`.** `git push -u origin fix/880-pre-push-test-database` → exit 0, tail: `✓ Bun tests passed` / `Python package unchanged; skipping Python package gate` / `openbrain package unchanged; skipping openbrain package gate` / `Client/contract paths unchanged; skipping contract parity subset` / `pre-push: all checks passed ✓` / `* [new branch] fix/880-pre-push-test-database`. That is the live receipt: the hook under change gated its own landing.
- The pre-commit gate also passed on the committed tree: gitleaks clean, `(no staged TypeScript/JavaScript — lint/typecheck skipped)`.

## Critical Self-Review

- Highest-risk behavior: the hook is now the only push gate that provisions a database, so every push pays for one `createdb` + full migration run. If `test-isolated.ts` fails to create or migrate its database — Postgres down, role missing, a broken migration on the branch — the hook fails and the failure text is about provisioning rather than the branch's tests. That is a real new failure surface, and it is the one being accepted deliberately: the alternative is the current state where the hook refuses *unconditionally*.
- Assumptions that could be wrong: (a) that `test-isolated.ts` drops its database on every exit path — the observed run did (`teardown (test-complete): ob_isolated_22184_mtaz50sfic dropped`) and the script claims SIGINT/SIGTERM handling, but a hard kill of the hook could still orphan one; the script prints the orphan name and the `dropdb` line when the drop itself fails, so this degrades loudly rather than silently. (b) that the #712 pipe-fd fix still holds — `test-isolated.ts` wraps `bun test`, and the redirect to `$TEST_LOG` is unchanged and still upstream of both, so bun's stderr is still a file; the GREEN and BITE runs both produced complete output with no `WriteFailed`.
- Missing/weak tests: clause 2 of the done-means runs the whole suite, so the check takes minutes — it is honest but expensive, and there is no cheap smoke variant. Nothing asserts the database is actually *dropped* after the hook runs; that is `test-isolated.ts`'s own contract and is not re-proven here.
- Security/permission risk: none new. No auth, namespace, or token path is touched. The hook now creates and drops a local Postgres database under the developer's existing credentials, which `bun run test:isolated` already did when run by hand.
- Migration/deploy risk: none to the service. No migration, schema, or runtime code changed. The hook does now execute `bun run migrate` against its throwaway database on every push, so a branch carrying a broken migration will be caught at push time instead of at CI — a tightening, but an intended one.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classification is not applicable — no MCP tool, schema, transport, protocol, or Python client surface is touched. `_githooks/pre-push` is developer tooling in this repo only.
- Rollback/cleanup concern: reverting is a one-line revert of the invocation, which restores the pre-#878 behaviour — i.e. restores the refusal, so a revert is only correct alongside reverting #878. Cleanup during this lane: the BITE edit was restored via `git restore` and the tree verified clean before staging; the scratch copy of the original test file lives under `{temp_workspace}/open-brain/_scratch/session7/` and is not in the repo.
- Fixes made before PR: none material — the change is one invocation plus a comment. The done-means was rewritten once during authoring so that a missing or empty hook exits 1 rather than reporting a vacuously clean text scan, which is the failure mode the #750 checks call out.
- Known residual risk: #761 is untouched, so the hook still judges the working tree rather than the pushed commits — a push can be green here and red for a reviewer who checks out the commits. That is stated rather than fixed, per the brief's scope.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is the third instance of an already-recorded pattern rather than a new one — the hook comments for #705 and #712 both state the rule ("a gate must not let anything it inherited from its caller decide its verdict", and a gate that refuses for something unrelated to the change in hand becomes noise routed around with `--no-verify`), and the fix here is that same rule applied to a database dependency, so a new entry would restate existing knowledge instead of adding a check a reviewer is not already making.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no service, tool, schema, or client surface changed — the diff is a developer git hook and a check script, neither of which the running service loads.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched; the hook's own parity gate correctly reported `Client/contract paths unchanged; skipping contract parity subset` on the push.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: `docs/downstream-rollout.md` scopes rollout to MCP tool/schema/protocol/client-facing changes. This diff is `_githooks/pre-push` (a local git hook, never shipped or loaded by the service) and a new `scripts/done-means/` check. No downstream consumer reads either.
