### PR TITLE
test(pg): entities, entities-graph, decompose-entry and tiering require the test database instead of skipping (#878)

### DIFF
--- a/server/tools/decompose-entry.pg.test.ts
+++ b/server/tools/decompose-entry.pg.test.ts
@@ -6,9 +6,9 @@
  * that the default path leaves the database alone -- so these tests seed a real
  * oversized row, plan against it, and count `thoughts` before and after.
  *
- * Skips loudly (via `describe.skip`) when `OPENBRAIN_TEST_DATABASE_URL` is
- * unset. It must point at an isolated test/playground database, never the
- * dogfood database.
+ * REQUIRES `OPENBRAIN_TEST_DATABASE_URL`, and fails hard without it (operator
+ * ruling 2026-08-27, issue #878). It must point at an isolated test/playground
+ * database, never the dogfood database. `bun run test:isolated` sets it.
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -16,11 +16,10 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import pino from "pino";
 import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../scripts/test-support/require-test-database.ts";
 import { registerDecomposeEntryTool } from "./decompose-entry.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-const pool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
 const NAMESPACE = `decompose-pg-${process.pid}`;
 const OTHER_NAMESPACE = `${NAMESPACE}-other`;
@@ -37,7 +36,6 @@ async function callDecompose(
   args: Record<string, unknown>,
   role = "agent",
 ): Promise<CallOutcome> {
-  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
   const server = new McpServer({ name: "decompose-test", version: "1.0.0" });
   registerDecomposeEntryTool(server, {
     pool,
@@ -45,7 +43,8 @@ async function callDecompose(
     logger: pino({ level: "silent" }),
     embeddingModel: "decompose-test",
   });
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
   const originalSend = clientTransport.send.bind(clientTransport);
   clientTransport.send = (message, options) =>
     originalSend(message, {
@@ -56,7 +55,10 @@ async function callDecompose(
   await server.connect(serverTransport);
   await client.connect(clientTransport);
   try {
-    const result = await client.callTool({ name: "decompose_entry", arguments: args });
+    const result = await client.callTool({
+      name: "decompose_entry",
+      arguments: args,
+    });
     const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
     let body: Record<string, unknown> = {};
     try {
@@ -72,38 +74,38 @@ async function callDecompose(
 }
 
 async function countThoughts(namespace: string): Promise<number> {
-  const { rows } = await pool!.query(
+  const { rows } = await pool.query(
     `SELECT COUNT(*)::int AS cnt FROM thoughts WHERE namespace = $1`,
     [namespace],
   );
   return rows[0].cnt;
 }
 
-dbDescribe("decompose_entry (live Postgres)", () => {
-  let sourceId = "";
-  let foreignId = "";
+/** Ids of the seeded rows, filled by the module-scope `beforeAll`. */
+let sourceId = "";
+let foreignId = "";
 
-  beforeAll(async () => {
-    const source = await pool!.query(
-      `INSERT INTO thoughts (content, namespace, created_by) VALUES ($1, $2, $2) RETURNING id`,
-      [OVERSIZED, NAMESPACE],
-    );
-    sourceId = source.rows[0].id;
-    const foreign = await pool!.query(
-      `INSERT INTO thoughts (content, namespace, created_by) VALUES ($1, $2, $2) RETURNING id`,
-      [OVERSIZED, OTHER_NAMESPACE],
-    );
-    foreignId = foreign.rows[0].id;
-  });
+beforeAll(async () => {
+  const source = await pool.query(
+    `INSERT INTO thoughts (content, namespace, created_by) VALUES ($1, $2, $2) RETURNING id`,
+    [OVERSIZED, NAMESPACE],
+  );
+  sourceId = source.rows[0].id;
+  const foreign = await pool.query(
+    `INSERT INTO thoughts (content, namespace, created_by) VALUES ($1, $2, $2) RETURNING id`,
+    [OVERSIZED, OTHER_NAMESPACE],
+  );
+  foreignId = foreign.rows[0].id;
+});
 
-  afterAll(async () => {
-    if (!pool) return;
-    await pool.query(`DELETE FROM thoughts WHERE namespace = ANY($1::text[])`, [
-      [NAMESPACE, OTHER_NAMESPACE],
-    ]);
-    await pool.end();
-  });
+afterAll(async () => {
+  await pool.query(`DELETE FROM thoughts WHERE namespace = ANY($1::text[])`, [
+    [NAMESPACE, OTHER_NAMESPACE],
+  ]);
+  await pool.end();
+});
 
+describe("decompose_entry planning (live Postgres)", () => {
   test("the default call plans and writes NOTHING", async () => {
     const before = await countThoughts(NAMESPACE);
     const { isError, body } = await callDecompose(NAMESPACE, {
@@ -127,7 +129,9 @@ dbDescribe("decompose_entry (live Postgres)", () => {
       dry_run: false,
     });
     expect(isError).toBe(true);
-    expect(body.text).toBe("dry_run=false requires apply_mode=write_replacements");
+    expect(body.text).toBe(
+      "dry_run=false requires apply_mode=write_replacements",
+    );
     expect(await countThoughts(NAMESPACE)).toBe(before);
   });
 
@@ -149,7 +153,9 @@ dbDescribe("decompose_entry (live Postgres)", () => {
     // Same text as a genuine miss, so existence is not disclosed.
     expect(body.text).toBe("Entry not found or archived");
   });
+});
 
+describe("decompose_entry applying (live Postgres)", () => {
   test("an explicit apply writes replacements linked to the source", async () => {
     const before = await countThoughts(NAMESPACE);
     const { isError, body } = await callDecompose(NAMESPACE, {
@@ -165,7 +171,7 @@ dbDescribe("decompose_entry (live Postgres)", () => {
     expect(await countThoughts(NAMESPACE)).toBe(before + writtenIds.length);
 
     // parent_id is the joinable lineage; provenance JSON alone is not.
-    const { rows } = await pool!.query(
+    const { rows } = await pool.query(
       `SELECT parent_id, chunk_index, source FROM thoughts WHERE id = ANY($1::uuid[]) ORDER BY chunk_index`,
       [writtenIds],
     );

--- a/server/tools/entities-graph.pg.test.ts
+++ b/server/tools/entities-graph.pg.test.ts
@@ -7,9 +7,9 @@
  * rules call out. These tests seed rows owned by a foreign namespace and prove
  * each tool refuses to read, list, mutate, or hydrate them.
  *
- * Skips loudly (via `describe.skip`) when `OPENBRAIN_TEST_DATABASE_URL` is
- * unset. It must point at an isolated test/playground database, never the
- * dogfood database.
+ * REQUIRES `OPENBRAIN_TEST_DATABASE_URL`, and fails hard without it (operator
+ * ruling 2026-08-27, issue #878). It must point at an isolated test/playground
+ * database, never the dogfood database. `bun run test:isolated` sets it.
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -17,12 +17,11 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import pino from "pino";
 import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../scripts/test-support/require-test-database.ts";
 import { registerEntityTools } from "./entities.ts";
 import { registerPeopleTools } from "./people.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-const pool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
 const NAMESPACE = `graph-pg-${process.pid}`;
 const OTHER_NAMESPACE = `${NAMESPACE}-other`;
@@ -33,7 +32,6 @@ async function callTool(
   args: Record<string, unknown>,
   role = "agent",
 ): Promise<{ isError: boolean; body: unknown }> {
-  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
   const server = new McpServer({ name: "graph-test", version: "1.0.0" });
   const dependencies = {
     pool,
@@ -43,7 +41,8 @@ async function callTool(
   };
   registerEntityTools(server, dependencies);
   registerPeopleTools(server, dependencies);
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
   const originalSend = clientTransport.send.bind(clientTransport);
   clientTransport.send = (message, options) =>
     originalSend(message, {
@@ -69,49 +68,51 @@ async function callTool(
   }
 }
 
-dbDescribe("graph and people namespace isolation (live Postgres)", () => {
-  let foreignEntityId = "";
-  let foreignLinkTargetId = "";
+/** Ids of the foreign-namespace rows, filled by the module-scope `beforeAll`. */
+let foreignEntityId = "";
+let foreignLinkTargetId = "";
 
-  beforeAll(async () => {
-    const foreign = await pool!.query(
-      `INSERT INTO ob_entities (entity_type, name, namespace, created_by, metadata)
+beforeAll(async () => {
+  const foreign = await pool.query(
+    `INSERT INTO ob_entities (entity_type, name, namespace, created_by, metadata)
        VALUES ('host', 'foreign-only-entity', $1, $1, '{}'::jsonb) RETURNING id`,
-      [OTHER_NAMESPACE],
-    );
-    foreignEntityId = foreign.rows[0].id;
-    const target = await pool!.query(
-      `INSERT INTO ob_entities (entity_type, name, namespace, created_by, metadata)
+    [OTHER_NAMESPACE],
+  );
+  foreignEntityId = foreign.rows[0].id;
+  const target = await pool.query(
+    `INSERT INTO ob_entities (entity_type, name, namespace, created_by, metadata)
        VALUES ('host', 'foreign-link-target', $1, $1, '{}'::jsonb) RETURNING id`,
-      [OTHER_NAMESPACE],
-    );
-    foreignLinkTargetId = target.rows[0].id;
-    await pool!.query(
-      `INSERT INTO ob_links (from_type, from_id, to_type, to_id, relation, weight, namespace, metadata, created_by)
+    [OTHER_NAMESPACE],
+  );
+  foreignLinkTargetId = target.rows[0].id;
+  await pool.query(
+    `INSERT INTO ob_links (from_type, from_id, to_type, to_id, relation, weight, namespace, metadata, created_by)
        VALUES ('entity', $1, 'entity', $2, 'relates_to', 1.0, $3, '{}'::jsonb, $3)`,
-      [foreignEntityId, foreignLinkTargetId, OTHER_NAMESPACE],
-    );
-    await pool!.query(
-      `INSERT INTO relationships (person_name, context, namespace, created_by)
+    [foreignEntityId, foreignLinkTargetId, OTHER_NAMESPACE],
+  );
+  await pool.query(
+    `INSERT INTO relationships (person_name, context, namespace, created_by)
        VALUES ('Foreign Person', 'lives in another lane', $1, $1)`,
-      [OTHER_NAMESPACE],
-    );
-  });
+    [OTHER_NAMESPACE],
+  );
+});
 
-  afterAll(async () => {
-    if (!pool) return;
-    await pool.query(`DELETE FROM ob_links WHERE namespace = ANY($1::text[])`, [
-      [NAMESPACE, OTHER_NAMESPACE],
-    ]);
-    await pool.query(`DELETE FROM ob_entities WHERE namespace = ANY($1::text[])`, [
-      [NAMESPACE, OTHER_NAMESPACE],
-    ]);
-    await pool.query(`DELETE FROM relationships WHERE namespace = ANY($1::text[])`, [
-      [NAMESPACE, OTHER_NAMESPACE],
-    ]);
-    await pool.end();
-  });
+afterAll(async () => {
+  await pool.query(`DELETE FROM ob_links WHERE namespace = ANY($1::text[])`, [
+    [NAMESPACE, OTHER_NAMESPACE],
+  ]);
+  await pool.query(
+    `DELETE FROM ob_entities WHERE namespace = ANY($1::text[])`,
+    [[NAMESPACE, OTHER_NAMESPACE]],
+  );
+  await pool.query(
+    `DELETE FROM relationships WHERE namespace = ANY($1::text[])`,
+    [[NAMESPACE, OTHER_NAMESPACE]],
+  );
+  await pool.end();
+});
 
+describe("entity and link tools (live Postgres)", () => {
   test("list_entities never returns a foreign-namespace row", async () => {
     const { isError, body } = await callTool("list_entities", NAMESPACE, {});
     expect(isError).toBe(false);
@@ -136,7 +137,7 @@ dbDescribe("graph and people namespace isolation (live Postgres)", () => {
     });
     expect(isError).toBe(true);
     expect(String(body)).toContain("Permission denied");
-    const { rows } = await pool!.query(
+    const { rows } = await pool.query(
       `SELECT COUNT(*)::int AS cnt FROM ob_entities WHERE namespace = $1 AND name = 'isolation-probe'`,
       [OTHER_NAMESPACE],
     );
@@ -154,7 +155,9 @@ dbDescribe("graph and people namespace isolation (live Postgres)", () => {
     });
     expect((first.body as { is_new: boolean }).is_new).toBe(true);
     expect((second.body as { is_new: boolean }).is_new).toBe(false);
-    expect((second.body as { id: string }).id).toBe((first.body as { id: string }).id);
+    expect((second.body as { id: string }).id).toBe(
+      (first.body as { id: string }).id,
+    );
   });
 
   test("unlink_entities cannot archive a foreign namespace's link", async () => {
@@ -173,7 +176,7 @@ dbDescribe("graph and people namespace isolation (live Postgres)", () => {
     // Admin may delete, but the predicate binds to the caller's own lane, so
     // the foreign link is simply not found -- and must remain active.
     expect(body).toBe("Already unlinked or not found");
-    const { rows } = await pool!.query(
+    const { rows } = await pool.query(
       `SELECT archived_at FROM ob_links WHERE namespace = $1`,
       [OTHER_NAMESPACE],
     );
@@ -186,14 +189,16 @@ dbDescribe("graph and people namespace isolation (live Postgres)", () => {
     });
     expect(isError).toBe(false);
     expect((body as { matched: number }).matched).toBe(0);
-    const { rows } = await pool!.query(
+    const { rows } = await pool.query(
       `SELECT COUNT(*)::int AS cnt FROM ob_entities
         WHERE namespace = $1 AND embedding IS NOT NULL`,
       [OTHER_NAMESPACE],
     );
     expect(rows[0].cnt).toBe(0);
   });
+});
 
+describe("people tools (live Postgres)", () => {
   test("find_person never returns a person from another lane", async () => {
     const { isError, body } = await callTool("find_person", NAMESPACE, {
       query: "Foreign",

--- a/server/tools/entities.pg.test.ts
+++ b/server/tools/entities.pg.test.ts
@@ -7,8 +7,9 @@
  * tests seed exactly that row, so a dropped predicate fails here instead of
  * leaking across namespaces in production.
  *
- * Skips loudly when `OPENBRAIN_TEST_DATABASE_URL` is unset. It must point at an
- * isolated test/playground database, never the dogfood database.
+ * REQUIRES `OPENBRAIN_TEST_DATABASE_URL`, and fails hard without it (operator
+ * ruling 2026-08-27, issue #878). It must point at an isolated test/playground
+ * database, never the dogfood database. `bun run test:isolated` sets it.
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -16,11 +17,10 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import pino from "pino";
 import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../scripts/test-support/require-test-database.ts";
 import { registerEntityTools } from "./entities.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-const pool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
 const NAMESPACE = `entities-pg-${process.pid}`;
 const FOREIGN_NAMESPACE = `${NAMESPACE}-foreign`;
@@ -29,25 +29,32 @@ async function getEntity(
   namespace: string,
   id: string,
 ): Promise<{ isError: boolean; text: string }> {
-  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
   const server = new McpServer({ name: "entities-test", version: "1.0.0" });
   registerEntityTools(server, {
     pool,
     embedFn: async () => null,
     logger: pino({ level: "silent" }),
   });
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
   const originalSend = clientTransport.send.bind(clientTransport);
   clientTransport.send = (message, options) =>
     originalSend(message, {
       ...options,
-      authInfo: { role: "agent", clientId: namespace, namespaceSource: "token" },
+      authInfo: {
+        role: "agent",
+        clientId: namespace,
+        namespaceSource: "token",
+      },
     } as never);
   const client = new Client({ name: "entities-test", version: "1.0.0" });
   await server.connect(serverTransport);
   await client.connect(clientTransport);
   try {
-    const result = await client.callTool({ name: "get_entity", arguments: { id } });
+    const result = await client.callTool({
+      name: "get_entity",
+      arguments: { id },
+    });
     return {
       isError: result.isError === true,
       text: (result.content as Array<{ text: string }>)[0]?.text ?? "",
@@ -58,25 +65,25 @@ async function getEntity(
   }
 }
 
-dbDescribe("get_entity namespace isolation (live Postgres)", () => {
+describe("get_entity namespace isolation (live Postgres)", () => {
   let ownId = "";
   let foreignId = "";
   let archivedId = "";
 
   beforeAll(async () => {
-    const own = await pool!.query(
+    const own = await pool.query(
       `INSERT INTO ob_entities (entity_type, name, namespace, created_by)
        VALUES ('service', 'own entity', $1, $1) RETURNING id`,
       [NAMESPACE],
     );
     ownId = own.rows[0].id;
-    const foreign = await pool!.query(
+    const foreign = await pool.query(
       `INSERT INTO ob_entities (entity_type, name, namespace, created_by)
        VALUES ('service', 'foreign entity', $1, $1) RETURNING id`,
       [FOREIGN_NAMESPACE],
     );
     foreignId = foreign.rows[0].id;
-    const archived = await pool!.query(
+    const archived = await pool.query(
       `INSERT INTO ob_entities (entity_type, name, namespace, created_by, archived_at)
        VALUES ('service', 'archived entity', $1, $1, NOW()) RETURNING id`,
       [NAMESPACE],
@@ -85,10 +92,10 @@ dbDescribe("get_entity namespace isolation (live Postgres)", () => {
   });
 
   afterAll(async () => {
-    if (!pool) return;
-    await pool.query(`DELETE FROM ob_entities WHERE namespace = ANY($1::text[])`, [
-      [NAMESPACE, FOREIGN_NAMESPACE],
-    ]);
+    await pool.query(
+      `DELETE FROM ob_entities WHERE namespace = ANY($1::text[])`,
+      [[NAMESPACE, FOREIGN_NAMESPACE]],
+    );
     await pool.end();
   });
 

--- a/server/tools/tiering.pg.test.ts
+++ b/server/tools/tiering.pg.test.ts
@@ -7,9 +7,9 @@
  * the `entry_access_log` promote join are exercised with data, and assert the
  * namespace boundary holds against a foreign row.
  *
- * Skips loudly (via `describe.skip`) when `OPENBRAIN_TEST_DATABASE_URL` is
- * unset. It must point at an isolated test/playground database, never the
- * dogfood database.
+ * REQUIRES `OPENBRAIN_TEST_DATABASE_URL`, and fails hard without it (operator
+ * ruling 2026-08-27, issue #878). It must point at an isolated test/playground
+ * database, never the dogfood database. `bun run test:isolated` sets it.
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -17,11 +17,10 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import pino from "pino";
 import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../scripts/test-support/require-test-database.ts";
 import { registerTieringTools } from "./tiering.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-const pool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
 const NAMESPACE = `tiering-pg-${process.pid}`;
 const OTHER_NAMESPACE = `${NAMESPACE}-other`;
@@ -30,27 +29,35 @@ async function callTierRecommendations(
   namespace: string,
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
-  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
   const server = new McpServer({ name: "tiering-test", version: "1.0.0" });
   registerTieringTools(server, {
     pool,
     embedFn: async () => null,
     logger: pino({ level: "silent" }),
   });
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
   const originalSend = clientTransport.send.bind(clientTransport);
   clientTransport.send = (message, options) =>
     originalSend(message, {
       ...options,
-      authInfo: { role: "agent", clientId: namespace, namespaceSource: "token" },
+      authInfo: {
+        role: "agent",
+        clientId: namespace,
+        namespaceSource: "token",
+      },
     } as never);
   const client = new Client({ name: "tiering-test", version: "1.0.0" });
   await server.connect(serverTransport);
   await client.connect(clientTransport);
   try {
-    const result = await client.callTool({ name: "tier_recommendations", arguments: args });
+    const result = await client.callTool({
+      name: "tier_recommendations",
+      arguments: args,
+    });
     const text = (result.content as Array<{ text: string }>)[0]?.text;
-    if (text === undefined) throw new Error("tier_recommendations returned no content");
+    if (text === undefined)
+      throw new Error("tier_recommendations returned no content");
     return JSON.parse(text);
   } finally {
     await client.close();
@@ -58,31 +65,31 @@ async function callTierRecommendations(
   }
 }
 
-dbDescribe("tier_recommendations (live Postgres)", () => {
+describe("tier_recommendations (live Postgres)", () => {
   let staleId = "";
   let accessedId = "";
 
   beforeAll(async () => {
-    const stale = await pool!.query(
+    const stale = await pool.query(
       `INSERT INTO thoughts (content, namespace, created_by, tier, access_count, last_accessed_at, created_at)
        VALUES ($1, $2, $2, 'warm', 0, NULL, NOW() - INTERVAL '200 days') RETURNING id`,
       ["tiering stale entry", NAMESPACE],
     );
     staleId = stale.rows[0].id;
-    const accessed = await pool!.query(
+    const accessed = await pool.query(
       `INSERT INTO thoughts (content, namespace, created_by, tier, access_count, last_accessed_at, created_at)
        VALUES ($1, $2, $2, 'warm', 1, NOW() - INTERVAL '120 days', NOW() - INTERVAL '150 days') RETURNING id`,
       ["tiering accessed entry", NAMESPACE],
     );
     accessedId = accessed.rows[0].id;
     // A busy row in ANOTHER namespace: it must never appear for our caller.
-    await pool!.query(
+    await pool.query(
       `INSERT INTO thoughts (content, namespace, created_by, tier, access_count, last_accessed_at, created_at)
        VALUES ($1, $2, $2, 'warm', 0, NULL, NOW() - INTERVAL '300 days')`,
       ["tiering foreign entry", OTHER_NAMESPACE],
     );
     // Seven log rows clears the observed ">5 recent accesses" promote rule.
-    await pool!.query(
+    await pool.query(
       `INSERT INTO entry_access_log (entry_id, source_table, accessed_at, context)
        SELECT $1, 'thoughts', NOW() - INTERVAL '1 hour', 'search' FROM generate_series(1, 7)`,
       [accessedId],
@@ -90,8 +97,9 @@ dbDescribe("tier_recommendations (live Postgres)", () => {
   });
 
   afterAll(async () => {
-    if (!pool) return;
-    await pool.query(`DELETE FROM entry_access_log WHERE entry_id = $1`, [accessedId]);
+    await pool.query(`DELETE FROM entry_access_log WHERE entry_id = $1`, [
+      accessedId,
+    ]);
     await pool.query(`DELETE FROM thoughts WHERE namespace = ANY($1::text[])`, [
       [NAMESPACE, OTHER_NAMESPACE],
     ]);
@@ -99,19 +107,27 @@ dbDescribe("tier_recommendations (live Postgres)", () => {
   });
 
   test("demote surfaces warm, rarely-accessed, stale entries", async () => {
-    const result = await callTierRecommendations(NAMESPACE, { action: "demote" });
+    const result = await callTierRecommendations(NAMESPACE, {
+      action: "demote",
+    });
     expect(result.action).toBe("demote");
     expect(result.threshold_days).toBe(30);
-    const ids = (result.candidates as Array<{ id: string }>).map((row) => row.id);
+    const ids = (result.candidates as Array<{ id: string }>).map(
+      (row) => row.id,
+    );
     expect(ids).toContain(staleId);
     expect(result.candidates_found).toBe(ids.length);
-    for (const candidate of result.candidates as Array<{ suggested_tier: string }>) {
+    for (const candidate of result.candidates as Array<{
+      suggested_tier: string;
+    }>) {
       expect(candidate.suggested_tier).toBe("cold");
     }
   });
 
   test("promote reads recency from entry_access_log, not access_count", async () => {
-    const result = await callTierRecommendations(NAMESPACE, { action: "promote" });
+    const result = await callTierRecommendations(NAMESPACE, {
+      action: "promote",
+    });
     expect(result.action).toBe("promote");
     expect(result.threshold_days).toBe(7);
     const candidates = result.candidates as Array<{
@@ -127,10 +143,12 @@ dbDescribe("tier_recommendations (live Postgres)", () => {
   });
 
   test("never returns an entry from a namespace the caller cannot read", async () => {
-    const result = await callTierRecommendations(NAMESPACE, { action: "demote" });
-    const previews = (result.candidates as Array<{ content_preview: string }>).map(
-      (row) => row.content_preview,
-    );
+    const result = await callTierRecommendations(NAMESPACE, {
+      action: "demote",
+    });
+    const previews = (
+      result.candidates as Array<{ content_preview: string }>
+    ).map((row) => row.content_preview);
     expect(previews).not.toContain("tiering foreign entry");
   });
 });


### PR DESCRIPTION
## Summary

- Four live-Postgres suites — `server/tools/entities.pg.test.ts`, `entities-graph.pg.test.ts`, `decompose-entry.pg.test.ts`, `tiering.pg.test.ts` — read `OPENBRAIN_TEST_DATABASE_URL` directly and swapped `describe` for `describe.skip` when it was unset. A run without the variable reported success while asserting nothing, so the namespace-isolation and planning-does-not-write guarantees these files exist to prove were silently unexercised.
- Each file now calls `requireTestDatabaseUrl()` from `scripts/test-support/require-test-database.ts` and builds its pool from the result, so a missing variable fails the run instead of hiding it.
- The nullable pool disappears with the skip machinery, which removes every `pool!` non-null assertion and every `if (!pool)` guard that existed only to satisfy the nullable type.
- `entities-graph` and `decompose-entry` each had one `describe` callback longer than the shared `max-lines-per-function` rule allows once the guards were gone. Both are split by SUBJECT following the pattern already landed in `server/tools/reporting.pg.test.ts`: seeded ids and the `beforeAll`/`afterAll` hooks move to module scope, and the tests divide into entity-and-link vs people tools, and decompose planning vs applying. No test body and no assertion changed.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts:

- RED at `origin/main` (26112dc): the checker exits 1, with clauses 1-3 FAIL on all four files (`self-skipping machinery survives on code lines`, `no import of requireTestDatabaseUrl`, `test_database_required present: no`).
- GREEN on this branch: exits 0, all four clauses PASS. Re-run with no argv resolves the subject to exactly these four files from the merge-base diff and also exits 0.
- `bunx tsc --noEmit` -> 0.
- `./node_modules/.bin/oxlint --deny-warnings` over all four files -> 0, no disable comments added.
- `bun run test:isolated` (whole suite, no path) -> 3944 pass, 35 skip, 0 fail, 15955 expect() calls across 261 files.
- The pre-push hook re-ran the isolated runner and passed.

## Critical Self-Review

- Highest-risk behavior: turning a silent skip into a hard failure. Any environment that runs `bun test` without `OPENBRAIN_TEST_DATABASE_URL` and previously saw green will now see a failure. That is the intended behavior change from #878, and `bun run test:isolated` — the documented default in AGENTS.md — sets the variable, as does CI.
- Assumptions that could be wrong: that the two describe splits are semantically neutral. Both files' hooks were already whole-module in effect (one `beforeAll`/`afterAll` pair per file), so hoisting them to module scope preserves ordering; the risk would be a hidden dependency of a people test on state a graph test wrote, which the passing suite argues against but does not prove for every interleaving bun could choose.
- Missing/weak tests: no test asserts the failure path itself — that an unset variable produces the hard error. The done-means checker covers it externally (clause 3 runs each file with the variable unset and requires exit 1 plus `test_database_required`), so the guarantee is enforced in CI rather than by a unit test.
- Security/permission risk: none introduced. The namespace-isolation assertions are unchanged in content, and this change makes them actually run rather than skip — a net gain for the isolation boundary the repo rules treat as a security boundary.
- Migration/deploy risk: none. No migration, no schema change, no runtime source file touched; the diff is confined to four `.pg.test.ts` files.
- Downstream client/runtime risk: none. Per `docs/downstream-rollout.md`, no MCP tool, schema, transport, or Python client contract changed, so rtech-mcps, mcp2cli, and rtech-hermes need no handoff.
- Rollback/cleanup concern: a plain revert restores the prior skip behavior with no residue. No temp artifacts, no generated files, no backup files left behind.
- Fixes made before PR: the first pass left two describe callbacks over the 100-line rule; rather than adding a disable comment, both files were split by subject to satisfy the rule as written. Prettier formatting was applied and the checks re-run on the committed tree, not the working tree.
- Known residual risk: the two split files now have two `describe` blocks sharing module-scope seeded state, so a future test added to the second block that mutates rows the first block asserts on would couple them without an obvious signal. The `afterAll` cleanup remains module-scope and deletes by namespace, so leakage across files is still bounded by the per-pid namespace.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical application of a pattern already landed in `server/tools/reporting.pg.test.ts` under issue #878, with no new failure mode discovered — the describe-splitting requirement is already enforced by the shared lint rule rather than by reviewer attention.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: test-only change, no server, tool, or contract behavior is touched.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no tool contract, schema, or response shape changed — the diff only alters how four test files obtain their database connection and how their tests are grouped.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Test-only diff across four `server/tools/*.pg.test.ts` files; no MCP tool, schema, transport, or client-facing surface is modified, so every downstream step above is not applicable.

Refs #878
