### PR TITLE
docs(handover): author session 8 of the standards sprint, the #878 hard test-database program

### DIFF
--- a/_DOCS/HANDOVER-RULES.md
+++ b/_DOCS/HANDOVER-RULES.md
@@ -236,3 +236,57 @@ only when a session actually needed it.
     `:901` — is blocked at commit. Sequence #868 (split the file, drop the
     `process.env` helper) before such a lane; a lint exemption for test files
     is a rung reopening and needs Rico.
+    Resolved 2026-08-26 by #872: the file is split into `server/config.test.ts`,
+    `server/config-extended.test.ts`, `server/config-equivalence.test.ts`, and
+    `parseServerConfig(environment)` at `server/config.ts:380` takes the env
+    object, so no test reads `process.env`. The rule stays as the pattern: a
+    lane blocked by pre-existing lint in a shared test file sequences the
+    split first, never `--no-verify` and never an exemption.
+36. **Every Postgres test runs against a real test database; skipping is a
+    HARD FAILURE.** Rico, 2026-08-26 (#878): "bad shit happens when we pretend
+    that we're using a database and we're not." The pattern is
+    `const pool = new Pool({ connectionString: requireTestDatabaseUrl() })`
+    from `scripts/test-support/require-test-database.ts` with a plain
+    `describe`; `describe.skip` on a missing `OPENBRAIN_TEST_DATABASE_URL` is
+    a defect, and so is a lint exemption for test files. Test files are held
+    to the server-code standard (rules 25/26). `_githooks/pre-push` runs
+    `bun run test:isolated` (#881), so the database is always there at push.
+37. **A pg suite rename or split updates `scripts/assert-db-tests-ran.ts` in
+    the SAME commit.** CI's anti-skip guard is a manifest of suite names and
+    minimum counts; #884's first CI run failed on the manifest alone, with
+    zero test failures. The lane brief names it; the collector reads the
+    guard's `MISSING` / `ran N expected M` lines before blaming a test.
+38. **`--no-verify` is never the answer, and the head checks for it.** The
+    #879 lane pushed with `--no-verify` when the old pre-push hook could not
+    find a database (self-reported). The fix was the hook (#880/#881), not
+    the flag. Every brief carries "never `--no-verify`" verbatim, and a lane
+    that used it reports the sha; the head records the deviation on the
+    scribe issue and re-runs the skipped gate itself before merge.
+39. **Every lane clone carries `core.hooksPath=_githooks` before dispatch.**
+    A fresh clone inherits the global `/Users/rico/.config/git/hooks`, so
+    the repo's pre-commit/pre-push gates do not run there, and
+    `bun scripts/verify-lane.ts` inherits the same setting and fails on the
+    `750-l2b2-lint-refuses-process-env.sh` clause (#872). The head sets it
+    with `git -C <clone> config core.hooksPath _githooks` on every clone at
+    State 2 and re-checks it in the re-probe list.
+40. **A done-means script diffs against the merge-base, scans the call line,
+    and is proven with a deliberate miss.** `750-l5-shared-namespace-importers.sh`
+    shipped three defects in one session (#875 origin/main instead of
+    merge-base; #876 import line only, alias rejected, zero-call importer
+    failed; #877 multiline regex merged adjacent calls). Each was found by a
+    dependent lane, not the author. A check lane's Done-check includes the
+    exit-1 run on a hand-broken input, and the check is on `origin/main`
+    before a dependent lane opens a PR (`pr-body-gate` refuses a Done-means
+    path that is not on the branch).
+41. **A read-only lane that needs `gh` or the network is native Opus 5 low,
+    not the Codex companion.** Codex companion lanes have no forge access and
+    no DNS; they also trip the graph-mode gate (EPERM on chmod) and finish
+    with that noise in their report. CI triage, run-log reads, and issue
+    searches route native with the reason stated (rule 28 covers write
+    lanes; this covers reads).
+42. **A CI failure on a file the PR does not touch is compared with `main`
+    before it blocks the merge, and it gets an issue.** #884's second run
+    failed on `server/maintenance/maintenance.pg.test.ts:353`, a timing race
+    the PR never touched (#889). The collector reruns the failed job once,
+    files the race with file:line and the run id, and merges on green; the
+    python-capture flake (#764) hit five PRs this way before its fix lane ran.

--- a/_DOCS/_handover/2026-08-27-pg-tests-session8.md
+++ b/_DOCS/_handover/2026-08-27-pg-tests-session8.md
@@ -1,0 +1,108 @@
+# Handover — #878 hard test-database program, session 8 (2026-08-27)
+
+## State 0 — BASE
+Read /Volumes/ThunderBolt/Development/_DOCS/HANDOVER-BASE.md in full
+(181 lines). It is the standing contract for this session.
+- Any question this document does not directly override → the rules layers
+  answer it, nearest layer first.
+- Anything neither the base nor this document covers → ask Rico before acting.
+- Output discipline: minimum verbosity, only the context needed, output tokens
+  low. If Rico wants more, he will ask.
+- Layer 0.1: read open-brain/_DOCS/HANDOVER-RULES.md in full (292 lines on
+  this branch). It overrides the base; this document overrides it. Rules 28-42
+  bind: head never works, own clones, FIVE lanes, no `rm`, no `--no-verify`,
+  manifest in the same commit, hooksPath on every clone.
+
+## State 1 — ORIENT
+- `origin/main` is `23239ba6` (#890); session 7 merged #871-#890 — MERGED (`git log --oneline origin/main -1`)
+- L5 cutover done: 0 `src/shared-namespace` importers in non-test `server/`;
+  #860 and #868 CLOSED with receipts; ladder line 3 reads "L3 MERGED" — MERGED (#871 #873 #875-#877)
+- #878 ruling (Rico, 2026-08-26): every pg test requires a real database, skip
+  is a HARD FAILURE, no lint exemption for tests; pattern
+  `requireTestDatabaseUrl()` in `scripts/test-support/require-test-database.ts` — MERGED (#879)
+- #878 census at `aa878c4f`: 37 `*.test.ts` files still `describe.skip`; the
+  list by size is the session-7 scribe comment on #878 — RUNNING (`git grep -c "describe.skip" origin/main -- '*.test.ts'`)
+- Program check `scripts/done-means/878-pg-tests-require-database.sh` — MERGED (#882)
+- `_githooks/pre-push` runs `bun run test:isolated` (#881); all eleven clones
+  have `core.hooksPath=_githooks` — RUNNING (`git -C <clone> config core.hooksPath`)
+- #764 python-capture flake CLOSED: committed fixture, done-means
+  `scripts/done-means/764-real-transcript-test-selects-operator-turns.sh` — MERGED (#890 23239ba6)
+- #889 maintenance lease race (`server/maintenance/maintenance.pg.test.ts:335-353`) OPEN — RUNNING (`gh issue view 889`)
+- #888 Forge migration is a planning item, not a build order — RUNNING (`gh issue view 888`)
+- Lane-8 clone `stash@{0}` + `_scratch/session7/lane-8-878-b2-src-tools-a.patch`:
+  bulk-set-tier/decompose-entry/list-stale converted, 25 pre-existing lint findings — WRITTEN
+- Reusable, temp: `/Volumes/ThunderBolt/_tmp/open-brain/_scratch/session7/{lane,recon}.workflow.js`, `collect.sh` — WRITTEN
+- Mac checkout `/Volumes/ThunderBolt/Development/open-brain` is DIRTY on `sprint/standards-fmt` (Rico's); lanes never work there — RUNNING
+- Graph mode: converted — RUNNING (`ls scripts/done-means/` has `878-*.sh`)
+Re-probe before dispatching anything (live state beats this doc):
+- `git log --oneline origin/main -1` → expect 23239ba6 or later with this PR merged
+- `gh pr list --state open --json number,headRefName` → only #745 and #739 (not this program)
+- `git -C /Volumes/ThunderBolt/_tmp/open-brain/_worktrees/lane-3 config core.hooksPath` → `_githooks`
+
+## State 2 — LAND THE PAPERWORK
+Branch: `docs/pg-tests-session8` from `origin/main` — cut it once THIS
+document's PR merges; if the checkout is `main` or `docs/l5-session7` is
+merged, switch first, never work there.
+Retire: `docs/l5-session7` (this document's PR); in lane-11
+`verify-lane/pr-824-*`, `pr-836-*`, `pr-845-*`, `pr-861-*`, `pr-870-*`
+(merged PRs, `git branch -D`); lane-1 `fix/880-*`, lane-2 `fix/764-*`, lane-3..6,9 `chore/878-b1-*`
+`chore/878-b2-src-tools-b` (merged, `git branch -d` after `git checkout main`
+in that clone). Worktrees: `none`.
+Commit this handover: branch `docs/l5-session7`, path
+`_DOCS/_handover/2026-08-27-pg-tests-session8.md` with `_DOCS/HANDOVER-RULES.md`,
+explicit-path staging, `git commit -F` message file. Done by the authoring session.
+Scribe: issue #878 — started: `gh issue comment 878 --body "Scribe, session 8: ..."`
+Done-check: `git log -1 --stat`
+
+## State 3 — Batch A: five migration tests hard-fail (one file per lane)
+Tier: T1 — shared test files; CI manifest changes with each
+Deliverable: `src/db/migrations/{025_normalize_legacy_development_lanes,027_source_registry,028_maintenance_jobs_lease_expired_compat,029_maintenance_jobs_terminal_category,031_source_sync_runs_running_only_unique}.test.ts` use `requireTestDatabaseUrl()`, plain `describe`, whole file lint-clean, manifest updated; one PR each
+Scope: the one file, `scripts/assert-db-tests-ran.ts`; own clone per lane
+Must NOT: `--no-verify`; touch `src/db/migrations/*.ts` sources; convert a guard keyed on any env other than `OPENBRAIN_TEST_DATABASE_URL` (report it)
+Record: PR, then #878 comment per merge
+Done-check: `CHANGED_FILES=<file> bash scripts/done-means/878-pg-tests-require-database.sh` → exit 0 (RED: not yet run; the pre-edit run on the file)
+
+## State 4 — Batch B: 032, reinforcement-and-said-at, 001_init, promote-shared, ingest-raw-turn
+Tier: T1 — same blast radius as State 3
+Deliverable: `src/db/migrations/{032_raw_turns,reinforcement-and-said-at,001_init}.test.ts`, `src/tools/__tests__/{promote-shared,ingest-raw-turn}.test.ts` converted as in State 3; one PR each
+Scope: the one file, `scripts/assert-db-tests-ran.ts`; own clone per lane, after State 3 lanes merge (manifest conflicts)
+Must NOT: as State 3; split a file that lands over 500 lines (report, it goes to the split batch)
+Record: PR, then #878 comment per merge
+Done-check: `CHANGED_FILES=<file> bash scripts/done-means/878-pg-tests-require-database.sh` → exit 0 (RED: not yet run; the pre-edit run on the file)
+
+## State 5 — Batch C: contracts, scripts, live tests under 500 lines
+Tier: T1 — `contracts/server-tool-parity.test.ts` composes tool deps itself (rule 33)
+Deliverable: `contracts/server-tool-parity.test.ts`, `scripts/{local-clone,retire-collab-migration}.test.ts`, `src/maintenance-sweep.live.test.ts`, `src/tools/__tests__/session-wrap-postgres.test.ts` converted; one PR each
+Scope: the one file, `scripts/assert-db-tests-ran.ts`; own clone per lane
+Must NOT: as State 3; a `*.live.test.ts` gated on an embedding or NATS env is reported with the env name, not converted
+Record: PR, then #878 comment per merge
+Done-check: `CHANGED_FILES=<file> bash scripts/done-means/878-pg-tests-require-database.sh` → exit 0 (RED: not yet run; the pre-edit run on the file)
+
+## State 6 — Batch D: the lane-8 three plus the remaining live tests
+Tier: T1 — the three carry 25 pre-existing lint findings each lane must clear whole (rule 25)
+Deliverable: `src/tools/__tests__/{bulk-set-tier,decompose-entry,list-stale}.pg.test.ts` from `_scratch/session7/lane-8-878-b2-src-tools-a.patch` (one file per lane, lint-clean), then `namespace-isolation-matrix-live`, `agent-context-pack-guidance-repo-facts-live`, `src/graph-derivation.live.test.ts`; one PR each
+Scope: the one file, `scripts/assert-db-tests-ran.ts`; own clone per lane
+Must NOT: as State 5; carry the lane-8 stash as a whole commit
+Record: PR, then #878 comment per merge; lane-8 `stash@{0}` dropped by Rico once the three merge
+Done-check: `CHANGED_FILES=<file> bash scripts/done-means/878-pg-tests-require-database.sh` → exit 0 (RED: not yet run; the pre-edit run on the file)
+
+## State 7 — WAYFINDER QUOTA
+Close: https://github.com/rodaddy/open-brain/issues/889 — a lane reads
+`server/maintenance/` and names which side owns the `runOnce()` contract
+(file:line), lands the fix with a 20-run done-means script under
+`scripts/done-means/`, RED shown on `aa878c4f` if reproducible; tick the map
+checkbox in the same motion.
+
+## State FINAL — WRAP
+Invoke the handover-author skill; next handover passes the validator; `aqmd up`.
+
+## HANDED-OVER UNKNOWNS
+- `878-pg-tests-require-database.sh` discovers `*.pg.test.ts` only; whether `CHANGED_FILES` bypasses that filter for the `*.test.ts` and `*.live.test.ts` files in States 3-6 is UNVERIFIED — the first lane proves it or widens the check first (own T1 lane).
+- Sixteen files over 500 lines (list on #878) need a split lane each before conversion; not sliced here.
+- Q1, since session 3: `.claude/agents/tracking-scribe.md` writes ONLY to the root checkout (Rico's dirty branch); sessions 3-7 scribed via comments — Rico's call.
+- Q2: `server/main.ts` reads `process.env` under the door override; moving them into `server/config.ts` is Rico's decision.
+- Q3: `_plans/750-standards-sprint-map.md` exists only on `sprint/standards-fmt`; no map tick possible.
+- Q5: `node/no-process-env` is scoped to `server/**`; 19 `src/` files still read env and retire at L6 — Rico confirms the scope.
+- Q7: lane-7 `stash@{0}` (`chore/l2b2-l5-shared-namespace-owner`) is superseded by #873; dropping it is Rico's, not a lane's.
+- Q8: #888 Forge migration — Rico decides when planning starts and whether it displaces #878 work.
+- `src/shared-namespace.ts` twin recorded on #826 (third pair); #784 closes only if Rico accepts resolved-by-observation.


### PR DESCRIPTION
## Summary

- Adds `_DOCS/_handover/2026-08-27-pg-tests-session8.md`, the session-8 brief for the standards sprint, and rules 36-42 in `_DOCS/HANDOVER-RULES.md` (rule 35 marked resolved by #872).
- Session 7 closed L3 (#860, #871), finished the L5 cutover (#872 split, #873 owner, #875-#877 importers), and took Rico's #878 ruling that every Postgres test runs against a real test database: 19 of 41 skipping files converted (#879 #883-#887 #884), `_githooks/pre-push` provides the database (#881), the program check landed (#882), and the python-capture flake got a committed fixture (#890, closes #764). On `origin/main` `23239ba6`, `git grep -c "describe.skip" origin/main -- '*.test.ts'` lists 37 files.
- Slice: four batches of one file per lane over the under-500-line remainder (migrations, tools, contracts/scripts/live, the lane-8 lint-debt three), #889 (maintenance lease race) as the wayfinder close. The sixteen files over 500 lines and #888 (Forge planning) stay on their issues.

## Verification

- Done-means: scripts/done-means/handover-validates.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed — not applicable, docs-only; `_ob/skills/handover-author/scripts/validate-handover.sh` exits 0 (108 lines)
- [x] Python package checks passed or are not applicable — not applicable, no Python touched
- [x] Live Open Brain smoke passed or is not applicable — not applicable, no runtime surface touched

## Critical Self-Review

- Highest-risk behavior: a stale map fact. Every State 1 line was re-probed against `origin/main` this session and carries its probe command; the census is the session-7 scribe comment on #878 taken at `aa878c4f`.
- Assumptions that could be wrong: that `CHANGED_FILES` lets `878-pg-tests-require-database.sh` judge a `*.test.ts` file that is not `*.pg.test.ts`; the script's discovery filters on `*.pg.test.ts` and the override path was not exercised on such a file. HANDED-OVER UNKNOWNS names it as the first lane's proof.
- Missing/weak tests: none — the handover's own check is the validator, seen passing.
- Security/permission risk: none, docs-only.
- Migration/deploy risk: none, docs-only.
- Downstream client/runtime risk: none, docs-only.
- Rollback/cleanup concern: State 2 names `docs/l5-session7` and the merged lane branches to retire; the lane-8 stash and patch are named in State 1 and dropped only by Rico (Q7).
- Fixes made before PR: Done-check lines rewritten from a `<file>` argv form to the `CHANGED_FILES` override after reading the script header (it takes no argv).
- Known residual risk: the reusable lane scripts live under the temp workspace with no persistence guarantee and the handover names them.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the session-7 lessons are HANDOVER-RULES rules 36-42 and issues #878, #889.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: docs-only change with no runtime surface

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, schema, or fixture is touched

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- `validate-handover.sh _DOCS/_handover/2026-08-27-pg-tests-session8.md` → `PASS ... (108 lines) [validator 2026-08-22.4]`, exit 0
- Map re-probed at `origin/main` `23239ba6`: `gh pr list --state open` → #745, #739 only; all eleven lane clones report `core.hooksPath=_githooks`
