### PR TITLE
test(pg): migration 031 test requires the test database instead of skipping (#878)

### DIFF
--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -174,6 +174,15 @@ export const REQUIRED_SUITES: ReadonlyArray<{
     name: "028 maintenance_jobs lease_expired compat (live Postgres)",
     minTests: 3,
   },
+  // Migration 031 converts a database that applied an earlier revision of 030
+  // from a permanent all-status UNIQUE constraint to a running-only partial
+  // index. Registered because the upgrade path it repairs exists only in
+  // Postgres: the suite rewinds a real schema to the legacy shape and proves
+  // the converged one, which no text assertion over the SQL can do.
+  {
+    name: "031 ob_source_sync_runs running-only uniqueness compat (live Postgres)",
+    minTests: 6,
+  },
 ];
 
 // Absolute floor on total executed (non-skipped) live-Postgres testcases,
@@ -192,9 +201,10 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // #878 registered the migration 029 terminal-category compat suite's 3 as that
 // suite stopped skipping itself, then 83 -> 85 when #878 also registered the
 // backgroundExtract tag-merge suite that shares migration 027's file and had
-// never been named here), so the global floor cannot silently fall behind the
-// per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 85;
+// never been named here, then 85 -> 91 when #878 registered the migration 031
+// upgrade-path suite and its 6), so the global floor cannot silently fall
+// behind the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 91;
 
 export interface SuiteStats {
   tests: number;

--- a/src/db/migrations/031_source_sync_runs_running_only_unique.test.ts
+++ b/src/db/migrations/031_source_sync_runs_running_only_unique.test.ts
@@ -8,8 +8,7 @@ import {
 } from "bun:test";
 import { Client } from "pg";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
 
 const migration030Url = new URL("030_source_sync.sql", import.meta.url);
 const migration031Url = new URL(
@@ -30,6 +29,12 @@ const TEST_SCHEMA_LOCK = 31_031;
 // defect 031 repairs.
 const LEGACY_CONSTRAINT = "ob_source_sync_runs_source_id_observation_hash_key";
 const RUNNING_INDEX = "idx_ob_source_sync_runs_running_obs";
+
+// The live-Postgres describe below REQUIRES `OPENBRAIN_TEST_DATABASE_URL` and
+// fails hard without it (operator ruling 2026-08-27, issue #878). It must point
+// at an isolated test database, never the dogfood one; `bun run test:isolated`
+// sets it. The drift-guard describe above reads only migration SQL text and
+// needs no database.
 
 const H = (n: number): string => n.toString(16).padStart(64, "0");
 
@@ -64,225 +69,228 @@ describe("031 targets the exact legacy constraint and restores the partial index
   });
 });
 
-dbDescribe(
-  "031 ob_source_sync_runs running-only uniqueness compat (live Postgres)",
-  () => {
-    const client = new Client({ connectionString: DB_URL });
+const client = new Client({ connectionString: requireTestDatabaseUrl() });
 
-    async function applyMigration030(): Promise<void> {
-      await client.query(await Bun.file(migration030Url).text());
-    }
+async function applyMigration031(): Promise<void> {
+  await client.query(await Bun.file(migration031Url).text());
+}
 
-    async function applyMigration031(): Promise<void> {
-      await client.query(await Bun.file(migration031Url).text());
-    }
-
-    // Rewind the schema to the shape a database that applied an EARLIER revision
-    // of 030 carries forward: the permanent all-status UNIQUE constraint present,
-    // the running-only partial index absent. Models the real upgrade path (like
-    // 028/029's installers) rather than the fresh-DB path.
-    async function installLegacyPermanentConstraint(): Promise<void> {
-      await client.query(`DROP INDEX IF EXISTS ${RUNNING_INDEX}`);
-      await client.query(
-        `ALTER TABLE ob_source_sync_runs
+// Rewind the schema to the shape a database that applied an EARLIER revision
+// of 030 carries forward: the permanent all-status UNIQUE constraint present,
+// the running-only partial index absent. Models the real upgrade path (like
+// 028/029's installers) rather than the fresh-DB path.
+async function installLegacyPermanentConstraint(): Promise<void> {
+  await client.query(`DROP INDEX IF EXISTS ${RUNNING_INDEX}`);
+  await client.query(
+    `ALTER TABLE ob_source_sync_runs
            DROP CONSTRAINT IF EXISTS ${LEGACY_CONSTRAINT}`,
-      );
-      await client.query(
-        `ALTER TABLE ob_source_sync_runs
+  );
+  await client.query(
+    `ALTER TABLE ob_source_sync_runs
            ADD CONSTRAINT ${LEGACY_CONSTRAINT}
            UNIQUE (source_id, observation_hash)`,
-      );
-    }
+  );
+}
 
