### PR TITLE
test(pg): migration 028 test requires the test database instead of skipping (#878)

### DIFF
--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -119,6 +119,15 @@ export const REQUIRED_SUITES: ReadonlyArray<{
     name: "rewrite entrypoint startup and shutdown ordering (live Postgres)",
     minTests: 3,
   },
+  // Migration 028's upgrade-path repair (#878). The defect it covers exists
+  // ONLY on a database upgraded across an earlier revision of 026, so a fresh
+  // schema proves nothing and a skipped run proves less: the queue's
+  // dead-letter category would be rejected in production while CI stayed
+  // green. Registered here so the run is proven, not assumed.
+  {
+    name: "028 maintenance_jobs lease_expired compat (live Postgres)",
+    minTests: 3,
+  },
 ];
 
 // Absolute floor on total executed (non-skipped) live-Postgres testcases,
@@ -129,9 +138,10 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // added its 9, then 53 -> 58 when the maintenance lease-boundary suite added
 // its 5, then 58 -> 65 when the two entrypoint suites added their 5 and 2, then
 // 65 -> 74 when #878 registered the two source-registry suites (8) and the
-// entrypoint split redistributed its own tests to 3 + 2 + 3), so the global
-// floor cannot silently fall behind the per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 74;
+// entrypoint split redistributed its own tests to 3 + 2 + 3, then 74 -> 77 when
+// #878 registered the migration 028 lease_expired compat suite's 3), so the
+// global floor cannot silently fall behind the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 77;
 
 export interface SuiteStats {
   tests: number;

--- a/src/db/migrations/028_maintenance_jobs_lease_expired_compat.test.ts
+++ b/src/db/migrations/028_maintenance_jobs_lease_expired_compat.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Upgrade-path regression for migration 028's repaired last_error_category
+ * CHECK constraint.
+ *
+ * REQUIRES `OPENBRAIN_TEST_DATABASE_URL`, and fails hard without it (operator
+ * ruling 2026-08-27, issue #878). It must point at an isolated test/playground
+ * database, never the dogfood database. `bun run test:isolated` sets it.
+ */
 import {
   afterAll,
   beforeAll,
@@ -7,9 +15,8 @@ import {
   it,
 } from "bun:test";
 import { Client } from "pg";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
 const migration026Url = new URL("026_maintenance_queue.sql", import.meta.url);
 const migration028Url = new URL(
   "028_maintenance_jobs_lease_expired_compat.sql",
@@ -54,7 +61,9 @@ function extractLastErrorCategorySet(sql: string): Set<string> {
       "could not locate a `last_error_category IN (...)` list in the migration SQL",
     );
   }
-  const values = [...match[1]!.matchAll(/'([^']*)'/g)].map((m) => m[1]!);
+  const values = [...(match[1] ?? "").matchAll(/'([^']*)'/g)].flatMap((m) =>
+    m[1] === undefined ? [] : [m[1]],
+  );
   if (values.length === 0) {
     throw new Error(
       "found a `last_error_category IN (...)` list but it contained no quoted values",
@@ -79,56 +88,56 @@ describe("028 / 026 last_error_category allow-lists stay in sync", () => {
   });
 });
 
-dbDescribe("028 maintenance_jobs lease_expired compat (live Postgres)", () => {
-  // A dedicated Client (not a Pool) so the schema-scoping search_path set once
-  // at connect time holds for every query in this file. A Pool hands out
-  // arbitrary connections, which would let a query leak back to public.
-  const client = new Client({ connectionString: DB_URL });
+// A dedicated Client (not a Pool) so the schema-scoping search_path set once
+// at connect time holds for every query in this file. A Pool hands out
+// arbitrary connections, which would let a query leak back to public.
+const client = new Client({ connectionString: requireTestDatabaseUrl() });
 
-  async function applyMigration026(): Promise<void> {
-    await client.query(await Bun.file(migration026Url).text());
-  }
+async function applyMigration026(): Promise<void> {
+  await client.query(await Bun.file(migration026Url).text());
+}
 
-  async function applyMigration028(): Promise<void> {
-    await client.query(await Bun.file(migration028Url).text());
-  }
+async function applyMigration028(): Promise<void> {
+  await client.query(await Bun.file(migration028Url).text());
+}
 
-  async function cleanup(): Promise<void> {
-    await client.query("DELETE FROM maintenance_jobs WHERE namespace = $1", [
-      namespace,
-    ]);
-  }
+async function cleanup(): Promise<void> {
+  await client.query("DELETE FROM maintenance_jobs WHERE namespace = $1", [
+    namespace,
+  ]);
+}
 
-  // Rewind the persisted constraint to the shape a database that applied an
-  // earlier revision of 026 (before 'lease_expired') carries forward, so the
-  // regression proves the real upgrade path rather than the fresh-DB path.
-  // Scoped to the test schema by search_path — public is never touched.
-  async function installPreLeaseExpiredConstraint(): Promise<void> {
-    // A CHECK constraint definition is DDL and cannot be parameterized, so the
-    // fixture list is inlined from the const above (SQL string literals).
-    const inList = PRE_LEASE_EXPIRED_CATEGORIES.map((c) => `'${c}'`).join(", ");
-    await client.query(
-      `ALTER TABLE maintenance_jobs DROP CONSTRAINT IF EXISTS ${CONSTRAINT_NAME}`,
-    );
-    await client.query(
-      `ALTER TABLE maintenance_jobs
-         ADD CONSTRAINT ${CONSTRAINT_NAME}
-         CHECK (last_error_category IN (${inList}))`,
-    );
-  }
+// Rewind the persisted constraint to the shape a database that applied an
+// earlier revision of 026 (before 'lease_expired') carries forward, so the
+// regression proves the real upgrade path rather than the fresh-DB path.
+// Scoped to the test schema by search_path — public is never touched.
+async function installPreLeaseExpiredConstraint(): Promise<void> {
+  // A CHECK constraint definition is DDL and cannot be parameterized, so the
+  // fixture list is inlined from the const above (SQL string literals).
+  const inList = PRE_LEASE_EXPIRED_CATEGORIES.map((c) => `'${c}'`).join(", ");
+  await client.query(
+    `ALTER TABLE maintenance_jobs DROP CONSTRAINT IF EXISTS ${CONSTRAINT_NAME}`,
+  );
+  await client.query(
+    `ALTER TABLE maintenance_jobs
+       ADD CONSTRAINT ${CONSTRAINT_NAME}
+       CHECK (last_error_category IN (${inList}))`,
+  );
+}
 
-  async function insertWithCategory(
-    idempotencyKey: string,
-    category: string | null,
-  ): Promise<void> {
-    await client.query(
-      `INSERT INTO maintenance_jobs
-         (job_kind, job_version, idempotency_key, namespace, last_error_category)
-       VALUES ($1, 1, $2, $3, $4)`,
-      ["maintenance.test", idempotencyKey, namespace, category],
-    );
-  }
+async function insertWithCategory(
+  idempotencyKey: string,
+  category: string | null,
+): Promise<void> {
+  await client.query(
+    `INSERT INTO maintenance_jobs
+       (job_kind, job_version, idempotency_key, namespace, last_error_category)
+     VALUES ($1, 1, $2, $3, $4)`,
+    ["maintenance.test", idempotencyKey, namespace, category],
+  );
+}
 
+describe("028 maintenance_jobs lease_expired compat (live Postgres)", () => {
   beforeAll(async () => {
     await client.connect();
     // Duplicate CI workflows can share one PostgreSQL database. Hold a


### PR DESCRIPTION
## Summary

Refs #878

The live-Postgres half of `src/db/migrations/028_maintenance_jobs_lease_expired_compat.test.ts` was gated behind a `dbDescribe` that resolved to `describe.skip` whenever `OPENBRAIN_TEST_DATABASE_URL` was unset. A skipped suite reports zero failures and exits 0, so a CI database that went missing was indistinguishable from a suite that ran and passed — while migration 028's upgrade-path repair, the one thing this file exists to prove, was never executed against a real constraint.

The suite now takes its connection string from `requireTestDatabaseUrl()` and throws `test_database_required` when the variable is absent. The drift guard at the top of the file needs no database and is unchanged, so it still runs standalone.

The suite is registered in `scripts/assert-db-tests-ran.ts` with its observed count of 3, and `MIN_TOTAL_LIVE_TESTCASES` moves 74 → 77 to keep the global floor tracking the sum of the per-suite counts, as that constant's own contract requires.

Whole-file standards pass on first touch: two non-null assertions replaced with explicit `undefined` handling, and the fixture helpers hoisted to module scope so no single function exceeds the configured line count.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

## Critical Self-Review

- Highest-risk behavior: the file now throws at module scope when the variable is unset, so the database-free drift guard shares that fate. Verified acceptable — every runner of this file is `bun run test:isolated`, which sets the variable, and a loud failure is the intended outcome of #878.
- Assumptions that could be wrong: that hoisting the helpers out of the `describe` body does not change execution order. The `Client` is constructed at module load rather than inside the block, which is a real behavior shift; `beforeAll` still owns `connect()`, and the isolated run passes 4/4.
- Missing/weak tests: none added. The deliverable is the removal of a skip path, and the existing three live tests are the proof; the anti-skip manifest entry is what stops them silently vanishing again.
- Security/permission risk: none. No auth, namespace, or SQL surface changed; the test schema isolation and advisory lock are untouched.
- Migration/deploy risk: none. No migration SQL changed — only the test that exercises 028.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface is touched, so `docs/downstream-rollout.md` does not apply.
- Rollback/cleanup concern: reverting the commit restores the skip path and the old floor together; the two changes are in one commit for that reason.
- Fixes made before PR: caught the `assert-db-tests-ran` floor test failing in the pre-push run — registering a suite without raising `MIN_TOTAL_LIVE_TESTCASES` breaks that constant's stated invariant. Fixed and re-ran the guard's own suite (16 pass).
- Known residual risk: the named done-means still filters `*.pg.test.ts` and this file is `.test.ts`, so it reports `SUBJECT: none` and exits 1 here. The widening PR in flight is what makes it cover this file; the check was run and its output recorded rather than skipped.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the skip-to-throw conversion is the subject of #878 itself and is already recorded in `scripts/test-support/require-test-database.ts`, so a lane entry would duplicate the canonical note rather than add a missed pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this changes a test's environment requirement only, with no runtime or service behavior touched.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, tool schema, or fixture shape changed — the diff is a test harness requirement plus its anti-skip manifest entry.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- RED at `origin/main`: `env -u OPENBRAIN_TEST_DATABASE_URL bun test src/db/migrations/028_maintenance_jobs_lease_expired_compat.test.ts` → exit 0, 1 pass / 5 skip / 0 fail.
- GREEN after the change: same command → exit 1, `test_database_required` in the output.
- `bun run test:isolated src/db/migrations/028_maintenance_jobs_lease_expired_compat.test.ts` → exit 0, 4 pass / 0 fail (3 live + 1 drift guard).
- `bun run test:isolated scripts/assert-db-tests-ran.test.ts` → 16 pass / 0 fail.
- `./node_modules/.bin/oxlint --deny-warnings` on both touched files → exit 0 (three pre-existing findings in the test file fixed: two `no-non-null-assertion`, one `max-lines-per-function`).
- `bunx tsc --noEmit` → exit 0.
- The pre-push hook ran the full isolated suite and passed.
