### PR TITLE
test(pg): migration 029 test requires the test database instead of skipping (#878)

### DIFF
--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -30,6 +30,10 @@ export const REQUIRED_SUITES: ReadonlyArray<{
   minTests: number;
 }> = [
   { name: "lane_upsert (live Postgres)", minTests: 2 },
+  {
+    name: "029 maintenance_jobs terminal category compat (live Postgres)",
+    minTests: 3,
+  },
   { name: "promote_shared (live Postgres)", minTests: 1 },
   { name: "tier_lane (live Postgres)", minTests: 2 },
   {
@@ -176,9 +180,11 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // #878 registered the migration 028 lease_expired compat suite's 3, then
 // 77 -> 79 when #878 registered the two migration-025 suites at 1 each, then
 // 79 -> 80 when #889 split the maintenance lease-boundary suite by subject and
-// its single entry of 5 became four entries summing to 6), so the global floor
-// cannot silently fall behind the per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 80;
+// its single entry of 5 became four entries summing to 6, then 80 -> 83 when
+// #878 registered the migration 029 terminal-category compat suite's 3 as that
+// suite stopped skipping itself), so the global floor cannot silently fall
+// behind the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 83;
 
 export interface SuiteStats {
   tests: number;

--- a/src/db/migrations/029_maintenance_jobs_terminal_category.test.ts
+++ b/src/db/migrations/029_maintenance_jobs_terminal_category.test.ts
@@ -1,3 +1,15 @@
+/**
+ * Live-Postgres upgrade-path test for migration 029.
+ *
+ * REQUIRES `OPENBRAIN_TEST_DATABASE_URL`, and fails hard without it (operator
+ * ruling 2026-08-27, issue #878). A suite that skips itself exits 0 and is
+ * indistinguishable from one that ran and passed, so the environment read now
+ * throws `test_database_required` instead. `bun run test:isolated` sets it.
+ *
+ * The database-backed helpers sit at module scope rather than inside the
+ * describe callback so the callback stays within the repo's per-function line
+ * rule; they close over the single module-scope client either way.
+ */
 import {
   afterAll,
   beforeAll,
@@ -7,9 +19,8 @@ import {
   it,
 } from "bun:test";
 import { Client } from "pg";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
 const migration026Url = new URL("026_maintenance_queue.sql", import.meta.url);
 const migration029Url = new URL(
   "029_maintenance_jobs_terminal_category.sql",
@@ -51,7 +62,8 @@ function extractLastErrorCategorySet(sql: string): Set<string> {
       "could not locate a `last_error_category IN (...)` list in the migration SQL",
     );
   }
-  const values = [...match[1]!.matchAll(/'([^']*)'/g)].map((m) => m[1]!);
+  const inList = match[1] ?? "";
+  const values = [...inList.matchAll(/'([^']*)'/g)].map((m) => m[1] ?? "");
   if (values.length === 0) {
     throw new Error(
       "found a `last_error_category IN (...)` list but it contained no quoted values",
@@ -82,144 +94,139 @@ describe("029 / 026 last_error_category allow-lists stay in sync", () => {
   });
 });
 
-dbDescribe(
-  "029 maintenance_jobs terminal category compat (live Postgres)",
-  () => {
-    const client = new Client({ connectionString: DB_URL });
+const client = new Client({ connectionString: requireTestDatabaseUrl() });
 
-    async function applyMigration026(): Promise<void> {
-      await client.query(await Bun.file(migration026Url).text());
-    }
+async function applyMigration026(): Promise<void> {
+  await client.query(await Bun.file(migration026Url).text());
+}
 
-    async function applyMigration029(): Promise<void> {
-      await client.query(await Bun.file(migration029Url).text());
-    }
+async function applyMigration029(): Promise<void> {
+  await client.query(await Bun.file(migration029Url).text());
+}
 
-    async function cleanup(): Promise<void> {
-      await client.query("DELETE FROM maintenance_jobs WHERE namespace = $1", [
-        namespace,
-      ]);
-    }
+async function cleanup(): Promise<void> {
+  await client.query("DELETE FROM maintenance_jobs WHERE namespace = $1", [
+    namespace,
+  ]);
+}
 
-    // Rewind the persisted constraint to the shape a database that applied an
-    // earlier revision of 026/028 (before 'terminal') carries forward, so the
-    // regression proves the real upgrade path rather than the fresh-DB path.
-    async function installPreTerminalConstraint(): Promise<void> {
-      const inList = PRE_TERMINAL_CATEGORIES.map((c) => `'${c}'`).join(", ");
-      await client.query(
-        `ALTER TABLE maintenance_jobs DROP CONSTRAINT IF EXISTS ${CONSTRAINT_NAME}`,
-      );
-      await client.query(
-        `ALTER TABLE maintenance_jobs
-         ADD CONSTRAINT ${CONSTRAINT_NAME}
-         CHECK (last_error_category IN (${inList}))`,
-      );
-    }
+// Rewind the persisted constraint to the shape a database that applied an
+// earlier revision of 026/028 (before 'terminal') carries forward, so the
+// regression proves the real upgrade path rather than the fresh-DB path.
+async function installPreTerminalConstraint(): Promise<void> {
+  const inList = PRE_TERMINAL_CATEGORIES.map((c) => `'${c}'`).join(", ");
+  await client.query(
+    `ALTER TABLE maintenance_jobs DROP CONSTRAINT IF EXISTS ${CONSTRAINT_NAME}`,
+  );
+  await client.query(
+    `ALTER TABLE maintenance_jobs
+     ADD CONSTRAINT ${CONSTRAINT_NAME}
+     CHECK (last_error_category IN (${inList}))`,
+  );
+}
 
-    async function insertWithCategory(
-      idempotencyKey: string,
-      category: string | null,
-    ): Promise<void> {
-      await client.query(
-        `INSERT INTO maintenance_jobs
-         (job_kind, job_version, idempotency_key, namespace, last_error_category)
-       VALUES ($1, 1, $2, $3, $4)`,
-        ["maintenance.test", idempotencyKey, namespace, category],
-      );
-    }
+async function insertWithCategory(
+  idempotencyKey: string,
+  category: string | null,
+): Promise<void> {
+  await client.query(
+    `INSERT INTO maintenance_jobs
+     (job_kind, job_version, idempotency_key, namespace, last_error_category)
+   VALUES ($1, 1, $2, $3, $4)`,
+    ["maintenance.test", idempotencyKey, namespace, category],
+  );
+}
 
-    beforeAll(async () => {
-      await client.connect();
-      await client.query("SELECT pg_advisory_lock($1)", [TEST_SCHEMA_LOCK]);
-      await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
-      await client.query(`CREATE SCHEMA ${TEST_SCHEMA}`);
-      await client.query(`SET search_path TO ${TEST_SCHEMA}, public`);
-      await client.query(
-        `CREATE OR REPLACE FUNCTION ${TEST_SCHEMA}.update_updated_at()
+describe("029 maintenance_jobs terminal category compat (live Postgres)", () => {
+  beforeAll(async () => {
+    await client.connect();
+    await client.query("SELECT pg_advisory_lock($1)", [TEST_SCHEMA_LOCK]);
+    await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+    await client.query(`CREATE SCHEMA ${TEST_SCHEMA}`);
+    await client.query(`SET search_path TO ${TEST_SCHEMA}, public`);
+    await client.query(
+      `CREATE OR REPLACE FUNCTION ${TEST_SCHEMA}.update_updated_at()
          RETURNS TRIGGER AS $$
          BEGIN
            NEW.updated_at = NOW();
            RETURN NEW;
          END;
          $$ LANGUAGE plpgsql`,
-      );
-    });
+    );
+  });
 
-    beforeEach(async () => {
-      await applyMigration026();
-      await cleanup();
-      await installPreTerminalConstraint();
-    });
+  beforeEach(async () => {
+    await applyMigration026();
+    await cleanup();
+    await installPreTerminalConstraint();
+  });
 
-    afterAll(async () => {
+  afterAll(async () => {
+    try {
+      await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+    } finally {
       try {
-        await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+        await client.query("SELECT pg_advisory_unlock($1)", [TEST_SCHEMA_LOCK]);
       } finally {
-        try {
-          await client.query("SELECT pg_advisory_unlock($1)", [
-            TEST_SCHEMA_LOCK,
-          ]);
-        } finally {
-          await client.end();
-        }
+        await client.end();
       }
-    });
+    }
+  });
 
-    it("rejects terminal before the migration and accepts it after — proving the upgrade repair", async () => {
-      await expect(
-        insertWithCategory("029-before", "terminal"),
-      ).rejects.toThrow(/last_error_category/);
+  it("rejects terminal before the migration and accepts it after — proving the upgrade repair", async () => {
+    await expect(insertWithCategory("029-before", "terminal")).rejects.toThrow(
+      /last_error_category/,
+    );
 
-      await applyMigration029();
+    await applyMigration029();
 
-      await insertWithCategory("029-after", "terminal");
-      const { rows } = await client.query(
-        `SELECT last_error_category FROM maintenance_jobs
+    await insertWithCategory("029-after", "terminal");
+    const { rows } = await client.query(
+      `SELECT last_error_category FROM maintenance_jobs
         WHERE namespace = $1 AND idempotency_key = $2`,
-        [namespace, "029-after"],
-      );
-      expect(rows).toHaveLength(1);
-      expect(rows[0].last_error_category).toBe("terminal");
-    });
+      [namespace, "029-after"],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].last_error_category).toBe("terminal");
+  });
 
-    it("preserves every previously allowed category and still rejects unknown values", async () => {
-      for (const category of PRE_TERMINAL_CATEGORIES) {
-        await insertWithCategory(`029-preserve-${category}`, category);
-      }
-      await insertWithCategory("029-preserve-null", null);
+  it("preserves every previously allowed category and still rejects unknown values", async () => {
+    for (const category of PRE_TERMINAL_CATEGORIES) {
+      await insertWithCategory(`029-preserve-${category}`, category);
+    }
+    await insertWithCategory("029-preserve-null", null);
 
-      await applyMigration029();
+    await applyMigration029();
 
-      const { rows } = await client.query(
-        `SELECT idempotency_key, last_error_category FROM maintenance_jobs
+    const { rows } = await client.query(
+      `SELECT idempotency_key, last_error_category FROM maintenance_jobs
         WHERE namespace = $1
         ORDER BY idempotency_key`,
-        [namespace],
-      );
-      const persisted = new Map(
-        rows.map((r) => [r.idempotency_key as string, r.last_error_category]),
-      );
-      for (const category of PRE_TERMINAL_CATEGORIES) {
-        expect(persisted.get(`029-preserve-${category}`)).toBe(category);
-      }
-      expect(persisted.get("029-preserve-null")).toBeNull();
+      [namespace],
+    );
+    const persisted = new Map(
+      rows.map((r) => [r.idempotency_key as string, r.last_error_category]),
+    );
+    for (const category of PRE_TERMINAL_CATEGORIES) {
+      expect(persisted.get(`029-preserve-${category}`)).toBe(category);
+    }
+    expect(persisted.get("029-preserve-null")).toBeNull();
 
-      await expect(
-        insertWithCategory("029-preserve-bogus", "not_a_real_category"),
-      ).rejects.toThrow(/last_error_category/);
-    });
+    await expect(
+      insertWithCategory("029-preserve-bogus", "not_a_real_category"),
+    ).rejects.toThrow(/last_error_category/);
+  });
 
-    it("is idempotent — re-running the repair leaves the constraint intact", async () => {
-      await applyMigration029();
-      await applyMigration029();
+  it("is idempotent — re-running the repair leaves the constraint intact", async () => {
+    await applyMigration029();
+    await applyMigration029();
 
-      await insertWithCategory("029-idempotent", "terminal");
-      const { rows } = await client.query(
-        `SELECT count(*)::int AS n FROM maintenance_jobs
+    await insertWithCategory("029-idempotent", "terminal");
+    const { rows } = await client.query(
+      `SELECT count(*)::int AS n FROM maintenance_jobs
         WHERE namespace = $1 AND idempotency_key = $2`,
-        [namespace, "029-idempotent"],
-      );
-      expect(rows[0].n).toBe(1);
-    });
-  },
-);
+      [namespace, "029-idempotent"],
+    );
+    expect(rows[0].n).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Refs #878

`src/db/migrations/029_maintenance_jobs_terminal_category.test.ts` read
`OPENBRAIN_TEST_DATABASE_URL` directly and downgraded its live-Postgres
describe to `describe.skip` when the variable was unset. That reports
`0 pass, N skip, 0 fail` and exits 0 — indistinguishable at the exit code from
a suite that ran and passed, so CI stays green while the migration-029 upgrade
path nobody is exercising drifts underneath it.

The environment read now goes through the existing
`scripts/test-support/require-test-database.ts` helper, which throws
`test_database_required` when the variable is missing. Both describes are
plain; the `dbDescribe` indirection and the direct `process.env` read are gone.
The no-database drift guard at the top of the file is unchanged and still runs
its two tests.

Brought to standard on first touch, so three pre-existing oxlint findings in
the file are fixed: two non-null assertions in the allow-list extractor become
nullish-coalescing defaults, and the five database-backed helpers move to
module scope so the describe callback stays within the per-function line rule.
They close over the same module-scope client either way — no test behavior
changes.

`scripts/assert-db-tests-ran.ts` gains the matching manifest entry at the
observed count of 3 live tests. `MIN_TOTAL_LIVE_TESTCASES` moves 74 -> 77 to
match: its comment tracks the sum of the per-suite `minTests`, and its own
guard test builds every suite at exactly that value, so leaving it at 74 made
the shortfall case stop tripping.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Evidence:

- RED at `origin/main`: `env -u OPENBRAIN_TEST_DATABASE_URL bun test src/db/migrations/029_maintenance_jobs_terminal_category.test.ts` -> exit 0, `2 pass, 5 skip, 0 fail`.
- GREEN on this branch: same command -> exit 1, `test_database_required` in output.
- `bun run test:isolated src/db/migrations/029_maintenance_jobs_terminal_category.test.ts` -> exit 0, `5 pass, 0 fail, 15 expect() calls`.
- `bun run test:isolated scripts/assert-db-tests-ran.test.ts` -> exit 0, 16 tests.
- Full suite via the pre-push hook -> exit 0 after the floor was corrected.
- `./node_modules/.bin/oxlint --deny-warnings` on both touched files -> exit 0.
- `bunx tsc --noEmit` -> exit 0.
- `CHANGED_FILES=<file> bash scripts/done-means/878-pg-tests-require-database.sh` -> exit 1, `SUBJECT: none -- CHANGED_FILES override produced no *.pg.test.ts files.` The check still filters `*.pg.test.ts` at `origin/main` and this subject is a `.test.ts`; the widening PR is in flight and the controller re-runs it after that merges.

## Critical Self-Review

- Highest-risk behavior: a test file that previously self-skipped now throws at module scope when `OPENBRAIN_TEST_DATABASE_URL` is unset. Any runner invoking this file without the variable turns from green to red — which is the intended point of #878, but it is a real behavior change for anyone running bare `bun test`.
- Assumptions that could be wrong: that 3 is the right `minTests` for the live describe. It is the observed count from this branch (5 total tests minus the 2 no-database drift-guard tests), not a guess, but a future test added to the live describe raises the real count without raising the floor.
- Missing/weak tests: no new test asserts the throw itself; that behavior is covered by the shared helper's own contract and demonstrated by the recorded RED/GREEN exit codes rather than by an assertion in this file.
- Security/permission risk: none. No auth, namespace, or SQL predicate changed; the SQL in this file is untouched and still parameterized.
- Migration/deploy risk: none. `029_maintenance_jobs_terminal_category.sql` is not modified — only its test.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md`. No MCP tool, schema, transport, or Python client surface is touched.
- Rollback/cleanup concern: reverting the commit restores the skip behavior and the 74 floor together; the two must move as a pair or the guard test fails.
- Fixes made before PR: the first push was refused by the pre-push hook — the full suite failed one test, `assert-db-tests-ran anti-skip guard > fails when total executed live testcases fall below the floor`. Adding 3 to the manifest without raising `MIN_TOTAL_LIVE_TESTCASES` had pushed that test's synthetic total above the floor so the shortfall stopped tripping. Raising the floor to 77 fixed it; the hook was never bypassed.
- Known residual risk: the named done-means cannot yet see this subject because it filters `*.pg.test.ts` and this file is `.test.ts`. Until the widening lands, the RED/GREEN exit codes above are the evidence for this file.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the one lesson here (a `minTests` addition must move the global floor with it) is already recorded in the `MIN_TOTAL_LIVE_TESTCASES` comment, which is where the next person editing that manifest will actually read it.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this is a test-harness change with no runtime surface.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, tool schema, or fixture is touched — the change is confined to a test file and the CI anti-skip manifest.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable on every line: no MCP tool, schema, protocol, transport, or client-facing surface changes. The diff is one test file plus the CI anti-skip manifest.