-    async function constraintExists(name: string): Promise<boolean> {
-      const { rows } = await client.query(
-        `SELECT 1 FROM pg_constraint
+async function constraintExists(name: string): Promise<boolean> {
+  const { rows } = await client.query(
+    `SELECT 1 FROM pg_constraint
           WHERE conrelid = 'ob_source_sync_runs'::regclass AND conname = $1`,
-        [name],
-      );
-      return rows.length > 0;
-    }
+    [name],
+  );
+  return rows.length > 0;
+}
 
-    async function indexExists(name: string): Promise<boolean> {
-      const { rows } = await client.query(
-        `SELECT 1 FROM pg_indexes
+async function indexExists(name: string): Promise<boolean> {
+  const { rows } = await client.query(
+    `SELECT 1 FROM pg_indexes
           WHERE tablename = 'ob_source_sync_runs' AND indexname = $1`,
-        [name],
-      );
-      return rows.length > 0;
-    }
+    [name],
+  );
+  return rows.length > 0;
+}
 
-    // Insert a sync run with the given observation_hash and status. A minimal
-    // synthetic source_id is enough: the FK to ob_sources is dropped in this
-    // isolated schema (no ob_sources table here), so uniqueness is exercised in
-    // isolation from the registry.
-    async function insertRun(
-      sourceId: string,
-      obsHash: string,
-      status: "running" | "completed",
-    ): Promise<void> {
-      await client.query(
-        `INSERT INTO ob_source_sync_runs
+// Insert a sync run with the given observation_hash and status. A minimal
+// synthetic source_id is enough: the FK to ob_sources is dropped in this
+// isolated schema (no ob_sources table here), so uniqueness is exercised in
+// isolation from the registry.
+async function insertRun(
+  sourceId: string,
+  obsHash: string,
+  status: "running" | "completed",
+): Promise<void> {
+  await client.query(
+    `INSERT INTO ob_source_sync_runs
            (source_id, namespace, observation_hash, status)
          VALUES ($1, $2, $3, $4)`,
-        [sourceId, "test-migration-031", obsHash, status],
-      );
-    }
+    [sourceId, "test-migration-031", obsHash, status],
+  );
+}
 
-    const SOURCE_ID = "11111111-1111-1111-1111-111111111111";
+const SOURCE_ID = "11111111-1111-1111-1111-111111111111";
 
-    beforeAll(async () => {
-      await client.connect();
-      await client.query("SELECT pg_advisory_lock($1)", [TEST_SCHEMA_LOCK]);
-      await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
-      await client.query(`CREATE SCHEMA ${TEST_SCHEMA}`);
-      await client.query(`SET search_path TO ${TEST_SCHEMA}, public`);
-      // 030 reuses the shared updated_at trigger function from 001_init.sql;
-      // provide it in the isolated schema so the CREATE TRIGGER in 030 resolves.
-      await client.query(
-        `CREATE OR REPLACE FUNCTION ${TEST_SCHEMA}.update_updated_at()
+// Create the isolated schema and the one shared function 030 depends on. Held
+// under an advisory lock so a concurrently running file cannot interleave with
+// the drop/create pair.
+async function createIsolatedSchema(): Promise<void> {
+  await client.connect();
+  await client.query("SELECT pg_advisory_lock($1)", [TEST_SCHEMA_LOCK]);
+  await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+  await client.query(`CREATE SCHEMA ${TEST_SCHEMA}`);
+  await client.query(`SET search_path TO ${TEST_SCHEMA}, public`);
+  // 030 reuses the shared updated_at trigger function from 001_init.sql;
+  // provide it in the isolated schema so the CREATE TRIGGER in 030 resolves.
+  await client.query(
+    `CREATE OR REPLACE FUNCTION ${TEST_SCHEMA}.update_updated_at()
          RETURNS TRIGGER AS $$
          BEGIN
            NEW.updated_at = NOW();
            RETURN NEW;
          END;
          $$ LANGUAGE plpgsql`,
-      );
-    });
+  );
+}
 
