### PR TITLE
test(pg): the reinforcement-and-said-at migration test requires the test database instead of skipping (#878)

### DIFF
--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -194,6 +194,26 @@ export const REQUIRED_SUITES: ReadonlyArray<{
     name: "032 raw turns retention and provenance (live Postgres)",
     minTests: 7,
   },
+  // Migrations 038/039. The CHECK constraints, the dedupe unique index, and the
+  // ON DELETE CASCADE are database guarantees a fake cannot enforce, so an
+  // unnoticed non-run here means nothing is proving them. The file's suites are
+  // FLAT for this guard's sake: its testcase-level cross-check keys on the JUnit
+  // `classname`, which for a nested suite carries the inner name only, so a
+  // wrapping describe would register here as a suite that executed nothing and
+  // fail even on a fully green run. All four are named; registering a subset
+  // would let the rest vanish unnoticed.
+  {
+    name:
+      "the operator queue is enforced by the database, not by convention " +
+      "(live Postgres)",
+    minTests: 6,
+  },
+  { name: "039 said-at timestamps (live Postgres)", minTests: 4 },
+  { name: "038 candidate_reinforcement writes (live Postgres)", minTests: 5 },
+  {
+    name: "038 candidate_reinforcement lifecycle (live Postgres)",
+    minTests: 4,
+  },
 ];
 
 // Absolute floor on total executed (non-skipped) live-Postgres testcases,
@@ -214,9 +234,11 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // backgroundExtract tag-merge suite that shares migration 027's file and had
 // never been named here, then 85 -> 91 when #878 registered the migration 031
 // upgrade-path suite and its 6, then 91 -> 108 when #878 registered the four
