### PR TITLE
fix(python-capture): the real-transcript test picks a transcript with operator turns instead of the largest file (#764)

### DIFF
--- a/python/openbrain/tests/fixtures/transcripts/session-with-operator-turns.jsonl
+++ b/python/openbrain/tests/fixtures/transcripts/session-with-operator-turns.jsonl
@@ -1,0 +1,10 @@
+{"type":"last-prompt","prompt":"placeholder"}
+{"type":"user","uuid":"u1","promptSource":"typed","sessionId":"s1","cwd":"/repo","parentUuid":null,"message":{"role":"user","content":"first operator question"}}
+{"type":"assistant","uuid":"a1","message":{"role":"assistant","model":"claude-fable-5","content":[{"type":"text","text":"first reply"}]}}
+{"type":"user","uuid":"t1","sessionId":"s1","userType":"external","message":{"role":"user","content":[{"type":"tool_result","content":"placeholder output"}]}}
+{"type":"user","uuid":"u2","promptSource":"typed","sessionId":"s1","cwd":"/repo","parentUuid":"a1","message":{"role":"user","content":"second operator question"}}
+{"type":"assistant","uuid":"a2","message":{"role":"assistant","model":"claude-fable-5","content":[{"type":"text","text":"second reply"}]}}
+{"type":"user","uuid":"t2","sessionId":"s1","userType":"external","message":{"role":"user","content":[{"type":"tool_result","content":"more placeholder output"}]}}
+{"type":"user","uuid":"e1","sessionId":"s1","isApiErrorMessage":true,"message":{"role":"user","content":"API Error: Request timed out."}}
+{"type":"user","uuid":"u3","promptSource":"queued","sessionId":"s1","cwd":"/repo","parentUuid":"a2","message":{"role":"user","content":"third operator question"}}
+{"type":"assistant","uuid":"a3","message":{"role":"assistant","model":"claude-fable-5","content":[{"type":"text","text":"third reply"}]}}

--- a/python/openbrain/tests/test_capture_transcript.py
+++ b/python/openbrain/tests/test_capture_transcript.py
@@ -27,12 +27,23 @@ from openbrain.apps.capture.watermark import (
     WatermarkStore,
 )
 
-#: A live Claude Code transcript, if this checkout has one.
+#: A committed transcript in the shape Claude Code actually writes (#764).
 #:
-#: Tests using it are skipped when absent, so the suite still passes on a clean
-#: machine -- but on a developer's machine they run against the real thing,
-#: which is what caught every wrong assumption about record shape on 2026-07-31.
-LIVE_TRANSCRIPT_DIR = Path.home() / ".claude" / "projects"
+#: These tests used to read whatever file was LARGEST under the runner's
+#: ``~/.claude``, which made them a property of the machine rather than of the
+#: code: on 2026-08-27 the largest file on several CI runners was a session in
+#: which every ``user`` record was an API error, so zero operator turns were
+#: found and ``assert 1 < 1`` failed on five unrelated PRs. The fixture carries
+#: the same three record classes the live measurement found -- operator turns,
+#: tool results replayed as ``user``, and an API-error record -- with
+#: synthesized content, so the assertions keep their meaning while the outcome
+#: no longer depends on the host.
+FIXTURE_TRANSCRIPT = (
+    Path(__file__).parent
+    / "fixtures"
+    / "transcripts"
+    / "session-with-operator-turns.jsonl"
+)
 
 #: A second process that takes the write lock, announces it, and holds briefly.
 #:
@@ -687,45 +698,43 @@ class TestModuleIndependence:
         assert raw_turn_from_line(operator_line("u1", "x")) is not None
 
 
-@pytest.mark.skipif(
-    not LIVE_TRANSCRIPT_DIR.is_dir(), reason="no live Claude Code transcripts present"
-)
 class TestAgainstARealTranscript:
-    """The assumptions this module encodes, checked against a real file.
+    """The assumptions this module encodes, checked against a real record shape.
 
     Every rule in records.py came from measuring a live transcript. These keep
     that honest: if Claude Code changes the format, this fails here rather than
-    silently capturing nothing in production.
+    silently capturing nothing in production. The file is committed rather than
+    discovered on the host, so a failure names a change in the code and never a
+    change in whatever session happened to be biggest on the runner (#764).
     """
 
     @staticmethod
-    def largest_transcript() -> Path | None:
-        candidates = [
-            path
-            for path in LIVE_TRANSCRIPT_DIR.rglob("*.jsonl")
-            if path.stat().st_size > 0
-        ]
-        if not candidates:
-            return None
-        return max(candidates, key=lambda path: path.stat().st_size)
+    def transcript() -> Path:
+        return FIXTURE_TRANSCRIPT
 
     async def test_operator_turns_are_found_and_tool_results_are_not(self) -> None:
-        path = self.largest_transcript()
-        if path is None:
-            pytest.skip("no non-empty transcript found")
+        path = self.transcript()
 
         result = await read_since(path, BEGINNING_OF_FILE)
         user_records = sum(
             1
             for line in path.read_text(encoding="utf-8", errors="replace").splitlines()
-            if line.startswith('{"type":"user"') or '"type":"user"' in line
+            if '"type":"user"' in line
         )
+        operator_turns = [turn for turn in result.turns if turn.is_human_prompt]
 
-        assert result.turns, "no operator turns found in a real transcript"
-        assert len(result.turns) < user_records, (
+        assert operator_turns, "no operator turns found in the transcript"
+        assert len(operator_turns) < user_records, (
             "every `user` record was treated as an operator turn; "
             "tool results are leaking into the lane"
         )
+        # The fixture holds six `user` records: three the operator typed, two
+        # tool results replayed under the user role, and one API-error record.
+        assert [turn.content for turn in operator_turns] == [
+            "first operator question",
+            "second operator question",
+            "third operator question",
+        ]
 
     @pytest.mark.parametrize("split_at", [0.1, 0.5, 0.9])
     async def test_reading_in_two_parts_matches_reading_in_one(
@@ -738,11 +747,9 @@ class TestAgainstARealTranscript:
         different points, because a boundary that happens to land between turns
         would prove nothing about one that lands mid-turn.
         """
-        live = self.largest_transcript()
-        if live is None:
-            pytest.skip("no non-empty transcript found")
+        live = self.transcript()
 
-        # Work on a copy: nothing in this suite writes near a live transcript.
+        # Work on a copy: nothing in this suite writes near the source file.
         path = tmp_path / "real.jsonl"
         path.write_bytes(live.read_bytes())
 
@@ -764,9 +771,7 @@ class TestAgainstARealTranscript:
         assert head.turns + tail.turns == whole.turns
 
     async def test_no_turn_uuid_is_duplicated(self) -> None:
-        path = self.largest_transcript()
-        if path is None:
-            pytest.skip("no non-empty transcript found")
+        path = self.transcript()
 
         turns = (await read_since(path, BEGINNING_OF_FILE)).turns
         uuids = [turn.turn_uuid for turn in turns]
@@ -774,9 +779,7 @@ class TestAgainstARealTranscript:
         assert len(uuids) == len(set(uuids))
 
     async def test_every_captured_turn_has_content(self) -> None:
-        path = self.largest_transcript()
-        if path is None:
-            pytest.skip("no non-empty transcript found")
+        path = self.transcript()
 
         for turn in (await read_since(path, BEGINNING_OF_FILE)).turns:
             assert isinstance(turn.content, str)

--- a/scripts/done-means/764-real-transcript-test-selects-operator-turns.sh
+++ b/scripts/done-means/764-real-transcript-test-selects-operator-turns.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for #764: the real-transcript test is deterministic.
+#
+#   bash scripts/done-means/764-real-transcript-test-selects-operator-turns.sh
+#
+# WHAT THIS GATES
+#
+# python/openbrain/tests/test_capture_transcript.py::TestAgainstARealTranscript
+# used to read whatever *.jsonl file was LARGEST under the runner's ~/.claude.
+# That made the outcome a property of the host, not of the code: when the
+# biggest session on a runner was one in which every `user` record was an API
+# error, zero operator turns were found and `assert 1 < 1` failed. It hit five
+# unrelated PRs on 2026-08-27 (#873 #875 #883 #885 #886).
+#
+# The fix points the class at a committed fixture. So a passing pytest run is
+# not enough on its own — it would also pass on a developer machine whose
+# largest live transcript happens to be healthy. C1 and C3 are what prove the
+# host is out of the loop.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+TEST_FILE="python/openbrain/tests/test_capture_transcript.py"
+FIXTURE="python/openbrain/tests/fixtures/transcripts/session-with-operator-turns.jsonl"
+EMPTY_HOME="/Volumes/ThunderBolt/_tmp/open-brain/_scratch/session7/empty-home"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# C1: selection is by committed fixture, not by file size on the host.
+if rg -q "largest_transcript|st_size > 0|LIVE_TRANSCRIPT_DIR" "$TEST_FILE"; then
+  fail "C1 $TEST_FILE still selects a transcript from the host"
+fi
+rg -q "FIXTURE_TRANSCRIPT" "$TEST_FILE" ||
+  fail "C1 $TEST_FILE does not reference the committed fixture"
+[ -s "$FIXTURE" ] || fail "C1 fixture missing or empty: $FIXTURE"
+echo "C1 ok: the test loads $FIXTURE and no longer selects by size"
+
+# C2: the class passes.
+(cd python/openbrain && uv run pytest -q tests/test_capture_transcript.py \
+  -k TestAgainstARealTranscript) ||
+  fail "C2 pytest -k TestAgainstARealTranscript did not exit 0"
+echo "C2 ok: TestAgainstARealTranscript passes"
+
+# C3: it passes just the same with no ~/.claude to find.
+mkdir -p "$EMPTY_HOME"
+(cd python/openbrain && HOME="$EMPTY_HOME" uv run pytest -q \
+  tests/test_capture_transcript.py -k TestAgainstARealTranscript) ||
+  fail "C3 the class depends on the machine's ~/.claude"
+echo "C3 ok: passes with HOME=$EMPTY_HOME"
+
+echo "DONE-MEANS 764: PASS"


### PR DESCRIPTION
## Summary

- Fixes #764. `python/openbrain/tests/test_capture_transcript.py::TestAgainstARealTranscript` read whatever `*.jsonl` file was LARGEST under the runner's `~/.claude`, which made the outcome a property of the host rather than of the code. On 2026-08-27 the biggest session on several runners was one where every `user` record was an API error, so no operator turns were found and `assert 1 < 1` failed on five unrelated PRs (#873 #875 #883 #885 #886).
- The class now reads a committed fixture, `python/openbrain/tests/fixtures/transcripts/session-with-operator-turns.jsonl`, carrying the three record classes the original live measurement found: three operator turns, two tool results replayed under the `user` role, and one API-error record. Content is synthesized; nothing real and nothing sensitive is in it.
- Assertion semantics are preserved in meaning — operator turns are found, and neither the tool results nor the API-error record counts as one. Because the file is now known, the test additionally names the exact three turns it expects rather than only comparing counts.
- Chose the fixture over "select the newest transcript containing a usable operator turn": the latter still leaves the assertion's strength dependent on whatever the host happens to hold, and it fails or skips on a clean machine for reasons unrelated to the change under test.
- Side effect worth stating: the class no longer skips when `~/.claude` is absent, so these six tests now genuinely run in CI and on a fresh checkout. Previously they skipped silently there, which is a pass that tested nothing.
- Closes #764.

## Verification

- Done-means: scripts/done-means/764-real-transcript-test-selects-operator-turns.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Evidence, run in this branch's clone:

- `bash scripts/done-means/764-real-transcript-test-selects-operator-turns.sh` -> exit 0 on the committed tree (`DONE-MEANS 764: PASS`). At `origin/main` C1 fails (`still selects a transcript from the host`) and C3 reports `6 skipped` instead of running.
- `cd python/openbrain && uv run pytest -q` -> `622 passed, 1 skipped, 19 deselected`.
- `cd python/openbrain && uv run mypy src/openbrain` -> `Success: no issues found in 50 source files`.
- `cd python/openbrain && uv run ruff check src tests` -> `All checks passed!`.
- `bunx tsc --noEmit` -> exit 0. No TypeScript or JavaScript file is touched by this change, so oxlint has no target here and the TypeScript suite is unaffected.

## Critical Self-Review

- Highest-risk behavior: the six tests in this class no longer exercise a live transcript at all, so a Claude Code format change that a developer's real `~/.claude` would have caught now goes unnoticed until the fixture is refreshed. That is the deliberate trade — the tests were only opportunistically running against a live file anyway, and on CI they were skipping outright.
- Assumptions that could be wrong: that the fixture's record shapes still match what Claude Code writes today. They were copied from the shapes the existing `operator_line`/`tool_result_line`/`assistant_reply_line` helpers in this same test module already encode, which were themselves measured against a live 26.5 MB transcript on 2026-07-31 and again on 2026-08-03 (#447), so the fixture is not a fresh guess.
- Missing/weak tests: nothing asserts that the API-error record specifically is the reason a `user` record was excluded — `records.py` has no API-error branch, it simply requires `promptSource`, so an error record is excluded by the same rule as a tool result. Writing a test that distinguishes them would assert a distinction the parser does not make.
- Security/permission risk: none. No auth, namespace, or SQL path is touched. The fixture is synthesized, contains no real conversation content and no credentials; gitleaks scanned the staged change and found none.
- Migration/deploy risk: none. Test-only change plus a new done-means script; no schema, no runtime code path, no config.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` applies to MCP tool/schema/protocol/client-facing changes; this alters no contract, no tool surface, and no Python client behavior.
- Rollback/cleanup concern: reverting the commit restores the previous selection helper exactly; the fixture file is orphaned by the revert and nothing else references it.
- Fixes made before PR: the original `len(result.turns) < user_records` comparison counted assistant turns too, so against a small known file it compared six turns to six user records and failed. Corrected to count operator turns specifically, which is what the assertion's own failure message always claimed to be about.
- Known residual risk: the fixture ages. If Claude Code changes its record format, this suite stays green while production capture silently degrades — which is the exact failure the class's docstring says it exists to prevent. The mitigation is refreshing the fixture whenever `records.py` rules are re-measured, and the docstring now says the file is committed so a reader knows to.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the pattern (a test whose input is discovered from the host machine rather than committed) is a single-instance fix here, and `docs/sme/` lanes are for review findings that a future swarm should scan code for, not for a one-file determinism fix already enforced by an executable done-means check.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no server, transport, or database path is touched; this is a test-input change in the Python capture package.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the new fixture is a Claude Code transcript sample used only as test input by the Python capture reader. It is not a contract fixture and has no TypeScript counterpart.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, transport, or client-facing surface changes. The diff is one test module, one test fixture, and one done-means script.
