### PR TITLE
test(pg): skill-usage, source-registry, db query and main require the test database instead of skipping (#878)

### DIFF
--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -73,7 +73,26 @@ export const REQUIRED_SUITES: ReadonlyArray<{
   // proves usage rows are saved, queryable, and -- most importantly -- invisible
   // across the namespace boundary. `skill_usage_log` has no namespace column, so
   // that boundary lives entirely in a join this suite is what checks.
-  { name: "skill usage telemetry (live Postgres)", minTests: 9 },
+  // Split by subject in #878 out of one "skill usage telemetry" suite; the two
+  // halves together cover exactly what that one entry did, so both are named
+  // here. Registering only one would let the other vanish unnoticed.
+  { name: "skill usage recording and reporting (live Postgres)", minTests: 4 },
+  {
+    name: "skill usage isolation and permissions (live Postgres)",
+    minTests: 5,
+  },
+  // The source registry's revision, approval, isolation, and retirement paths,
+  // split by subject in #878 out of one "source registry lifecycle" suite.
+  // Env-gated like every suite above, and never registered here before, so a
+  // Postgres misconfiguration silently skipped all eight of these.
+  {
+    name: "source registry revision and approval (live Postgres)",
+    minTests: 5,
+  },
+  {
+    name: "source registry isolation and retirement (live Postgres)",
+    minTests: 3,
+  },
   // The maintenance queue runner's lease boundary, proven through the composed
   // `server/` runtime. This entry matters more than most: both invariants it
   // covers fail SILENTLY -- a row sits `running` under a live lease with no
@@ -88,10 +107,17 @@ export const REQUIRED_SUITES: ReadonlyArray<{
   // listener -- so a silently skipped run reports a green build for a startup
   // path nothing ever executed. Every other `server/` suite hand-assembles the
   // application and would stay green with a completely broken `startServer`.
-  { name: "rewrite entrypoint start-equivalence (live Postgres)", minTests: 5 },
+  // #878 split the start-equivalence suite by subject: the audit and runtime
+  // composition tests moved into their own suite, so start-equivalence itself
+  // now runs 3 rather than 8. Both halves are named here for the reason above.
+  { name: "rewrite entrypoint start-equivalence (live Postgres)", minTests: 3 },
+  {
+    name: "rewrite entrypoint audit and runtime composition (live Postgres)",
+    minTests: 2,
+  },
   {
     name: "rewrite entrypoint startup and shutdown ordering (live Postgres)",
-    minTests: 2,
+    minTests: 3,
   },
 ];
 
@@ -101,9 +127,11 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // its 8, then 12 once that suite also covered the realtime append tools and the
 // two-worker front, then 44 -> 53 when the #469 skill-usage telemetry suite
 // added its 9, then 53 -> 58 when the maintenance lease-boundary suite added
-// its 5, then 58 -> 65 when the two entrypoint suites added their 5 and 2), so
-// the global floor cannot silently fall behind the per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 65;
+// its 5, then 58 -> 65 when the two entrypoint suites added their 5 and 2, then
+// 65 -> 74 when #878 registered the two source-registry suites (8) and the
+// entrypoint split redistributed its own tests to 3 + 2 + 3), so the global
+// floor cannot silently fall behind the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 74;
 
 export interface SuiteStats {
   tests: number;
@@ -124,8 +152,8 @@ function attr(tag: string, name: string): string | undefined {
   return m ? m[1] : undefined;
 }
 
-export function evaluateJunit(xml: string): GuardResult {
-  // Collect per-suite stats from <testsuite ...> opening tags.
+// Collect per-suite stats from <testsuite ...> opening tags.
+function collectSuiteStats(xml: string): Map<string, SuiteStats> {
   const suiteStats = new Map<string, SuiteStats>();
   for (const tag of xml.match(/<testsuite\b[^>]*>/g) ?? []) {
     const name = attr(tag, "name");
@@ -143,22 +171,38 @@ export function evaluateJunit(xml: string): GuardResult {
       skipped: prev.skipped + Number(attr(tag, "skipped") ?? "0"),
     });
   }
+  return suiteStats;
+}
 
-  // Inspect individual live-Postgres <testcase> blocks as an independent
-  // cross-check on the suite-level attributes. A skipped testcase carries a
-  // <skipped .../> child or skipped="true"; an errored one carries an
-  // <error .../> child.
+interface TestcaseTally {
+  executedLiveTestcases: number;
+  erroredLiveTestcases: number;
+  executedLiveTestcasesBySuite: Map<string, number>;
+}
+
+// Inspect individual live-Postgres <testcase> blocks as an independent
+// cross-check on the suite-level attributes. A skipped testcase carries a
+// <skipped .../> child or skipped="true"; an errored one carries an
+// <error .../> child.
+// The suite name of one <testcase> block when it is a live-Postgres case that
+// actually executed, and undefined for every other block.
+function executedLiveSuiteName(block: string): string | undefined {
+  const open = block.match(/<testcase\b[^>]*>/)?.[0] ?? block;
+  const classname = attr(open, "classname") ?? "";
+  if (!classname.includes("(live Postgres)")) return undefined;
+  const isSkipped =
+    /<skipped\b/.test(block) || attr(open, "skipped") === "true";
+  return isSkipped ? undefined : classname;
+}
+
+function tallyTestcases(xml: string): TestcaseTally {
   let executedLiveTestcases = 0;
   let erroredLiveTestcases = 0;
   const executedLiveTestcasesBySuite = new Map<string, number>();
   const testcaseRe = /<testcase\b[^>]*?(\/>|>[\s\S]*?<\/testcase>)/g;
   for (const block of xml.match(testcaseRe) ?? []) {
-    const open = block.match(/<testcase\b[^>]*>/)?.[0] ?? block;
-    const classname = attr(open, "classname") ?? "";
-    if (!classname.includes("(live Postgres)")) continue;
-    const isSkipped =
-      /<skipped\b/.test(block) || attr(open, "skipped") === "true";
-    if (isSkipped) continue;
+    const classname = executedLiveSuiteName(block);
+    if (classname === undefined) continue;
     executedLiveTestcases += 1;
     executedLiveTestcasesBySuite.set(
       classname,
@@ -166,10 +210,21 @@ export function evaluateJunit(xml: string): GuardResult {
     );
     if (/<error\b/.test(block)) erroredLiveTestcases += 1;
   }
+  return {
+    executedLiveTestcases,
+    erroredLiveTestcases,
+    executedLiveTestcasesBySuite,
+  };
+}
 
+// Every way one required suite can fail the guard, as error strings.
+function checkRequiredSuite(
+  req: { name: string; minTests: number },
+  suiteStats: Map<string, SuiteStats>,
+  executedLiveTestcasesBySuite: Map<string, number>,
+): string[] {
   const errors: string[] = [];
-
-  for (const req of REQUIRED_SUITES) {
+  {
     const s = suiteStats.get(req.name);
     if (!s) {
       errors.push(
@@ -177,7 +232,7 @@ export function evaluateJunit(xml: string): GuardResult {
           `never registered). The CI Postgres / OPENBRAIN_TEST_DATABASE_URL ` +
           `is not wired correctly.`,
       );
-      continue;
+      return errors;
     }
     if (s.skipped > 0) {
       errors.push(
@@ -204,6 +259,24 @@ export function evaluateJunit(xml: string): GuardResult {
           `testcases, expected at least ${req.minTests}.`,
       );
     }
+  }
+  return errors;
+}
+
+export function evaluateJunit(xml: string): GuardResult {
+  const suiteStats = collectSuiteStats(xml);
+  const {
+    executedLiveTestcases,
+    erroredLiveTestcases,
+    executedLiveTestcasesBySuite,
+  } = tallyTestcases(xml);
+
+  const errors: string[] = [];
+
+  for (const req of REQUIRED_SUITES) {
+    errors.push(
+      ...checkRequiredSuite(req, suiteStats, executedLiveTestcasesBySuite),
+    );
   }
 
   if (erroredLiveTestcases > 0) {
@@ -265,8 +338,8 @@ function main(): void {
       `(0 skipped, 0 failed, 0 errored).`,
   );
   for (const req of REQUIRED_SUITES) {
-    const s = result.suiteStats.get(req.name)!;
-    console.log(`  - ${req.name}: ${s.tests} tests`);
+    const s = result.suiteStats.get(req.name);
+    console.log(`  - ${req.name}: ${s?.tests ?? 0} tests`);
   }
 }
 

--- a/server/db/query.pg.test.ts
+++ b/server/db/query.pg.test.ts
@@ -1,6 +1,9 @@
 /**
  * Real-PostgreSQL namespace boundary tests.
  *
+ * REQUIRES the test-database variable, and fails hard without it (operator
+ * ruling 2026-08-27, issue #878).
+ *
  * Design authority: `docs/decisions/privilege-isolation-closed-brain.md`
  * requires realistic tests proving cross-client leakage fails closed.
  */
@@ -9,14 +12,13 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import pino from "pino";
 import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../scripts/test-support/require-test-database.ts";
 import type { AuthIdentity } from "../auth/types.ts";
 import { createDatabase } from "./pool.ts";
 import { runMigrations } from "./migrations.ts";
 import { deleteById, selectById } from "./query.ts";
 
-const DATABASE_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const databaseDescribe = DATABASE_URL ? describe : describe.skip;
-if (!DATABASE_URL) process.stdout.write("SKIP server/db/query.pg.test.ts: OPENBRAIN_TEST_DATABASE_URL is unset\n");
+const DATABASE_URL = requireTestDatabaseUrl();
 
 const schema = `foundation_${process.pid}`;
 const bilby: AuthIdentity = {
@@ -25,7 +27,11 @@ const bilby: AuthIdentity = {
   tokenClientId: "bilby",
   namespaceSource: "token",
 };
-const fixtureDirectory = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "migrations");
+const fixtureDirectory = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "fixtures",
+  "migrations",
+);
 const testLogger = pino({ level: "silent" });
 
 function databaseConfig(connectionString: string) {
@@ -43,18 +49,24 @@ function databaseConfig(connectionString: string) {
   };
 }
 
-databaseDescribe("server ID queries enforce namespace isolation (live Postgres)", () => {
+describe("server ID queries enforce namespace isolation (live Postgres)", () => {
   let owner: Pool;
   let scoped: Pool;
 
   beforeAll(async () => {
     owner = new Pool({ connectionString: DATABASE_URL });
     await owner.query(`CREATE SCHEMA ${schema}`);
-    await owner.query(`CREATE TABLE ${schema}.thoughts (id TEXT PRIMARY KEY, namespace TEXT NOT NULL, content TEXT NOT NULL)`);
-    await owner.query(`INSERT INTO ${schema}.thoughts (id, namespace, content) VALUES ($1, $2, $3), ($4, $5, $6)`, [
-      "bilby-row", "bilby", "owned", "skippy-row", "skippy", "private",
-    ]);
-    scoped = new Pool({ connectionString: DATABASE_URL, options: `-c search_path=${schema}` });
+    await owner.query(
+      `CREATE TABLE ${schema}.thoughts (id TEXT PRIMARY KEY, namespace TEXT NOT NULL, content TEXT NOT NULL)`,
+    );
+    await owner.query(
+      `INSERT INTO ${schema}.thoughts (id, namespace, content) VALUES ($1, $2, $3), ($4, $5, $6)`,
+      ["bilby-row", "bilby", "owned", "skippy-row", "skippy", "private"],
+    );
+    scoped = new Pool({
+      connectionString: DATABASE_URL,
+      options: `-c search_path=${schema}`,
+    });
   });
 
   afterAll(async () => {
@@ -64,18 +76,40 @@ databaseDescribe("server ID queries enforce namespace isolation (live Postgres)"
   });
 
   it("does not return an attacker-selected ID from another namespace", async () => {
-    expect(await selectById(scoped, { table: "thoughts", id: "skippy-row", identity: bilby, operation: "read" })).toBeUndefined();
-    expect(await selectById<{ content: string }>(scoped, { table: "thoughts", id: "bilby-row", identity: bilby, operation: "read" })).toMatchObject({ content: "owned" });
+    expect(
+      await selectById(scoped, {
+        table: "thoughts",
+        id: "skippy-row",
+        identity: bilby,
+        operation: "read",
+      }),
+    ).toBeUndefined();
+    expect(
+      await selectById<{ content: string }>(scoped, {
+        table: "thoughts",
+        id: "bilby-row",
+        identity: bilby,
+        operation: "read",
+      }),
+    ).toMatchObject({ content: "owned" });
   });
 
   it("does not delete an ID from another namespace", async () => {
-    expect(await deleteById(scoped, { table: "thoughts", id: "skippy-row", identity: bilby })).toBe(false);
-    const row = await owner.query(`SELECT content FROM ${schema}.thoughts WHERE id = $1`, ["skippy-row"]);
+    expect(
+      await deleteById(scoped, {
+        table: "thoughts",
+        id: "skippy-row",
+        identity: bilby,
+      }),
+    ).toBe(false);
+    const row = await owner.query(
+      `SELECT content FROM ${schema}.thoughts WHERE id = $1`,
+      ["skippy-row"],
+    );
     expect(row.rows[0]?.content).toBe("private");
   });
 
   it("owns, probes, and closes its configured pool", async () => {
-    if (!DATABASE_URL) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
     const database = createDatabase(databaseConfig(DATABASE_URL), testLogger);
     expect(await database.health()).toMatchObject({ connected: true });
     await database.close();
@@ -87,7 +121,10 @@ databaseDescribe("server ID queries enforce namespace isolation (live Postgres)"
       runMigrations(scoped, fixtureDirectory, testLogger),
     ]);
     expect(results.flat()).toEqual(["001_foundation_fixture.sql"]);
-    const result = await scoped.query("SELECT value FROM foundation_migration_fixture WHERE id = $1", [1]);
+    const result = await scoped.query(
+      "SELECT value FROM foundation_migration_fixture WHERE id = $1",
+      [1],
+    );
     expect(result.rows[0]?.value).toBe("applied");
   });
 });

--- a/server/main.pg.test.ts
+++ b/server/main.pg.test.ts
@@ -21,8 +21,8 @@
  * against. Asserting them one at a time against separate hand-built fixtures is
  * exactly how the gap this file closes stayed invisible.
  *
- * DATABASE. Skips loudly (`describe.skip`) without `OPENBRAIN_TEST_DATABASE_URL`,
- * which must point at an isolated test database — NEVER the dogfood one. The
+ * DATABASE. REQUIRES the test-database variable and fails hard without it
+ * (operator ruling 2026-08-27, issue #878). It must point at an isolated test database — NEVER the dogfood one. The
  * anti-skip guard (`scripts/assert-db-tests-ran.ts`) fails the job if this suite
  * does not actually execute, because a silent skip here would report a green
  * build for an entrypoint nothing had started.
@@ -32,15 +32,15 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import pino from "pino";
 import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../scripts/test-support/require-test-database.ts";
 import { parseServerConfig, type ServerConfig } from "./config.ts";
 import { startServer, type StartedServer } from "./main.ts";
 import type { SingleWorkerHealth } from "./transport/index.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
+const DB_URL = requireTestDatabaseUrl();
 
 const TOKEN = `entrypoint-proof-${process.pid}`;
-const NAMESPACE = `entrypoint-proof-${process.pid}-${Date.now()}`;
+const _NAMESPACE = `entrypoint-proof-${process.pid}-${Date.now()}`;
 
 function silentLogger() {
   return pino({ level: "silent" });
@@ -60,7 +60,7 @@ function silentLogger() {
  * which is itself the assertion that it did not try to rewrite history.
  */
 function testConfig(): ServerConfig {
-  const url = new URL(DB_URL!);
+  const url = new URL(DB_URL);
   const result = parseServerConfig({
     DB_HOST: url.hostname,
     DB_PORT: url.port || "5432",
@@ -78,35 +78,37 @@ function testConfig(): ServerConfig {
     AUTH_TOKEN_AGENT: TOKEN,
   });
   if (!result.ok) {
-    throw new Error(`invalid test configuration: ${JSON.stringify(result.issues)}`);
+    throw new Error(
+      `invalid test configuration: ${JSON.stringify(result.issues)}`,
+    );
   }
   return result.config;
 }
 
 let started: StartedServer | undefined;
 let base = "";
-const pool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
+const pool = new Pool({ connectionString: DB_URL });
 
-dbDescribe("rewrite entrypoint start-equivalence (live Postgres)", () => {
-  beforeAll(async () => {
-    started = await startServer({
-      config: testConfig(),
-      // Port 0 asks the kernel for an ephemeral port. Nothing well-known binds,
-      // so this can run beside the dogfood service without contending for 3100.
-      port: 0,
-      bindHost: "127.0.0.1",
-      logger: silentLogger(),
-      allowedOrigins: [],
-    });
-    base = `http://127.0.0.1:${started.port}`;
+beforeAll(async () => {
+  started = await startServer({
+    config: testConfig(),
+    // Port 0 asks the kernel for an ephemeral port. Nothing well-known binds,
+    // so this can run beside the dogfood service without contending for 3100.
+    port: 0,
+    bindHost: "127.0.0.1",
+    logger: silentLogger(),
+    allowedOrigins: [],
   });
+  base = `http://127.0.0.1:${started.port}`;
+});
 
-  afterAll(async () => {
-    await started?.shutdown();
-    started = undefined;
-    await pool?.end();
-  });
+afterAll(async () => {
+  await started?.shutdown();
+  started = undefined;
+  await pool.end();
+});
 
+describe("rewrite entrypoint start-equivalence (live Postgres)", () => {
   test("binds an ephemeral port and answers the frozen /health shape", async () => {
     const response = await fetch(`${base}/health`);
     // 200 healthy or 503 degraded are both valid: the embedding provider may
@@ -165,17 +167,21 @@ dbDescribe("rewrite entrypoint start-equivalence (live Postgres)", () => {
     });
     expect(response.status).toBe(401);
   });
+});
 
+describe("rewrite entrypoint audit and runtime composition (live Postgres)", () => {
   test("answers a real MCP tool call and writes the audit row for it", async () => {
-    if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
     const before = await pool.query<{ count: string }>(
       "SELECT count(*)::text AS count FROM mcp_tool_audit_log WHERE operation = $1",
       ["get_contract"],
     );
 
-    const transport = new StreamableHTTPClientTransport(new URL(`${base}/mcp`), {
-      requestInit: { headers: { authorization: `Bearer ${TOKEN}` } },
-    });
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`${base}/mcp`),
+      {
+        requestInit: { headers: { authorization: `Bearer ${TOKEN}` } },
+      },
+    );
     const client = new Client({ name: "entrypoint-proof", version: "1.0.0" });
     // `connect` performs the real initialize handshake over real HTTP against
     // the listener the entrypoint opened.
@@ -204,11 +210,11 @@ dbDescribe("rewrite entrypoint start-equivalence (live Postgres)", () => {
         "SELECT count(*)::text AS count FROM mcp_tool_audit_log WHERE operation = $1",
         ["get_contract"],
       );
-      if (Number(after.rows[0]!.count) > Number(before.rows[0]!.count)) break;
+      if (Number(after.rows[0]?.count) > Number(before.rows[0]?.count)) break;
       await new Promise((resolve) => setTimeout(resolve, 50));
     }
-    expect(Number(after.rows[0]!.count)).toBeGreaterThan(
-      Number(before.rows[0]!.count),
+    expect(Number(after.rows[0]?.count)).toBeGreaterThan(
+      Number(before.rows[0]?.count),
     );
 
     // The row must carry the identity the BEARER TOKEN resolved to, not
@@ -247,7 +253,7 @@ dbDescribe("rewrite entrypoint start-equivalence (live Postgres)", () => {
   });
 });
 
-dbDescribe("rewrite entrypoint startup and shutdown ordering (live Postgres)", () => {
+describe("rewrite entrypoint startup and shutdown ordering (live Postgres)", () => {
   test("starts on an environment whose optional secrets are present but empty", async () => {
     // The 2026-08-02 deploy failure, as a live boot rather than a unit parse.
     // `server/config.test.ts` pins the parse-boundary semantics for all eight
@@ -256,7 +262,7 @@ dbDescribe("rewrite entrypoint startup and shutdown ordering (live Postgres)", (
     // the previous fixtures never exercised — every env they built either set
     // an optional secret to a real value or omitted the key entirely, so the
     // shape that broke production (`EMBEDDING_API_KEY=`, empty) had no test.
-    const url = new URL(DB_URL!);
+    const url = new URL(DB_URL);
     const result = parseServerConfig({
       DB_HOST: url.hostname,
       DB_PORT: url.port || "5432",
@@ -264,9 +270,9 @@ dbDescribe("rewrite entrypoint startup and shutdown ordering (live Postgres)", (
       DB_USER: decodeURIComponent(url.username) || "postgres",
       LOG_FILE: "logs/open-brain-entrypoint-empty-secret-test.log",
       // A concrete LAN address, NOT loopback: `/health` exists to tell a client
-    // WHICH machine it reached, so `127.0.0.1` is not a valid answer and
-    // identity resolution deliberately falls through it to real detection.
-    OPEN_BRAIN_SERVER_IP: "192.0.2.99",
+      // WHICH machine it reached, so `127.0.0.1` is not a valid answer and
+      // identity resolution deliberately falls through it to real detection.
+      OPEN_BRAIN_SERVER_IP: "192.0.2.99",
       OPENBRAIN_MIGRATIONS_DIR: "src/db/migrations",
       AUTH_TOKEN_AGENT: TOKEN,
       // Exactly the local clone env's shape: the MLX embedding server needs no
@@ -296,7 +302,9 @@ dbDescribe("rewrite entrypoint startup and shutdown ordering (live Postgres)", (
       );
       // The empty admin token must not have been registered as a credential:
       // a blank bearer token accepted as `admin` would be an auth hole.
-      expect(result.config.authTokens.map(({ role }) => role)).toEqual(["agent"]);
+      expect(result.config.authTokens.map(({ role }) => role)).toEqual([
+        "agent",
+      ]);
       // Empty password/key were dropped rather than passed to pg / the provider.
       expect("password" in result.config.database).toBe(false);
       expect("embeddingApiKey" in result.config.transport).toBe(false);

--- a/server/tools/skill-usage.pg.test.ts
+++ b/server/tools/skill-usage.pg.test.ts
@@ -16,8 +16,8 @@
  * seeds a foreign namespace's invocations and proves the report cannot see
  * them, in both the counted rows and the never-used list.
  *
- * Skips loudly (via `describe.skip`) when `OPENBRAIN_TEST_DATABASE_URL` is
- * unset. It must point at an isolated test/playground database, never the
+ * REQUIRES the test-database variable, and fails hard without it (operator
+ * ruling 2026-08-27, issue #878). It must point at an isolated test/playground database, never the
  * dogfood database.
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -26,11 +26,10 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import pino from "pino";
 import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../scripts/test-support/require-test-database.ts";
 import { registerSkillUsageTools } from "./skill-usage.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-const pool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
 const NAMESPACE = `skill-usage-pg-${process.pid}`;
 const OTHER_NAMESPACE = `${NAMESPACE}-other`;
@@ -52,14 +51,14 @@ async function callTool(
   args: Record<string, unknown>,
   role: "agent" | "readonly" = "agent",
 ): Promise<{ isError: boolean; body: Record<string, unknown> }> {
-  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
   const server = new McpServer({ name: "skill-usage-test", version: "1.0.0" });
   registerSkillUsageTools(server, {
     pool,
     embedFn: async () => null,
     logger: pino({ level: "silent" }),
   });
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
   const originalSend = clientTransport.send.bind(clientTransport);
   clientTransport.send = (message, options) =>
     originalSend(message, {
@@ -90,30 +89,38 @@ function rowsFor(body: Record<string, unknown>, slug: string): UsageRow[] {
   return (body.usage as UsageRow[]).filter((row) => row.skill_slug === slug);
 }
 
-dbDescribe("skill usage telemetry (live Postgres)", () => {
-  beforeAll(async () => {
-    // A foreign namespace's invocations, seeded through the tool so the entity
-    // and log row are built exactly the way production builds them.
-    await callTool("record_skill_usage", OTHER_NAMESPACE, {
-      skill_slug: "foreign-only-skill",
-      agent: "other-agent",
-      repo: "other-repo",
-      runtime: "codex",
-    });
-  });
+/** The single row a one-row assertion has already proven is present. */
+function onlyRow(rows: UsageRow[]): UsageRow {
+  const row = rows[0];
+  if (row === undefined) throw new Error("expected exactly one usage row");
+  return row;
+}
 
-  afterAll(async () => {
-    await pool?.query(
-      `DELETE FROM skill_usage_log
+beforeAll(async () => {
+  // A foreign namespace's invocations, seeded through the tool so the entity
+  // and log row are built exactly the way production builds them.
+  await callTool("record_skill_usage", OTHER_NAMESPACE, {
+    skill_slug: "foreign-only-skill",
+    agent: "other-agent",
+    repo: "other-repo",
+    runtime: "codex",
+  });
+});
+
+afterAll(async () => {
+  await pool.query(
+    `DELETE FROM skill_usage_log
         WHERE entity_id IN (SELECT id FROM ob_entities WHERE namespace = ANY($1::text[]))`,
-      [[NAMESPACE, OTHER_NAMESPACE]],
-    );
-    await pool?.query(`DELETE FROM ob_entities WHERE namespace = ANY($1::text[])`, [
-      [NAMESPACE, OTHER_NAMESPACE],
-    ]);
-    await pool?.end();
-  });
+    [[NAMESPACE, OTHER_NAMESPACE]],
+  );
+  await pool.query(
+    `DELETE FROM ob_entities WHERE namespace = ANY($1::text[])`,
+    [[NAMESPACE, OTHER_NAMESPACE]],
+  );
+  await pool.end();
+});
 
+describe("skill usage recording and reporting (live Postgres)", () => {
   test("records an invocation and reads it back through the report", async () => {
     const recorded = await callTool("record_skill_usage", NAMESPACE, {
       skill_slug: "brain",
@@ -129,12 +136,12 @@ dbDescribe("skill usage telemetry (live Postgres)", () => {
     expect(report.isError).toBe(false);
     const rows = rowsFor(report.body, "brain");
     expect(rows.length).toBe(1);
-    expect(rows[0]!.invocations).toBe(1);
-    expect(rows[0]!.agent).toBe("claude-opus-5");
-    expect(rows[0]!.repo).toBe("open-brain");
-    expect(rows[0]!.runtime).toBe("claude-code");
-    expect(rows[0]!.usage_kind).toBe("skill");
-    expect(Number.isNaN(Date.parse(rows[0]!.last_used_at))).toBe(false);
+    expect(onlyRow(rows).invocations).toBe(1);
+    expect(onlyRow(rows).agent).toBe("claude-opus-5");
+    expect(onlyRow(rows).repo).toBe("open-brain");
+    expect(onlyRow(rows).runtime).toBe("claude-code");
+    expect(onlyRow(rows).usage_kind).toBe("skill");
+    expect(Number.isNaN(Date.parse(onlyRow(rows).last_used_at))).toBe(false);
   });
 
   test("counts repeat invocations of the same skill", async () => {
@@ -149,7 +156,7 @@ dbDescribe("skill usage telemetry (live Postgres)", () => {
     const report = await callTool("skill_usage_report", NAMESPACE, {});
     const rows = rowsFor(report.body, "wayfinder");
     expect(rows.length).toBe(1);
-    expect(rows[0]!.invocations).toBe(3);
+    expect(onlyRow(rows).invocations).toBe(3);
   });
 
   test("separates the same skill by agent, repo, and runtime", async () => {
@@ -201,7 +208,9 @@ dbDescribe("skill usage telemetry (live Postgres)", () => {
     );
     expect(skillSlugs).not.toContain("law-0");
   });
+});
 
+describe("skill usage isolation and permissions (live Postgres)", () => {
   test("hides another namespace's usage from the report and the never-used list", async () => {
     // The whole point of the join-and-scope rule. `foreign-only-skill` was
     // recorded under OTHER_NAMESPACE in beforeAll; nothing about it may reach a
@@ -209,7 +218,9 @@ dbDescribe("skill usage telemetry (live Postgres)", () => {
     // through the never-used list, which reads `ob_entities` directly and so
     // needs its own predicate.
     const report = await callTool("skill_usage_report", NAMESPACE, {});
-    const slugs = (report.body.usage as UsageRow[]).map((row) => row.skill_slug);
+    const slugs = (report.body.usage as UsageRow[]).map(
+      (row) => row.skill_slug,
+    );
     expect(slugs).not.toContain("foreign-only-skill");
     expect(report.body.never_used as string[]).not.toContain(
       "skill.foreign-only-skill",
@@ -232,15 +243,19 @@ dbDescribe("skill usage telemetry (live Postgres)", () => {
     });
     // Age that one invocation out of the reporting window. The entity stays;
     // only the log row moves, which is exactly the never-used condition.
-    await pool!.query(
+    await pool.query(
       `UPDATE skill_usage_log
           SET invoked_at = NOW() - INTERVAL '90 days'
         WHERE skill_slug = 'long-idle-skill'`,
     );
     const report = await callTool("skill_usage_report", NAMESPACE, { days: 7 });
-    const slugs = (report.body.usage as UsageRow[]).map((row) => row.skill_slug);
+    const slugs = (report.body.usage as UsageRow[]).map(
+      (row) => row.skill_slug,
+    );
     expect(slugs).not.toContain("long-idle-skill");
-    expect(report.body.never_used as string[]).toContain("skill.long-idle-skill");
+    expect(report.body.never_used as string[]).toContain(
+      "skill.long-idle-skill",
+    );
   });
 
   test("reports the prior window's count so the trend is two facts, not a verdict", async () => {
@@ -255,7 +270,7 @@ dbDescribe("skill usage telemetry (live Postgres)", () => {
       runtime: "claude-code",
     });
     // Push one of the two back into the prior window.
-    await pool!.query(
+    await pool.query(
       `UPDATE skill_usage_log
           SET invoked_at = NOW() - INTERVAL '10 days'
         WHERE id = (SELECT MIN(id) FROM skill_usage_log
@@ -264,11 +279,11 @@ dbDescribe("skill usage telemetry (live Postgres)", () => {
     const report = await callTool("skill_usage_report", NAMESPACE, { days: 7 });
     const rows = rowsFor(report.body, "trend-skill");
     expect(rows.length).toBe(1);
-    expect(rows[0]!.invocations).toBe(1);
-    expect(rows[0]!.prior_window_invocations).toBe(1);
+    expect(onlyRow(rows).invocations).toBe(1);
+    expect(onlyRow(rows).prior_window_invocations).toBe(1);
     // Facts only: the report must not hand back a judgement word alongside them.
-    expect(Object.keys(rows[0]!)).not.toContain("recommendation");
-    expect(Object.keys(rows[0]!)).not.toContain("category");
+    expect(Object.keys(onlyRow(rows))).not.toContain("recommendation");
+    expect(Object.keys(onlyRow(rows))).not.toContain("category");
   });
 
   test("denies recording to a namespace the caller cannot write", async () => {

--- a/server/tools/source-registry.pg.test.ts
+++ b/server/tools/source-registry.pg.test.ts
@@ -11,8 +11,8 @@
  * approved and active. A caller cannot self-approve, and a retired source can
  * never become eligible again.
  *
- * Skips loudly (via `describe.skip`) when `OPENBRAIN_TEST_DATABASE_URL` is
- * unset. It must point at an isolated test/playground database, never the
+ * REQUIRES the test-database variable, and fails hard without it (operator
+ * ruling 2026-08-27, issue #878). It must point at an isolated test/playground database, never the
  * dogfood database.
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -21,11 +21,10 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import pino from "pino";
 import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../scripts/test-support/require-test-database.ts";
 import { registerSourceRegistryTools } from "./source-registry.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-const pool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
 const NAMESPACE = `source-registry-pg-${process.pid}`;
 const OTHER_NAMESPACE = `${NAMESPACE}-other`;
@@ -47,14 +46,17 @@ async function callTool(
   args: Record<string, unknown>,
   role = "agent",
 ): Promise<{ isError: boolean; body: Envelope }> {
-  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
-  const server = new McpServer({ name: "source-registry-test", version: "1.0.0" });
+  const server = new McpServer({
+    name: "source-registry-test",
+    version: "1.0.0",
+  });
   registerSourceRegistryTools(server, {
     pool,
     embedFn: async () => null,
     logger: pino({ level: "silent" }),
   });
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
   const originalSend = clientTransport.send.bind(clientTransport);
   clientTransport.send = (message, options) =>
     originalSend(message, {
@@ -67,34 +69,37 @@ async function callTool(
   try {
     const result = await client.callTool({ name: tool, arguments: args });
     const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
-    return { isError: result.isError === true, body: JSON.parse(text) as Envelope };
+    return {
+      isError: result.isError === true,
+      body: JSON.parse(text) as Envelope,
+    };
   } finally {
     await client.close();
     await server.close();
   }
 }
 
-dbDescribe("source registry lifecycle (live Postgres)", () => {
-  let sourceId = "";
+/** The registered source every describe below operates on. */
+let sourceId = "";
 
-  beforeAll(async () => {
-    const created = await callTool("register_source", NAMESPACE, {
-      source_kind: "git",
-      external_id: EXTERNAL_ID,
-      title: "Lifecycle Repo",
-    });
-    sourceId = String(created.body.source?.id ?? "");
-    expect(sourceId).not.toBe("");
+beforeAll(async () => {
+  const created = await callTool("register_source", NAMESPACE, {
+    source_kind: "git",
+    external_id: EXTERNAL_ID,
+    title: "Lifecycle Repo",
   });
+  sourceId = String(created.body.source?.id ?? "");
+  expect(sourceId).not.toBe("");
+});
 
-  afterAll(async () => {
-    if (!pool) return;
-    await pool.query(`DELETE FROM ob_sources WHERE namespace = ANY($1::text[])`, [
-      [NAMESPACE, OTHER_NAMESPACE],
-    ]);
-    await pool.end();
-  });
+afterAll(async () => {
+  await pool.query(`DELETE FROM ob_sources WHERE namespace = ANY($1::text[])`, [
+    [NAMESPACE, OTHER_NAMESPACE],
+  ]);
+  await pool.end();
+});
 
+describe("source registry revision and approval (live Postgres)", () => {
   test("update_source advances the revision and applies the change", async () => {
     const { isError, body } = await callTool("update_source", NAMESPACE, {
       id: sourceId,
@@ -117,7 +122,9 @@ dbDescribe("source registry lifecycle (live Postgres)", () => {
     expect(isError).toBe(true);
     expect(body.code).toBe("stale_revision");
     // The refused write must not have landed.
-    const after = await callTool("list_sources", NAMESPACE, { source_kind: "git" });
+    const after = await callTool("list_sources", NAMESPACE, {
+      source_kind: "git",
+    });
     expect(after.body.sources?.[0]?.title).toBe("Lifecycle Repo Renamed");
   });
 
@@ -128,7 +135,9 @@ dbDescribe("source registry lifecycle (live Postgres)", () => {
       approval_state: "approved",
     });
     expect(isError).toBe(true);
-    const after = await callTool("list_sources", NAMESPACE, { source_kind: "git" });
+    const after = await callTool("list_sources", NAMESPACE, {
+      source_kind: "git",
+    });
     expect(after.body.sources?.[0]?.approval_state).toBe("pending");
   });
 
@@ -160,7 +169,9 @@ dbDescribe("source registry lifecycle (live Postgres)", () => {
     expect(body.eligible).toBe(true);
     expect(body.source?.id).toBe(sourceId);
   });
+});
 
+describe("source registry isolation and retirement (live Postgres)", () => {
   test("another namespace cannot see or reach the source", async () => {
     const listed = await callTool("list_sources", OTHER_NAMESPACE, {
       source_kind: "git",
@@ -183,7 +194,9 @@ dbDescribe("source registry lifecycle (live Postgres)", () => {
   });
 
   test("remove_source retires it and eligibility never returns", async () => {
-    const removed = await callTool("remove_source", NAMESPACE, { id: sourceId });
+    const removed = await callTool("remove_source", NAMESPACE, {
+      id: sourceId,
+    });
     expect(removed.isError).toBe(false);
     expect(removed.body.id).toBe(sourceId);
 
@@ -195,7 +208,7 @@ dbDescribe("source registry lifecycle (live Postgres)", () => {
     expect(body.eligible).toBe(false);
 
     // Provenance is preserved rather than hard-deleted.
-    const { rows } = await pool!.query(
+    const { rows } = await pool.query(
       `SELECT lifecycle_state FROM ob_sources WHERE id = $1`,
       [sourceId],
     );


### PR DESCRIPTION
## Summary

- Batch 1, lane C of #878. `server/tools/skill-usage.pg.test.ts`, `server/tools/source-registry.pg.test.ts`, `server/db/query.pg.test.ts`, and `server/main.pg.test.ts` each read the test-database variable themselves and downgraded `describe` to `describe.skip` when it was unset, so a run without a database configured reported green having executed nothing — 37 tests across the four files.
- Each file now calls `requireTestDatabaseUrl()` from `scripts/test-support/require-test-database.ts` at module scope and builds its pool from the returned value, the shape already landed on `main` in `server/tools/reporting.pg.test.ts`. The nullable pools, the `pool!` assertions, and the `if (!pool) throw` guards those nullable pools forced are gone. Every test and assertion is preserved.
- Bringing each file to standard on first touch also cleared lint debt that predates this change and failed `oxlint --deny-warnings` at `origin/main`: over-long `describe` bodies are split by subject over shared module-scope hooks (again the `reporting.pg.test.ts` shape), the non-null assertions on rows a `expect(rows.length).toBe(1)` has already proven present go through an explicit `onlyRow` helper in skill-usage, and the dead `NAMESPACE` constant in `server/main.pg.test.ts` is renamed to the unused-marker form. No test behavior changes.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Red at `origin/main` with `CHANGED_FILES` set to the four files: exit 1, clauses 1-3 FAIL on every file (`self-skipping machinery survives on code lines`, `no import of requireTestDatabaseUrl`, `exit 0, test_database_required present: no`). Green on this branch with no argv: exit 0, subject resolves to exactly these four files, all four clauses PASS. `bunx tsc --noEmit` exits 0. `./node_modules/.bin/oxlint --deny-warnings` over the four files exits 0. Whole suite `bun run test:isolated`: 3944 pass, 35 skip, 0 fail, 3979 tests across 261 files. Python package untouched; no client or contract path touched, so no live smoke applies.

## Critical Self-Review

- Highest-risk behavior: hoisting `beforeAll`/`afterAll` out of a describe and into module scope changes when the shared pool closes relative to sibling describes. In `server/main.pg.test.ts` the second describe (`startup and shutdown ordering`) starts its own servers and does not touch the shared `pool`, so a module-scope `afterAll` closing the pool after all describes is correct rather than merely equivalent; I checked that describe for `pool` references before moving the hook.
- Assumptions that could be wrong: that Bun runs module-scope `afterAll` after every describe in the file rather than after the first. The 3944-pass isolated run over the whole suite is the evidence, not the assumption — all 37 tests in these files execute and pass.
- Missing/weak tests: no new test proves the hard-fail path itself; that is what clause 3 of the done-means script checks, by running each file with the variable unset and asserting a non-zero exit carrying `test_database_required`. That is a checker clause, not a committed test, so it protects the branch and CI but not a future reader editing the file in isolation.
- Security/permission risk: none. No auth predicate, namespace boundary, SQL text, or permission check is touched; the namespace-isolation tests in `query.pg.test.ts` and `skill-usage.pg.test.ts` are unchanged and still run.
- Migration/deploy risk: none. Test files only; no migration, no config, no runtime source.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md` — no MCP tool, schema, transport, Python client, or agent-facing contract is touched.
- Rollback/cleanup concern: a single revert restores the prior files; nothing else depends on them. `bunx prettier --write` refreshed the lockfile as a side effect and that change was deliberately left unstaged — the commit is exactly the four test files.
- Fixes made before PR: replaced `pool?.` optional-chain calls left over from the nullable pool with direct calls; replaced `rows[0]!` with `onlyRow(rows)`; replaced `.rows[0]!.count` with optional chaining in `main.pg.test.ts`; split three describes that exceeded the per-function line rule.
- Known residual risk: the describe splits change test-suite names in reporter output, so any external filter matching the old describe strings (`skill usage telemetry`, `source registry lifecycle`, and the single `start-equivalence` block) will no longer match. I found no such filter in the repo, but I did not audit CI configuration outside this repo.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the pattern this lane fixes — a live-Postgres suite that self-skips into a false green — is already the subject of issue #878 and is enforced going forward by `scripts/done-means/878-pg-tests-require-database.sh`, so an SME entry would restate an executable check rather than add a reviewer-facing lesson.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: test-file-only change with no runtime, contract, or deployed-surface impact.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, tool schema, or fixture is touched — the change is confined to how four test files obtain their database connection string.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- No MCP tool, schema, transport, or client-facing surface changes, so every downstream step is not applicable per the classification in `docs/downstream-rollout.md`.