-// migration 032 raw-turns suites' 2 + 4 + 4 + 7), so the global floor cannot
-// silently fall behind the per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 108;
+// migration 032 raw-turns suites' 2 + 4 + 4 + 7, then 108 -> 127 when #878
+// registered the migrations 038/039 reinforcement + said-at file's four
+// flattened suites at 6 + 4 + 5 + 4), so the global floor cannot silently
+// fall behind the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 127;
 
 export interface SuiteStats {
   tests: number;

--- a/src/db/migrations/reinforcement-and-said-at.test.ts
+++ b/src/db/migrations/reinforcement-and-said-at.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
 import { runMigrations } from "../migrate.ts";
 
 /**
@@ -26,404 +27,435 @@ import { runMigrations } from "../migrate.ts";
  *     member: deleting a mid-chain survivor would cascade away a reinforcement
  *     row and silently lose a restatement.
  *
- * Gated on OPENBRAIN_TEST_DATABASE_URL, matching the 025/027/032 convention:
- * skips when unset so a DB-less run passes, and runs in the db-integration job.
+ * REQUIRES a test database, and fails hard without one (operator ruling
+ * 2026-08-27, issue #878). It must point at an isolated test/playground
+ * database, never the dogfood database; `bun run test:isolated` arranges that.
+ * The suite formerly swapped in `describe.skip` when the variable was absent,
+ * which reported `0 pass, 20 skip` and exited 0 -- a run that proved nothing
+ * and looked exactly like one that proved everything.
+ *
  * Every row this suite writes carries a namespace it owns exclusively, and
  * cleanup deletes by that namespace only -- it never touches captured data.
  */
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
+// The fixture is module-scope rather than nested inside one enclosing
+// `describe`. The four suites below are SIBLINGS for two reasons: the anti-skip
+// guard's testcase-level cross-check keys on the JUnit `classname`, which for a
+// nested suite is the inner name only -- so a wrapping describe registers in
+// scripts/assert-db-tests-ran.ts as a suite that executed nothing -- and one
+// describe holding all nineteen tests is a single function far past the length
+// the repo lint allows.
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+const NS = "test-reinforce-038";
 
-dbDescribe("038/039 candidate reinforcement + said-at (live Postgres)", () => {
-  const pool = new Pool({ connectionString: DB_URL });
-  const NS = "test-reinforce-038";
+/**
+ * The first row of a result that is expected to have one, as a real assertion.
+ *
+ * Every read below queries by primary key or by this suite's own namespace, so
+ * an empty result is a genuine failure of the thing under test rather than a
+ * type-level maybe. Throwing here reports that as a named failure on the test
+ * that caused it; the `!` operator this replaces would have thrown too, but
+ * with no message and against a repo lint rule that forbids it.
+ */
+function firstRow<T>(rows: T[]): T {
+  const row = rows[0];
+  if (row === undefined) throw new Error("expected at least one row, got none");
+  return row;
+}
 
-  async function cleanup(): Promise<void> {
-    // candidate_reinforcement rows cascade with their candidates, but they are
-    // deleted explicitly first so a broken cascade cannot leave orphans behind
-    // and quietly pass the next run.
+async function cleanup(): Promise<void> {
+  // candidate_reinforcement rows cascade with their candidates, but they are
+  // deleted explicitly first so a broken cascade cannot leave orphans behind
+  // and quietly pass the next run.
+  await pool.query("DELETE FROM candidate_reinforcement WHERE namespace = $1", [
+    NS,
+  ]);
+  await pool.query("DELETE FROM candidate_memory WHERE namespace = $1", [NS]);
+}
+
+beforeEach(async () => {
+  await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+  await runMigrations(pool);
+  await cleanup();
+});
+
+afterAll(async () => {
+  await cleanup();
+  await pool.end();
+});
+
+let n = 0;
+const turnId = () => `99999999-9999-4999-8999-${String(++n).padStart(12, "0")}`;
+
+async function insertCandidate(
+  over: {
+    content?: string;
+    hash?: string;
+    firstSaid?: string | null;
+    lastSaid?: string | null;
+  } = {},
+): Promise<string> {
+  const hash = over.hash ?? `hash-${++n}`;
+  const { rows } = await pool.query<{ id: string }>(
+    `INSERT INTO candidate_memory
+       (namespace, candidate_type, content, content_hash, source_turn_ids,
+        model, first_said_at, last_said_at)
+     VALUES ($1, 'decision', $2, $3, ARRAY[$4]::uuid[], 'test-model', $5, $6)
+     RETURNING id`,
+    [
+      NS,
+      over.content ?? `claim ${hash}`,
+      hash,
+      turnId(),
+      over.firstSaid ?? null,
+      over.lastSaid ?? null,
+    ],
+  );
+  return firstRow(rows).id;
+}
+
+/** Inserts one reinforcement row, deduped by (candidate_id, dup_content_hash). */
+async function reinforce(
+  candidateId: string,
+  over: {
+    hash?: string;
+    occurredAt?: string;
+    similarity?: number | null;
+    turns?: string[];
+  } = {},
+) {
+  return pool.query(
+    `INSERT INTO candidate_reinforcement
+       (namespace, candidate_id, dup_content_hash, dup_occurred_at,
+        dup_source_turn_ids, similarity, model)
+     VALUES ($1, $2, $3, $4, $5::uuid[], $6, 'test-model')
+     ON CONFLICT (candidate_id, dup_content_hash) DO NOTHING
+     RETURNING id`,
+    [
+      NS,
+      candidateId,
+      over.hash ?? "dup-hash-1",
+      over.occurredAt ?? "2026-07-20T00:00:00Z",
+      over.turns ?? [turnId()],
+      over.similarity === undefined ? 0.04 : over.similarity,
+    ],
+  );
+}
+
+describe("the operator queue is enforced by the database, not by convention (live Postgres)", () => {
+  it("rejects review_action without reviewed_at", async () => {
+    // candidate_memory_review_paired. A half-written review would make every
+    // "unreviewed" query silently wrong.
+    const id = await insertCandidate();
+    await expect(
+      pool.query(
+        "UPDATE candidate_memory SET review_action = 'promoted' WHERE id = $1",
+        [id],
+      ),
+    ).rejects.toThrow(/review_paired/);
+  });
+
+  it("rejects reviewed_at without review_action", async () => {
+    const id = await insertCandidate();
+    await expect(
+      pool.query(
+        "UPDATE candidate_memory SET reviewed_at = now() WHERE id = $1",
+        [id],
+      ),
+    ).rejects.toThrow(/review_paired/);
+  });
+
+  it("accepts the pair together, which is why a machine must never write it", async () => {
+    // THE MECHANISM behind the whole no-machine-grading rule: writing
+    // review_action necessarily sets reviewed_at, which necessarily removes
+    // the row from `reviewed_at IS NULL`.
+    const id = await insertCandidate();
     await pool.query(
-      "DELETE FROM candidate_reinforcement WHERE namespace = $1",
-      [NS],
-    );
-    await pool.query("DELETE FROM candidate_memory WHERE namespace = $1", [NS]);
-  }
-
-  beforeEach(async () => {
-    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
-    await runMigrations(pool);
-    await cleanup();
-  });
-
-  afterAll(async () => {
-    await cleanup();
-    await pool.end();
-  });
-
-  let n = 0;
-  const turnId = () =>
-    `99999999-9999-4999-8999-${String(++n).padStart(12, "0")}`;
-
-  async function insertCandidate(
-    over: {
-      content?: string;
-      hash?: string;
-      firstSaid?: string | null;
-      lastSaid?: string | null;
-    } = {},
-  ): Promise<string> {
-    const hash = over.hash ?? `hash-${++n}`;
-    const { rows } = await pool.query<{ id: string }>(
-      `INSERT INTO candidate_memory
-         (namespace, candidate_type, content, content_hash, source_turn_ids,
-          model, first_said_at, last_said_at)
-       VALUES ($1, 'decision', $2, $3, ARRAY[$4]::uuid[], 'test-model', $5, $6)
-       RETURNING id`,
-      [
-        NS,
-        over.content ?? `claim ${hash}`,
-        hash,
-        turnId(),
-        over.firstSaid ?? null,
-        over.lastSaid ?? null,
-      ],
-    );
-    return rows[0]!.id;
-  }
-
-  describe("the operator queue is enforced by the database, not by convention", () => {
-    it("rejects review_action without reviewed_at", async () => {
-      // candidate_memory_review_paired. A half-written review would make every
-      // "unreviewed" query silently wrong.
-      const id = await insertCandidate();
-      await expect(
-        pool.query(
-          "UPDATE candidate_memory SET review_action = 'promoted' WHERE id = $1",
-          [id],
-        ),
-      ).rejects.toThrow(/review_paired/);
-    });
-
-    it("rejects reviewed_at without review_action", async () => {
-      const id = await insertCandidate();
-      await expect(
-        pool.query(
-          "UPDATE candidate_memory SET reviewed_at = now() WHERE id = $1",
-          [id],
-        ),
-      ).rejects.toThrow(/review_paired/);
-    });
-
-    it("accepts the pair together, which is why a machine must never write it", async () => {
-      // THE MECHANISM behind the whole no-machine-grading rule: writing
-      // review_action necessarily sets reviewed_at, which necessarily removes
-      // the row from `reviewed_at IS NULL`.
-      const id = await insertCandidate();
-      await pool.query(
-        `UPDATE candidate_memory
+      `UPDATE candidate_memory
             SET review_action = 'inconclusive', reviewed_at = now(), graded_by = 'rico'
           WHERE id = $1`,
-        [id],
-      );
-      const { rows } = await pool.query<{ n: string }>(
-        "SELECT count(*)::text AS n FROM candidate_memory WHERE namespace = $1 AND reviewed_at IS NULL",
-        [NS],
-      );
-      expect(rows[0]!.n).toBe("0");
-    });
+      [id],
+    );
+    const { rows } = await pool.query<{ n: string }>(
+      "SELECT count(*)::text AS n FROM candidate_memory WHERE namespace = $1 AND reviewed_at IS NULL",
+      [NS],
+    );
+    expect(firstRow(rows).n).toBe("0");
+  });
 
-    it("lets a machine_grade write leave reviewed_at NULL -- the row stays on the queue", async () => {
-      // 037:43-57. The two columns exist so their disagreement rate is
-      // measurable, and that only works while writing one does not consume the
-      // other.
-      const id = await insertCandidate();
-      await pool.query(
-        `UPDATE candidate_memory
+  it("lets a machine_grade write leave reviewed_at NULL -- the row stays on the queue", async () => {
+    // 037:43-57. The two columns exist so their disagreement rate is
+    // measurable, and that only works while writing one does not consume the
+    // other.
+    const id = await insertCandidate();
+    await pool.query(
+      `UPDATE candidate_memory
             SET machine_grade = 'promoted', machine_grade_model = 'rem-heuristic-v1'
           WHERE id = $1`,
-        [id],
-      );
-      const { rows } = await pool.query<{
-        reviewed_at: Date | null;
-        review_action: string | null;
-        graded_by: string | null;
-        machine_grade: string;
-      }>(
-        "SELECT reviewed_at, review_action, graded_by, machine_grade FROM candidate_memory WHERE id = $1",
-        [id],
-      );
-      expect(rows[0]!.machine_grade).toBe("promoted");
-      expect(rows[0]!.reviewed_at).toBeNull();
-      expect(rows[0]!.review_action).toBeNull();
-      expect(rows[0]!.graded_by).toBeNull();
-    });
+      [id],
+    );
+    const { rows } = await pool.query<{
+      reviewed_at: Date | null;
+      review_action: string | null;
+      graded_by: string | null;
+      machine_grade: string;
+    }>(
+      "SELECT reviewed_at, review_action, graded_by, machine_grade FROM candidate_memory WHERE id = $1",
+      [id],
+    );
+    expect(firstRow(rows).machine_grade).toBe("promoted");
+    expect(firstRow(rows).reviewed_at).toBeNull();
+    expect(firstRow(rows).review_action).toBeNull();
+    expect(firstRow(rows).graded_by).toBeNull();
+  });
 
-    it("rejects a machine_grade with no model naming it", async () => {
-      // Grades from different models are not comparable, so an unattributed
-      // grade is not usable evidence.
+  it("rejects a machine_grade with no model naming it", async () => {
+    // Grades from different models are not comparable, so an unattributed
+    // grade is not usable evidence.
+    const id = await insertCandidate();
+    await expect(
+      pool.query(
+        "UPDATE candidate_memory SET machine_grade = 'promoted' WHERE id = $1",
+        [id],
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("accepts exactly the four review values and nothing else", async () => {
+    for (const action of [
+      "promoted",
+      "rejected",
+      "duplicate",
+      "inconclusive",
+    ]) {
       const id = await insertCandidate();
-      await expect(
-        pool.query(
-          "UPDATE candidate_memory SET machine_grade = 'promoted' WHERE id = $1",
-          [id],
-        ),
-      ).rejects.toThrow();
-    });
-
-    it("accepts exactly the four review values and nothing else", async () => {
-      for (const action of [
-        "promoted",
-        "rejected",
-        "duplicate",
-        "inconclusive",
-      ]) {
-        const id = await insertCandidate();
-        await pool.query(
-          "UPDATE candidate_memory SET review_action = $2, reviewed_at = now() WHERE id = $1",
-          [id, action],
-        );
-      }
-      const bad = await insertCandidate();
-      await expect(
-        pool.query(
-          "UPDATE candidate_memory SET review_action = 'approved', reviewed_at = now() WHERE id = $1",
-          [bad],
-        ),
-      ).rejects.toThrow();
-    });
-  });
-
-  describe("039 said-at timestamps", () => {
-    it("refuses a last_said_at earlier than first_said_at", async () => {
-      // candidate_memory_said_order. A backwards move would mean a "duplicate"
-      // older than the original was absorbed as the newer statement, inverting
-      // the recency signal #396 reads.
-      await expect(
-        insertCandidate({
-          firstSaid: "2026-07-28T00:00:00Z",
-          lastSaid: "2026-07-01T00:00:00Z",
-        }),
-      ).rejects.toThrow(/said_order/);
-    });
-
-    it("allows equal timestamps -- said once", async () => {
-      const id = await insertCandidate({
-        firstSaid: "2026-07-28T00:00:00Z",
-        lastSaid: "2026-07-28T00:00:00Z",
-      });
-      expect(id).toBeTruthy();
-    });
-
-    it("allows both NULL, so a candidate with purged turns keeps no fabricated time", async () => {
-      const id = await insertCandidate({ firstSaid: null, lastSaid: null });
-      const { rows } = await pool.query(
-        "SELECT first_said_at, last_said_at FROM candidate_memory WHERE id = $1",
-        [id],
-      );
-      expect(rows[0]!.first_said_at).toBeNull();
-      expect(rows[0]!.last_said_at).toBeNull();
-    });
-
-    it("lets last_said_at advance while first_said_at stays put", async () => {
-      // The merge behaviour of #398, at the storage level. The SPAN is the
-      // evidence.
-      const id = await insertCandidate({
-        firstSaid: "2026-05-01T00:00:00Z",
-        lastSaid: "2026-05-01T00:00:00Z",
-      });
       await pool.query(
-        "UPDATE candidate_memory SET last_said_at = $2 WHERE id = $1",
-        [id, "2026-07-28T00:00:00Z"],
-      );
-      const { rows } = await pool.query<{
-        first_said_at: Date;
-        last_said_at: Date;
-      }>(
-        "SELECT first_said_at, last_said_at FROM candidate_memory WHERE id = $1",
-        [id],
-      );
-      expect(rows[0]!.first_said_at.toISOString()).toBe(
-        "2026-05-01T00:00:00.000Z",
-      );
-      expect(rows[0]!.last_said_at.toISOString()).toBe(
-        "2026-07-28T00:00:00.000Z",
-      );
-    });
-  });
-
-  describe("038 candidate_reinforcement", () => {
-    async function reinforce(
-      candidateId: string,
-      over: {
-        hash?: string;
-        occurredAt?: string;
-        similarity?: number | null;
-        turns?: string[];
-      } = {},
-    ) {
-      return pool.query(
-        `INSERT INTO candidate_reinforcement
-           (namespace, candidate_id, dup_content_hash, dup_occurred_at,
-            dup_source_turn_ids, similarity, model)
-         VALUES ($1, $2, $3, $4, $5::uuid[], $6, 'test-model')
-         ON CONFLICT (candidate_id, dup_content_hash) DO NOTHING
-         RETURNING id`,
-        [
-          NS,
-          candidateId,
-          over.hash ?? "dup-hash-1",
-          over.occurredAt ?? "2026-07-20T00:00:00Z",
-          over.turns ?? [turnId()],
-          over.similarity === undefined ? 0.04 : over.similarity,
-        ],
+        "UPDATE candidate_memory SET review_action = $2, reviewed_at = now() WHERE id = $1",
+        [id, action],
       );
     }
+    const bad = await insertCandidate();
+    await expect(
+      pool.query(
+        "UPDATE candidate_memory SET review_action = 'approved', reviewed_at = now() WHERE id = $1",
+        [bad],
+      ),
+    ).rejects.toThrow();
+  });
+});
 
-    it("counts a repeat merge once -- a retry cannot inflate reinforcement", async () => {
-      // idx_candidate_reinforcement_dedupe. This is correctness, not speed: the
-      // maintenance queue is at-least-once.
-      const id = await insertCandidate();
-      const first = await reinforce(id);
-      const second = await reinforce(id);
-      expect(first.rowCount).toBe(1);
-      expect(second.rowCount).toBe(0);
+describe("039 said-at timestamps (live Postgres)", () => {
+  it("refuses a last_said_at earlier than first_said_at", async () => {
+    // candidate_memory_said_order. A backwards move would mean a "duplicate"
+    // older than the original was absorbed as the newer statement, inverting
+    // the recency signal #396 reads.
+    await expect(
+      insertCandidate({
+        firstSaid: "2026-07-28T00:00:00Z",
+        lastSaid: "2026-07-01T00:00:00Z",
+      }),
+    ).rejects.toThrow(/said_order/);
+  });
 
-      const { rows } = await pool.query<{ n: string }>(
-        "SELECT count(*)::text AS n FROM candidate_reinforcement WHERE candidate_id = $1",
-        [id],
-      );
-      expect(rows[0]!.n).toBe("1");
+  it("allows equal timestamps -- said once", async () => {
+    const id = await insertCandidate({
+      firstSaid: "2026-07-28T00:00:00Z",
+      lastSaid: "2026-07-28T00:00:00Z",
+    });
+    expect(id).toBeTruthy();
+  });
+
+  it("allows both NULL, so a candidate with purged turns keeps no fabricated time", async () => {
+    const id = await insertCandidate({ firstSaid: null, lastSaid: null });
+    const { rows } = await pool.query(
+      "SELECT first_said_at, last_said_at FROM candidate_memory WHERE id = $1",
+      [id],
+    );
+    expect(firstRow(rows).first_said_at).toBeNull();
+    expect(firstRow(rows).last_said_at).toBeNull();
+  });
+
+  it("lets last_said_at advance while first_said_at stays put", async () => {
+    // The merge behaviour of #398, at the storage level. The SPAN is the
+    // evidence.
+    const id = await insertCandidate({
+      firstSaid: "2026-05-01T00:00:00Z",
+      lastSaid: "2026-05-01T00:00:00Z",
+    });
+    await pool.query(
+      "UPDATE candidate_memory SET last_said_at = $2 WHERE id = $1",
+      [id, "2026-07-28T00:00:00Z"],
+    );
+    const { rows } = await pool.query<{
+      first_said_at: Date;
+      last_said_at: Date;
+    }>(
+      "SELECT first_said_at, last_said_at FROM candidate_memory WHERE id = $1",
+      [id],
+    );
+    expect(firstRow(rows).first_said_at.toISOString()).toBe(
+      "2026-05-01T00:00:00.000Z",
+    );
+    expect(firstRow(rows).last_said_at.toISOString()).toBe(
+      "2026-07-28T00:00:00.000Z",
+    );
+  });
+});
+
+describe("038 candidate_reinforcement writes (live Postgres)", () => {
+  it("counts a repeat merge once -- a retry cannot inflate reinforcement", async () => {
+    // idx_candidate_reinforcement_dedupe. This is correctness, not speed: the
+    // maintenance queue is at-least-once.
+    const id = await insertCandidate();
+    const first = await reinforce(id);
+    const second = await reinforce(id);
+    expect(first.rowCount).toBe(1);
+    expect(second.rowCount).toBe(0);
+
+    const { rows } = await pool.query<{ n: string }>(
+      "SELECT count(*)::text AS n FROM candidate_reinforcement WHERE candidate_id = $1",
+      [id],
+    );
+    expect(firstRow(rows).n).toBe("1");
+  });
+
+  it("records distinct restatements separately", async () => {
+    const id = await insertCandidate();
+    await reinforce(id, {
+      hash: "dup-a",
+      occurredAt: "2026-06-12T00:00:00Z",
+    });
+    await reinforce(id, {
+      hash: "dup-b",
+      occurredAt: "2026-07-19T00:00:00Z",
     });
 
-    it("records distinct restatements separately", async () => {
-      const id = await insertCandidate();
-      await reinforce(id, {
-        hash: "dup-a",
-        occurredAt: "2026-06-12T00:00:00Z",
-      });
-      await reinforce(id, {
-        hash: "dup-b",
-        occurredAt: "2026-07-19T00:00:00Z",
-      });
+    // The receipt query: count, first, and last from one index scan
+    // (dream-design.md:688-692).
+    const { rows } = await pool.query<{
+      n: string;
+      first_at: Date;
+      last_at: Date;
+    }>(
+      `SELECT count(*)::text AS n, min(dup_occurred_at) AS first_at,
+              max(dup_occurred_at) AS last_at
+         FROM candidate_reinforcement WHERE candidate_id = $1`,
+      [id],
+    );
+    expect(firstRow(rows).n).toBe("2");
+    expect(firstRow(rows).first_at.toISOString()).toBe(
+      "2026-06-12T00:00:00.000Z",
+    );
+    expect(firstRow(rows).last_at.toISOString()).toBe(
+      "2026-07-19T00:00:00.000Z",
+    );
+  });
 
-      // The receipt query: count, first, and last from one index scan
-      // (dream-design.md:688-692).
-      const { rows } = await pool.query<{
-        n: string;
-        first_at: Date;
-        last_at: Date;
-      }>(
-        `SELECT count(*)::text AS n, min(dup_occurred_at) AS first_at,
-                max(dup_occurred_at) AS last_at
-           FROM candidate_reinforcement WHERE candidate_id = $1`,
-        [id],
-      );
-      expect(rows[0]!.n).toBe("2");
-      expect(rows[0]!.first_at.toISOString()).toBe("2026-06-12T00:00:00.000Z");
-      expect(rows[0]!.last_at.toISOString()).toBe("2026-07-19T00:00:00.000Z");
-    });
+  it("refuses a reinforcement with no source turns", async () => {
+    // Non-empty by constraint: a reinforcement with no source cannot be
+    // audited and cannot be undone, which defeats the reversibility that
+    // licenses the merge at all.
+    const id = await insertCandidate();
+    await expect(reinforce(id, { turns: [] })).rejects.toThrow(
+      /source_turns_check/,
+    );
+  });
 
-    it("refuses a reinforcement with no source turns", async () => {
-      // Non-empty by constraint: a reinforcement with no source cannot be
-      // audited and cannot be undone, which defeats the reversibility that
-      // licenses the merge at all.
-      const id = await insertCandidate();
-      await expect(reinforce(id, { turns: [] })).rejects.toThrow(
-        /source_turns_check/,
-      );
-    });
+  it("refuses a similarity outside the cosine-distance range", async () => {
+    // A value outside [0, 2] is a unit error -- similarity written where
+    // distance was meant -- which would silently invert every later audit of
+    // the threshold.
+    const id = await insertCandidate();
+    await expect(reinforce(id, { similarity: -0.1 })).rejects.toThrow(
+      /similarity_range/,
+    );
+    await expect(reinforce(id, { hash: "x", similarity: 2.5 })).rejects.toThrow(
+      /similarity_range/,
+    );
+    // The bounds themselves are legal.
+    expect((await reinforce(id, { hash: "lo", similarity: 0 })).rowCount).toBe(
+      1,
+    );
+    expect((await reinforce(id, { hash: "hi", similarity: 2 })).rowCount).toBe(
+      1,
+    );
+  });
 
-    it("refuses a similarity outside the cosine-distance range", async () => {
-      // A value outside [0, 2] is a unit error -- similarity written where
-      // distance was meant -- which would silently invert every later audit of
-      // the threshold.
-      const id = await insertCandidate();
-      await expect(reinforce(id, { similarity: -0.1 })).rejects.toThrow(
-        /similarity_range/,
-      );
-      await expect(
-        reinforce(id, { hash: "x", similarity: 2.5 }),
-      ).rejects.toThrow(/similarity_range/);
-      // The bounds themselves are legal.
-      expect(
-        (await reinforce(id, { hash: "lo", similarity: 0 })).rowCount,
-      ).toBe(1);
-      expect(
-        (await reinforce(id, { hash: "hi", similarity: 2 })).rowCount,
-      ).toBe(1);
-    });
+  it("allows a NULL similarity rather than forcing a fabricated distance", async () => {
+    const id = await insertCandidate();
+    expect((await reinforce(id, { similarity: null })).rowCount).toBe(1);
+  });
+});
 
-    it("allows a NULL similarity rather than forcing a fabricated distance", async () => {
-      const id = await insertCandidate();
-      expect((await reinforce(id, { similarity: null })).rowCount).toBe(1);
-    });
+// Split from the suite above by subject: that one covers what the table ACCEPTS
+// and REJECTS on write, this one covers what happens to a row afterwards --
+// deletion, reverse lookup, the time it preserves, and the shape it must never
+// grow.
+describe("038 candidate_reinforcement lifecycle (live Postgres)", () => {
+  it("cascades away with its candidate -- which is why chains resolve to the oldest", async () => {
+    // src/candidate-dedupe.ts walks a merge chain to its terminal node
+    // precisely because of this: deleting a mid-chain survivor would cascade
+    // away a reinforcement row pointing at it and silently lose a
+    // restatement.
+    const id = await insertCandidate();
+    await reinforce(id);
+    await pool.query("DELETE FROM candidate_memory WHERE id = $1", [id]);
+    const { rows } = await pool.query<{ n: string }>(
+      "SELECT count(*)::text AS n FROM candidate_reinforcement WHERE candidate_id = $1",
+      [id],
+    );
+    expect(firstRow(rows).n).toBe("0");
+  });
 
-    it("cascades away with its candidate -- which is why chains resolve to the oldest", async () => {
-      // src/candidate-dedupe.ts walks a merge chain to its terminal node
-      // precisely because of this: deleting a mid-chain survivor would cascade
-      // away a reinforcement row pointing at it and silently lose a
-      // restatement.
-      const id = await insertCandidate();
-      await reinforce(id);
-      await pool.query("DELETE FROM candidate_memory WHERE id = $1", [id]);
-      const { rows } = await pool.query<{ n: string }>(
-        "SELECT count(*)::text AS n FROM candidate_reinforcement WHERE candidate_id = $1",
-        [id],
-      );
-      expect(rows[0]!.n).toBe("0");
-    });
+  it("supports the reverse lookup that makes a bad merge recoverable", async () => {
+    // "Which candidate absorbed this hash?" -- the unmerge and audit path.
+    const id = await insertCandidate();
+    await reinforce(id, { hash: "findable-hash" });
+    const { rows } = await pool.query<{ candidate_id: string }>(
+      `SELECT candidate_id FROM candidate_reinforcement
+        WHERE namespace = $1 AND dup_content_hash = $2`,
+      [NS, "findable-hash"],
+    );
+    expect(rows).toHaveLength(1);
+    expect(firstRow(rows).candidate_id).toBe(id);
+  });
 
-    it("supports the reverse lookup that makes a bad merge recoverable", async () => {
-      // "Which candidate absorbed this hash?" -- the unmerge and audit path.
-      const id = await insertCandidate();
-      await reinforce(id, { hash: "findable-hash" });
-      const { rows } = await pool.query<{ candidate_id: string }>(
-        `SELECT candidate_id FROM candidate_reinforcement
-          WHERE namespace = $1 AND dup_content_hash = $2`,
-        [NS, "findable-hash"],
-      );
-      expect(rows).toHaveLength(1);
-      expect(rows[0]!.candidate_id).toBe(id);
-    });
+  it("stores the said time, distinct from the merge time", async () => {
+    // #396 hard constraint. A backfill keyed on write time would collapse
+    // months of history onto the import moment.
+    const id = await insertCandidate();
+    await reinforce(id, { occurredAt: "2026-01-15T08:30:00Z" });
+    const { rows } = await pool.query<{
+      dup_occurred_at: Date;
+      created_at: Date;
+    }>(
+      "SELECT dup_occurred_at, created_at FROM candidate_reinforcement WHERE candidate_id = $1",
+      [id],
+    );
+    expect(firstRow(rows).dup_occurred_at.toISOString()).toBe(
+      "2026-01-15T08:30:00.000Z",
+    );
+    expect(firstRow(rows).created_at.getTime()).toBeGreaterThan(
+      firstRow(rows).dup_occurred_at.getTime(),
+    );
+  });
 
-    it("stores the said time, distinct from the merge time", async () => {
-      // #396 hard constraint. A backfill keyed on write time would collapse
-      // months of history onto the import moment.
-      const id = await insertCandidate();
-      await reinforce(id, { occurredAt: "2026-01-15T08:30:00Z" });
-      const { rows } = await pool.query<{
-        dup_occurred_at: Date;
-        created_at: Date;
-      }>(
-        "SELECT dup_occurred_at, created_at FROM candidate_reinforcement WHERE candidate_id = $1",
-        [id],
-      );
-      expect(rows[0]!.dup_occurred_at.toISOString()).toBe(
-        "2026-01-15T08:30:00.000Z",
-      );
-      expect(rows[0]!.created_at.getTime()).toBeGreaterThan(
-        rows[0]!.dup_occurred_at.getTime(),
-      );
-    });
-
-    it("has no count column on the candidate row to go stale", async () => {
-      // dream-design.md:686 -- the count must never be denormalized. This
-      // asserts against the live catalog, which is the only place a well-meant
-      // future ALTER TABLE would show up.
-      const { rows } = await pool.query<{ column_name: string }>(
-        `SELECT column_name FROM information_schema.columns
-          WHERE table_name = 'candidate_memory'`,
-      );
-      const columns = rows.map((r) => r.column_name);
-      for (const forbidden of [
-        "reinforcement_count",
-        "occurrence_count",
-        "session_count",
-        "dup_count",
-      ]) {
-        expect(columns).not.toContain(forbidden);
-      }
-    });
+  it("has no count column on the candidate row to go stale", async () => {
+    // dream-design.md:686 -- the count must never be denormalized. This
+    // asserts against the live catalog, which is the only place a well-meant
+    // future ALTER TABLE would show up.
+    const { rows } = await pool.query<{ column_name: string }>(
+      `SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'candidate_memory'`,
+    );
+    const columns = rows.map((r) => r.column_name);
+    for (const forbidden of [
+      "reinforcement_count",
+      "occurrence_count",
+      "session_count",
+      "dup_count",
+    ]) {
+      expect(columns).not.toContain(forbidden);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Refs #878. `src/db/migrations/reinforcement-and-said-at.test.ts` read `OPENBRAIN_TEST_DATABASE_URL` itself and swapped in `describe.skip` when it was unset, reporting 0 pass / 20 skip and exiting 0 without a database. It now calls `requireTestDatabaseUrl()` at module scope and fails with `test_database_required`.
- The suites are flattened from one enclosing `describe` into four siblings. `scripts/assert-db-tests-ran.ts` cross-checks executed testcases by JUnit `classname`, which for a nested suite carries the inner name only, so registering the wrapping describe would have tallied zero executed testcases against it and failed the guard on a fully green run.
- Four suite entries added to `scripts/assert-db-tests-ran.ts`: the operator-queue suite (6), 039 said-at timestamps (4), 038 candidate_reinforcement writes (5), 038 candidate_reinforcement lifecycle (4). **floor +19** — `MIN_TOTAL_LIVE_TESTCASES` 77 -> 96.
- Whole-file standards pass on first touch: 19 non-null assertions replaced by a `firstRow()` helper that throws a named error, two over-length describe functions resolved by the flattening plus one subject split of the 9-test 038 suite, and the fourth callback nesting level removed. File is 461 lines. No test body changed behavior.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED at `origin/main`: `env -u OPENBRAIN_TEST_DATABASE_URL bun test src/db/migrations/reinforcement-and-said-at.test.ts` -> exit 0, 0 pass / 20 skip.
GREEN on this branch: same command -> exit 1, `test_database_required` present twice.
`bun run test:isolated src/db/migrations/reinforcement-and-said-at.test.ts scripts/assert-db-tests-ran.test.ts` -> exit 0, 35 pass / 0 fail.
`CHANGED_FILES=src/db/migrations/reinforcement-and-said-at.test.ts bash scripts/done-means/878-pg-tests-require-database.sh` -> exit 0, clauses 1-4 all PASS.
`./node_modules/.bin/oxlint --deny-warnings` on both touched files -> clean. `bunx tsc --noEmit` -> clean.

## Critical Self-Review

- Highest-risk behavior: the four suite names now registered in `scripts/assert-db-tests-ran.ts` must match the JUnit output exactly, or CI's db-integration job fails on a vanished suite name. The names were read back from a real JUnit run on this branch rather than transcribed from source, and the per-suite counts (6/4/5/4) are the `tests=` attributes that run emitted.
- Assumptions that could be wrong: that the flattening is behavior-neutral. The `beforeEach` and `afterAll` moved from inside the enclosing describe to module scope, so they now run around every test in all four suites rather than around the one describe's tests. That is the same set of tests in the same file, and the run confirms 19 executed and 0 failed, but a future suite added to this file would inherit the migrate-and-cleanup hooks whether or not it wants them.
- Missing/weak tests: no test asserts that the four registered names stay in sync with the describes — that coupling is checked only by CI running the real thing. `scripts/assert-db-tests-ran.test.ts` covers the guard's parsing, not this file's registration.
- Security/permission risk: none. The suite writes only under the namespace `test-reinforce-038` and deletes by that namespace; no auth, token, or namespace-isolation code path changed.
- Migration/deploy risk: none. No migration SQL changed; `runMigrations` is called against a throwaway isolated database created and dropped by `test:isolated`.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md` — no MCP tool, schema, transport, or Python client surface is touched. This is test-side only.
- Rollback/cleanup concern: reverting the commit restores the skip behavior and the old floor together; the floor bump and the suite entries are in the same commit as the conversion, so there is no state where the manifest expects suites that do not exist.
- Fixes made before PR: caught that registering only the outer describe name would have tallied 0 executed testcases and failed CI on a green run — that is what drove the flattening rather than a cosmetic preference. Also caught that dropping `!` alone broke `tsc` under `noUncheckedIndexedAccess` (17 errors), which is why `firstRow()` exists instead of a bare index.
- Known residual risk: the header comment retains the phrase "0 pass, 20 skip" from the observed RED run while the converted file registers 19 executed testcases; the 20th was the enclosing describe counted as a skipped unit. The prose is accurate about what the old run printed and could read as a discrepancy against the new counts.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the pattern here (a nested describe registering as a suite that executed nothing under the anti-skip guard) is recorded in the PR comment for harvest rather than promoted as an SME entry by this lane, and no MEDIUM+ review finding surfaced.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no server, tool, or transport behavior changed — the diff is one test file and the CI anti-skip manifest.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface is touched; parity fixtures freeze tool shapes and this change is test-side only.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: `docs/downstream-rollout.md` scopes rollout to MCP tool/schema/protocol/client-facing changes. This diff touches `src/db/migrations/reinforcement-and-said-at.test.ts` and `scripts/assert-db-tests-ran.ts` only — no tool registration, no schema, no transport, no Python client.