-    beforeEach(async () => {
-      // Rebuild the tables 030 owns from scratch each test, then rewind to the
-      // legacy permanent-constraint shape. gen_random_uuid() is a core function
-      // in Postgres 18, so no pgcrypto is required for the UUID defaults.
-      // Qualify the isolated schema explicitly. On the first test these tables do
-      // not exist in TEST_SCHEMA yet; an unqualified DROP would continue through
-      // search_path to `public` and destroy the shared source-sync tables used by
-      // concurrently running suites.
-      await client.query(
-        `DROP TABLE IF EXISTS ${TEST_SCHEMA}.ob_source_sync_runs CASCADE`,
-      );
-      await client.query(
-        `DROP TABLE IF EXISTS ${TEST_SCHEMA}.ob_source_files CASCADE`,
-      );
-      // ob_source_sync_runs FK-references ob_sources (id); in this isolated
-      // schema there is no registry, so strip the FK from the 030 body before
-      // applying it. Uniqueness — the only thing under test — is untouched.
-      const sql030 = (await Bun.file(migration030Url).text()).replace(
-        /REFERENCES ob_sources \(id\) ON DELETE CASCADE/g,
-        "",
-      );
-      await client.query(sql030);
-      await installLegacyPermanentConstraint();
-    });
+// Rebuild the tables 030 owns from scratch, then rewind them to the legacy
+// permanent-constraint shape every test starts from.
+async function rebuildAtLegacyShape(): Promise<void> {
+  // Rebuild the tables 030 owns from scratch each test, then rewind to the
+  // legacy permanent-constraint shape. gen_random_uuid() is a core function
+  // in Postgres 18, so no pgcrypto is required for the UUID defaults.
+  // Qualify the isolated schema explicitly. On the first test these tables do
+  // not exist in TEST_SCHEMA yet; an unqualified DROP would continue through
+  // search_path to `public` and destroy the shared source-sync tables used by
+  // concurrently running suites.
+  await client.query(
+    `DROP TABLE IF EXISTS ${TEST_SCHEMA}.ob_source_sync_runs CASCADE`,
+  );
+  await client.query(
+    `DROP TABLE IF EXISTS ${TEST_SCHEMA}.ob_source_files CASCADE`,
+  );
+  // ob_source_sync_runs FK-references ob_sources (id); in this isolated
+  // schema there is no registry, so strip the FK from the 030 body before
+  // applying it. Uniqueness — the only thing under test — is untouched.
+  const sql030 = (await Bun.file(migration030Url).text()).replace(
+    /REFERENCES ob_sources \(id\) ON DELETE CASCADE/g,
+    "",
+  );
+  await client.query(sql030);
+  await installLegacyPermanentConstraint();
+}
 
-    afterAll(async () => {
-      try {
-        await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
-      } finally {
-        try {
-          await client.query("SELECT pg_advisory_unlock($1)", [
-            TEST_SCHEMA_LOCK,
-          ]);
-        } finally {
-          await client.end();
-        }
-      }
-    });
+// Drop the isolated schema, release the advisory lock, and close the
+// connection -- each step in its own finally so an earlier failure cannot leak
+// the lock or the socket.
+async function teardownIsolatedSchema(): Promise<void> {
+  try {
+    await client.query(`DROP SCHEMA IF EXISTS ${TEST_SCHEMA} CASCADE`);
+  } finally {
+    try {
+      await client.query("SELECT pg_advisory_unlock($1)", [TEST_SCHEMA_LOCK]);
+    } finally {
+      await client.end();
+    }
+  }
+}
 
