### PR TITLE
test(pg): chunk-write, maintenance-queue, session-events-recall and set-tier require the test database instead of skipping (#878)

### DIFF
--- a/src/chunk-write.pg.test.ts
+++ b/src/chunk-write.pg.test.ts
@@ -6,9 +6,9 @@
  * must land as a parent row holding the COMPLETE text with its own vector,
  * plus chunk rows that each carry their own vector and point back at it.
  *
- * Gated on OPENBRAIN_TEST_DATABASE_URL (repo convention); skips when unset.
- * NOTE: a skipped run proves nothing -- set the variable when the result of
- * this file is being used as evidence.
+ * REQUIRES the test database, and fails hard without it (operator ruling
+ * 2026-08-27, issue #878): a suite that skips itself reports a false green.
+ * `bun run test:isolated` supplies it.
  *
  * The embedding PROVIDER is stubbed with a deterministic vector so the test
  * does not depend on a live MLX endpoint; the splitting, the inserts, the
@@ -20,9 +20,8 @@ import { runMigrations } from "./db/migrate.ts";
 import { EMBEDDING_DIMENSIONS, contentHash } from "./embedding.ts";
 import { writeEntryChunks } from "./chunk-write.ts";
 import { toSql } from "pgvector/pg";
+import { requireTestDatabaseUrl } from "../scripts/test-support/require-test-database.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
 
 // Per-process namespace so concurrent CI runs cannot collide. The `check` job
 // runs against a SHARED, persistent Postgres on the runner (unlike the
@@ -38,33 +37,32 @@ const CREATED_BY = "chunk-write-test";
 const stubEmbed = async (): Promise<number[]> =>
   Array(EMBEDDING_DIMENSIONS).fill(0.01);
 
-dbDescribe("parent + chunk entry storage (live Postgres)", () => {
-  let pool: Pool;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
-  beforeAll(async () => {
-    pool = new Pool({ connectionString: DB_URL });
-    await runMigrations(pool);
-  });
+beforeAll(async () => {
+  await runMigrations(pool);
+});
 
-  afterAll(async () => {
-    await pool.end();
-  });
+afterAll(async () => {
+  await pool.end();
+});
 
-  afterEach(async () => {
-    await pool.query(`DELETE FROM thoughts WHERE namespace = $1`, [NS]);
-  });
+afterEach(async () => {
+  await pool.query(`DELETE FROM thoughts WHERE namespace = $1`, [NS]);
+});
 
-  async function insertParent(content: string): Promise<string> {
-    const { rows } = await pool.query(
-      `INSERT INTO thoughts
-         (content, tags, source, created_by, namespace, embedding, content_hash)
-       VALUES ($1, '{}', 'test', $2, $3, $4, $5)
-       RETURNING id`,
-      [content, CREATED_BY, NS, toSql(await stubEmbed()), contentHash(content)],
-    );
-    return rows[0].id as string;
-  }
+async function insertParent(content: string): Promise<string> {
+  const { rows } = await pool.query(
+    `INSERT INTO thoughts
+       (content, tags, source, created_by, namespace, embedding, content_hash)
+     VALUES ($1, '{}', 'test', $2, $3, $4, $5)
+     RETURNING id`,
+    [content, CREATED_BY, NS, toSql(await stubEmbed()), contentHash(content)],
+  );
+  return rows[0].id as string;
+}
 
+describe("parent + chunk entry storage (live Postgres)", () => {
   it("stores the parent's COMPLETE text, however long", async () => {
     // 51,283 is the longest turn actually captured in the live dogfood clone
     // (open_brain_local_20260724, ob_raw_turns, measured 2026-07-30).
@@ -127,9 +125,10 @@ dbDescribe("parent + chunk entry storage (live Postgres)", () => {
     // not disturb.
     const indexes = rows.map((row) => row.chunk_index as number);
     expect(indexes[0]).toBe(0);
-    for (let i = 1; i < indexes.length; i++) {
-      expect(indexes[i]!).toBeGreaterThan(indexes[i - 1]!);
-    }
+    const strictlyIncreasing = indexes.every(
+      (value, i, all) => i === 0 || value > (all[i - 1] ?? Number.NEGATIVE_INFINITY),
+    );
+    expect(strictlyIncreasing).toBe(true);
   });
 
   it("keeps text that only appears in the middle of a long entry", async () => {
@@ -158,6 +157,9 @@ dbDescribe("parent + chunk entry storage (live Postgres)", () => {
     expect(rows[0].hits).toBeGreaterThan(0);
   });
 
+});
+
+describe("chunk write duplicate and fallback handling (live Postgres)", () => {
   it("reports repeated chunks as duplicates rather than as written rows", async () => {
     // Long entries with repeated text (log dumps, retried tool output) produce
     // byte-identical chunks. The row is refused by the content_hash unique

--- a/src/maintenance-queue.pg.test.ts
+++ b/src/maintenance-queue.pg.test.ts
@@ -4,8 +4,9 @@
  * the real CHECK constraint on last_error_category, and the real CASE forks in
  * MaintenanceQueue.fail.
  *
- * Gated on OPENBRAIN_TEST_DATABASE_URL (repo convention); skips when unset so a
- * DB-less CI job passes while the db-integration job runs it against Postgres.
+ * REQUIRES the test database, and fails hard without it (operator ruling
+ * 2026-08-27, issue #878): a suite that skips itself reports a false green.
+ * `bun run test:isolated` supplies it.
  *
  * The two facts proven end to end:
  *  1. A terminal handler failure dead-letters on attempt 1 — before the retry
@@ -23,7 +24,7 @@ import {
   expect,
   it,
 } from "bun:test";
-import type { Pool } from "pg";
+import { Pool } from "pg";
 import { runMigrations } from "./db/migrate.ts";
 import {
   MaintenanceQueue,
@@ -31,42 +32,38 @@ import {
   MaintenanceTerminalError,
   type MaintenanceJob,
 } from "./maintenance-queue.ts";
+import { requireTestDatabaseUrl } from "../scripts/test-support/require-test-database.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
 
 // Every job this suite enqueues shares this idempotency-key prefix so cleanup
 // deletes exactly the queue rows this suite owns and nothing else.
 const JOB_KEY_PREFIX = "lane346-queue-";
 
-dbDescribe("maintenance queue terminal dead-letter (live Postgres)", () => {
-  let pool: Pool;
-  let queue: MaintenanceQueue;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+let queue: MaintenanceQueue;
 
-  beforeAll(async () => {
-    const { Pool } = await import("pg");
-    pool = new Pool({ connectionString: DB_URL });
-    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
-    await runMigrations(pool);
-    queue = new MaintenanceQueue(pool);
-  });
+beforeAll(async () => {
+  await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+  await runMigrations(pool);
+  queue = new MaintenanceQueue(pool);
+});
 
-  afterAll(async () => {
-    await cleanup();
-    await pool.end();
-  });
+afterAll(async () => {
+  await cleanup();
+  await pool.end();
+});
 
-  async function cleanup(): Promise<void> {
-    await pool.query(
-      "DELETE FROM maintenance_jobs WHERE idempotency_key LIKE $1",
-      [`${JOB_KEY_PREFIX}%`],
-    );
-  }
+async function cleanup(): Promise<void> {
+  await pool.query(
+    "DELETE FROM maintenance_jobs WHERE idempotency_key LIKE $1",
+    [`${JOB_KEY_PREFIX}%`],
+  );
+}
 
-  beforeEach(cleanup);
+beforeEach(cleanup);
 
-  /** Enqueue one bounded test job and claim it so it is running at attempts=1. */
-  async function enqueueAndClaim(key: string): Promise<MaintenanceJob> {
+/** Enqueue one bounded test job and claim it so it is running at attempts=1. */
+async function enqueueAndClaim(key: string): Promise<MaintenanceJob> {
     await queue.enqueue({
       kind: "maintenance.test",
       version: 1,
@@ -92,6 +89,7 @@ dbDescribe("maintenance queue terminal dead-letter (live Postgres)", () => {
     return rows[0];
   }
 
+describe("maintenance queue terminal dead-letter (live Postgres)", () => {
   it("dead-letters a terminal failure on attempt 1, before the retry bound", async () => {
     const job = await enqueueAndClaim("terminal-1");
     expect(job.attempts).toBe(1);
@@ -152,6 +150,9 @@ dbDescribe("maintenance queue terminal dead-letter (live Postgres)", () => {
     expect(row.last_error_category).toBe("terminal");
   });
 
+});
+
+describe("maintenance queue handler lease renewal (live Postgres)", () => {
   it("renews a live handler lease across competing claim windows", async () => {
     await queue.enqueue({
       kind: "maintenance.heartbeat-test",

--- a/src/tools/__tests__/session-events-recall.pg.test.ts
+++ b/src/tools/__tests__/session-events-recall.pg.test.ts
@@ -21,9 +21,9 @@
  * carrying the auth-derived namespace through the lane join exposes every
  * agent's session history to every other namespace.
  *
- * Gated on OPENBRAIN_TEST_DATABASE_URL (repo dbDescribe convention). Note that
- * without it these SKIP SILENTLY -- a green `bun test` run with the variable
- * unset has proven nothing here.
+ * REQUIRES the test database, and fails hard without it (operator ruling
+ * 2026-08-27, issue #878): a suite that skips itself reports a false green.
+ * `bun run test:isolated` supplies it.
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
@@ -33,10 +33,10 @@ import {
   executeSearch as executeSearchServer,
   readableSearchSources,
 } from "../../../server/tools/search-engine.ts";
+import pino from "pino";
 import { createMockEmbed } from "./test-helpers.ts";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
 
 const CREATED_BY = "session-events-recall-pg-test";
 const OWNER_NS = "test-433-owner";
@@ -46,59 +46,72 @@ const OTHER_NS = "test-433-other";
 // on its own, so a vector hit cannot mask a lexical path that was never wired.
 const embed = createMockEmbed(null);
 
-dbDescribe("session-event recall visibility (#433 defect 1)", () => {
-  const pool = new Pool({ connectionString: DB_URL });
-  const deps = { pool: pool as any, embedFn: embed };
+/** The subset of a search result row these assertions read. */
+type SearchRow = {
+  source_type?: unknown;
+  source_ref?: unknown;
+  namespace?: unknown;
+  content_preview?: unknown;
+};
 
-  beforeAll(async () => {
-    await runMigrations(pool as any);
-  });
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
-  afterEach(async () => {
-    await cleanup();
-  });
+const deps = { pool, embedFn: embed, logger: pino({ level: "silent" }) };
 
-  afterAll(async () => {
-    await cleanup();
-    await pool.end();
-  });
+beforeAll(async () => {
+  await runMigrations(pool);
+});
 
-  async function cleanup(): Promise<void> {
-    await pool.query(
-      `DELETE FROM ob_session_events
-        WHERE lane_id IN (SELECT id FROM ob_session_lanes WHERE created_by = $1)`,
-      [CREATED_BY],
-    );
-    await pool.query("DELETE FROM ob_session_lanes WHERE created_by = $1", [
-      CREATED_BY,
-    ]);
-  }
+afterEach(async () => {
+  await cleanup();
+});
 
-  /** Seed one lane in `namespace` holding one event whose content is `content`. */
-  async function seedEvent(
-    namespace: string,
-    content: string,
-  ): Promise<string> {
-    const { rows } = await pool.query<{ id: string }>(
-      `INSERT INTO ob_session_lanes (session_key, namespace, created_by)
-       VALUES ($1, $2, $3) RETURNING id`,
-      [`${CREATED_BY}-${namespace}-${content.slice(0, 12)}`, namespace, CREATED_BY],
-    );
-    const laneId = rows[0]!.id;
-    await pool.query(
-      `INSERT INTO ob_session_events (lane_id, event_type, content, importance, created_by)
-       VALUES ($1, 'fact', $2, 'hot', $3)`,
-      [laneId, content, CREATED_BY],
-    );
-    return laneId;
-  }
+afterAll(async () => {
+  await cleanup();
+  await pool.end();
+});
 
-  function markerRows(rows: readonly any[], marker: string): any[] {
-    return rows.filter((row) =>
-      String(row.content_preview ?? "").includes(marker),
-    );
-  }
+async function cleanup(): Promise<void> {
+  await pool.query(
+    `DELETE FROM ob_session_events
+      WHERE lane_id IN (SELECT id FROM ob_session_lanes WHERE created_by = $1)`,
+    [CREATED_BY],
+  );
+  await pool.query("DELETE FROM ob_session_lanes WHERE created_by = $1", [
+    CREATED_BY,
+  ]);
+}
 
+/** Seed one lane in `namespace` holding one event whose content is `content`. */
+async function seedEvent(
+  namespace: string,
+  content: string,
+): Promise<string> {
+  const { rows } = await pool.query<{ id: string }>(
+    `INSERT INTO ob_session_lanes (session_key, namespace, created_by)
+     VALUES ($1, $2, $3) RETURNING id`,
+    [`${CREATED_BY}-${namespace}-${content.slice(0, 12)}`, namespace, CREATED_BY],
+  );
+  const laneId = rows[0]?.id as string | undefined;
+  if (!laneId) throw new Error("seed lane insert returned no id");
+  await pool.query(
+    `INSERT INTO ob_session_events (lane_id, event_type, content, importance, created_by)
+     VALUES ($1, 'fact', $2, 'hot', $3)`,
+    [laneId, content, CREATED_BY],
+  );
+  return laneId;
+}
+
+function markerRows(
+  rows: readonly SearchRow[],
+  marker: string,
+): SearchRow[] {
+  return rows.filter((row) =>
+    String(row.content_preview ?? "").includes(marker),
+  );
+}
+
+describe("session-event recall visibility (#433 defect 1)", () => {
   it("brain_answer's source list reaches the session-event corpus", () => {
     // The regression that started #433 was a table list, so pin the list. Both
     // serving trees are asserted because both are live: server/main.ts is the
@@ -125,13 +138,16 @@ dbDescribe("session-event recall visibility (#433 defect 1)", () => {
     expect(readableSearchSources("discord")).not.toContain("session_events");
   });
 
+});
+
+describe("session-event recall against live Postgres (#433 defect 1)", () => {
   it("surfaces a session event from the src serving tree", async () => {
     const marker = "marker433src";
     await seedEvent(OWNER_NS, `${marker} a thing that happened this session`);
 
     const rows = await executeSearch(
       deps,
-      readableSearchTables("admin") as any,
+      readableSearchTables("admin"),
       marker,
       25,
       "keyword",
@@ -142,11 +158,11 @@ dbDescribe("session-event recall visibility (#433 defect 1)", () => {
 
     const hits = markerRows(rows, marker);
     expect(hits.length).toBe(1);
-    expect(hits[0]!.source_type).toBe("session_event");
+    expect(hits[0]?.source_type).toBe("session_event");
     // brain_answer refuses to cite a row without citation metadata, so an
     // invisible-to-citation row would be as useless as an unsearchable one.
-    expect(hits[0]!.source_ref).toBeTruthy();
-    expect(hits[0]!.namespace).toBe(OWNER_NS);
+    expect(hits[0]?.source_ref).toBeTruthy();
+    expect(hits[0]?.namespace).toBe(OWNER_NS);
   });
 
   it("surfaces a session event from the server serving tree", async () => {
@@ -154,8 +170,8 @@ dbDescribe("session-event recall visibility (#433 defect 1)", () => {
     await seedEvent(OWNER_NS, `${marker} a thing that happened this session`);
 
     const rows = await executeSearchServer(
-      deps as any,
-      readableSearchSources("admin") as any,
+      deps,
+      readableSearchSources("admin"),
       marker,
       25,
       "keyword",
@@ -166,8 +182,8 @@ dbDescribe("session-event recall visibility (#433 defect 1)", () => {
 
     const hits = markerRows(rows, marker);
     expect(hits.length).toBe(1);
-    expect(hits[0]!.source_type).toBe("session_event");
-    expect(hits[0]!.namespace).toBe(OWNER_NS);
+    expect(hits[0]?.source_type).toBe("session_event");
+    expect(hits[0]?.namespace).toBe(OWNER_NS);
   });
 
   it("does not leak another namespace's session events (src tree)", async () => {
@@ -180,7 +196,7 @@ dbDescribe("session-event recall visibility (#433 defect 1)", () => {
 
     const rows = await executeSearch(
       deps,
-      readableSearchTables("admin") as any,
+      readableSearchTables("admin"),
       marker,
       25,
       "keyword",
@@ -197,8 +213,8 @@ dbDescribe("session-event recall visibility (#433 defect 1)", () => {
     await seedEvent(OWNER_NS, `${marker} private to the owning namespace`);
 
     const rows = await executeSearchServer(
-      deps as any,
-      readableSearchSources("admin") as any,
+      deps,
+      readableSearchSources("admin"),
       marker,
       25,
       "keyword",
@@ -221,7 +237,7 @@ dbDescribe("session-event recall visibility (#433 defect 1)", () => {
 
     const rows = await executeSearch(
       deps,
-      readableSearchTables("admin") as any,
+      readableSearchTables("admin"),
       shared,
       25,
       "keyword",
@@ -232,7 +248,7 @@ dbDescribe("session-event recall visibility (#433 defect 1)", () => {
 
     const hits = markerRows(rows, shared);
     expect(hits.length).toBe(1);
-    expect(hits[0]!.namespace).toBe(OWNER_NS);
-    expect(String(hits[0]!.content_preview)).toContain("owned by the caller");
+    expect(hits[0]?.namespace).toBe(OWNER_NS);
+    expect(String(hits[0]?.content_preview)).toContain("owned by the caller");
   });
 });

--- a/src/tools/__tests__/set-tier.pg.test.ts
+++ b/src/tools/__tests__/set-tier.pg.test.ts
@@ -22,7 +22,9 @@
  *     including a same-value write, which must report success rather than
  *     "not found" -- UPDATE matches the row even when the value is unchanged.
  *
- * Gated on OPENBRAIN_TEST_DATABASE_URL (repo dbDescribe convention).
+ * REQUIRES the test database, and fails hard without it (operator ruling
+ * 2026-08-27, issue #878): a suite that skips itself reports a false green.
+ * `bun run test:isolated` supplies it.
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
@@ -33,9 +35,8 @@ import { runMigrations } from "../../db/migrate.ts";
 import { registerSetTier } from "../set-tier.ts";
 import type { ToolDeps } from "../index.ts";
 import type { AuthInfo } from "../../types.ts";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
 
 const CREATED_BY = "dream-set-tier-pg-test";
 const OWNER_NS = "dream-set-tier-owner-ns";
@@ -49,90 +50,89 @@ const ownerAuth: AuthInfo = {
   namespaceSource: "token",
 };
 
-dbDescribe("set_tier (live Postgres)", () => {
-  let pool: Pool;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
-  beforeAll(async () => {
-    pool = new Pool({ connectionString: DB_URL });
-    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
-    await runMigrations(pool);
-    await cleanup();
-  });
+beforeAll(async () => {
+  await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+  await runMigrations(pool);
+  await cleanup();
+});
 
-  afterEach(cleanup);
+afterEach(cleanup);
 
-  afterAll(async () => {
-    await cleanup();
-    await pool.end();
-  });
+afterAll(async () => {
+  await cleanup();
+  await pool.end();
+});
 
-  async function cleanup(): Promise<void> {
-    for (const table of ["thoughts", "decisions"]) {
-      await pool.query(`DELETE FROM ${table} WHERE created_by = $1`, [
-        CREATED_BY,
-      ]);
-    }
+async function cleanup(): Promise<void> {
+  for (const table of ["thoughts", "decisions"]) {
+    await pool.query(`DELETE FROM ${table} WHERE created_by = $1`, [
+      CREATED_BY,
+    ]);
   }
+}
 
-  async function seedThought(opts: {
-    namespace: string;
-    tier: string;
-    content: string;
-    archivedAt?: Date | null;
-  }): Promise<string> {
-    const { rows } = await pool.query(
-      `INSERT INTO thoughts (content, created_by, namespace, tier, archived_at)
-       VALUES ($1, $2, $3, $4, $5) RETURNING id`,
-      [
-        opts.content,
-        CREATED_BY,
-        opts.namespace,
-        opts.tier,
-        opts.archivedAt ?? null,
-      ],
-    );
-    return rows[0].id as string;
+async function seedThought(opts: {
+  namespace: string;
+  tier: string;
+  content: string;
+  archivedAt?: Date | null;
+}): Promise<string> {
+  const { rows } = await pool.query(
+    `INSERT INTO thoughts (content, created_by, namespace, tier, archived_at)
+     VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+    [
+      opts.content,
+      CREATED_BY,
+      opts.namespace,
+      opts.tier,
+      opts.archivedAt ?? null,
+    ],
+  );
+  return rows[0].id as string;
+}
+
+async function readRow(id: string): Promise<Record<string, unknown>> {
+  const { rows } = await pool.query(
+    `SELECT id, tier, namespace, archived_at, content, updated_at
+       FROM thoughts WHERE id = $1`,
+    [id],
+  );
+  return rows[0];
+}
+
+async function readTier(id: string): Promise<string> {
+  return (await readRow(id)).tier as string;
+}
+
+async function callSetTier(
+  auth: AuthInfo,
+  args: { table: string; id: string; tier: string },
+) {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool, embedFn: async () => null };
+  registerSetTier(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message, options) =>
+    originalSend(message, { ...options, authInfo: auth } as never);
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  try {
+    return await client.callTool({ name: "set_tier", arguments: args });
+  } finally {
+    await client.close();
+    await server.close();
   }
+}
 
-  async function readRow(id: string): Promise<Record<string, unknown>> {
-    const { rows } = await pool.query(
-      `SELECT id, tier, namespace, archived_at, content, updated_at
-         FROM thoughts WHERE id = $1`,
-      [id],
-    );
-    return rows[0];
-  }
-
-  async function readTier(id: string): Promise<string> {
-    return (await readRow(id)).tier as string;
-  }
-
-  async function callSetTier(
-    auth: AuthInfo,
-    args: { table: string; id: string; tier: string },
-  ) {
-    const server = new McpServer({ name: "test", version: "1.0.0" });
-    const deps: ToolDeps = { pool: pool as any, embedFn: async () => null };
-    registerSetTier(server, deps);
-
-    const [clientTransport, serverTransport] =
-      InMemoryTransport.createLinkedPair();
-    const originalSend = clientTransport.send.bind(clientTransport);
-    clientTransport.send = (message: any, options?: any) =>
-      originalSend(message, { ...options, authInfo: auth });
-
-    const client = new Client({ name: "test-client", version: "1.0.0" });
-    await server.connect(serverTransport);
-    await client.connect(clientTransport);
-
-    try {
-      return await client.callTool({ name: "set_tier", arguments: args });
-    } finally {
-      await client.close();
-      await server.close();
-    }
-  }
-
+describe("set_tier (live Postgres)", () => {
   it("persists the new tier for a row in the caller's namespace", async () => {
     const id = await seedThought({
       namespace: OWNER_NS,
@@ -147,7 +147,7 @@ dbDescribe("set_tier (live Postgres)", () => {
     });
 
     expect(result.isError).toBeFalsy();
-    expect(JSON.parse((result.content as any)[0].text)).toEqual({
+    expect(JSON.parse((result.content as Array<{ text: string }>)[0]?.text ?? "")).toEqual({
       id,
       table: "thoughts",
       tier: "hot",
@@ -176,7 +176,7 @@ dbDescribe("set_tier (live Postgres)", () => {
     // would confirm the existence of a row in a namespace the caller cannot
     // read. Pinned here so the ambiguity is understood as intended.
     expect(result.isError).toBe(true);
-    expect((result.content as any)[0].text).toBe("Entry not found or archived");
+    expect((result.content as Array<{ text: string }>)[0]?.text ?? "").toBe("Entry not found or archived");
 
     // The whole row, not just the tier: this is the assertion the mock cannot
     // make, and the one that fails if the predicate is ever dropped.
@@ -193,7 +193,7 @@ dbDescribe("set_tier (live Postgres)", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect((result.content as any)[0].text).toBe("Entry not found or archived");
+    expect((result.content as Array<{ text: string }>)[0]?.text ?? "").toBe("Entry not found or archived");
   });
 
   it("refuses an archived row in the caller's own namespace", async () => {
@@ -252,7 +252,7 @@ dbDescribe("set_tier (live Postgres)", () => {
     });
 
     expect(result.isError).toBeFalsy();
-    expect(JSON.parse((result.content as any)[0].text).tier).toBe("hot");
+    expect(JSON.parse((result.content as Array<{ text: string }>)[0]?.text ?? "").tier).toBe("hot");
     expect(await readTier(id)).toBe("hot");
   });
 });


### PR DESCRIPTION
## Summary

- Four `.pg.test.ts` files under `src/` read `OPENBRAIN_TEST_DATABASE_URL` themselves and swapped in `describe.skip` when it was unset. Such a suite reports `0 pass, N skip, 0 fail` and exits 0, which at the exit code is indistinguishable from a suite that ran and passed. CI stays green while the Postgres behavior nobody exercised drifts underneath it.
- Each file now imports `requireTestDatabaseUrl` from `scripts/test-support/require-test-database.ts` and builds its pool from it at module scope, so an absent variable throws `test_database_required` and takes the run down loudly. This follows the shape already landed in `server/tools/reporting.pg.test.ts` on main: no `DB_URL` constant, no `dbDescribe`, plain `describe`, pool constructed once rather than assigned inside `beforeAll`.
- `src/maintenance-queue.pg.test.ts` also drops its dynamic `await import("pg")`, which existed only to defer pool construction past the skip decision, and its `import type { Pool }` becomes a value import.
- Every test and assertion is preserved. No behavior under test changed; the four files hold the same cases before and after.
- Files: `src/chunk-write.pg.test.ts`, `src/maintenance-queue.pg.test.ts`, `src/tools/__tests__/session-events-recall.pg.test.ts`, `src/tools/__tests__/set-tier.pg.test.ts`.

Each file was brought fully to standard on first touch, because the pre-commit gate lints staged files whole rather than only the changed hunks:

- Hooks and helpers hoisted to module scope, which is what the reporting exemplar does and what brings the top-level `describe` callbacks back under the 100-line rule.
- Where hoisting alone was not enough, the suites split at a real subject seam rather than an arbitrary line: handler-lease renewal separated from terminal dead-lettering, duplicate/fallback handling from parent+chunk storage, and live-Postgres recall from the source-list assertions that need no database at all.
- `no-explicit-any` cleared by typing what the assertions actually read: a local `SearchRow` covering the four fields touched, `Array<{ text: string }>` for MCP tool content, and `as never` on the transport `authInfo` — the same three shapes the exemplar uses. Dropping `pool as any` let the real `ToolDeps` and `SearchDependencies` types apply, which is what surfaced a genuinely missing `logger` on the two server-tree `executeSearch` calls.
- `no-non-null-assertion` cleared without weakening any assertion: the chunk-index monotonicity check became an `every` over the array, and the session-event seed helper now throws a named error if the lane insert returns no id.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED, taken at `origin/main` before any edit existed to discover, via the `CHANGED_FILES` override: exit 1, with CLAUSE 1 (self-skipping machinery survives), CLAUSE 2 (no import of `requireTestDatabaseUrl`) and CLAUSE 3 (exit 0, `test_database_required` absent) all FAIL on each of the four files. CLAUSE 4 already passed, which is the point of the RED — the tests worked, they just never had to run.

GREEN, on this branch with no argv so the check discovers its own subject: exit 0, subject exactly the four files above, CLAUSE 1/2/3/4 all PASS.

- `./node_modules/.bin/oxlint --deny-warnings <file>` → 0 errors on each of the four files, no disable comments added.
- `bunx tsc --noEmit` → exit 0.
- `bun run test:isolated` (whole suite, no path) → 3944 pass, 35 skip, 0 fail, 15957 expect() calls across 261 files, exit 0. Run before push; the pre-push hook ran the isolated runner again and passed.
- Longest file after the change is 258 lines, well under the 500-line file rule.

Python package untouched. No migration, no schema change, no runtime source change — this PR touches four test files and nothing else.

## Critical Self-Review

- Highest-risk behavior: a conversion that silently drops a test or weakens an assertion while still satisfying all four clauses. Clause 4 only proves the surviving tests pass, not that the same tests survived. Checked by diffing the case list before and after: every `it` title is present in both, the count is unchanged per file, and the suite total moved only by the tests these files contribute.
- Assumptions that could be wrong: that hoisting `beforeAll`/`afterAll`/`afterEach` from inside a `describe` to module scope leaves ordering unchanged. In `bun:test` a module-scope hook applies to the whole file rather than one block, which is a real widening where a file now has more than one `describe`. It is safe here because in every split file the hooks are the same setup and the same cleanup that both halves already needed, and clause 4 exercises it — but it is the assumption I would attack first.
- Missing/weak tests: no test asserts the hard-fail behavior from inside the suites themselves; that lives in the done-means clause 3, which runs each file with `env -u OPENBRAIN_TEST_DATABASE_URL` and demands both a non-zero exit and the `test_database_required` string. That is a check, not a test, so it protects the branch but does not follow the files if the check is later deleted.
- Security/permission risk: none introduced. The namespace-boundary assertions in `set-tier.pg.test.ts` and `session-events-recall.pg.test.ts` are unchanged in content. Their value goes UP: those are exactly the isolation predicates that a silent skip was leaving unproven, and they now cannot be skipped.
- Migration/deploy risk: none. No migration, no schema, no runtime code path touched.
- Downstream client/runtime risk: none. Per `docs/downstream-rollout.md` this is test-only with no MCP tool, schema, transport, or client-facing surface change, so no rtech-mcps, mcp2cli, or Hermes step applies.
- Rollback/cleanup concern: revert of this single commit is clean and self-contained; it restores the four files verbatim and nothing else depends on them.
- Fixes made before PR: dropping `pool as any` surfaced a missing `logger` on the two `executeSearchServer` calls in `session-events-recall.pg.test.ts` — the `any` had been hiding an incomplete `SearchDependencies`. Fixed by passing `pino({ level: "silent" })`, matching the exemplar, rather than by re-widening the type.
- Known residual risk: the module-scope hook widening described above, and the fact that a `describe` split changes test *grouping* in reporter output. Neither changes what is asserted, but a reader diffing CI output by group name will see the new groups.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical conversion to an already-landed exemplar under an existing operator ruling, and the reusable lesson (a self-skipping pg suite is a false green) is already captured by `scripts/test-support/require-test-database.ts` and its done-means check, which enforce it on every future lane rather than asking a reviewer to remember it.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: test-only change, no runtime or contract surface touched.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched — the change is confined to four TypeScript test files.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Test-only change. `docs/downstream-rollout.md` scopes the rollout gate to MCP tool, schema, protocol, and client-facing changes; none apply, so every downstream step is not applicable rather than complete.
- Batch 1, lane D of issue #878. The helper and the done-means check landed with `server/tools/reporting.pg.test.ts` in #879; this PR converts four of the remaining `src/` suites against them.
