### PR TITLE
fix(maintenance): the lease-boundary test waits for the reclaimed job to settle, and the suite requires the test database (#889, #878)

### DIFF
--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -108,12 +108,32 @@ export const REQUIRED_SUITES: ReadonlyArray<{
     minTests: 3,
   },
   // The maintenance queue runner's lease boundary, proven through the composed
-  // `server/` runtime. This entry matters more than most: both invariants it
-  // covers fail SILENTLY -- a row sits `running` under a live lease with no
+  // `server/` runtime. These entries matter more than most: the invariants they
+  // cover fail SILENTLY -- a row sits `running` under a live lease with no
   // handler, nothing throws, and nothing is logged -- so a skipped run and a
   // passing run look identical from the outside. That is precisely the shape
   // this guard exists for.
-  { name: "maintenance runtime lease boundary (live Postgres)", minTests: 5 },
+  //
+  // #889 split the single lease-boundary suite by subject, so the one entry
+  // that stood here became the four below. Each is named separately on purpose:
+  // a single entry covering all six tests would stay satisfied if an entire
+  // subject stopped running, as long as the others made up the count.
+  {
+    name: "maintenance runtime shutdown drain (live Postgres)",
+    minTests: 2,
+  },
+  {
+    name: "maintenance runtime lease expiry (live Postgres)",
+    minTests: 1,
+  },
+  {
+    name: "maintenance runtime failure classification (live Postgres)",
+    minTests: 1,
+  },
+  {
+    name: "maintenance runtime composition (live Postgres)",
+    minTests: 2,
+  },
   // The rewrite's real process entrypoint (`server/main.ts`), charter Phase 5.
   // Registered for the strongest version of this guard's reason: these are the
   // ONLY suites that start the entrypoint as a process -- real config parse,
@@ -154,9 +174,11 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // 65 -> 74 when #878 registered the two source-registry suites (8) and the
 // entrypoint split redistributed its own tests to 3 + 2 + 3, then 74 -> 77 when
 // #878 registered the migration 028 lease_expired compat suite's 3, then
-// 77 -> 79 when #878 registered the two migration-025 suites at 1 each), so the
-// global floor cannot silently fall behind the per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 79;
+// 77 -> 79 when #878 registered the two migration-025 suites at 1 each, then
+// 79 -> 80 when #889 split the maintenance lease-boundary suite by subject and
+// its single entry of 5 became four entries summing to 6), so the global floor
+// cannot silently fall behind the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 80;
 
 export interface SuiteStats {
   tests: number;

--- a/scripts/done-means/889-lease-boundary-test-settles.sh
+++ b/scripts/done-means/889-lease-boundary-test-settles.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #889 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/889-lease-boundary-test-settles.sh
+#
+# THE DEFECT. `server/maintenance/maintenance.pg.test.ts` drove the composed
+# runtime with `await runtime.runner.runOnce()` and then read the reclaimed row
+# back immediately. `runOnce()` awaits `tick()` only (src/maintenance-queue.ts
+# :744), and `tick()` dispatches each claimed job into the runner's `active` set
+# WITHOUT awaiting it (src/maintenance-queue.ts:826-831) — the drain lives in
+# `stop()` (:754-762). So the row was legitimately still `running` when the
+# assertion read it, and `expect(recovered.state).toBe("succeeded")` failed on
+# CI three times on branches that never touched the file.
+#
+# WHY THE CHECK IS A REPEAT RUN AND NOT A SINGLE ONE. The defect is a race whose
+# losing side is rare: a single green run is exactly what the broken tree
+# produced most of the time, which is why it survived to CI in the first place.
+# One run therefore carries no information. Twenty consecutive clean runs is the
+# smallest observation that distinguishes "the wait is real" from "the machine
+# happened to be fast", and it is the shape issue #889 asked for by name.
+#
+# Each iteration goes through `bun run test:isolated`, which stands up its own
+# freshly-migrated database and drops it again (AGENTS.md — a full run against
+# the dogfood database is not evidence). The run is therefore slow by design.
+#
+# Exits 1 on the FIRST non-zero iteration, naming which one, so a failure is
+# never reported as a pass and never hides behind a later success.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || {
+  echo "DONE-MEANS 889: FAIL — cannot enter repo root" >&2
+  exit 1
+}
+
+TARGET="server/maintenance/maintenance.pg.test.ts"
+RUNS=20
+
+if [[ ! -f "$TARGET" ]]; then
+  echo "DONE-MEANS 889: FAIL — $TARGET not found" >&2
+  exit 1
+fi
+
+for ((i = 1; i <= RUNS; i++)); do
+  echo "DONE-MEANS 889: iteration $i/$RUNS"
+  if ! bun run test:isolated "$TARGET"; then
+    echo "DONE-MEANS 889: FAIL — iteration $i/$RUNS exited non-zero" >&2
+    exit 1
+  fi
+done
+
+echo "DONE-MEANS 889: PASS"

--- a/server/maintenance/maintenance.pg.test.ts
+++ b/server/maintenance/maintenance.pg.test.ts
@@ -24,15 +24,30 @@
  *     defect was a mid-loop `if (stopping) return` that abandoned them until
  *     lease expiry.
  *
- *  2. `docs/sme/correctness.md` — the retry bound governs the EXPIRY path too.
+ *  2. `docs/sme/correctness.md` — the retry rule governs the EXPIRY path too.
  *     An expired `running` row that has consumed `max_attempts` executions
  *     dead-letters inside the claim statement instead of being reclaimed
  *     forever, and never appears to the runner as claimed work.
  *
- * DATABASE. Skips loudly without `OPENBRAIN_TEST_DATABASE_URL`, which must point
- * at an isolated test database. Never the dogfood database. Each test uses its
- * own job-kind prefix and deletes only its own rows, so a shared test database
- * stays usable and no test can observe another's jobs.
+ * DATABASE. REQUIRES `OPENBRAIN_TEST_DATABASE_URL` and fails hard without it
+ * (operator ruling 2026-08-27, issue #878): `requireTestDatabaseUrl()` throws
+ * `test_database_required` at module scope rather than letting the suite
+ * downgrade itself to a skip that exits 0 and proves nothing. It must point at
+ * an isolated test database, never the dogfood database; `bun run
+ * test:isolated` sets it. Each test uses its own job-kind prefix and deletes
+ * only its own rows, so a shared test database stays usable and no test can
+ * observe another's jobs.
+ *
+ * HOW THE SUITES BELOW ARE GROUPED. Four describes, split by SUBJECT over one
+ * shared set of module-scope helpers, so each reads as a statement about one
+ * behavior of the runtime rather than as a single undifferentiated block:
+ * shutdown drain, lease expiry, handler-failure classification, and
+ * composition. Every name keeps the literal `(live Postgres)` marker — it is
+ * REQUIRED, not decorative, because the anti-skip guard
+ * (`scripts/assert-db-tests-ran.ts`) matches suites by name, and without it a
+ * CI Postgres misconfiguration would silently skip the suites that prove the
+ * lease invariants survive the port, leaving the job green while proving
+ * nothing about a failure mode that never throws.
  */
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import pg from "pg";
@@ -42,12 +57,11 @@ import {
   type MaintenanceJob,
   type MaintenanceJobHandler,
 } from "../../src/maintenance-queue.ts";
+import { requireTestDatabaseUrl } from "../../scripts/test-support/require-test-database.ts";
 import { createMaintenanceRuntime } from "./index.ts";
 import type { MaintenanceConfig } from "../config/maintenance.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-const pool = DB_URL ? new pg.Pool({ connectionString: DB_URL }) : null;
+const pool = new pg.Pool({ connectionString: requireTestDatabaseUrl() });
 
 /** Job kinds are namespaced per run so concurrent suites cannot collide. */
 const KIND_PREFIX = `maint.port.${process.pid}`;
@@ -61,8 +75,45 @@ function config(overrides: Partial<MaintenanceConfig> = {}): MaintenanceConfig {
 }
 
 async function db(): Promise<pg.Pool> {
-  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
   return pool;
+}
+
+/**
+ * Compose a runtime for one test, failing loudly when composition returns
+ * nothing. Every suite below wants the same three arguments — the shared pool,
+ * a silent logger, and no timer — so they live here rather than in each test.
+ */
+async function runtimeFor(options: {
+  handlers: Map<string, MaintenanceJobHandler>;
+  config?: Partial<MaintenanceConfig>;
+}) {
+  const runtime = createMaintenanceRuntime({
+    config: config(options.config ?? {}),
+    logger: silentLogger(),
+    pool: await db(),
+    handlers: options.handlers,
+    autoStart: false,
+  });
+  if (!runtime) throw new Error("maintenance runtime should be composed");
+  return runtime;
+}
+
+/**
+ * A handler that records the ids it was handed, returned alongside that log.
+ * The `seen` array is the in-memory half of every assertion; the row read back
+ * with SQL is the other, and the two disagreeing is the whole failure mode.
+ */
+function recordingHandler(): {
+  seen: string[];
+  handler: MaintenanceJobHandler;
+} {
+  const seen: string[] = [];
+  return {
+    seen,
+    handler: async (job: MaintenanceJob) => {
+      seen.push(job.id);
+    },
+  };
 }
 
 /** Read a row back by id. The durable row is the oracle, never the job object. */
@@ -88,31 +139,60 @@ async function readRow(id: string): Promise<{
   return row;
 }
 
+/**
+ * Read a row back once it has left `running`.
+ *
+ * `runner.runOnce()` is NOT a drain. It awaits `tick()`
+ * (`src/maintenance-queue.ts:744`), and `tick()` dispatches each claimed job
+ * into the runner's `active` set without awaiting it (`:826-831`) so that
+ * `concurrency` means anything at all; the only method contracted to await
+ * handlers is `stop()` (`:754-762`). A test that drives `runOnce()` and then
+ * reads the row has therefore raced the handler, and the race is one the test
+ * usually wins -- which is exactly how issue #889 reached CI three times on
+ * branches that never touched this file.
+ *
+ * So the durable row is polled until it reaches a terminal state rather than
+ * sampled once. The deadline exists to keep a genuinely stuck job from hanging
+ * the suite, and it fails with the job's last observed state named, so a real
+ * regression reports what the row was doing instead of a bare timeout.
+ */
+async function readSettledRow(
+  id: string,
+  deadlineMs = 5_000,
+): Promise<Awaited<ReturnType<typeof readRow>>> {
+  const giveUpAt = Date.now() + deadlineMs;
+  let row = await readRow(id);
+  while (row.state === "running" || row.state === "queued") {
+    if (Date.now() >= giveUpAt) {
+      throw new Error(
+        `maintenance job ${id} never settled: still ${row.state} after ${deadlineMs}ms`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    row = await readRow(id);
+  }
+  return row;
+}
+
 async function deleteKind(kind: string): Promise<void> {
   const client = await db();
   await client.query(`DELETE FROM maintenance_jobs WHERE job_kind = $1`, [kind]);
 }
 
-afterAll(async () => {
-  if (!pool) return;
+/** Clear this run's rows. Shared by every suite's `beforeEach`. */
+async function clearOwnJobs(): Promise<void> {
   await pool.query(`DELETE FROM maintenance_jobs WHERE job_kind LIKE $1`, [
     `${KIND_PREFIX}%`,
   ]);
+}
+
+afterAll(async () => {
+  await clearOwnJobs();
   await pool.end();
 });
 
-// The "(live Postgres)" marker is REQUIRED, not decorative: the anti-skip guard
-// (`scripts/assert-db-tests-ran.ts`) matches suites by this name, and without it
-// a CI Postgres misconfiguration would silently skip the ONE suite that proves
-// the lease invariants survive the port -- leaving the job green while proving
-// nothing about the failure mode that never throws.
-dbDescribe("maintenance runtime lease boundary (live Postgres)", () => {
-  beforeEach(async () => {
-    if (!pool) return;
-    await pool.query(`DELETE FROM maintenance_jobs WHERE job_kind LIKE $1`, [
-      `${KIND_PREFIX}%`,
-    ]);
-  });
+describe("maintenance runtime shutdown drain (live Postgres)", () => {
+  beforeEach(clearOwnJobs);
 
   it("drains a job whose claim was already in flight when stop() began", async () => {
     // INVARIANT 1, and the reason this whole port had to be proven rather than
@@ -146,22 +226,14 @@ dbDescribe("maintenance runtime lease boundary (live Postgres)", () => {
     const claimMayReturn = new Promise<void>((resolve) => {
       releaseClaim = resolve;
     });
-    const seen: string[] = [];
+    const { seen, handler } = recordingHandler();
 
-    const handler: MaintenanceJobHandler = async (job: MaintenanceJob) => {
-      seen.push(job.id);
-    };
-
-    const runtime = createMaintenanceRuntime({
-      config: config({ concurrency: 1, leaseMs: 60_000 }),
-      logger: silentLogger(),
-      pool: await db(),
+    // No timer: the tick boundary must be exact for this window to be a window
+    // rather than a race.
+    const runtime = await runtimeFor({
+      config: { concurrency: 1, leaseMs: 60_000 },
       handlers: new Map([[kind, handler]]),
-      // No timer: the tick boundary must be exact for this window to be a
-      // window rather than a race.
-      autoStart: false,
     });
-    if (!runtime) throw new Error("maintenance runtime should be composed");
 
     const job = await runtime.queue.enqueue({
       kind,
@@ -223,27 +295,16 @@ dbDescribe("maintenance runtime lease boundary (live Postgres)", () => {
 
   it("refuses to begin a new claim once stopping, leaving queued work untouched", async () => {
     // The other half of invariant 1. Refusing to BEGIN a claim is what keeps
-    // shutdown bounded: a claim mutates durable state, so starting one during
+    // shutdown ordered: a claim mutates durable state, so starting one during
     // stop would lease rows this process is about to stop being able to run.
     // A queued row must therefore still be `queued`, unleased, and at attempts
     // 0 after a stop -- available to the next worker rather than stranded.
     const kind = `${KIND_PREFIX}.noclaim`;
-    const seen: string[] = [];
-    const runtime = createMaintenanceRuntime({
-      config: config({ concurrency: 1 }),
-      logger: silentLogger(),
-      pool: await db(),
-      handlers: new Map([
-        [
-          kind,
-          async (job: MaintenanceJob) => {
-            seen.push(job.id);
-          },
-        ],
-      ]),
-      autoStart: false,
+    const { seen, handler } = recordingHandler();
+    const runtime = await runtimeFor({
+      config: { concurrency: 1 },
+      handlers: new Map([[kind, handler]]),
     });
-    if (!runtime) throw new Error("maintenance runtime should be composed");
 
     const job = await runtime.queue.enqueue({
       kind,
@@ -264,33 +325,26 @@ dbDescribe("maintenance runtime lease boundary (live Postgres)", () => {
 
     await deleteKind(kind);
   });
+});
+
+describe("maintenance runtime lease expiry (live Postgres)", () => {
+  beforeEach(clearOwnJobs);
 
   it("dead-letters an expired lease that has consumed its attempts instead of reclaiming it", async () => {
     // INVARIANT 2. A handler that hangs or crashes never calls complete/fail, so
     // the ONLY path that ever revisits its row is the expiry reclaim. If that
-    // path ignores max_attempts the job is re-executed forever past its bound --
-    // the retry cap enforced on one exit and not the other.
+    // path ignores max_attempts the job is re-executed forever past its retry
+    // rule -- enforced on one exit and not the other.
     //
     // The expired state is constructed durably (a past lease_until on a row that
     // has already consumed its attempts) rather than by waiting out a real lease,
     // so the assertion is about the claim statement's rule and not about timing.
     const kind = `${KIND_PREFIX}.expired`;
-    const seen: string[] = [];
-    const runtime = createMaintenanceRuntime({
-      config: config({ concurrency: 4 }),
-      logger: silentLogger(),
-      pool: await db(),
-      handlers: new Map([
-        [
-          kind,
-          async (job: MaintenanceJob) => {
-            seen.push(job.id);
-          },
-        ],
-      ]),
-      autoStart: false,
+    const { seen, handler } = recordingHandler();
+    const runtime = await runtimeFor({
+      config: { concurrency: 4 },
+      handlers: new Map([[kind, handler]]),
     });
-    if (!runtime) throw new Error("maintenance runtime should be composed");
 
     const exhausted = await runtime.queue.enqueue({
       kind,
@@ -299,8 +353,8 @@ dbDescribe("maintenance runtime lease boundary (live Postgres)", () => {
       idempotencyKey: "expired-1",
       retry: { maxAttempts: 2 },
     });
-    // A second job with budget REMAINING, expired the same way. It proves the
-    // rule terminates only the bounded row and does not simply stop reclaiming
+    // A second job with attempts REMAINING, expired the same way. It proves the
+    // rule terminates only the exhausted row and does not simply stop reclaiming
     // expired leases altogether -- a "fix" that stalled every recoverable job
     // would otherwise pass the first assertion.
     const recoverable = await runtime.queue.enqueue({
@@ -344,30 +398,35 @@ dbDescribe("maintenance runtime lease boundary (live Postgres)", () => {
     expect(dead.terminal_at).not.toBeNull();
     expect(dead.dead_lettered_at).not.toBeNull();
     // attempts stays at the number of leases actually consumed; the sweep must
-    // not inflate the counter that gates the bound.
+    // not inflate the counter the retry rule reads.
     expect(dead.attempts).toBe(dead.max_attempts);
 
-    // The row with budget left was reclaimed and run normally.
+    // The row with attempts remaining was reclaimed and run normally. The wait comes
+    // FIRST: `runOnce()` resolved once the job was dispatched, not once its
+    // handler finished, so both the handler's `seen` push and the row's final
+    // state are still in flight at this point (#889).
+    const recovered = await readSettledRow(recoverable.id);
     expect(seen).toContain(recoverable.id);
-    const recovered = await readRow(recoverable.id);
     expect(recovered.state).toBe("succeeded");
 
     await deleteKind(kind);
   });
+});
 
-  it("dead-letters a terminal handler failure on this attempt and keeps bounded retry otherwise", async () => {
+describe("maintenance runtime failure classification (live Postgres)", () => {
+  beforeEach(clearOwnJobs);
+
+  it("dead-letters a terminal handler failure on this attempt and keeps ordinary retry otherwise", async () => {
     // The runner's failure classification, proven through the composed runtime.
     // A handler declaring its own failure non-retryable must dead-letter NOW
-    // regardless of remaining budget, while an ordinary throw must go back to
-    // `queued` with a future run_after -- the two must not collapse into one
-    // policy, because that is how a permanent failure burns three retries or a
-    // transient one is discarded after the first.
+    // regardless of how many attempts remain, while an ordinary throw must go
+    // back to `queued` with a future run_after -- the two must not collapse into
+    // one policy, because that is how a permanent failure burns three retries or
+    // a transient one is discarded after the first.
     const kind = `${KIND_PREFIX}.terminal`;
     const ordinaryKind = `${KIND_PREFIX}.ordinary`;
-    const runtime = createMaintenanceRuntime({
-      config: config({ concurrency: 4 }),
-      logger: silentLogger(),
-      pool: await db(),
+    const runtime = await runtimeFor({
+      config: { concurrency: 4 },
       handlers: new Map<string, MaintenanceJobHandler>([
         [
           kind,
@@ -382,9 +441,7 @@ dbDescribe("maintenance runtime lease boundary (live Postgres)", () => {
           },
         ],
       ]),
-      autoStart: false,
     });
-    if (!runtime) throw new Error("maintenance runtime should be composed");
 
     const terminal = await runtime.queue.enqueue({
       kind,
@@ -407,7 +464,8 @@ dbDescribe("maintenance runtime lease boundary (live Postgres)", () => {
     const dead = await readRow(terminal.id);
     expect(dead.state).toBe("dead_letter");
     expect(dead.last_error_category).toBe("terminal");
-    // Dead-lettered on attempt 1 of 3: the budget was NOT consumed first.
+    // Dead-lettered on attempt 1 of 3: the remaining attempts were NOT consumed
+    // first.
     expect(dead.attempts).toBe(1);
     expect(dead.max_attempts).toBe(3);
 
@@ -420,6 +478,10 @@ dbDescribe("maintenance runtime lease boundary (live Postgres)", () => {
     await deleteKind(kind);
     await deleteKind(ordinaryKind);
   });
+});
+
+describe("maintenance runtime composition (live Postgres)", () => {
+  beforeEach(clearOwnJobs);
 
   it("starts a producer, so an autostarted runtime enqueues without an operator", async () => {
     // THE #384 REGRESSION. This boundary composed the CONSUMER half and nothing
@@ -437,6 +499,9 @@ dbDescribe("maintenance runtime lease boundary (live Postgres)", () => {
     // Asserting `runtime.sweep !== undefined` would pass against a sweep that
     // is constructed and never ticks, which is the defect's own shape one level
     // up.
+    //
+    // This is the one test that does NOT go through `runtimeFor`: it needs
+    // `autoStart` left on, which is exactly the behavior under test.
     const client = await db();
     const namespace = `${KIND_PREFIX}.producer`;
     const contentHash = "a".repeat(64);
@@ -508,9 +573,10 @@ dbDescribe("maintenance runtime lease boundary (live Postgres)", () => {
       // Both sweep-produced kinds, for the same reason: leftover
       // `ob_raw_turns` fixtures (`parity-raw-turn-*`) make the distill arm
       // produce `memory.distill` rows just as globally.
-      await client.query(`DELETE FROM maintenance_jobs WHERE job_kind = ANY($1)`, [
-        ["graph.derive", "memory.distill"],
-      ]);
+      await client.query(
+        `DELETE FROM maintenance_jobs WHERE job_kind = ANY($1)`,
+        [["graph.derive", "memory.distill"]],
+      );
       await client.query(`DELETE FROM ob_sources WHERE namespace = $1`, [
         namespace,
       ]);


### PR DESCRIPTION
## Summary

- Closes #889. The maintenance lease-boundary expiry test drove the composed runtime with `await runtime.runner.runOnce()` and then read the reclaimed row back immediately. `runOnce()` awaits `tick()` only (`src/maintenance-queue.ts:744`), and `tick()` dispatches each claimed job into the runner's `active` set WITHOUT awaiting it (`:826-831`) so `concurrency` means anything at all; the only method contracted to await handlers is `stop()` (`:754-762`). The read therefore raced the handler, and it is a race the test usually wins — which is why `expect(recovered.state).toBe("succeeded")` reached CI three times on branches that never touched the file.
- `readSettledRow()` polls the durable row until it leaves `running`/`queued` rather than sampling once. Its deadline keeps a genuinely stuck job from hanging the suite and names the job's last observed state when it fires, so a real regression reports what the row was doing instead of a bare timeout.
- Refs #878. The pre-commit gate refused this commit on `node/no-process-env` and `max-lines-per-function`, and no exemption was taken, so the file's standards debt is paid here and the change doubles as this file's #878 conversion. The suite now calls `requireTestDatabaseUrl()` at module scope instead of reading the environment and downgrading itself to `describe.skip` — a self-skip reports `0 pass, N skip, 0 fail` and exits 0, which at the exit code is indistinguishable from a suite that ran.
- The single 268-line describe is split into four grouped by subject — shutdown drain, lease expiry, failure classification, composition — each well under 100 code lines, over shared module-scope helpers (`runtimeFor`, `recordingHandler`, `clearOwnJobs`) rather than duplicated setup. The file stays one module at 339 code lines, so no sibling file was needed.
- Every suite name keeps the literal `(live Postgres)` marker, since `scripts/assert-db-tests-ran.ts` matches suites by name. That guard registers the four new names with their observed counts (2, 1, 1, 2) in place of the one entry of 5, so an entire subject silently ceasing to run is caught rather than absorbed by the others' count. `MIN_TOTAL_LIVE_TESTCASES` moves 74 → 75 by the net change.

## Verification

- Done-means: scripts/done-means/889-lease-boundary-test-settles.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts, all run in this lane's clone:

- `./node_modules/.bin/oxlint --deny-warnings server/maintenance/maintenance.pg.test.ts scripts/assert-db-tests-ran.ts` → exit 0
- `bunx tsc --noEmit` → exit 0
- `env -u OPENBRAIN_TEST_DATABASE_URL bun test server/maintenance/` → exit 1, `test_database_required` printed (the #878 hard fail observed, not merely arranged)
- `bun run test:isolated server/maintenance/ scripts/assert-db-tests-ran.test.ts` → exit 0, 22 pass / 0 fail
- `bash scripts/done-means/889-lease-boundary-test-settles.sh` → PASS, 20/20 iterations, each through its own freshly-migrated database
- `CHANGED_FILES="server/maintenance/maintenance.pg.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` → exit 0, clauses 1–4 PASS

## Critical Self-Review

- Highest-risk behavior: the poll deadline in `readSettledRow()`. At 5s it is generous for a handler that only pushes an id, but a loaded CI machine is the environment where both the original race and this wait matter most. A deadline that fires reports the row's last observed state by name, so the failure would be diagnosable rather than a bare timeout — but it would still be a failure, and the honest position is that 20 local iterations do not prove CI's timing.
- Assumptions that could be wrong: that `succeeded`/`dead_letter`/`queued` are the only states worth settling on, i.e. that polling out of `running` and `queued` is the right exit condition. If a future state were added between dispatch and terminal, the loop would exit early on it and assert against a non-terminal row.
- Missing/weak tests: the wait helper itself has no test that its deadline fires — the red proof for #889 is the 20-run gate, which exercises the success path repeatedly and never the give-up path. Constructing a genuinely stuck job to prove the error message would be a real addition and is not here.
- Security/permission risk: none. No auth, namespace, or token path is touched; the change is confined to a test file, a test-count guard, and a check script.
- Migration/deploy risk: none. No migration, no schema change, no runtime source file — `src/maintenance-queue.ts` and `server/maintenance/index.ts` are unmodified, and the runtime behavior under test is unchanged.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md`. No MCP tool, schema, protocol, transport, or Python client surface changes, so there is nothing for rtech-mcps, mcp2cli, or rtech-hermes to pick up.
- Rollback/cleanup concern: the guard's four new suite names and the 75 floor must move together with the file's describes. Reverting only the test file would leave the guard demanding four suites that no longer exist, which fails loudly rather than silently — the preferable direction, but worth knowing before a partial revert.
- Fixes made before PR: the producer test was left calling `createMaintenanceRuntime` directly rather than routed through the new `runtimeFor` helper, because it needs `autoStart` left on — that is the behavior under test, and folding it into the helper would have made the helper's default silently wrong for one caller. The exception is stated in a comment at the call site rather than left for a reader to rediscover.
- Known residual risk: the split changes how a name-matching guard sees this file, and any other tooling keying on the old suite name `maintenance runtime lease boundary (live Postgres)` would stop matching. `rg` over the repo found the name only in `scripts/assert-db-tests-ran.ts`, which is updated here; something outside the repo keying on it is beyond what I can check from this clone.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the underlying lesson — `runOnce()` is not a drain, so a durable row must be polled rather than sampled — is already recorded in `docs/sme/correctness.md` and is restated at length in the helper's own TSDoc and in the done-means script's header, which is where a future author of this file will actually be standing.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or tool surface changes — this is a test file, a test-count guard, and a check script.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched; `contracts/` is unmodified and the pre-push contract-parity subset was skipped on that basis.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable throughout. The rollout gate keys on MCP tool, schema, protocol, or client-facing changes; this branch changes `server/maintenance/maintenance.pg.test.ts`, `scripts/assert-db-tests-ran.ts`, and `scripts/done-means/889-lease-boundary-test-settles.sh` and nothing else. `git diff --stat` against the merge base shows no file under `src/tools/`, `server/tools/`, `contracts/`, or `python/`.
