### PR TITLE
chore(done-means): the #878 check accepts any *.test.ts subject through CHANGED_FILES, not only *.pg.test.ts

### DIFF
--- a/scripts/done-means/878-pg-tests-require-database.sh
+++ b/scripts/done-means/878-pg-tests-require-database.sh
@@ -22,7 +22,9 @@
 # GENERIC BY DESIGN -- NO ARGUMENTS
 # ---------------------------------------------------------------------------
 # This check takes no argv. It discovers its own subject: files matching
-# `*.pg.test.ts` changed against the MERGE BASE of origin/main and HEAD.
+# `*.pg.test.ts` changed against the MERGE BASE of origin/main and HEAD. That
+# `*.pg.test.ts` match is the DISCOVERY rule only; see the `CHANGED_FILES`
+# paragraph below for the wider rule an explicit subject is held to.
 # Diffing against the moving tip of origin/main instead would drag in files
 # other branches changed after this one was cut and judge them as if this lane
 # had touched them. The merge base is the branch's own diff.
@@ -36,7 +38,12 @@
 # subject list for free.
 #
 # `CHANGED_FILES` (space-separated) overrides the discovery, which is how the
-# RED receipt is taken before any edit exists to be discovered.
+# RED receipt is taken before any edit exists to be discovered. An overridden
+# subject is held to `*.test.ts` rather than `*.pg.test.ts`: the conversion also
+# covers `*.test.ts` and `*.live.test.ts` files that read the variable, and a
+# caller naming a file explicitly has already chosen its subject. Discovery
+# keeps the narrower `*.pg.test.ts` match so an unrelated changed test file is
+# never dragged in as a conversion subject.
 #
 # ---------------------------------------------------------------------------
 # Four clauses, and all four must pass
@@ -101,7 +108,7 @@ HELPER_BASENAME='require-test-database'
 HARD_FAIL_STRING='test_database_required'
 
 # ---------------------------------------------------------------------------
-# SUBJECT -- the *.pg.test.ts files changed against origin/main.
+# SUBJECT -- the test files changed against origin/main.
 # ---------------------------------------------------------------------------
 if [ -n "${CHANGED_FILES:-}" ]; then
   SUBJECT="$(printf '%s\n' $CHANGED_FILES)"
@@ -110,16 +117,20 @@ else
   MERGE_BASE="$(cd "$REPO_ROOT" && git merge-base origin/main HEAD 2>/dev/null)"
   [ -n "$MERGE_BASE" ] || fail_hard "git merge-base origin/main HEAD produced nothing"
   SUBJECT="$(cd "$REPO_ROOT" && git diff --name-only "$MERGE_BASE" 2>/dev/null)"
+  SUBJECT="$(printf '%s\n' "$SUBJECT" | rg '\.pg\.test\.ts$' || true)"
   SUBJECT_SOURCE="git diff --name-only \$(git merge-base origin/main HEAD)"
 fi
-SUBJECT="$(printf '%s\n' "$SUBJECT" | rg '\.pg\.test\.ts$' || true)"
+# Discovery narrows itself to `*.pg.test.ts` above. An explicit CHANGED_FILES
+# subject is only held to `*.test.ts`, because the conversion also covers
+# `*.test.ts` and `*.live.test.ts` files that read the variable.
+SUBJECT="$(printf '%s\n' "$SUBJECT" | rg '\.test\.ts$' || true)"
 # The helper directory is never a conversion subject, whether discovery or
 # CHANGED_FILES put it there.
 SUBJECT="$(printf '%s\n' "$SUBJECT" | rg -v '^scripts/test-support/' || true)"
 SUBJECT="$(printf '%s\n' "$SUBJECT" | rg -v '^$' || true)"
 
 if [ -z "$SUBJECT" ]; then
-  printf 'SUBJECT: none -- %s produced no *.pg.test.ts files.\n' "$SUBJECT_SOURCE" >&2
+  printf 'SUBJECT: none -- %s produced no test files.\n' "$SUBJECT_SOURCE" >&2
   printf 'A check with nothing to examine is not a pass. Exiting 1.\n' >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Refs #878. The `*.pg.test.ts` filter in `scripts/done-means/878-pg-tests-require-database.sh` was applied to `SUBJECT` *after* the `CHANGED_FILES` override rather than inside the discovery branch, so it narrowed both paths. Pointing the check at a `*.test.ts` file produced an empty subject and exit 1 on `SUBJECT: none` before any clause ran.