-    it("before 031: the legacy permanent constraint rejects two completed runs sharing an observation", async () => {
-      expect(await constraintExists(LEGACY_CONSTRAINT)).toBe(true);
-      await insertRun(SOURCE_ID, H(1), "completed");
-      // The all-status constraint blocks a second row with the same
-      // (source_id, observation_hash), even though both are terminal history.
-      await expect(insertRun(SOURCE_ID, H(1), "completed")).rejects.toThrow(
-        /unique/i,
-      );
-    });
+describe("031 ob_source_sync_runs running-only uniqueness compat (live Postgres)", () => {
+  beforeAll(createIsolatedSchema);
+  beforeEach(rebuildAtLegacyShape);
+  afterAll(teardownIsolatedSchema);
 
-    it("after 031: the legacy constraint is gone and the running-only partial index exists", async () => {
-      await applyMigration031();
+  it("before 031: the legacy permanent constraint rejects two completed runs sharing an observation", async () => {
+    expect(await constraintExists(LEGACY_CONSTRAINT)).toBe(true);
+    await insertRun(SOURCE_ID, H(1), "completed");
+    // The all-status constraint blocks a second row with the same
+    // (source_id, observation_hash), even though both are terminal history.
+    await expect(insertRun(SOURCE_ID, H(1), "completed")).rejects.toThrow(
+      /unique/i,
+    );
+  });
 
-      expect(await constraintExists(LEGACY_CONSTRAINT)).toBe(false);
-      expect(await indexExists(RUNNING_INDEX)).toBe(true);
-    });
+  it("after 031: the legacy constraint is gone and the running-only partial index exists", async () => {
+    await applyMigration031();
 
-    it("after 031: two completed runs with the SAME observation coexist (repeated / A->B->A revert)", async () => {
-      await applyMigration031();
+    expect(await constraintExists(LEGACY_CONSTRAINT)).toBe(false);
+    expect(await indexExists(RUNNING_INDEX)).toBe(true);
+  });
 
-      await insertRun(SOURCE_ID, H(2), "completed");
-      // A repeated observation and the A->B->A revert both plan a fresh run whose
-      // hash equals a completed history row's; that must be allowed now.
-      await insertRun(SOURCE_ID, H(2), "completed");
+  it("after 031: two completed runs with the SAME observation coexist (repeated / A->B->A revert)", async () => {
+    await applyMigration031();
 
-      const { rows } = await client.query(
-        `SELECT count(*)::int AS n FROM ob_source_sync_runs
+    await insertRun(SOURCE_ID, H(2), "completed");
+    // A repeated observation and the A->B->A revert both plan a fresh run whose
+    // hash equals a completed history row's; that must be allowed now.
+    await insertRun(SOURCE_ID, H(2), "completed");
+
+    const { rows } = await client.query(
+      `SELECT count(*)::int AS n FROM ob_source_sync_runs
           WHERE source_id = $1 AND observation_hash = $2 AND status = 'completed'`,
-        [SOURCE_ID, H(2)],
-      );
-      expect(rows[0].n).toBe(2);
-    });
+      [SOURCE_ID, H(2)],
+    );
+    expect(rows[0].n).toBe(2);
+  });
 
-    it("after 031: the running-only index still forbids two RUNNING runs for one observation", async () => {
-      await applyMigration031();
+  it("after 031: the running-only index still forbids two RUNNING runs for one observation", async () => {
+    await applyMigration031();
 
-      await insertRun(SOURCE_ID, H(3), "running");
-      // Concurrent planners must still converge on ONE running row.
-      await expect(insertRun(SOURCE_ID, H(3), "running")).rejects.toThrow(
-        /unique/i,
-      );
+    await insertRun(SOURCE_ID, H(3), "running");
+    // Concurrent planners must still converge on ONE running row.
+    await expect(insertRun(SOURCE_ID, H(3), "running")).rejects.toThrow(
+      /unique/i,
+    );
 
-      // ...but a completed history row for that same observation never blocks it.
-      await client.query(
-        `UPDATE ob_source_sync_runs SET status = 'completed'
+    // ...but a completed history row for that same observation never blocks it.
+    await client.query(
+      `UPDATE ob_source_sync_runs SET status = 'completed'
           WHERE source_id = $1 AND observation_hash = $2`,
-        [SOURCE_ID, H(3)],
-      );
-      await insertRun(SOURCE_ID, H(3), "running");
-      const { rows } = await client.query(
-        `SELECT count(*)::int AS n FROM ob_source_sync_runs
+      [SOURCE_ID, H(3)],
+    );
+    await insertRun(SOURCE_ID, H(3), "running");
+    const { rows } = await client.query(
+      `SELECT count(*)::int AS n FROM ob_source_sync_runs
           WHERE source_id = $1 AND observation_hash = $2 AND status = 'running'`,
-        [SOURCE_ID, H(3)],
-      );
-      expect(rows[0].n).toBe(1);
-    });
+      [SOURCE_ID, H(3)],
+    );
+    expect(rows[0].n).toBe(1);
+  });
 
-    it("is idempotent — re-running 031 leaves the schema at the same converged shape", async () => {
-      await applyMigration031();
-      await applyMigration031();
+  it("is idempotent — re-running 031 leaves the schema at the same converged shape", async () => {
+    await applyMigration031();
+    await applyMigration031();
 
-      expect(await constraintExists(LEGACY_CONSTRAINT)).toBe(false);
-      expect(await indexExists(RUNNING_INDEX)).toBe(true);
+    expect(await constraintExists(LEGACY_CONSTRAINT)).toBe(false);
+    expect(await indexExists(RUNNING_INDEX)).toBe(true);
 
-      await insertRun(SOURCE_ID, H(4), "completed");
-      await insertRun(SOURCE_ID, H(4), "completed");
-      const { rows } = await client.query(
-        `SELECT count(*)::int AS n FROM ob_source_sync_runs
+    await insertRun(SOURCE_ID, H(4), "completed");
+    await insertRun(SOURCE_ID, H(4), "completed");
+    const { rows } = await client.query(
+      `SELECT count(*)::int AS n FROM ob_source_sync_runs
           WHERE source_id = $1 AND observation_hash = $2`,
-        [SOURCE_ID, H(4)],
-      );
-      expect(rows[0].n).toBe(2);
-    });
+      [SOURCE_ID, H(4)],
+    );
+    expect(rows[0].n).toBe(2);
+  });
 
-    it("harmless on a fresh corrected-030 database (no legacy constraint to drop)", async () => {
-      // Simulate the fresh path: corrected 030 already produced the partial
-      // index and never had the permanent constraint.
-      await client.query(
-        `ALTER TABLE ob_source_sync_runs
+  it("harmless on a fresh corrected-030 database (no legacy constraint to drop)", async () => {
+    // Simulate the fresh path: corrected 030 already produced the partial
+    // index and never had the permanent constraint.
+    await client.query(
+      `ALTER TABLE ob_source_sync_runs
            DROP CONSTRAINT IF EXISTS ${LEGACY_CONSTRAINT}`,
-      );
-      await client.query(
-        `CREATE UNIQUE INDEX IF NOT EXISTS ${RUNNING_INDEX}
+    );
+    await client.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS ${RUNNING_INDEX}
            ON ob_source_sync_runs (source_id, observation_hash)
            WHERE status = 'running'`,
-      );
+    );
 
-      // 031 must be a clean no-op here.
-      await applyMigration031();
+    // 031 must be a clean no-op here.
+    await applyMigration031();
 
-      expect(await constraintExists(LEGACY_CONSTRAINT)).toBe(false);
-      expect(await indexExists(RUNNING_INDEX)).toBe(true);
-      await insertRun(SOURCE_ID, H(5), "completed");
-      await insertRun(SOURCE_ID, H(5), "completed");
-    });
-  },
-);
+    expect(await constraintExists(LEGACY_CONSTRAINT)).toBe(false);
+    expect(await indexExists(RUNNING_INDEX)).toBe(true);
+    await insertRun(SOURCE_ID, H(5), "completed");
+    await insertRun(SOURCE_ID, H(5), "completed");
+  });
+});


### PR DESCRIPTION
## Summary

- Refs #878
- `src/db/migrations/031_source_sync_runs_running_only_unique.test.ts` read `OPENBRAIN_TEST_DATABASE_URL` and degraded its live half to `describe.skip` when the variable was unset. It now calls `requireTestDatabaseUrl()` from `scripts/test-support/require-test-database.ts` and fails hard with `test_database_required` instead.
- Whole-file standard pass surfaced two pre-existing oxlint findings, both fixed: `applyMigration030` was declared and never called, and the live describe body ran 167 code lines. The client, the SQL helpers, and the three lifecycle bodies are now module-scope named functions (`createIsolatedSchema`, `rebuildAtLegacyShape`, `teardownIsolatedSchema`), leaving the describe holding only its six tests. No assertion, schema, or test ordering changed.
- The suite was missing from `scripts/assert-db-tests-ran.ts`, so CI's anti-skip guard would not have caught it disappearing either. It is registered with `minTests: 6` and `MIN_TOTAL_LIVE_TESTCASES` moves 74 -> 80.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable — no Python touched
- [x] Live Open Brain smoke passed or is not applicable — test-only change, no runtime or contract surface

Evidence:

- Before, at `origin/main`: `env -u OPENBRAIN_TEST_DATABASE_URL bun test <file>` -> exit 0, `3 pass, 8 skip, 0 fail`. A green exit for a Postgres upgrade path nothing executed.
- After: same command -> exit 1, `test_database_required` in output.
- `bun run test:isolated <file>` -> `9 pass, 0 fail, 17 expect() calls` (3 drift-guard + 6 live).
- `bun run test:isolated scripts/assert-db-tests-ran.test.ts` -> `16 pass, 0 fail`.
- `./node_modules/.bin/oxlint --deny-warnings` on both touched files -> exit 0.
- `bunx tsc --noEmit` -> exit 0.
- `CHANGED_FILES=<file> bash scripts/done-means/878-pg-tests-require-database.sh` -> `SUBJECT: none`, exit 1. Expected: the check currently selects only `*.pg.test.ts`, and this file is a `.test.ts` beside its migration. PR #893 widens that selector; this check passes once #893 merges.

## Critical Self-Review

- Highest-risk behavior: the schema isolation. `beforeEach` drops `${TEST_SCHEMA}.ob_source_sync_runs` and `ob_source_files` by qualified name specifically so an unqualified drop cannot walk `search_path` into `public` and destroy the shared source-sync tables of a concurrently running suite. Hoisting that body out of the describe preserved the qualification verbatim — it is the one line in this diff worth re-reading.
- Assumptions that could be wrong: that Bun binds a module-scope `const client` before `beforeAll` runs it. `requireTestDatabaseUrl()` is now evaluated at module load rather than inside the describe factory, so the throw happens at import time. Both observed states confirm the intent — exit 1 with the named error unset, 9 pass set — but it does mean the drift-guard tests, which need no database, no longer run when the variable is absent. That is the ruling's intent (the file fails, loudly) and not an accident.
- Missing/weak tests: none added. This lane converts a guard; the six live tests are unchanged and were already the coverage. There is no test asserting the file itself throws without a database — that property is proven by the recorded red/green commands, not by an assertion.
- Security/permission risk: none. No auth, namespace, token, or SQL-construction path is touched. The interpolated identifiers (`TEST_SCHEMA`, `LEGACY_CONSTRAINT`, `RUNNING_INDEX`) are the same code-owned constants as before, never derived from input.
- Migration/deploy risk: none. No migration SQL is modified; 030 and 031 are read as text, not rewritten.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface is involved, so `docs/downstream-rollout.md` does not apply.
- Rollback/cleanup concern: reverting the commit restores the skip and would drop `MIN_TOTAL_LIVE_TESTCASES` back to 74 — fine standalone, but a revert landing after a sibling #878 PR has raised the same constant would clobber it. Revert the test file and re-check the constant by hand.
- Fixes made before PR: removed the dead `applyMigration030`; split the 167-line describe body under the 100-line rule; corrected the manifest's running provenance comment so the 74 -> 80 step reads as one sentence.
- Known residual risk: the done-means script cannot exercise this file until #893 widens its selector, so the check is recorded as `SUBJECT: none` rather than a pass. `MIN_TOTAL_LIVE_TESTCASES` is also the known conflict point across the concurrent #878 lanes — expect a rebase conflict on that constant.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical application of the existing #878 ruling that a `.pg.test.ts` demands its database, already captured by `scripts/test-support/require-test-database.ts` and its module docblock; no new failure pattern surfaced that a future reviewer would need warned about.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: test-only change with no runtime, transport, or contract surface.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no tool contract, schema, or fixture shape is touched; the change is a test-harness guard.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- All four are not applicable: the diff is one test file plus the anti-skip manifest. No MCP tool, schema, protocol, or client-facing surface changes, so no downstream runtime can observe it.
