### PR TITLE
test(pg): list-stale, promotion and session-lifecycle require the test database instead of skipping (#878)

### DIFF
--- a/server/tools/list-stale.pg.test.ts
+++ b/server/tools/list-stale.pg.test.ts
@@ -7,8 +7,8 @@
  * rows so the `last_accessed_at`-falls-back-to-`created_at` rule, the tier
  * filter, pagination, and the namespace boundary are each exercised with data.
  *
- * Skips loudly (via `describe.skip`) when `OPENBRAIN_TEST_DATABASE_URL` is
- * unset. It must point at an isolated test/playground database, never the
+ * REQUIRES `OPENBRAIN_TEST_DATABASE_URL`, and fails hard without it (operator
+ * ruling 2026-08-27, issue #878). It must point at an isolated test/playground database, never the
  * dogfood database.
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -17,11 +17,10 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import pino from "pino";
 import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../scripts/test-support/require-test-database.ts";
 import { registerTieringTools } from "./tiering.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-const pool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
 const NAMESPACE = `list-stale-pg-${process.pid}`;
 const OTHER_NAMESPACE = `${NAMESPACE}-other`;
@@ -43,25 +42,32 @@ async function callListStale(
   namespace: string,
   args: Record<string, unknown>,
 ): Promise<unknown> {
-  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
   const server = new McpServer({ name: "list-stale-test", version: "1.0.0" });
   registerTieringTools(server, {
     pool,
     embedFn: async () => null,
     logger: pino({ level: "silent" }),
   });
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
   const originalSend = clientTransport.send.bind(clientTransport);
   clientTransport.send = (message, options) =>
     originalSend(message, {
       ...options,
-      authInfo: { role: "agent", clientId: namespace, namespaceSource: "token" },
+      authInfo: {
+        role: "agent",
+        clientId: namespace,
+        namespaceSource: "token",
+      },
     } as never);
   const client = new Client({ name: "list-stale-test", version: "1.0.0" });
   await server.connect(serverTransport);
   await client.connect(clientTransport);
   try {
-    const result = await client.callTool({ name: "list_stale", arguments: args });
+    const result = await client.callTool({
+      name: "list_stale",
+      arguments: args,
+    });
     const text = (result.content as Array<{ text: string }>)[0]?.text;
     if (text === undefined) throw new Error("list_stale returned no content");
     return JSON.parse(text);
@@ -71,59 +77,65 @@ async function callListStale(
   }
 }
 
-dbDescribe("list_stale (live Postgres)", () => {
-  let neverAccessedId = "";
-  let longAgoId = "";
-  let freshId = "";
-  let coldId = "";
+/**
+ * Ids of the seeded rows, filled by the module-scope `beforeAll`.
+ *
+ * The two describes below split by SUBJECT over ONE shared fixture -- the
+ * staleness predicate itself, then the envelope and boundary rules that read
+ * the same rows. Seeding is module-scope rather than duplicated per describe.
+ */
+let neverAccessedId = "";
+let longAgoId = "";
+let freshId = "";
+let coldId = "";
 
-  beforeAll(async () => {
-    // Never accessed, created long ago: stale only if the query falls back to
-    // created_at. A COALESCE-less predicate would drop this row.
-    const neverAccessed = await pool!.query(
-      `INSERT INTO thoughts (content, namespace, created_by, tier, access_count, last_accessed_at, created_at)
+beforeAll(async () => {
+  // Never accessed, created long ago: stale only if the query falls back to
+  // created_at. A COALESCE-less predicate would drop this row.
+  const neverAccessed = await pool.query(
+    `INSERT INTO thoughts (content, namespace, created_by, tier, access_count, last_accessed_at, created_at)
        VALUES ($1, $2, $2, 'hot', 0, NULL, NOW() - INTERVAL '200 days') RETURNING id`,
-      ["list-stale never accessed", NAMESPACE],
-    );
-    neverAccessedId = neverAccessed.rows[0].id;
+    ["list-stale never accessed", NAMESPACE],
+  );
+  neverAccessedId = neverAccessed.rows[0].id;
 
-    const longAgo = await pool!.query(
-      `INSERT INTO thoughts (content, namespace, created_by, tier, access_count, last_accessed_at, created_at)
+  const longAgo = await pool.query(
+    `INSERT INTO thoughts (content, namespace, created_by, tier, access_count, last_accessed_at, created_at)
        VALUES ($1, $2, $2, 'warm', 4, NOW() - INTERVAL '100 days', NOW() - INTERVAL '300 days') RETURNING id`,
-      ["list-stale accessed long ago", NAMESPACE],
-    );
-    longAgoId = longAgo.rows[0].id;
+    ["list-stale accessed long ago", NAMESPACE],
+  );
+  longAgoId = longAgo.rows[0].id;
 
-    // Accessed yesterday: must NEVER appear at a 30-day threshold.
-    const fresh = await pool!.query(
-      `INSERT INTO thoughts (content, namespace, created_by, tier, access_count, last_accessed_at, created_at)
+  // Accessed yesterday: must NEVER appear at a 30-day threshold.
+  const fresh = await pool.query(
+    `INSERT INTO thoughts (content, namespace, created_by, tier, access_count, last_accessed_at, created_at)
        VALUES ($1, $2, $2, 'hot', 9, NOW() - INTERVAL '1 day', NOW() - INTERVAL '400 days') RETURNING id`,
-      ["list-stale fresh", NAMESPACE],
-    );
-    freshId = fresh.rows[0].id;
+    ["list-stale fresh", NAMESPACE],
+  );
+  freshId = fresh.rows[0].id;
 
-    const cold = await pool!.query(
-      `INSERT INTO thoughts (content, namespace, created_by, tier, access_count, last_accessed_at, created_at)
+  const cold = await pool.query(
+    `INSERT INTO thoughts (content, namespace, created_by, tier, access_count, last_accessed_at, created_at)
        VALUES ($1, $2, $2, 'cold', 0, NULL, NOW() - INTERVAL '250 days') RETURNING id`,
-      ["list-stale cold tier", NAMESPACE],
-    );
-    coldId = cold.rows[0].id;
+    ["list-stale cold tier", NAMESPACE],
+  );
+  coldId = cold.rows[0].id;
 
-    await pool!.query(
-      `INSERT INTO thoughts (content, namespace, created_by, tier, access_count, last_accessed_at, created_at)
+  await pool.query(
+    `INSERT INTO thoughts (content, namespace, created_by, tier, access_count, last_accessed_at, created_at)
        VALUES ($1, $2, $2, 'warm', 0, NULL, NOW() - INTERVAL '500 days')`,
-      ["list-stale foreign entry", OTHER_NAMESPACE],
-    );
-  });
+    ["list-stale foreign entry", OTHER_NAMESPACE],
+  );
+});
 
-  afterAll(async () => {
-    if (!pool) return;
-    await pool.query(`DELETE FROM thoughts WHERE namespace = ANY($1::text[])`, [
-      [NAMESPACE, OTHER_NAMESPACE],
-    ]);
-    await pool.end();
-  });
+afterAll(async () => {
+  await pool.query(`DELETE FROM thoughts WHERE namespace = ANY($1::text[])`, [
+    [NAMESPACE, OTHER_NAMESPACE],
+  ]);
+  await pool.end();
+});
 
+describe("list_stale staleness predicate (live Postgres)", () => {
   test("falls back to created_at for entries that were never accessed", async () => {
     const result = (await callListStale(NAMESPACE, {
       table: "thoughts",
@@ -161,7 +173,9 @@ dbDescribe("list_stale (live Postgres)", () => {
     expect(ids).toEqual([coldId]);
     expect(result.total_count).toBe(1);
   });
+});
 
+describe("list_stale envelope, paging and namespace boundary (live Postgres)", () => {
   test("envelope counts the whole match set, not just the returned page", async () => {
     const page = (await callListStale(NAMESPACE, {
       table: "thoughts",

--- a/server/tools/promotion.pg.test.ts
+++ b/server/tools/promotion.pg.test.ts
@@ -9,8 +9,8 @@
  * live: the legacy target is refused, the dry-run default writes nothing, and
  * secret/private content is refused even for an authorized promoter.
  *
- * Skips loudly (via `describe.skip`) when `OPENBRAIN_TEST_DATABASE_URL` is
- * unset. It must point at an isolated test/playground database, never the
+ * REQUIRES `OPENBRAIN_TEST_DATABASE_URL`, and fails hard without it (operator
+ * ruling 2026-08-27, issue #878). It must point at an isolated test/playground database, never the
  * dogfood database.
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -19,13 +19,12 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import pino from "pino";
 import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../scripts/test-support/require-test-database.ts";
 import { registerPromotionTools } from "./promotion.ts";
 import { sharedNamespaceConfig } from "../../src/shared-namespace.ts";
 import { DEFAULT_SHARED_NAMESPACE_NAMES } from "./shared-namespace-fixture.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-const pool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
 const NAMESPACE = `promotion-pg-${process.pid}`;
 const SHARED = sharedNamespaceConfig();
@@ -36,7 +35,6 @@ async function callTool(
   args: Record<string, unknown>,
   role = "promoter",
 ): Promise<{ isError: boolean; body: Record<string, unknown> }> {
-  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
   const server = new McpServer({ name: "promotion-test", version: "1.0.0" });
   registerPromotionTools(server, {
     pool,
@@ -73,7 +71,7 @@ async function callTool(
 }
 
 async function sharedCount(content: string): Promise<number> {
-  const { rows } = await pool!.query(
+  const { rows } = await pool.query(
     `SELECT COUNT(*)::int AS cnt FROM thoughts
       WHERE namespace = $1 AND content = $2 AND archived_at IS NULL`,
     [SHARED.physicalSharedNamespace, content],
@@ -96,33 +94,40 @@ const SHAREABLE =
 const SECRET_ISH =
   "The staging database is reachable at postgres://svc-user:hunter2horse@db.internal:5432/appdb which is why the job works.";
 
-dbDescribe("promote_shared and list_namespaces (live Postgres)", () => {
-  let shareableId = "";
-  let secretId = "";
+/**
+ * Ids of the seeded rows, filled by the module-scope `beforeAll`.
+ *
+ * The two describes below split by SUBJECT over ONE shared fixture -- the
+ * promotion rules themselves, then the identity rules and `list_namespaces`.
+ * They read the same seeded rows, so seeding is module-scope rather than
+ * duplicated per describe.
+ */
+let shareableId = "";
+let secretId = "";
 
-  beforeAll(async () => {
-    const shareable = await pool!.query(
-      `INSERT INTO thoughts (content, namespace, created_by) VALUES ($1, $2, $2) RETURNING id`,
-      [SHAREABLE, NAMESPACE],
-    );
-    shareableId = shareable.rows[0].id;
-    const secret = await pool!.query(
-      `INSERT INTO thoughts (content, namespace, created_by) VALUES ($1, $2, $2) RETURNING id`,
-      [SECRET_ISH, NAMESPACE],
-    );
-    secretId = secret.rows[0].id;
-  });
+beforeAll(async () => {
+  const shareable = await pool.query(
+    `INSERT INTO thoughts (content, namespace, created_by) VALUES ($1, $2, $2) RETURNING id`,
+    [SHAREABLE, NAMESPACE],
+  );
+  shareableId = shareable.rows[0].id;
+  const secret = await pool.query(
+    `INSERT INTO thoughts (content, namespace, created_by) VALUES ($1, $2, $2) RETURNING id`,
+    [SECRET_ISH, NAMESPACE],
+  );
+  secretId = secret.rows[0].id;
+});
 
-  afterAll(async () => {
-    if (!pool) return;
-    await pool.query(`DELETE FROM thoughts WHERE namespace = $1`, [NAMESPACE]);
-    await pool.query(
-      `DELETE FROM thoughts WHERE namespace = $1 AND content = ANY($2::text[])`,
-      [SHARED.physicalSharedNamespace, [SHAREABLE, SECRET_ISH]],
-    );
-    await pool.end();
-  });
+afterAll(async () => {
+  await pool.query(`DELETE FROM thoughts WHERE namespace = $1`, [NAMESPACE]);
+  await pool.query(
+    `DELETE FROM thoughts WHERE namespace = $1 AND content = ANY($2::text[])`,
+    [SHARED.physicalSharedNamespace, [SHAREABLE, SECRET_ISH]],
+  );
+  await pool.end();
+});
 
+describe("promote_shared promotion rules (live Postgres)", () => {
   test("the dry-run default previews and writes NOTHING to shared truth", async () => {
     const before = await sharedCount(SHAREABLE);
     const { isError } = await callTool("promote_shared", NAMESPACE, {
@@ -146,7 +151,7 @@ dbDescribe("promote_shared and list_namespaces (live Postgres)", () => {
     expect(isError).toBe(true);
     expect(String(body.text)).toContain("legacy migration source");
     // And nothing landed under the legacy name either.
-    const { rows } = await pool!.query(
+    const { rows } = await pool.query(
       `SELECT COUNT(*)::int AS cnt FROM thoughts WHERE namespace = 'collab' AND content = $1`,
       [SHAREABLE],
     );
@@ -179,7 +184,9 @@ dbDescribe("promote_shared and list_namespaces (live Postgres)", () => {
     expect(String(body.text)).toContain("Refused");
     expect(await sharedCount(SECRET_ISH)).toBe(before);
   });
+});
 
+describe("promotion identity rules and list_namespaces (live Postgres)", () => {
   test("a plain agent identity cannot promote at all", async () => {
     const { isError, body } = await callTool(
       "promote_shared",

--- a/server/tools/session-lifecycle.pg.test.ts
+++ b/server/tools/session-lifecycle.pg.test.ts
@@ -9,8 +9,8 @@
  * more events than the bounds and prove the row counts, so the old behavior
  * fails them.
  *
- * Skips loudly (via `describe.skip`) when `OPENBRAIN_TEST_DATABASE_URL` is
- * unset. It must point at an isolated test/playground database, never the
+ * REQUIRES `OPENBRAIN_TEST_DATABASE_URL`, and fails hard without it (operator
+ * ruling 2026-08-27, issue #878). It must point at an isolated test/playground database, never the
  * dogfood database.
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -19,11 +19,10 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import pino from "pino";
 import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../scripts/test-support/require-test-database.ts";
 import { registerSessionLifecycleTools } from "./session-lifecycle.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-const pool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
 const NAMESPACE = `session-lifecycle-pg-${process.pid}`;
 const SESSION_KEY = `${NAMESPACE}-lane`;
@@ -42,39 +41,58 @@ interface StartEnvelope {
   is_new: boolean;
 }
 
-async function callTool(name: string, args: Record<string, unknown>): Promise<unknown> {
+async function callTool(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
   return JSON.parse(await callToolText(name, args));
 }
 
 /** The tool's raw text. Error results are sentences, not JSON envelopes. */
-async function callToolText(name: string, args: Record<string, unknown>): Promise<string> {
-  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
-  const server = new McpServer({ name: "session-lifecycle-test", version: "1.0.0" });
+async function callToolText(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const server = new McpServer({
+    name: "session-lifecycle-test",
+    version: "1.0.0",
+  });
   registerSessionLifecycleTools(server, {
     pool,
     embedFn: async () => null,
     logger: pino({ level: "silent" }),
   });
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
   const originalSend = clientTransport.send.bind(clientTransport);
   clientTransport.send = (message, options) =>
     originalSend(message, {
       ...options,
-      authInfo: { role: "agent", clientId: NAMESPACE, namespaceSource: "token" },
+      authInfo: {
+        role: "agent",
+        clientId: NAMESPACE,
+        namespaceSource: "token",
+      },
     } as never);
-  const client = new Client({ name: "session-lifecycle-test", version: "1.0.0" });
-  await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+  const client = new Client({
+    name: "session-lifecycle-test",
+    version: "1.0.0",
+  });
+  await Promise.all([
+    client.connect(clientTransport),
+    server.connect(serverTransport),
+  ]);
   const result = await client.callTool({ name, arguments: args });
-  const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? "";
+  const text =
+    (result.content as Array<{ type: string; text: string }>)[0]?.text ?? "";
   await client.close();
   return text;
 }
 
-dbDescribe("session lifecycle event bounds (#515)", () => {
+describe("session lifecycle event bounds (#515)", () => {
   let laneId: string;
 
   beforeAll(async () => {
-    if (!pool) return;
     const lane = await pool.query(
       `INSERT INTO ob_session_lanes
          (session_key, namespace, status, metadata, created_by)
@@ -94,8 +112,9 @@ dbDescribe("session lifecycle event bounds (#515)", () => {
   });
 
   afterAll(async () => {
-    if (!pool) return;
-    await pool.query(`DELETE FROM ob_session_events WHERE lane_id = $1`, [laneId]);
+    await pool.query(`DELETE FROM ob_session_events WHERE lane_id = $1`, [
+      laneId,
+    ]);
     await pool.query(`DELETE FROM ob_session_lanes WHERE id = $1`, [laneId]);
     // `pool` is module-level and shared by every suite's callTool(); closing it
     // here made the #646 suite fail with "Cannot use a pool after calling end",
@@ -156,7 +175,7 @@ dbDescribe("session lifecycle event bounds (#515)", () => {
  * The old behavior fails the first two tests here: it returned NULL scope
  * columns unchanged, and it never refused a conflicting lane.
  */
-dbDescribe("session_start exact-scope establishment (#646)", () => {
+describe("session_start exact-scope establishment (#646)", () => {
   const SCOPE = {
     agent: "agent-646",
     platform: "cli-646",
@@ -165,10 +184,13 @@ dbDescribe("session_start exact-scope establishment (#646)", () => {
   };
   const partialKey = `${NAMESPACE}-646-partial`;
   const conflictKey = `${NAMESPACE}-646-conflict`;
-  const scopePool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
+  const scopePool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
-  const seed = async (sessionKey: string, agent: string | null): Promise<void> => {
-    await scopePool?.query(
+  const seed = async (
+    sessionKey: string,
+    agent: string | null,
+  ): Promise<void> => {
+    await scopePool.query(
       `INSERT INTO ob_session_lanes
          (session_key, namespace, status, agent, metadata, created_by)
        VALUES ($1, $2, 'active', $3, '{}'::jsonb, $2)`,
@@ -177,7 +199,6 @@ dbDescribe("session_start exact-scope establishment (#646)", () => {
   };
 
   beforeAll(async () => {
-    if (!scopePool) return;
     // The shape a head session leaves behind: an agent, and nothing else.
     await seed(partialKey, "openbrain-capture");
     // A lane that genuinely belongs to a different scope.
@@ -185,11 +206,10 @@ dbDescribe("session_start exact-scope establishment (#646)", () => {
   });
 
   afterAll(async () => {
-    if (!scopePool) return;
-    await scopePool.query(`DELETE FROM ob_session_lanes WHERE namespace = $1 AND session_key = ANY($2)`, [
-      NAMESPACE,
-      [partialKey, conflictKey],
-    ]);
+    await scopePool.query(
+      `DELETE FROM ob_session_lanes WHERE namespace = $1 AND session_key = ANY($2)`,
+      [NAMESPACE, [partialKey, conflictKey]],
+    );
     await scopePool.end();
   });
 
@@ -199,7 +219,12 @@ dbDescribe("session_start exact-scope establishment (#646)", () => {
       ...SCOPE,
       agent: "openbrain-capture", // matches the lane; the NULLs are what fill in
     })) as StartEnvelope & {
-      lane: { agent: string; source: string; channel_id: string; metadata: Record<string, unknown> };
+      lane: {
+        agent: string;
+        source: string;
+        channel_id: string;
+        metadata: Record<string, unknown>;
+      };
     };
 
     expect(started.is_new).toBe(false);
@@ -208,7 +233,7 @@ dbDescribe("session_start exact-scope establishment (#646)", () => {
     expect(started.lane.metadata.server_id).toBe(SCOPE.server_id);
 
     // Durably written, not just reflected in the response.
-    const row = await scopePool!.query(
+    const row = await scopePool.query(
       `SELECT source, channel_id, metadata->>'server_id' AS server_id
          FROM ob_session_lanes WHERE namespace = $1 AND session_key = $2`,
       [NAMESPACE, partialKey],
@@ -229,7 +254,7 @@ dbDescribe("session_start exact-scope establishment (#646)", () => {
     expect(text).toContain("does not match");
 
     // And the conflicting lane is left exactly as it was — never re-pointed.
-    const row = await scopePool!.query(
+    const row = await scopePool.query(
       `SELECT agent, source FROM ob_session_lanes WHERE namespace = $1 AND session_key = $2`,
       [NAMESPACE, conflictKey],
     );


### PR DESCRIPTION
## Summary

- Issue #878 batch 1, lane B: `server/tools/list-stale.pg.test.ts`, `server/tools/promotion.pg.test.ts` and `server/tools/session-lifecycle.pg.test.ts` now demand the test database instead of skipping themselves when `OPENBRAIN_TEST_DATABASE_URL` is absent.
- All three read the variable themselves and swapped in `describe.skip`, which reports `0 pass, N skip, 0 fail` and exits 0 — indistinguishable at the exit code from a suite that ran and passed. That is the false green the issue exists to close.
- Each file now calls `requireTestDatabaseUrl()` at module scope, so an absent variable throws `test_database_required` and takes the run down loudly. The nullable pool, every `pool!` non-null assertion, and every `if (!pool) return` guard that existed only to satisfy the nullable type go with it. `session-lifecycle` gets the same treatment for its second suite's `scopePool`.
- Every test and assertion is unchanged. This follows the shape already landed on `main` in `server/tools/reporting.pg.test.ts`.
- Bringing the touched files fully to standard also required splitting two oversized suites, each already over the 100-line lint threshold before this change (`max-lines-per-function`, reported at 123 and 117 lines against the pre-change tree). Following the same `reporting.pg.test.ts` shape, the seeded ids and the seed/teardown hooks move to module scope and each file's single describe becomes two that split by SUBJECT over that one shared fixture: `list-stale` into the staleness predicate and then the envelope/paging/namespace-boundary rules; `promotion` into the promotion rules and then the identity rules with `list_namespaces`. No test body changed and the fixture is seeded once either way.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED, before any edit, at `origin/main` with the three files named via `CHANGED_FILES`: exit 1 — clause 1 FAIL (`const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL`, `const dbDescribe = DB_URL ? describe : describe.skip`, `if (!pool) throw ...` and the `dbDescribe(` call sites on code lines in each file), clause 2 FAIL (no import of `requireTestDatabaseUrl`), clause 3 FAIL (`exit 0, test_database_required present: no` — each file reported `0 pass, N skip, 0 fail` with the variable removed, which is the defect itself).

GREEN, on this branch, run with NO argv so the check discovers its own subject: exit 0, subject exactly the three files, all four clauses PASS — clause 3 now reports `exited 1 and printed test_database_required` for each file, and clause 4 `bun run test:isolated` over the subject exits 0.

- `./node_modules/.bin/oxlint --deny-warnings` on all three files -> exit 0 (the pre-change tree reported 16 errors across them: `node/no-process-env`, `typescript/no-non-null-assertion`, `eslint/max-lines-per-function`).
- `bunx tsc --noEmit` -> exit 0.
- `bun run test:isolated` (whole suite, no path) -> 3944 pass, 35 skip, 0 fail across 261 files, exit 0.

## Critical Self-Review

- Highest-risk behavior: the pool is now constructed unconditionally at module scope, so importing any of these files without the variable throws during module evaluation rather than at first use. That is the intended behavior and clause 3 observes it, but it means these files can no longer be imported for any purpose in an environment without a test database.
- Assumptions that could be wrong: that no other module imports these `.pg.test.ts` files (nothing should import a test file, and `rg` found no importer). Also that the removed `if (!pool) return` early returns in `beforeAll`/`afterAll` were purely type guards and never a real runtime path — true only because the pool is now non-nullable, which the typechecker confirms.
- Missing/weak tests: no new test asserts the throw itself; that assertion lives in the done-means check's clause 3 rather than in the suite, which is the pattern `reporting.pg.test.ts` established. The `requireTestDatabaseUrl` helper's own behavior is not unit-tested in this PR.
- Security/permission risk: none. No auth, namespace predicate, SQL, or role handling is touched; the namespace-boundary tests in `list-stale` and the promoter-identity tests in `promotion` are carried over unmodified and still run.
- Migration/deploy risk: none. Test-only files, no schema and no runtime code.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python-client surface changes, so `docs/downstream-rollout.md` does not apply.
- Rollback/cleanup concern: a plain revert restores the previous files exactly; there is no state to unwind. The describe split is contained within each file.
- Fixes made before PR: the initial conversion left both `list-stale` and `promotion` failing `max-lines-per-function` — pre-existing, but rule 25 requires each touched file fully to standard — so both were split by subject over a module-scope fixture before committing, and oxlint re-run to 0 on the committed tree.
- Known residual risk: the pre-push hook's first full-suite run failed one unrelated test, `maintenance runtime lease boundary (live Postgres) > dead-letters an expired lease that has consumed its attempts instead of reclaiming it`, in `server/maintenance/maintenance.pg.test.ts`. That file is untouched here; it passed on its own (6 pass, 0 fail), passed in my own full-suite run of the identical tree, and passed on the hook's second run. It reads as flake in a file this change cannot reach, and it is worth a separate look.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane is a mechanical application of a pattern already landed and already gated by an executable done-means check, and it surfaced no new review finding — the one lint surprise (pre-existing oversized suites blocking a to-standard touch) is already covered by the repo's rule 25 and by the check itself.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: test-only change with no runtime, schema, or client-facing surface.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, tool schema, or envelope shape changes — this only alters how three Postgres test files obtain their connection string.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable throughout: no MCP tool, schema, protocol, transport, or Python-client change. The diff is three `.pg.test.ts` files.
