### PR TITLE
test(pg): promote-entry, tier-recommendations and the nats worker watermark test require the test database instead of skipping (#878)

### DIFF
--- a/scripts/run-nats-worker-live-watermark.pg.test.ts
+++ b/scripts/run-nats-worker-live-watermark.pg.test.ts
@@ -77,13 +77,14 @@
  * behavior and is expected to FAIL until an observer is built by default. This
  * file does not implement it.
  *
- * Gated on OPENBRAIN_TEST_DATABASE_URL (repo dbDescribe convention). Run it the
- * trustworthy way, per AGENTS.md:
+ * REQUIRES OPENBRAIN_TEST_DATABASE_URL and fails hard without it (operator
+ * ruling 2026-08-27, issue #878). Run it the trustworthy way, per AGENTS.md:
  *
  *   bun run test:isolated scripts/run-nats-worker-live-watermark.pg.test.ts
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "./test-support/require-test-database.ts";
 import { runMigrations } from "../src/db/migrate.ts";
 import { createNatsBridgeHealth } from "../src/nats-bridge.ts";
 import {
@@ -92,8 +93,6 @@ import {
 } from "../src/nats-worker.ts";
 import { startNatsWorkerProcess } from "./run-nats-worker.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
 
 /** Namespace/author marker so this file's rows are identifiable and removable. */
 const CREATED_BY = "wm-live-observer-pg-test";
@@ -254,11 +253,11 @@ function requireBlock(body: Record<string, unknown>): EmbedWatermarkBlock {
   return block as EmbedWatermarkBlock;
 }
 
-dbDescribe(
+describe(
   "nats worker composes a LIVE embed watermark observer by default (#724 item 3)",
   () => {
     beforeAll(async () => {
-      pool = new Pool({ connectionString: DB_URL });
+      pool = new Pool({ connectionString: requireTestDatabaseUrl() });
       await runMigrations(pool);
     });
 

--- a/src/tools/__tests__/promote-entry.pg.test.ts
+++ b/src/tools/__tests__/promote-entry.pg.test.ts
@@ -26,20 +26,20 @@
  *  6. Frozen-namespace and same-namespace rejections are enforced, and the
  *     kill switch blocks apply mode while leaving dry-run available.
  *
- * Gated on OPENBRAIN_TEST_DATABASE_URL (repo dbDescribe convention).
+ * REQUIRES OPENBRAIN_TEST_DATABASE_URL and fails hard without it (operator
+ * ruling 2026-08-27, issue #878). `bun run test:isolated` sets it.
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
 import { runMigrations } from "../../db/migrate.ts";
 import { registerPromoteEntry } from "../promote-entry.ts";
 import type { ToolDeps } from "../index.ts";
 import type { AuthInfo } from "../../types.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
 
 const CREATED_BY = "dream-promote-entry-pg-test";
 const SOURCE_NS = "dream-promote-source-ns";
@@ -52,94 +52,99 @@ const promoterAuth: AuthInfo = {
   clientId: "promoter-client",
 };
 
-dbDescribe("promote_entry (live Postgres)", () => {
-  let pool: Pool;
+/** First text block of an MCP tool result, or "" when the result carries none. */
+function textOf(result: Record<string, unknown>): string {
+  return (result.content as Array<{ text: string }> | undefined)?.[0]?.text ?? "";
+}
 
-  beforeAll(async () => {
-    pool = new Pool({ connectionString: DB_URL });
-    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
-    await runMigrations(pool);
-    await cleanup();
-  });
+let pool: Pool;
 
-  afterEach(async () => {
-    delete process.env.OPENBRAIN_PROMOTION_KILL_SWITCH;
-    await cleanup();
-  });
+beforeAll(async () => {
+  pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+  await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+  await runMigrations(pool);
+  await cleanup();
+});
 
-  afterAll(async () => {
-    await cleanup();
-    await pool.end();
-  });
+afterEach(async () => {
+  delete process.env.OPENBRAIN_PROMOTION_KILL_SWITCH;
+  await cleanup();
+});
 
-  async function cleanup(): Promise<void> {
-    // Promoted copies inherit created_by from the source, so this deletes the
-    // copies as well as the originals.
-    for (const table of ["thoughts", "decisions"]) {
-      await pool.query(`DELETE FROM ${table} WHERE created_by = $1`, [
-        CREATED_BY,
-      ]);
-    }
+afterAll(async () => {
+  await cleanup();
+  await pool.end();
+});
+
+async function cleanup(): Promise<void> {
+  // Promoted copies inherit created_by from the source, so this deletes the
+  // copies as well as the originals.
+  for (const table of ["thoughts", "decisions"]) {
+    await pool.query(`DELETE FROM ${table} WHERE created_by = $1`, [
+      CREATED_BY,
+    ]);
   }
+}
 
-  async function seedThought(opts: {
-    namespace: string;
-    content: string;
-    contentHash?: string;
-    metadata?: Record<string, unknown>;
-  }): Promise<string> {
-    const { rows } = await pool.query(
-      `INSERT INTO thoughts (content, created_by, namespace, content_hash, extracted_metadata)
-       VALUES ($1, $2, $3, $4, $5::jsonb) RETURNING id`,
-      [
-        opts.content,
-        CREATED_BY,
-        opts.namespace,
-        opts.contentHash ?? null,
-        JSON.stringify(opts.metadata ?? {}),
-      ],
-    );
-    return rows[0].id as string;
+async function seedThought(opts: {
+  namespace: string;
+  content: string;
+  contentHash?: string;
+  metadata?: Record<string, unknown>;
+}): Promise<string> {
+  const { rows } = await pool.query(
+    `INSERT INTO thoughts (content, created_by, namespace, content_hash, extracted_metadata)
+     VALUES ($1, $2, $3, $4, $5::jsonb) RETURNING id`,
+    [
+      opts.content,
+      CREATED_BY,
+      opts.namespace,
+      opts.contentHash ?? null,
+      JSON.stringify(opts.metadata ?? {}),
+    ],
+  );
+  return rows[0].id as string;
+}
+
+async function countIn(namespace: string): Promise<number> {
+  const { rows } = await pool.query(
+    `SELECT count(*)::int AS n FROM thoughts WHERE namespace = $1 AND created_by = $2`,
+    [namespace, CREATED_BY],
+  );
+  return rows[0].n as number;
+}
+
+async function callPromote(auth: AuthInfo, args: Record<string, unknown>) {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool, embedFn: async () => null };
+  registerPromoteEntry(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message, options) =>
+    originalSend(message, { ...options, authInfo: auth } as never);
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  try {
+    return await client.callTool({
+      name: "promote_entry",
+      arguments: args,
+    });
+  } finally {
+    await client.close();
+    await server.close();
   }
+}
 
-  async function countIn(namespace: string): Promise<number> {
-    const { rows } = await pool.query(
-      `SELECT count(*)::int AS n FROM thoughts WHERE namespace = $1 AND created_by = $2`,
-      [namespace, CREATED_BY],
-    );
-    return rows[0].n as number;
-  }
+function parse(result: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(textOf(result));
+}
 
-  async function callPromote(auth: AuthInfo, args: Record<string, unknown>) {
-    const server = new McpServer({ name: "test", version: "1.0.0" });
-    const deps: ToolDeps = { pool: pool as any, embedFn: async () => null };
-    registerPromoteEntry(server, deps);
-
-    const [clientTransport, serverTransport] =
-      InMemoryTransport.createLinkedPair();
-    const originalSend = clientTransport.send.bind(clientTransport);
-    clientTransport.send = (message: any, options?: any) =>
-      originalSend(message, { ...options, authInfo: auth });
-
-    const client = new Client({ name: "test-client", version: "1.0.0" });
-    await server.connect(serverTransport);
-    await client.connect(clientTransport);
-
-    try {
-      return await client.callTool({
-        name: "promote_entry",
-        arguments: args,
-      });
-    } finally {
-      await client.close();
-      await server.close();
-    }
-  }
-
-  function parse(result: any): any {
-    return JSON.parse((result.content as any)[0].text);
-  }
-
+describe("promote_entry copy semantics (live Postgres)", () => {
   it("dry_run reports a planned promotion and inserts nothing", async () => {
     // The DreamEngine safety guarantee, proven by row count rather than by the
     // report's own claim about itself.
@@ -251,6 +256,9 @@ dbDescribe("promote_entry (live Postgres)", () => {
     expect(src[0].extracted_metadata.share_candidate).toBe(true);
   });
 
+});
+
+describe("promote_entry provenance and duplicate detection (live Postgres)", () => {
   it("persists provenance to the promoted_from column", async () => {
     const id = await seedThought({
       namespace: SOURCE_NS,
@@ -312,7 +320,9 @@ dbDescribe("promote_entry (live Postgres)", () => {
     // Still exactly the one pre-existing row.
     expect(await countIn(TARGET_NS)).toBe(1);
   });
+});
 
+describe("promote_entry rejections and the kill switch (live Postgres)", () => {
   it("refuses to promote an entry into its own namespace", async () => {
     const id = await seedThought({
       namespace: SOURCE_NS,
@@ -328,7 +338,7 @@ dbDescribe("promote_entry (live Postgres)", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect((result.content as any)[0].text).toContain("already in namespace");
+    expect(textOf(result)).toContain("already in namespace");
     expect(await countIn(SOURCE_NS)).toBe(1);
   });
 
@@ -350,7 +360,7 @@ dbDescribe("promote_entry (live Postgres)", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect((result.content as any)[0].text).toContain("not found or archived");
+    expect(textOf(result)).toContain("not found or archived");
     expect(await countIn(TARGET_NS)).toBe(0);
   });
 
@@ -373,7 +383,7 @@ dbDescribe("promote_entry (live Postgres)", () => {
       dry_run: false,
     });
     expect(applied.isError).toBe(true);
-    expect((applied.content as any)[0].text).toContain("KILL_SWITCH");
+    expect(textOf(applied)).toContain("KILL_SWITCH");
     expect(await countIn(TARGET_NS)).toBe(0);
 
     const planned = await callPromote(promoterAuth, {

--- a/src/tools/__tests__/tier-recommendations.pg.test.ts
+++ b/src/tools/__tests__/tier-recommendations.pg.test.ts
@@ -31,20 +31,20 @@
  *     to the right entry and source_table -- the correlated subquery's join
  *     conditions, which a fake cannot exercise.
  *
- * Gated on OPENBRAIN_TEST_DATABASE_URL (repo dbDescribe convention).
+ * REQUIRES OPENBRAIN_TEST_DATABASE_URL and fails hard without it (operator
+ * ruling 2026-08-27, issue #878). `bun run test:isolated` sets it.
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
 import { runMigrations } from "../../db/migrate.ts";
 import { registerTierRecommendations } from "../tier-recommendations.ts";
 import type { ToolDeps } from "../index.ts";
 import type { AuthInfo } from "../../types.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
 
 const CREATED_BY = "dream-tier-rec-pg-test";
 const OWNER_NS = "dream-tier-rec-owner-ns";
@@ -55,114 +55,122 @@ const ownerAuth: AuthInfo = {
   namespaceSource: "token",
 };
 
-dbDescribe("tier_recommendations (live Postgres)", () => {
-  let pool: Pool;
+/** First text block of an MCP tool result, or "" when the result carries none. */
+function textOf(result: Record<string, unknown>): string {
+  return (result.content as Array<{ text: string }> | undefined)?.[0]?.text ?? "";
+}
 
-  beforeAll(async () => {
-    pool = new Pool({ connectionString: DB_URL });
-    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
-    await runMigrations(pool);
-    await cleanup();
-  });
+let pool: Pool;
 
-  afterEach(cleanup);
+beforeAll(async () => {
+  pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+  await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+  await runMigrations(pool);
+  await cleanup();
+});
 
-  afterAll(async () => {
-    await cleanup();
-    await pool.end();
-  });
+afterEach(cleanup);
 
-  async function cleanup(): Promise<void> {
-    // entry_access_log rows are removed first: they reference the thoughts
-    // this suite created, and they carry no created_by of their own.
-    await pool.query(
-      `DELETE FROM entry_access_log
-        WHERE entry_id IN (SELECT id FROM thoughts WHERE created_by = $1)`,
-      [CREATED_BY],
-    );
-    await pool.query(`DELETE FROM thoughts WHERE created_by = $1`, [
+afterAll(async () => {
+  await cleanup();
+  await pool.end();
+});
+
+async function cleanup(): Promise<void> {
+  // entry_access_log rows are removed first: they reference the thoughts
+  // this suite created, and they carry no created_by of their own.
+  await pool.query(
+    `DELETE FROM entry_access_log
+      WHERE entry_id IN (SELECT id FROM thoughts WHERE created_by = $1)`,
+    [CREATED_BY],
+  );
+  await pool.query(`DELETE FROM thoughts WHERE created_by = $1`, [
+    CREATED_BY,
+  ]);
+}
+
+async function seedThought(opts: {
+  content: string;
+  tier?: string;
+  accessCount?: number;
+  accessedDaysAgo?: number | null;
+  namespace?: string;
+}): Promise<string> {
+  const { rows } = await pool.query(
+    `INSERT INTO thoughts
+       (content, created_by, namespace, tier, access_count, last_accessed_at)
+     VALUES ($1, $2, $3, $4, $5,
+             CASE WHEN $6::numeric IS NULL THEN NULL
+                  ELSE NOW() - INTERVAL '1 day' * $6 END)
+     RETURNING id`,
+    [
+      opts.content,
       CREATED_BY,
-    ]);
-  }
+      opts.namespace ?? OWNER_NS,
+      opts.tier ?? "warm",
+      opts.accessCount ?? 0,
+      opts.accessedDaysAgo ?? null,
+    ],
+  );
+  return rows[0].id as string;
+}
 
-  async function seedThought(opts: {
-    content: string;
-    tier?: string;
-    accessCount?: number;
-    accessedDaysAgo?: number | null;
-    namespace?: string;
-  }): Promise<string> {
-    const { rows } = await pool.query(
-      `INSERT INTO thoughts
-         (content, created_by, namespace, tier, access_count, last_accessed_at)
-       VALUES ($1, $2, $3, $4, $5,
-               CASE WHEN $6::numeric IS NULL THEN NULL
-                    ELSE NOW() - INTERVAL '1 day' * $6 END)
-       RETURNING id`,
-      [
-        opts.content,
-        CREATED_BY,
-        opts.namespace ?? OWNER_NS,
-        opts.tier ?? "warm",
-        opts.accessCount ?? 0,
-        opts.accessedDaysAgo ?? null,
-      ],
-    );
-    return rows[0].id as string;
-  }
-
-  /** Record `count` accesses for an entry, `daysAgo` before now. */
-  async function logAccesses(
-    entryId: string,
-    count: number,
-    daysAgo: number,
-    sourceTable = "thoughts",
-  ): Promise<void> {
-    for (let i = 0; i < count; i++) {
-      await pool.query(
-        `INSERT INTO entry_access_log (entry_id, source_table, accessed_at)
-         VALUES ($1, $2, NOW() - INTERVAL '1 day' * $3)`,
-        [entryId, sourceTable, daysAgo],
-      );
-    }
-  }
-
-  async function callRecommendations(
-    auth: AuthInfo,
-    args: Record<string, unknown>,
-  ) {
-    const server = new McpServer({ name: "test", version: "1.0.0" });
-    const deps: ToolDeps = { pool: pool as any, embedFn: async () => null };
-    registerTierRecommendations(server, deps);
-
-    const [clientTransport, serverTransport] =
-      InMemoryTransport.createLinkedPair();
-    const originalSend = clientTransport.send.bind(clientTransport);
-    clientTransport.send = (message: any, options?: any) =>
-      originalSend(message, { ...options, authInfo: auth });
-
-    const client = new Client({ name: "test-client", version: "1.0.0" });
-    await server.connect(serverTransport);
-    await client.connect(clientTransport);
-
-    try {
-      return await client.callTool({
-        name: "tier_recommendations",
-        arguments: args,
-      });
-    } finally {
-      await client.close();
-      await server.close();
-    }
-  }
-
-  function previews(result: any): string[] {
-    const parsed = JSON.parse((result.content as any)[0].text);
-    return (parsed.recommendations ?? parsed.candidates ?? []).map(
-      (c: any) => c.content_preview,
+/** Record `count` accesses for an entry, `daysAgo` before now. */
+async function logAccesses(
+  entryId: string,
+  count: number,
+  daysAgo: number,
+  sourceTable = "thoughts",
+): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await pool.query(
+      `INSERT INTO entry_access_log (entry_id, source_table, accessed_at)
+       VALUES ($1, $2, NOW() - INTERVAL '1 day' * $3)`,
+      [entryId, sourceTable, daysAgo],
     );
   }
+}
 
+async function callRecommendations(
+  auth: AuthInfo,
+  args: Record<string, unknown>,
+) {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool, embedFn: async () => null };
+  registerTierRecommendations(server, deps);
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message, options) =>
+    originalSend(message, { ...options, authInfo: auth } as never);
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  try {
+    return await client.callTool({
+      name: "tier_recommendations",
+      arguments: args,
+    });
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+function previews(result: Record<string, unknown>): string[] {
+  const parsed = JSON.parse(textOf(result)) as {
+    recommendations?: Array<{ content_preview: string }>;
+    candidates?: Array<{ content_preview: string }>;
+  };
+  return (parsed.recommendations ?? parsed.candidates ?? []).map(
+    (c) => c.content_preview,
+  );
+}
+
+describe("tier_recommendations demote selection (live Postgres)", () => {
   it("demotes only warm, rarely-accessed, stale entries", async () => {
     // The candidate: warm, 1 access, last touched 90 days ago.
     await seedThought({
@@ -258,7 +266,9 @@ dbDescribe("tier_recommendations (live Postgres)", () => {
 
     expect(found).toEqual(["zero-accesses", "one-access", "two-accesses"]);
   });
+});
 
+describe("tier_recommendations promote selection (live Postgres)", () => {
   it("promotes on a strict access threshold: five is not enough, six is", async () => {
     // The promote branch counts entry_access_log rows in the window and
     // requires `> 5`. A fixture cannot show the boundary, so both sides are


### PR DESCRIPTION
## Summary

- Issue #878, batch 2 lane F. Three `.pg.test.ts` files stop skipping themselves when `OPENBRAIN_TEST_DATABASE_URL` is unset and now fail hard instead: `src/tools/__tests__/promote-entry.pg.test.ts`, `src/tools/__tests__/tier-recommendations.pg.test.ts`, `scripts/run-nats-worker-live-watermark.pg.test.ts`.
- Each carried the `dbDescribe` idiom — read the variable, and when it is missing downgrade the whole suite to `describe.skip`. That reports `0 pass, N skip, 0 fail` and exits 0, which is indistinguishable at the exit code from a suite that ran and passed, so the Postgres behavior nobody exercises drifts under a green run.
- Each file now calls `requireTestDatabaseUrl()` from `scripts/test-support/require-test-database.ts` where it builds its pool, and uses a plain `describe`. The client each file builds is unchanged; only the source of the connection string moved. Absent the variable the suite throws `test_database_required` and exits non-zero.
- Every test and assertion is preserved — 8, 6, and 4 cases respectively, matching `origin/main`. Neither `src/tools/__tests__` file gated on anything besides the database, and the nats watermark test gates on no NATS variable either, so no second gate needed preserving.
- Bringing each file fully to standard on first touch also cleared the lint debt they carried, none of it a behavior change: the 15 `any` annotations are gone (`pool as any` was vestigial — `ToolDeps` already declares `pool: pg.Pool`; the `(message: any, options?: any)` annotations on the transport `send` override were masking a real `AuthInfo` mismatch between this repo's type and the SDK's, now handled with the same `as never` cast the landed `server/tools/reporting.pg.test.ts` uses; the repeated `(result.content as any)[0].text` is one module-scope `textOf` helper), and the two top-level `describe` callbacks that ran 267 and 229 lines are split into subject describes with helpers and lifecycle hooks hoisted to module scope, following that same landed file's shape. `.oxlintrc.json` deliberately does not exempt tests from `max-lines-per-function`; it is paid per-file as tests are touched.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`scripts/done-means/878-pg-tests-require-database.sh` at `origin/main` with these three files as `CHANGED_FILES` exits 1, clauses 1-3 FAIL on each file (clause 1 naming the surviving `const DB_URL`/`dbDescribe`/`dbDescribe(` code lines, clause 3 observing `0 pass, 10 skip, 0 fail` / `0 pass, 8 skip, 0 fail` / `0 pass, 6 skip, 0 fail` and exit 0 with no `test_database_required`). On this branch it exits 0 with all four clauses PASS, both with that `CHANGED_FILES` override and with no argv at all — the no-argv subject resolves to exactly these three files.

- `./node_modules/.bin/oxlint --deny-warnings` on all three files -> 0 findings, no disable comments added.
- `bunx tsc --noEmit` -> 0 errors.
- `bun run test:isolated` (no path, whole suite) -> 3944 pass, 35 skip, 0 fail, 15958 expect() calls across 261 files, exit 0. The pre-push hook re-ran the isolated runner and passed.
- File sizes after the split: 399, 342, and 388 lines — all under 500.

Python package and live smoke are not applicable: nothing under `python/` or `clients/` is touched, and this changes only how three test files obtain a connection string.

## Critical Self-Review

- Highest-risk behavior: a `.pg.test.ts` file that silently runs nothing. This PR is the fix for that in three files, but the same change also means any environment that ran these suites without the variable and passed will now fail loudly. That is the intended outcome of #878, and `bun run test:isolated` sets the variable, so the documented path is unaffected.
- Assumptions that could be wrong: that `requireTestDatabaseUrl()` called inside `beforeAll` (where each file builds its pool) is as good as the module-scope call the landed reference uses. It throws in the hook rather than at import, so the failure surfaces as a failing hook instead of a module load error. Clause 3 of the done-means check verifies the observable outcome either way — non-zero exit with `test_database_required` printed — and it passes for all three files.
- Missing/weak tests: no new test asserts the throw; the done-means script is what exercises it, by running each file with the variable unset and checking the exit code and the error string. A unit test of `requireTestDatabaseUrl` itself would be redundant with that.
- Security/permission risk: none. No auth, namespace predicate, or SQL changed. The `as never` cast on the transport `send` options is confined to test scaffolding injecting `authInfo` and matches the landed pattern; it does not widen anything the server trusts.
- Migration/deploy risk: none. No migration, no schema change, no runtime source file touched — all three files are tests.
- Downstream client/runtime risk: none. Per `docs/downstream-rollout.md` this is not an MCP tool, schema, protocol, or client-facing change, so rtech-mcps, mcp2cli, and rtech-hermes are unaffected.
- Rollback/cleanup concern: single commit, three test files, revertable on its own. No scaffolding left behind.
- Fixes made before PR: removing the `any` annotations exposed a genuine type error the annotations had been suppressing — this repo's `AuthInfo` is missing `token` and `scopes` relative to the SDK's, so `originalSend(message, { ...options, authInfo: auth })` did not typecheck once `message`/`options` were inferred. Fixed by copying the `as never` cast from `server/tools/reporting.pg.test.ts` rather than restoring the `any`. A first attempt at typing `textOf` as `{ content?: unknown }` tripped TypeScript's weak-type check against the `toolResult` union member of `callTool`'s return; `Record<string, unknown>` accepts both members and typechecks.
- Known residual risk: the describe splits changed test grouping and names, so historical per-describe test-name matching in any external report will not line up across this commit. Case count and assertions are unchanged.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the self-skipping-test pattern this PR removes is already the subject of issue #878 and is captured in the doc comment of `scripts/test-support/require-test-database.ts`, which every converted file now imports; no new MEDIUM+ finding surfaced in this lane.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: test-only change with no MCP, transport, or client-facing surface.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched — the change is confined to how three test files obtain a Postgres connection string.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: three `.pg.test.ts` files changed, no runtime source, no MCP tool or schema, no transport, no Python client.