- That is the wrong verdict for the 37 remaining #878 files, which are `*.test.ts` and `*.live.test.ts` rather than `*.pg.test.ts`. The check could not be aimed at any of them, so every remaining conversion lane was left without its done-means gate.
- Discovery (the `git diff` path) keeps the narrower `*.pg.test.ts` match, so an unrelated changed test file is still never dragged in as a conversion subject. An explicit `CHANGED_FILES` subject is now held to `*.test.ts` only, because a caller naming a file has already chosen its subject.
- The `scripts/test-support/` exclusion and all four clauses are unchanged. One file, 16 insertions, 5 deletions; the header comment, the `SUBJECT` comment, and the empty-subject message are updated to describe the split rule.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts, all re-run on the committed tree at b408d95:

- RED at `origin/main`: `CHANGED_FILES=src/db/migrations/025_normalize_legacy_development_lanes.test.ts bash scripts/done-means/878-pg-tests-require-database.sh` -> exit 1, `SUBJECT: none -- CHANGED_FILES override produced no *.pg.test.ts files.`
- GREEN, same command on this branch -> still exit 1, but now on CLAUSE 1 with the real finding: `const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL` and `dbDescribe = DB_URL ? describe : describe.skip`. That is the verdict the check exists to give; the file is genuinely unconverted.
- Already-converted file still passes: `CHANGED_FILES=server/tools/reporting.pg.test.ts bash ...` -> exit 0, all four clauses PASS.
- Exclusion kept: `CHANGED_FILES=scripts/test-support/require-test-database.ts bash ...` -> exit 1, `SUBJECT: none`.
- No-arg discovery on this branch -> exit 1, `SUBJECT: none -- git diff ... produced no test files.` Expected: this branch's diff contains only the shell script, so discovery correctly finds no conversion subject.
- `bunx tsc --noEmit` -> exit 0. `oxlint --deny-warnings` on the touched path -> `No files found to lint` (a `.sh` file is not in scope); no TypeScript changed.
- `shellcheck` -> 2 `SC2086` infos on lines 114 and 216, both pre-existing and both intentional word-splitting that the space-separated `CHANGED_FILES` contract and the `test:isolated` argument list depend on. `origin/main` has 3; this branch has 2. None introduced.
- Pre-push gate ran the Bun suite and passed.

## Critical Self-Review

- Highest-risk behavior: the check could silently widen its own discovery subject and start judging unrelated changed test files as failed #878 conversions, turning an unrelated PR red. Guarded by keeping the `*.pg.test.ts` filter inside the `else` branch, so the widened match is reachable only when a caller sets `CHANGED_FILES` explicitly. Verified by receipt (d): no-arg discovery on a branch whose diff has no `*.pg.test.ts` file reports `SUBJECT: none` rather than picking up the shell script.
- Assumptions that could be wrong: that no caller depends on `CHANGED_FILES` silently discarding non-`*.pg.test.ts` entries — for example a wrapper that passes a whole changed-file list and expects the script to filter it down. Such a caller would now see those files fail CLAUSE 1/2 instead of being dropped. I found no in-repo caller passing a broad list; the documented use is the RED receipt with one named file. This is a behavior change by design and is the point of the issue, but it is the one way this could surprise someone.
- Missing/weak tests: the done-means scripts have no unit tests of their own, so the four receipts above are the whole evidence and they are manual. There is no automated regression proving discovery stays narrow; a future edit could re-merge the two filters and only a careful reader would notice. A test harness for `scripts/done-means/` is worth having and is out of scope here.
- Security/permission risk: none. No auth, namespace, SQL, or network path is touched; the script reads a git diff and runs tests already in the repo.
- Migration/deploy risk: none. No migration, no schema, no runtime code — this file runs only when a developer or CI invokes it.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md`. No MCP tool, schema, transport, or client-facing contract changes, so rtech-mcps, mcp2cli, and rtech-hermes are unaffected.
- Rollback/cleanup concern: single-file revert with no state to unwind. Reverting restores the previous over-narrow filter and re-blocks the remaining #878 lanes; nothing else depends on the change.
- Fixes made before PR: an initial `perl -0777` in-place edit mangled the regex escaping on the discovery line (emitting `\\.pg\\.test\\.ts`) and its second substitution did not fire. I repaired both lines forward with exact-string edits and re-read the full diff to confirm the committed result contains only the intended delta and no escaping damage.
- Known residual risk: callers passing a broad file list through `CHANGED_FILES` now get a stricter verdict, as described under assumptions. Low, and detectable immediately as a loud clause failure rather than a silent pass.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a scope fix to a done-means check's own subject selection, not a code-review finding about repo code, and it produced no new reviewer-facing pattern beyond what the script's own header comment now documents.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, service, or database behavior changes; the change affects only a developer/CI-invoked shell check.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing surface is touched — the change is confined to one done-means shell script.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, protocol, transport, or Python client path changes. The single touched file is `scripts/done-means/878-pg-tests-require-database.sh`, which no runtime imports and no client calls.
