### PR TITLE
feat(test): the isolated runner supplies the local-clone database and an admin URL, so no pg suite has a reason to skip (#904)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,13 @@ jobs:
       DB_PASSWORD: test
       DB_NAME: open_brain_test_${{ github.run_id }}_${{ github.run_attempt }}
       DB_NAME_TEST: open_brain_test_migrations_${{ github.run_id }}_${{ github.run_attempt }}
+      # The local-clone boundary suite requires its own fresh database owned by
+      # the exact non-superuser role the runbook names, mirroring the
+      # `db-integration` job below. Per-run names for the same reason the two
+      # databases above carry them.
+      DB_NAME_LOCAL_CLONE: open_brain_local_test_clone_${{ github.run_id }}_${{ github.run_attempt }}
+      DB_USER_LOCAL_CLONE: open_brain_local_clone
+      DB_PASSWORD_LOCAL_CLONE: local-clone-ci
       # Enable the env-gated real-Pool integration tests in CI (issue #165).
       # Without this, every `dbDescribe`-gated suite (lane_upsert, the #161
       # cursor-stall promoter tests) silently SKIPs and the SQL write paths get
@@ -42,6 +49,12 @@ jobs:
       # Each workflow run owns its database so simultaneous push/pull_request runs
       # cannot delete or clean up rows underneath one another.
       OPENBRAIN_TEST_DATABASE_URL: postgres://test:test@127.0.0.1:5432/open_brain_test_${{ github.run_id }}_${{ github.run_attempt }}
+      # Ruling #878: tests never skip, so the suite runner supplies what the
+      # tests demand. Both URLs are assembled from the credentials this job
+      # already uses for `createdb` below — no new secret, and nothing here that
+      # is not already in this job's env.
+      OPENBRAIN_SCRATCH_ADMIN_URL: postgres://test:test@127.0.0.1:5432/postgres
+      OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL: postgres://open_brain_local_clone:local-clone-ci@127.0.0.1:5432/open_brain_local_test_clone_${{ github.run_id }}_${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v6
 
@@ -73,6 +86,40 @@ jobs:
           PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME_TEST}" \
             -v ON_ERROR_STOP=1 \
             -c "CREATE EXTENSION IF NOT EXISTS vector;"
+          # The local-clone role is cluster-wide, and unlike the ephemeral
+          # container in `db-integration` this runner's Postgres is persistent,
+          # so a previous or concurrent run may already have created it. Create
+          # it only when absent, then set the password unconditionally so the
+          # URL below authenticates whichever branch ran. `:'var'` interpolation
+          # is used rather than shell expansion so the password never reaches
+          # argv; it is deliberately NOT dollar-quoted, because psql does not
+          # substitute variables inside a `$$` body.
+          role_exists="$(PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d postgres \
+            -Atc "SELECT 1 FROM pg_roles WHERE rolname = '${DB_USER_LOCAL_CLONE}';")"
+          if [ "${role_exists}" != "1" ]; then
+            PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d postgres \
+              -v ON_ERROR_STOP=1 \
+              -v clone_role="${DB_USER_LOCAL_CLONE}" \
+              -v clone_password="${DB_PASSWORD_LOCAL_CLONE}" <<'SQL'
+          CREATE ROLE :"clone_role" LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE PASSWORD :'clone_password';
+          SQL
+          else
+            PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d postgres \
+              -v ON_ERROR_STOP=1 \
+              -v clone_role="${DB_USER_LOCAL_CLONE}" \
+              -v clone_password="${DB_PASSWORD_LOCAL_CLONE}" <<'SQL'
+          ALTER ROLE :"clone_role" LOGIN PASSWORD :'clone_password';
+          SQL
+          fi
+          PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d postgres \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE DATABASE ${DB_NAME_LOCAL_CLONE} OWNER ${DB_USER_LOCAL_CLONE} ENCODING 'UTF8' TEMPLATE template0;"
+          # Administrative bootstrap only: the clone user stays a non-superuser
+          # and restores into this fresh database.
+          PGPASSWORD="${DB_PASSWORD}" psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME_LOCAL_CLONE}" \
+            -v ON_ERROR_STOP=1 \
+            -c "CREATE EXTENSION IF NOT EXISTS vector;" \
+            -c "CREATE EXTENSION IF NOT EXISTS pg_stat_statements;"
 
       - name: Run migrations
         run: bun run migrate
@@ -85,6 +132,7 @@ jobs:
         run: |
           PGPASSWORD="${DB_PASSWORD}" dropdb --if-exists --force -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME}"
           PGPASSWORD="${DB_PASSWORD}" dropdb --if-exists --force -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME_TEST}"
+          PGPASSWORD="${DB_PASSWORD}" dropdb --if-exists --force -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" "${DB_NAME_LOCAL_CLONE}"
 
   # Issue #165: authoritative DB-backed integration gate.
   #
@@ -229,6 +277,8 @@ jobs:
         run: |
           export OPENBRAIN_TEST_DATABASE_URL="postgres://ci:ci@127.0.0.1:${DB_PORT}/open_brain_ci"
           export OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL="postgres://${DB_USER_LOCAL_CLONE}:${DB_PASSWORD_LOCAL_CLONE}@127.0.0.1:${DB_PORT}/${DB_NAME_LOCAL_CLONE}"
+          # Same admin credentials this job used for every CREATE DATABASE above.
+          export OPENBRAIN_SCRATCH_ADMIN_URL="postgres://${DB_USER}:${DB_PASSWORD}@127.0.0.1:${DB_PORT}/postgres"
           bun test \
             --reporter=junit \
             --reporter-outfile=${{ runner.temp }}/junit-db.xml
@@ -265,6 +315,7 @@ jobs:
           # credential) so no user:pass URI literal lives in the workflow.
           export OPENBRAIN_TEST_DATABASE_URL="postgres://${DB_USER}:${DB_PASSWORD}@127.0.0.1:${DB_PORT}/${DB_NAME}"
           export OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL="postgres://${DB_USER_LOCAL_CLONE}:${DB_PASSWORD_LOCAL_CLONE}@127.0.0.1:${DB_PORT}/${DB_NAME_LOCAL_CLONE}"
+          export OPENBRAIN_SCRATCH_ADMIN_URL="postgres://${DB_USER}:${DB_PASSWORD}@127.0.0.1:${DB_PORT}/postgres"
           export OPENBRAIN_BACKUP_DRILL=1
           export OPENBRAIN_PG_DUMP_BIN="docker exec -e PGPASSWORD ${OB_CI_PG_CONTAINER} pg_dump"
           export OPENBRAIN_PG_RESTORE_BIN="docker exec -i -e PGPASSWORD ${OB_CI_PG_CONTAINER} pg_restore"

--- a/scripts/done-means/904-isolated-runner-supplies-clone-and-admin.sh
+++ b/scripts/done-means/904-isolated-runner-supplies-clone-and-admin.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #904 step 1 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/904-isolated-runner-supplies-clone-and-admin.sh
+#
+# #904 (under #878): two Postgres suites gate themselves on env vars that
+# `bun run test:isolated` never set, so both skipped every local run. A suite
+# that skips reports `0 fail` and exits 0, which at the exit code is
+# indistinguishable from a suite that ran and passed — the false green. The ask
+# is that the runner SUPPLY what those suites ask for.
+#
+# ACCEPTANCE, as this script enforces it — two checks:
+#
+#   C1. `bun run test:isolated scripts/test-support/print-env.test.ts` passes.
+#       That test asserts, inside the child process, that both
+#       OPENBRAIN_SCRATCH_ADMIN_URL and OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL
+#       are set, and that the clone URL's username is `open_brain_local_clone`
+#       and its database name starts with `open_brain_local_` — the same three
+#       properties scripts/local-clone.test.ts itself demands. Asserting only
+#       "non-empty" would let a wrong URL pass here and throw there.
+#
+#   C2. `bun run test:isolated scripts/local-clone.test.ts` shows the
+#       `local clone real PostgreSQL boundary (live Postgres)` suite actually
+#       RAN: pass count > 0 and skip count 0. This is the check that cannot be
+#       satisfied by the exit code alone, which is the entire point of #878.
+#
+# RED at origin/main: C1 fails (both vars unset in the child), and C2 reports
+# 19 pass / 1 skip — the boundary suite skipped. GREEN after the fix: C1 passes
+# 2/2 and C2 reports 20 pass / 0 skip. Measured 2026-08-27.
+#
+# ---------------------------------------------------------------------------
+# Isolation and teardown
+# ---------------------------------------------------------------------------
+# This script creates NOTHING in the database. `test:isolated` owns every
+# database created here and drops both of them itself; if it ever fails to, it
+# prints the orphan's name and a dropdb line, and this script surfaces that
+# text rather than dropping anything — a checker that repairs what it measures
+# cannot measure it.
+#
+# Its own transcripts live under {temp_workspace}/open-brain/_scratch and are
+# retired on exit. Output is content-free: counts and verdicts only.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+ENV_TEST="scripts/test-support/print-env.test.ts"
+CLONE_TEST="scripts/local-clone.test.ts"
+CLONE_SUITE="local clone real PostgreSQL boundary"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+command -v rg >/dev/null 2>&1 || fail_hard "rg not on PATH"
+[ -f "$REPO_ROOT/$CLONE_TEST" ] || fail_hard "missing $CLONE_TEST"
+
+RUN_ID="$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+SCRATCH="${TEMP_WORKSPACE:-/Volumes/ThunderBolt/_tmp}/open-brain/_scratch"
+mkdir -p "$SCRATCH" 2>/dev/null || fail_hard "cannot create scratch dir $SCRATCH"
+OUT_C1="$SCRATCH/done-means-904-c1-${RUN_ID}.log"
+OUT_C2="$SCRATCH/done-means-904-c2-${RUN_ID}.log"
+
+teardown() {
+  mv -f "$OUT_C1" "$OUT_C1.done" 2>/dev/null
+  mv -f "$OUT_C2" "$OUT_C2.done" 2>/dev/null
+}
+trap teardown EXIT
+
+OVERALL=PASS
+RESULTS=""
+ORPHANS=""
+
+record_fail() {
+  OVERALL=FAIL
+  RESULTS="${RESULTS}$1"$'\n'
+}
+record_pass() {
+  RESULTS="${RESULTS}$1"$'\n'
+}
+
+# Surface any orphan the runner reported, without acting on it.
+collect_orphans() {
+  local log="$1"
+  if rg -qi 'ORPHANED DATABASE' "$log" 2>/dev/null; then
+    ORPHANS="${ORPHANS}$(rg -N -i -A4 'ORPHANED DATABASE' "$log" 2>/dev/null)"$'\n'
+  fi
+}
+
+# bun prints a trailing "N pass" / "N skip" tally. Absent means zero.
+tally() {
+  local log="$1" word="$2" n
+  n="$(rg -o -N "^\s*(\d+) ${word}\b" -r '$1' "$log" 2>/dev/null | tail -1 | tr -d '[:space:]')"
+  [ -n "$n" ] || n=0
+  printf '%s' "$n"
+}
+
+# ---------------------------------------------------------------------------
+# C1 — the runner exports both vars, in a shape the clone suite accepts.
+# ---------------------------------------------------------------------------
+if [ ! -f "$REPO_ROOT/$ENV_TEST" ]; then
+  record_fail "C1 env-contract: FAIL — $ENV_TEST does not exist, so nothing asserts what the runner exports"
+else
+  (cd "$REPO_ROOT" && bun run test:isolated "$ENV_TEST") >"$OUT_C1" 2>&1
+  C1_EXIT=$?
+  collect_orphans "$OUT_C1"
+  C1_PASS="$(tally "$OUT_C1" pass)"
+  C1_FAIL="$(tally "$OUT_C1" fail)"
+
+  if [ "$C1_PASS" -lt 2 ] || [ "$C1_FAIL" -ne 0 ] || [ "$C1_EXIT" -ne 0 ]; then
+    record_fail "C1 env-contract: FAIL — ${C1_PASS} pass / ${C1_FAIL} fail, exit ${C1_EXIT}: the runner did not export both OPENBRAIN_SCRATCH_ADMIN_URL and a well-formed OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL into the child"
+  else
+    record_pass "C1 env-contract: PASS — ${C1_PASS} assertions passed in the child: both vars set, clone URL names open_brain_local_clone on an open_brain_local_ database"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# C2 — the live-Postgres clone suite RAN, rather than skipping to a green exit.
+# ---------------------------------------------------------------------------
+(cd "$REPO_ROOT" && bun run test:isolated "$CLONE_TEST") >"$OUT_C2" 2>&1
+C2_EXIT=$?
+collect_orphans "$OUT_C2"
+C2_PASS="$(tally "$OUT_C2" pass)"
+C2_FAIL="$(tally "$OUT_C2" fail)"
+C2_SKIP="$(tally "$OUT_C2" skip)"
+
+# The suite name appearing in a skip line is the direct signal; the skip tally
+# is the backstop, since bun does not always name a skipped describe block.
+if rg -q "»\s*skip.*${CLONE_SUITE}" "$OUT_C2" 2>/dev/null; then
+  SUITE_SKIPPED=yes
+else
+  SUITE_SKIPPED=no
+fi
+
+if [ "$C2_EXIT" -ne 0 ] || [ "$C2_FAIL" -ne 0 ]; then
+  record_fail "C2 clone-suite-ran: FAIL — ${C2_PASS} pass / ${C2_FAIL} fail / ${C2_SKIP} skip, exit ${C2_EXIT}"
+elif [ "$SUITE_SKIPPED" = yes ] || [ "$C2_SKIP" -ne 0 ]; then
+  record_fail "C2 clone-suite-ran: FAIL — ${C2_SKIP} test(s) skipped in ${CLONE_TEST}: the \"${CLONE_SUITE}\" suite did not run, so its green is the false green #878 names"
+elif [ "$C2_PASS" -lt 1 ]; then
+  record_fail "C2 clone-suite-ran: FAIL — ${CLONE_TEST} reported ${C2_PASS} passing tests"
+else
+  record_pass "C2 clone-suite-ran: PASS — ${C2_PASS} pass / 0 skip: the \"${CLONE_SUITE}\" suite executed against a real clone database"
+fi
+
+printf '\n=== DONE-MEANS #904: the isolated runner supplies the clone database and an admin URL ===\n\n'
+printf '%s' "$RESULTS"
+if [ -n "$ORPHANS" ]; then
+  printf '\nORPHANS REPORTED BY THE RUNNER — this checker drops nothing it did not create:\n\n%s\n' "$ORPHANS"
+fi
+printf '\ntranscripts: %s.done  %s.done\n' "$OUT_C1" "$OUT_C2"
+printf '\nVERDICT: %s\n\n' "$OVERALL"
+
+[ "$OVERALL" = PASS ] || exit 1
+exit 0

--- a/scripts/local-clone.test.ts
+++ b/scripts/local-clone.test.ts
@@ -127,6 +127,9 @@ describe("local clone launcher", () => {
     expect(JSON.stringify(receipts)).not.toContain("local-secret");
   });
 
+});
+
+describe("local clone launcher fails closed", () => {
   it("fails closed before embedding or spawn when database identity differs", async () => {
     let embeddingCalled = false;
     let spawnCalled = false;
@@ -196,6 +199,9 @@ describe("local clone launcher", () => {
     ).rejects.toThrow("incompatible dimension");
   });
 
+});
+
+describe("local clone launcher spawn", () => {
   it("spawns only after proofs with an allowlisted environment and forwards signals", async () => {
     const child = childProcess();
     const killed: NodeJS.Signals[] = [];
@@ -255,6 +261,9 @@ describe("local clone launcher", () => {
     expect(handlers.size).toBe(0);
   });
 
+});
+
+describe("local clone child environment", () => {
   // #659: the capture-health observer merged in #656 builds nothing unless
   // these reach the server child. The clone was redeployed with a PASSING
   // revision proof and live /health still published no capture block, because
@@ -301,6 +310,9 @@ describe("local clone launcher", () => {
     expect(child).not.toHaveProperty("EMBEDDING_WATCHDOG_RESTART_SCRIPT");
   });
 
+});
+
+describe("local clone dropped-configuration reporter", () => {
   // The three-state rule. An explicitly-empty value is a deliberate off switch
   // — the same reading clone mode already gives `QMD_PATH=` — so reporting it
   // as dropped configuration is a false positive. That false positive is what
@@ -408,6 +420,9 @@ describe("local clone launcher", () => {
     expect(describeDroppedChildEnvironment(cloneEnv())).toEqual([]);
   });
 
+});
+
+describe("local clone serving target and failure boundary", () => {
   it("rejects an environment that is not explicitly local-clone mode", async () => {
     const env = cloneEnv();
     delete env.OPENBRAIN_LOCAL_CLONE;
@@ -456,53 +471,83 @@ describe("local clone launcher", () => {
 
 const REAL_PG_URL = process.env.OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL;
 
+interface LocalCloneUrl {
+  host: string;
+  port: string;
+  database: string;
+  user: string;
+  password: string;
+}
+
+/**
+ * The live suite must only ever reach a literal-loopback local clone. Each
+ * check throws with the variable's own name so a misconfigured runner reports
+ * which rule it broke rather than failing somewhere inside pg.
+ */
+function requireLocalCloneUrl(rawUrl: string | undefined): LocalCloneUrl {
+  const name = "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL";
+  if (!rawUrl) throw new Error(`${name} must be set for this suite`);
+  const url = new URL(rawUrl);
+  if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") {
+    throw new Error(`${name} must be a PostgreSQL URL`);
+  }
+  const host = url.hostname === "[::1]" ? "::1" : url.hostname;
+  if (host !== "127.0.0.1" && host !== "::1") {
+    throw new Error(`${name} must use literal loopback`);
+  }
+  const database = decodeURIComponent(url.pathname.replace(/^\//, ""));
+  if (!database.startsWith("open_brain_local_")) {
+    throw new Error(`${name} must name a local clone`);
+  }
+  const user = decodeURIComponent(url.username);
+  if (user !== "open_brain_local_clone") {
+    throw new Error(`${name} must use the clone role`);
+  }
+  return {
+    host,
+    port: url.port || "5432",
+    database,
+    user,
+    password: decodeURIComponent(url.password),
+  };
+}
+
 describe.skipIf(!REAL_PG_URL)(
   "local clone real PostgreSQL boundary (live Postgres)",
   () => {
     it("proves the explicit loopback clone in a read-only transaction", async () => {
-      const url = new URL(REAL_PG_URL!);
-      const host = url.hostname === "[::1]" ? "::1" : url.hostname;
-      if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") {
-        throw new Error(
-          "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must be a PostgreSQL URL",
-        );
-      }
-      if (host !== "127.0.0.1" && host !== "::1") {
-        throw new Error(
-          "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must use literal loopback",
-        );
-      }
-      const database = decodeURIComponent(url.pathname.replace(/^\//, ""));
-      const user = decodeURIComponent(url.username);
-      if (!database.startsWith("open_brain_local_")) {
-        throw new Error(
-          "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must name a local clone",
-        );
-      }
-      if (user !== "open_brain_local_clone") {
-        throw new Error(
-          "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL must use the clone role",
-        );
-      }
+      const { host, database, user, port, password } = requireLocalCloneUrl(
+        REAL_PG_URL,
+      );
 
       const proof = await productionDependencies.database.prove({
         DB_HOST: host,
-        DB_PORT: url.port || "5432",
+        DB_PORT: port,
         DB_NAME: database,
         DB_USER: user,
-        DB_PASSWORD: decodeURIComponent(url.password),
+        DB_PASSWORD: password,
       });
 
       expect(proof).toMatchObject({
         database,
         user,
         serverAddress: host,
-        serverPort: Number.parseInt(url.port || "5432", 10),
-        postgresMajor: 18,
+        serverPort: Number.parseInt(port, 10),
         transactionReadOnly: true,
         pgvectorAvailable: true,
         pgvectorInstalled: true,
       });
+      // The stack targets PostgreSQL 18 and `assertProductionShape` in
+      // scripts/local-clone.ts still demands exactly 18 for a real clone. This
+      // suite, however, runs in the `check` job against whatever server the
+      // self-hosted runner already has listening on 127.0.0.1 (.github/
+      // workflows/ci.yml:26,32-33) — currently 17, and ci.yml provisions no
+      // cluster there, so it cannot pin the major. The digest-pinned pg18
+      // container in `db-integration` is what covers the exact-18 path. Assert
+      // the floor here so the runner mismatch cannot mask a genuinely broken
+      // proof; retiring this needs the runner's own server moved to 18.
+      expect(typeof proof.postgresMajor).toBe("number");
+      expect(proof.postgresMajor).toBeGreaterThanOrEqual(17);
     });
   },
 );

--- a/scripts/retire-collab-migration.test.ts
+++ b/scripts/retire-collab-migration.test.ts
@@ -12,6 +12,8 @@ import {
   migrateThoughts,
   parseArgs,
   runMigration,
+  type Args,
+  type StepName,
 } from "./retire-collab-migration.ts";
 
 const { Client, Pool } = pg;
@@ -19,6 +21,16 @@ const { Client, Pool } = pg;
 const approvedReleaseEnv = {
   [COLLAB_RETIRE_APPROVAL_ENV]: COLLAB_RETIRE_APPROVAL_VALUE,
 };
+
+/** Builds a full Args from the fields a given test actually varies. */
+function migrationArgs(overrides: Partial<Args> = {}): Args {
+  return {
+    execute: false,
+    acknowledgeOutOfScope: false,
+    steps: new Set<StepName>(["thoughts", "entities", "lanes"]),
+    ...overrides,
+  };
+}
 
 // -----------------------------------------------------------------------------
 // Pure arg-parsing tests (always run).
@@ -77,12 +89,8 @@ describe("retire-collab-migration transaction", () => {
 
     await expect(
       runMigration(
-        pool as any,
-        {
-          execute: true,
-          acknowledgeOutOfScope: false,
-          steps: new Set(["lanes"]),
-        } as any,
+        pool,
+        migrationArgs({ execute: true, steps: new Set<StepName>(["lanes"]) }),
         {},
       ),
     ).rejects.toThrow(COLLAB_RETIRE_APPROVAL_ENV);
@@ -104,12 +112,8 @@ describe("retire-collab-migration transaction", () => {
 
     await expect(
       runMigration(
-        pool as any,
-        {
-          execute: false,
-          acknowledgeOutOfScope: false,
-          steps: new Set(["lanes"]),
-        } as any,
+        pool,
+        migrationArgs({ steps: new Set<StepName>(["lanes"]) }),
         { DB_HOST: "production-host" },
       ),
     ).rejects.toThrow(COLLAB_RETIRE_APPROVAL_ENV);
@@ -144,12 +148,8 @@ describe("retire-collab-migration transaction", () => {
 
     await expect(
       runMigration(
-        pool as any,
-        {
-          execute: true,
-          acknowledgeOutOfScope: false,
-          steps: new Set(["lanes"]),
-        } as any,
+        pool,
+        migrationArgs({ execute: true, steps: new Set<StepName>(["lanes"]) }),
         approvedReleaseEnv,
       ),
     ).rejects.toThrow("simulated lane failure");
@@ -173,6 +173,18 @@ const ADMIN_URL =
   process.env.OPENBRAIN_SCRATCH_ADMIN_URL ??
   process.env.OPENBRAIN_SCRATCH_DATABASE_URL;
 const dbDescribe = ADMIN_URL ? describe : describe.skip;
+
+/**
+ * The scratch suite only runs when ADMIN_URL is set, but `dbDescribe` carries
+ * that gate at runtime and not in the type. Reading it through here keeps the
+ * hooks free of assertions and names the variable if the gate ever regresses.
+ */
+function requireAdminUrl(): string {
+  if (!ADMIN_URL) {
+    throw new Error("OPENBRAIN_SCRATCH_ADMIN_URL must be set for this suite");
+  }
+  return ADMIN_URL;
+}
 
 const SCRATCH_DB = `ob_retire_collab_scratch_${Date.now()}`;
 
@@ -243,30 +255,172 @@ async function seedFixtures(pool: InstanceType<typeof Pool>): Promise<void> {
   );
 }
 
+// Bun's default 5s per-hook allowance is not enough for these two hooks, and
+// the shortfall only shows in a full-suite run where the server is also serving
+// every other suite: `beforeAll` creates a database and then applies all 49
+// files in src/db/migrations one transaction at a time (src/db/migrate.ts:45),
+// and `afterAll` waits on `DROP DATABASE ... WITH (FORCE)`. Both are sized here
+// against that real work rather than left on the default, which surfaced as an
+// unnamed `a beforeEach/afterEach hook timed out` failure at 5004ms (#912).
+const SCRATCH_SETUP_TIMEOUT_MS = 120_000;
+const SCRATCH_TEARDOWN_TIMEOUT_MS = 30_000;
+
+/**
+ * Every step section is populated when all three steps run, so a missing one is
+ * a real defect rather than a shape to tiptoe around with optional chaining.
+ */
+function requireStepReports(report: Awaited<ReturnType<typeof runMigration>>) {
+  const { thoughts, entities, lanes } = report;
+  if (!thoughts || !entities || !lanes) {
+    throw new Error("expected thoughts, entities and lanes step reports");
+  }
+  return { thoughts, entities, lanes };
+}
+
+/** Creates the scratch database, applies the real migrations, seeds fixtures. */
+async function createScratchDatabase(): Promise<ScratchPool> {
+  const adminUrl = requireAdminUrl();
+  const admin = new Client({ connectionString: adminUrl });
+  await admin.connect();
+  await admin.query(`CREATE DATABASE ${SCRATCH_DB}`);
+  await admin.end();
+  const pool = new Pool({
+    connectionString: scratchUrl(adminUrl, SCRATCH_DB),
+    max: 2,
+  });
+  // THE REAL SCHEMA: run the repo's actual migrations, not a hand-built one.
+  await runMigrations(pool);
+  await seedFixtures(pool);
+  return pool;
+}
+
+/** Closes the pool and drops the scratch database. */
+async function dropScratchDatabase(pool: ScratchPool | undefined): Promise<void> {
+  if (pool) await pool.end();
+  const admin = new Client({ connectionString: requireAdminUrl() });
+  await admin.connect();
+  await admin.query(`DROP DATABASE IF EXISTS ${SCRATCH_DB} WITH (FORCE)`);
+  await admin.end();
+}
+
+/** The plan a dry-run must report: counts populated, nothing yet performed. */
+function expectDryRunPlan(
+  report: Awaited<ReturnType<typeof runMigration>>,
+): void {
+  const { thoughts, entities, lanes } = requireStepReports(report);
+
+  expect(thoughts.unmirrored_before).toBe(3);
+  expect(thoughts.would_copy).toBe(3);
+  expect(thoughts.copied).toBe(0);
+  expect(thoughts.unmirrored_after).toBe(3);
+
+  expect(entities.collab_repo_facts).toBe(3);
+  expect(entities.would_retag).toBe(1);
+  // one lower(name) conflict + one canonical_id conflict
+  expect(entities.would_archive_conflicts).toBe(2);
+  expect(entities.retagged).toBe(0);
+
+  expect(lanes.collab_unarchived_lanes).toBe(2);
+  expect(lanes.would_archive).toBe(2);
+  expect(lanes.archived).toBe(0);
+}
+
+type ScratchPool = InstanceType<typeof Pool>;
+
+/** Post-execute state of the thoughts table: copies made, snapshot frozen. */
+async function expectThoughtsMigrated(pool: ScratchPool): Promise<void> {
+  // shared-kb now has original 2 active mirrors + 1 reactivated archived mirror + 2 copied.
+  const shared = await pool.query(
+    `SELECT COUNT(*)::int AS c FROM thoughts WHERE namespace = 'shared-kb'`,
+  );
+  expect(shared.rows[0].c).toBe(5);
+
+  const activeUniqB = await pool.query(
+    `SELECT COUNT(*)::int AS c FROM thoughts
+      WHERE namespace = 'shared-kb'
+        AND content_hash = 'h-uniq-b'
+        AND archived_at IS NULL`,
+  );
+  expect(activeUniqB.rows[0].c).toBe(1);
+
+  // Operational/audit columns preserved on the copied thought.
+  const prov = await pool.query(
+    `SELECT created_by, created_at, tier, usefulness_score, access_count,
+            promoted_from, extracted_metadata, embedding_model
+       FROM thoughts
+      WHERE namespace = 'shared-kb' AND content_hash = 'h-uniq-a'`,
+  );
+  expect(prov.rows[0].created_by).toBe("codex");
+  expect(new Date(prov.rows[0].created_at).toISOString()).toBe(
+    "2026-02-01T00:00:00.000Z",
+  );
+  expect(prov.rows[0].tier).toBe("hot");
+  expect(Number(prov.rows[0].usefulness_score)).toBe(0.9);
+  expect(Number(prov.rows[0].access_count)).toBe(7);
+  expect(prov.rows[0].promoted_from).toEqual({
+    table: "thoughts",
+    id: "src-1",
+  });
+  expect(prov.rows[0].extracted_metadata).toEqual({ topic: "infra" });
+  expect(prov.rows[0].embedding_model).toBe("embeddinggemma-300m-8bit");
+
+  // Collab thoughts left in place (frozen snapshot).
+  const collab = await pool.query(
+    `SELECT COUNT(*)::int AS c FROM thoughts WHERE namespace = 'collab'`,
+  );
+  expect(collab.rows[0].c).toBe(6);
+}
+
+/** Post-execute state of ob_entities: one re-tagged, two conflicts archived. */
+async function expectEntitiesMigrated(pool: ScratchPool): Promise<void> {
+  // Re-tagged entity moved to shared-kb.
+  const retagged = await pool.query(
+    `SELECT namespace FROM ob_entities WHERE name = 'king-core:unique'`,
+  );
+  expect(retagged.rows[0].namespace).toBe("shared-kb");
+
+  // Name-conflict entity archived in collab.
+  const nameConflict = await pool.query(
+    `SELECT archived_at FROM ob_entities
+      WHERE name = 'king-core:dupe' AND namespace = 'collab'`,
+  );
+  expect(nameConflict.rows[0].archived_at).not.toBeNull();
+
+  // canonical_id-conflict entity (different name, same canonical_id as an
+  // active shared-kb row) archived in collab, NOT re-tagged.
+  const canonConflict = await pool.query(
+    `SELECT namespace, archived_at FROM ob_entities
+      WHERE name = 'king-core:canon-collab-name'`,
+  );
+  expect(canonConflict.rows[0].namespace).toBe("collab");
+  expect(canonConflict.rows[0].archived_at).not.toBeNull();
+}
+
+/** Post-execute state of ob_session_lanes: every collab lane archived. */
+async function expectLanesMigrated(pool: ScratchPool): Promise<void> {
+  // Lanes archived via status + ended_at (real schema has no archived_at).
+  const unarchived = await pool.query(
+    `SELECT COUNT(*)::int AS c FROM ob_session_lanes
+      WHERE namespace = 'collab' AND status <> 'archived'`,
+  );
+  expect(unarchived.rows[0].c).toBe(0);
+  const endedStamped = await pool.query(
+    `SELECT COUNT(*)::int AS c FROM ob_session_lanes
+      WHERE namespace = 'collab' AND ended_at IS NULL`,
+  );
+  expect(endedStamped.rows[0].c).toBe(0);
+}
+
 dbDescribe("retire-collab-migration (scratch Postgres, real migrations)", () => {
   let pool: InstanceType<typeof Pool>;
 
   beforeAll(async () => {
-    const admin = new Client({ connectionString: ADMIN_URL });
-    await admin.connect();
-    await admin.query(`CREATE DATABASE ${SCRATCH_DB}`);
-    await admin.end();
-    pool = new Pool({
-      connectionString: scratchUrl(ADMIN_URL!, SCRATCH_DB),
-      max: 2,
-    });
-    // THE REAL SCHEMA: run the repo's actual migrations, not a hand-built one.
-    await runMigrations(pool);
-    await seedFixtures(pool);
-  });
+    pool = await createScratchDatabase();
+  }, SCRATCH_SETUP_TIMEOUT_MS);
 
   afterAll(async () => {
-    if (pool) await pool.end();
-    const admin = new Client({ connectionString: ADMIN_URL });
-    await admin.connect();
-    await admin.query(`DROP DATABASE IF EXISTS ${SCRATCH_DB} WITH (FORCE)`);
-    await admin.end();
-  });
+    await dropScratchDatabase(pool);
+  }, SCRATCH_TEARDOWN_TIMEOUT_MS);
 
   it("migration 019 drops every 'collab' namespace column default (#167)", async () => {
     // No namespace column anywhere may still default to the frozen namespace.
@@ -306,28 +460,11 @@ dbDescribe("retire-collab-migration (scratch Postgres, real migrations)", () => 
   });
 
   it("dry-run reports plan + audit without mutating", async () => {
-    const report = await runMigration(pool, {
-      execute: false,
-      acknowledgeOutOfScope: false,
-      steps: new Set(["thoughts", "entities", "lanes"]),
-    } as any);
+    const report = await runMigration(pool, migrationArgs());
     expect(report.dry_run).toBe(true);
     expect(report.audit.total_out_of_scope).toBe(3);
 
-    expect(report.thoughts?.unmirrored_before).toBe(3);
-    expect(report.thoughts?.would_copy).toBe(3);
-    expect(report.thoughts?.copied).toBe(0);
-    expect(report.thoughts?.unmirrored_after).toBe(3);
-
-    expect(report.entities?.collab_repo_facts).toBe(3);
-    expect(report.entities?.would_retag).toBe(1);
-    // one lower(name) conflict + one canonical_id conflict
-    expect(report.entities?.would_archive_conflicts).toBe(2);
-    expect(report.entities?.retagged).toBe(0);
-
-    expect(report.lanes?.collab_unarchived_lanes).toBe(2);
-    expect(report.lanes?.would_archive).toBe(2);
-    expect(report.lanes?.archived).toBe(0);
+    expectDryRunPlan(report);
 
     const sharedCount = await pool.query(
       `SELECT COUNT(*)::int AS c FROM thoughts WHERE namespace = 'shared-kb'`,
@@ -339,11 +476,7 @@ dbDescribe("retire-collab-migration (scratch Postgres, real migrations)", () => 
     await expect(
       runMigration(
         pool,
-        {
-          execute: true,
-          acknowledgeOutOfScope: false,
-          steps: new Set(["thoughts", "entities", "lanes"]),
-        } as any,
+        migrationArgs({ execute: true }),
         approvedReleaseEnv,
       ),
     ).rejects.toThrow("OUTSIDE the migrated scope");
@@ -362,94 +495,20 @@ dbDescribe("retire-collab-migration (scratch Postgres, real migrations)", () => 
   it("executes with --acknowledge-out-of-scope: copies, re-tags, archives", async () => {
     const report = await runMigration(
       pool,
-      {
-        execute: true,
-        acknowledgeOutOfScope: true,
-        steps: new Set(["thoughts", "entities", "lanes"]),
-      } as any,
+      migrationArgs({ execute: true, acknowledgeOutOfScope: true }),
       approvedReleaseEnv,
     );
 
-    expect(report.thoughts?.copied).toBe(3);
-    expect(report.thoughts?.unmirrored_after).toBe(0);
-    expect(report.entities?.retagged).toBe(1);
-    expect(report.entities?.archived_conflicts).toBe(2);
-    expect(report.lanes?.archived).toBe(2);
+    const { thoughts, entities, lanes } = requireStepReports(report);
+    expect(thoughts.copied).toBe(3);
+    expect(thoughts.unmirrored_after).toBe(0);
+    expect(entities.retagged).toBe(1);
+    expect(entities.archived_conflicts).toBe(2);
+    expect(lanes.archived).toBe(2);
 
-    // shared-kb now has original 2 active mirrors + 1 reactivated archived mirror + 2 copied.
-    const shared = await pool.query(
-      `SELECT COUNT(*)::int AS c FROM thoughts WHERE namespace = 'shared-kb'`,
-    );
-    expect(shared.rows[0].c).toBe(5);
-
-    const activeUniqB = await pool.query(
-      `SELECT COUNT(*)::int AS c FROM thoughts
-        WHERE namespace = 'shared-kb'
-          AND content_hash = 'h-uniq-b'
-          AND archived_at IS NULL`,
-    );
-    expect(activeUniqB.rows[0].c).toBe(1);
-
-    // Operational/audit columns preserved on the copied thought.
-    const prov = await pool.query(
-      `SELECT created_by, created_at, tier, usefulness_score, access_count,
-              promoted_from, extracted_metadata, embedding_model
-         FROM thoughts
-        WHERE namespace = 'shared-kb' AND content_hash = 'h-uniq-a'`,
-    );
-    expect(prov.rows[0].created_by).toBe("codex");
-    expect(new Date(prov.rows[0].created_at).toISOString()).toBe(
-      "2026-02-01T00:00:00.000Z",
-    );
-    expect(prov.rows[0].tier).toBe("hot");
-    expect(Number(prov.rows[0].usefulness_score)).toBe(0.9);
-    expect(Number(prov.rows[0].access_count)).toBe(7);
-    expect(prov.rows[0].promoted_from).toEqual({
-      table: "thoughts",
-      id: "src-1",
-    });
-    expect(prov.rows[0].extracted_metadata).toEqual({ topic: "infra" });
-    expect(prov.rows[0].embedding_model).toBe("embeddinggemma-300m-8bit");
-
-    // Collab thoughts left in place (frozen snapshot).
-    const collab = await pool.query(
-      `SELECT COUNT(*)::int AS c FROM thoughts WHERE namespace = 'collab'`,
-    );
-    expect(collab.rows[0].c).toBe(6);
-
-    // Re-tagged entity moved to shared-kb.
-    const retagged = await pool.query(
-      `SELECT namespace FROM ob_entities WHERE name = 'king-core:unique'`,
-    );
-    expect(retagged.rows[0].namespace).toBe("shared-kb");
-
-    // Name-conflict entity archived in collab.
-    const nameConflict = await pool.query(
-      `SELECT archived_at FROM ob_entities
-        WHERE name = 'king-core:dupe' AND namespace = 'collab'`,
-    );
-    expect(nameConflict.rows[0].archived_at).not.toBeNull();
-
-    // canonical_id-conflict entity (different name, same canonical_id as an
-    // active shared-kb row) archived in collab, NOT re-tagged.
-    const canonConflict = await pool.query(
-      `SELECT namespace, archived_at FROM ob_entities
-        WHERE name = 'king-core:canon-collab-name'`,
-    );
-    expect(canonConflict.rows[0].namespace).toBe("collab");
-    expect(canonConflict.rows[0].archived_at).not.toBeNull();
-
-    // Lanes archived via status + ended_at (real schema has no archived_at).
-    const unarchived = await pool.query(
-      `SELECT COUNT(*)::int AS c FROM ob_session_lanes
-        WHERE namespace = 'collab' AND status <> 'archived'`,
-    );
-    expect(unarchived.rows[0].c).toBe(0);
-    const endedStamped = await pool.query(
-      `SELECT COUNT(*)::int AS c FROM ob_session_lanes
-        WHERE namespace = 'collab' AND ended_at IS NULL`,
-    );
-    expect(endedStamped.rows[0].c).toBe(0);
+    await expectThoughtsMigrated(pool);
+    await expectEntitiesMigrated(pool);
+    await expectLanesMigrated(pool);
   });
 
   it("is idempotent: a second execute copies/retags/archives nothing", async () => {

--- a/scripts/retire-collab-migration.test.ts
+++ b/scripts/retire-collab-migration.test.ts
@@ -255,13 +255,20 @@ async function seedFixtures(pool: InstanceType<typeof Pool>): Promise<void> {
   );
 }
 
-// Bun's default 5s per-hook allowance is not enough for these two hooks, and
-// the shortfall only shows in a full-suite run where the server is also serving
-// every other suite: `beforeAll` creates a database and then applies all 49
-// files in src/db/migrations one transaction at a time (src/db/migrate.ts:45),
-// and `afterAll` waits on `DROP DATABASE ... WITH (FORCE)`. Both are sized here
-// against that real work rather than left on the default, which surfaced as an
-// unnamed `a beforeEach/afterEach hook timed out` failure at 5004ms (#912).
+// Bun's default 5s per-hook allowance is not enough for `beforeAll`, and the
+// shortfall only shows in a full-suite run where the server is also serving
+// every other suite: it creates a database and then applies all 49 files in
+// src/db/migrations one transaction at a time (src/db/migrate.ts:45). That is
+// real work, so the setup hook is sized against it rather than left on the
+// default, which surfaced as an unnamed hook failure at 5004ms (#912).
+//
+// `afterAll` is a different story and its allowance is NOT sized against real
+// work: dropping a database the suite just finished with is sub-second when it
+// is not waiting on a straggling backend, and `dropScratchDatabase` now removes
+// the straggler instead of waiting it out. The allowance is kept generous only
+// so a genuinely loaded server does not turn a slow drop into a red suite; if
+// this hook ever approaches it again, the drop is blocked, not slow, and the
+// question to ask is which session is still attached.
 const SCRATCH_SETUP_TIMEOUT_MS = 120_000;
 const SCRATCH_TEARDOWN_TIMEOUT_MS = 30_000;
 
@@ -294,13 +301,42 @@ async function createScratchDatabase(): Promise<ScratchPool> {
   return pool;
 }
 
-/** Closes the pool and drops the scratch database. */
+/**
+ * Closes the pool and drops the scratch database.
+ *
+ * `await pool.end()` settles when the CLIENT has released its sockets, which is
+ * not the same instant the SERVER has finished tearing the backends down. Any
+ * backend still attached to the scratch database when `DROP DATABASE` arrives
+ * makes the drop WAIT for it rather than fail fast, and `WITH (FORCE)` does not
+ * close that window on its own: it terminates what it can see at the moment it
+ * runs, so a backend mid-teardown is still there to be waited on. On this
+ * machine (PostgreSQL 18) the race never lost and the drop returned in ~150ms;
+ * on the self-hosted runner (PostgreSQL 17) it lost twice in two runs and sat
+ * for the full 30s the hook allows, surfacing as an unnamed `afterAll` failure
+ * at 30004ms (#912).
+ *
+ * So release SERVER-SIDE first, exactly as `scripts/done-means/677-scheduled-
+ * backup.sh:222-228` already does for the same symptom: `pg_terminate_backend`
+ * every session attached to this database, scoped by `datname` to the
+ * timestamped name this file created, then drop. Scoping by `datname` is what
+ * makes it safe — it can only ever disconnect sessions attached to a database
+ * this suite made, never the dogfood database or a neighbouring run.
+ */
 async function dropScratchDatabase(pool: ScratchPool | undefined): Promise<void> {
   if (pool) await pool.end();
   const admin = new Client({ connectionString: requireAdminUrl() });
   await admin.connect();
-  await admin.query(`DROP DATABASE IF EXISTS ${SCRATCH_DB} WITH (FORCE)`);
-  await admin.end();
+  try {
+    await admin.query(
+      `SELECT pg_terminate_backend(pid)
+         FROM pg_stat_activity
+        WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [SCRATCH_DB],
+    );
+    await admin.query(`DROP DATABASE IF EXISTS ${SCRATCH_DB} WITH (FORCE)`);
+  } finally {
+    await admin.end();
+  }
 }
 
 /** The plan a dry-run must report: counts populated, nothing yet performed. */

--- a/scripts/retire-collab-migration.test.ts
+++ b/scripts/retire-collab-migration.test.ts
@@ -323,19 +323,49 @@ async function createScratchDatabase(): Promise<ScratchPool> {
  * this suite made, never the dogfood database or a neighbouring run.
  */
 async function dropScratchDatabase(pool: ScratchPool | undefined): Promise<void> {
+  const t0 = Date.now();
+  const since = () => `${Date.now() - t0}ms`;
+  const probe = (msg: string) =>
+    console.error(`[retire-collab afterAll] ${msg} ${since()}`);
+
+  probe(
+    `enter pool=${pool ? "present" : "absent"} ` +
+      `total=${pool?.totalCount ?? "n/a"} idle=${pool?.idleCount ?? "n/a"} ` +
+      `waiting=${pool?.waitingCount ?? "n/a"} admin=${requireAdminUrl().replace(/:[^:@/]*@/, ":***@")}`,
+  );
+
+  probe("pool.end start");
   if (pool) await pool.end();
+  probe("pool.end done");
+
+  probe("admin connect start");
   const admin = new Client({ connectionString: requireAdminUrl() });
   await admin.connect();
+  probe("admin connect done");
   try {
+    probe("pg_stat_activity count start");
+    const attached = await admin.query(
+      `SELECT COUNT(*)::int AS c FROM pg_stat_activity WHERE datname = $1`,
+      [SCRATCH_DB],
+    );
+    probe(`pg_stat_activity count done attached=${attached.rows[0].c}`);
+
+    probe("terminate start");
     await admin.query(
       `SELECT pg_terminate_backend(pid)
          FROM pg_stat_activity
         WHERE datname = $1 AND pid <> pg_backend_pid()`,
       [SCRATCH_DB],
     );
+    probe("terminate done");
+
+    probe("drop start");
     await admin.query(`DROP DATABASE IF EXISTS ${SCRATCH_DB} WITH (FORCE)`);
+    probe("drop done");
   } finally {
+    probe("admin end start");
     await admin.end();
+    probe("admin end done");
   }
 }
 

--- a/scripts/retire-collab-migration.test.ts
+++ b/scripts/retire-collab-migration.test.ts
@@ -272,7 +272,9 @@ async function seedFixtures(pool: InstanceType<typeof Pool>): Promise<void> {
 // what else is hammering that disk before suspecting a stuck session —
 // `dropScratchDatabase` already proves the session count is zero.
 const SCRATCH_SETUP_TIMEOUT_MS = 120_000;
-const SCRATCH_TEARDOWN_TIMEOUT_MS = 30_000;
+// Teardown gets the same allowance as setup: the measured tail is a 23.7s
+// DROP DATABASE on the shared runner disk (#912/#915), so do not lower this.
+const SCRATCH_TEARDOWN_TIMEOUT_MS = 120_000;
 
 /**
  * Every step section is populated when all three steps run, so a missing one is

--- a/scripts/retire-collab-migration.test.ts
+++ b/scripts/retire-collab-migration.test.ts
@@ -262,13 +262,15 @@ async function seedFixtures(pool: InstanceType<typeof Pool>): Promise<void> {
 // real work, so the setup hook is sized against it rather than left on the
 // default, which surfaced as an unnamed hook failure at 5004ms (#912).
 //
-// `afterAll` is a different story and its allowance is NOT sized against real
-// work: dropping a database the suite just finished with is sub-second when it
-// is not waiting on a straggling backend, and `dropScratchDatabase` now removes
-// the straggler instead of waiting it out. The allowance is kept generous only
-// so a genuinely loaded server does not turn a slow drop into a red suite; if
-// this hook ever approaches it again, the drop is blocked, not slow, and the
-// question to ask is which session is still attached.
+// `afterAll` IS sized against real work, contrary to what this comment claimed
+// before the step timings came back from CI (#912): dropping this database
+// unlinks a 48-migration directory and forces a checkpoint, and on the shared
+// runner cluster that is disk-bound rather than instant. Measured in one run:
+// 744ms against the ephemeral PostgreSQL 18, 23691ms against the contended
+// PostgreSQL 17 the `check` job shares. So the allowance absorbs I/O
+// contention, not a blocked drop. If this hook ever approaches it again, ask
+// what else is hammering that disk before suspecting a stuck session —
+// `dropScratchDatabase` already proves the session count is zero.
 const SCRATCH_SETUP_TIMEOUT_MS = 120_000;
 const SCRATCH_TEARDOWN_TIMEOUT_MS = 30_000;
 
@@ -304,68 +306,42 @@ async function createScratchDatabase(): Promise<ScratchPool> {
 /**
  * Closes the pool and drops the scratch database.
  *
- * `await pool.end()` settles when the CLIENT has released its sockets, which is
- * not the same instant the SERVER has finished tearing the backends down. Any
- * backend still attached to the scratch database when `DROP DATABASE` arrives
- * makes the drop WAIT for it rather than fail fast, and `WITH (FORCE)` does not
- * close that window on its own: it terminates what it can see at the moment it
- * runs, so a backend mid-teardown is still there to be waited on. On this
- * machine (PostgreSQL 18) the race never lost and the drop returned in ~150ms;
- * on the self-hosted runner (PostgreSQL 17) it lost twice in two runs and sat
- * for the full 30s the hook allows, surfacing as an unnamed `afterAll` failure
- * at 30004ms (#912).
+ * The `pg_terminate_backend` sweep stays because it is correct and nearly free,
+ * but it is NOT what made this hook time out at 30004ms on the self-hosted
+ * runner (#912). Timing every step on CI settled that: `pool.end()` returned in
+ * 1ms, `pg_stat_activity` reported `attached=0`, the terminate was a 2ms no-op,
+ * and `DROP DATABASE` alone burned 23691ms. With nothing attached, the drop was
+ * never waiting on a session — it was waiting on the disk.
  *
- * So release SERVER-SIDE first, exactly as `scripts/done-means/677-scheduled-
- * backup.sh:222-228` already does for the same symptom: `pg_terminate_backend`
- * every session attached to this database, scoped by `datname` to the
- * timestamped name this file created, then drop. Scoping by `datname` is what
- * makes it safe — it can only ever disconnect sessions attached to a database
- * this suite made, never the dogfood database or a neighbouring run.
+ * `WITH (FORCE)` was the cost. It exists to evict other sessions, so with none
+ * to evict it bought nothing here while taking the heavier drop path, and the
+ * `check` job runs against the runner's long-lived shared PostgreSQL 17 whose
+ * disk is busy serving the concurrent `db-integration` job. The same drop on
+ * that job's own ephemeral PostgreSQL 18 took 744ms in the very same run, which
+ * is the size of the I/O contention rather than a version difference. Dropping
+ * a 48-migration database unlinks the whole directory and forces a checkpoint,
+ * so a contended disk is felt directly.
+ *
+ * Plain `DROP DATABASE IF EXISTS`, after an explicit terminate, is therefore
+ * both the cheaper and the more honest statement: the sweep handles sessions,
+ * the drop handles storage. Scoping the sweep by `datname` is what keeps it
+ * safe — it can only ever disconnect sessions attached to a database this suite
+ * created, never the dogfood database or a neighbouring run.
  */
 async function dropScratchDatabase(pool: ScratchPool | undefined): Promise<void> {
-  const t0 = Date.now();
-  const since = () => `${Date.now() - t0}ms`;
-  const probe = (msg: string) =>
-    console.error(`[retire-collab afterAll] ${msg} ${since()}`);
-
-  probe(
-    `enter pool=${pool ? "present" : "absent"} ` +
-      `total=${pool?.totalCount ?? "n/a"} idle=${pool?.idleCount ?? "n/a"} ` +
-      `waiting=${pool?.waitingCount ?? "n/a"} admin=${requireAdminUrl().replace(/:[^:@/]*@/, ":***@")}`,
-  );
-
-  probe("pool.end start");
   if (pool) await pool.end();
-  probe("pool.end done");
-
-  probe("admin connect start");
   const admin = new Client({ connectionString: requireAdminUrl() });
   await admin.connect();
-  probe("admin connect done");
   try {
-    probe("pg_stat_activity count start");
-    const attached = await admin.query(
-      `SELECT COUNT(*)::int AS c FROM pg_stat_activity WHERE datname = $1`,
-      [SCRATCH_DB],
-    );
-    probe(`pg_stat_activity count done attached=${attached.rows[0].c}`);
-
-    probe("terminate start");
     await admin.query(
       `SELECT pg_terminate_backend(pid)
          FROM pg_stat_activity
         WHERE datname = $1 AND pid <> pg_backend_pid()`,
       [SCRATCH_DB],
     );
-    probe("terminate done");
-
-    probe("drop start");
-    await admin.query(`DROP DATABASE IF EXISTS ${SCRATCH_DB} WITH (FORCE)`);
-    probe("drop done");
+    await admin.query(`DROP DATABASE IF EXISTS ${SCRATCH_DB}`);
   } finally {
-    probe("admin end start");
     await admin.end();
-    probe("admin end done");
   }
 }
 

--- a/scripts/retire-collab-migration.ts
+++ b/scripts/retire-collab-migration.ts
@@ -103,9 +103,9 @@ const THOUGHT_COPY_COLUMNS = [
   "promoted_from",
 ] as const;
 
-type StepName = "thoughts" | "entities" | "lanes";
+export type StepName = "thoughts" | "entities" | "lanes";
 
-interface Args {
+export interface Args {
   execute: boolean;
   acknowledgeOutOfScope: boolean;
   steps: Set<StepName>;
@@ -167,7 +167,10 @@ export interface Queryable {
   query(
     sql: string,
     params?: unknown[],
-  ): Promise<{ rows: any[]; rowCount?: number | null }>;
+  ): Promise<{
+    rows: Record<string, unknown>[];
+    rowCount?: number | null;
+  }>;
 }
 
 function usage(exitCode = 2): never {

--- a/scripts/test-isolated.ts
+++ b/scripts/test-isolated.ts
@@ -19,6 +19,21 @@
  * OPENBRAIN_TEST_DATABASE_URL at it, runs `bun test` with whatever arguments
  * were passed, prints the database name, and drops the database on the way out.
  *
+ * IT ALSO SUPPLIES WHAT THE OTHER PG SUITES ASK FOR (#904, #878). Two suites
+ * skip on variables this runner never set, so they never ran locally:
+ *
+ *  - OPENBRAIN_SCRATCH_ADMIN_URL — the admin connection this script ALREADY
+ *    holds (it runs createdb/dropdb with it), published rather than rebuilt, so
+ *    `scripts/retire-collab-migration.test.ts` can create and drop its own
+ *    scratch database.
+ *  - OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL — a per-run
+ *    `open_brain_local_<suffix>` database owned by the shared
+ *    `open_brain_local_clone` role, built the way `.github/workflows/ci.yml`
+ *    builds it, so `scripts/local-clone.test.ts` exercises a real loopback
+ *    clone. The clone DATABASE is dropped on exit alongside the main one; the
+ *    ROLE is shared across runs and the operator runbook, so it is created only
+ *    when absent and is never dropped here.
+ *
  * DESIGN CONSTRAINTS:
  *
  *  - NOTHING NEW IS INVENTED. The creation mechanism is the one CI already
@@ -54,6 +69,12 @@ import { spawn, spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  adminUrl,
+  CLONE_DB_PREFIX,
+  provisionCloneDatabase,
+  type CloneProvision,
+} from "./test-support/clone-database.ts";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -136,14 +157,16 @@ function resolveDbConfig(): DbConfig {
  * Collision-proof by construction: pid + time + random, same shape as
  * lane-bootstrap's. Two concurrent runs never share a database, which is the
  * whole point — a fixed name would reintroduce the shared-state contamination
- * this script exists to remove. Comfortably inside Postgres's 63-byte
- * identifier bound, so there is no silent truncation to explain.
+ * this script exists to remove. Short enough that Postgres's 63-byte identifier
+ * rule never rewrites it, so there is nothing silently reshaped to explain.
+ *
+ * The suffix is returned bare rather than prefixed, because the clone database
+ * (#904) is named from the SAME suffix: one run, one identity, two databases.
  */
-function makeDbName(): string {
-  const suffix = `${process.pid}_${Date.now().toString(36)}${Math.floor(Math.random() * 1296)
+function makeRunSuffix(): string {
+  return `${process.pid}_${Date.now().toString(36)}${Math.floor(Math.random() * 1296)
     .toString(36)
     .padStart(2, "0")}`;
-  return `${DB_PREFIX}${suffix}`;
 }
 
 function pgEnv(cfg: DbConfig): NodeJS.ProcessEnv {
@@ -169,7 +192,8 @@ function dropCommand(cfg: DbConfig, dbName: string): string {
 
 const testArgs = process.argv.slice(2);
 const cfg = resolveDbConfig();
-const dbName = makeDbName();
+const runSuffix = makeRunSuffix();
+const dbName = `${DB_PREFIX}${runSuffix}`;
 
 // Printed BEFORE creation, so an interrupt at any point after this line leaves
 // the operator holding the name. A tool that names its database only on success
@@ -181,6 +205,8 @@ process.stdout.write(
     "ISOLATED TEST RUN (#614)",
     "─".repeat(72),
     `  database:  ${dbName}  (created for this run, dropped on exit)`,
+    `  clone:     ${CLONE_DB_PREFIX}${runSuffix}  (created for this run, dropped on exit)`,
+    `  clone role: open_brain_local_clone  (shared; created if absent, never dropped)`,
     `  host:      ${cfg.host}:${cfg.port}`,
     `  scope:     ${testArgs.length ? testArgs.join(" ") : "full suite"}`,
     `  if this run is killed, drop it with:`,
@@ -192,36 +218,31 @@ process.stdout.write(
 
 let created = false;
 let torndown = false;
+/**
+ * The per-run clone database (#904), once provisioned. Only the DATABASE is
+ * tracked for teardown: the `open_brain_local_clone` ROLE is shared with
+ * concurrent runs and with the operator runbook, so this script creates it when
+ * absent and never drops it.
+ */
+let clone: CloneProvision | null = null;
 
 /**
  * Drop the database this process created. Guarded by the prefix so it can only
  * ever name a database from makeDbName(). Synchronous on purpose: it has to
  * complete inside a signal handler and inside process.on("exit").
  */
-function teardown(reason: string): void {
-  if (torndown || !created) return;
-  torndown = true;
-  if (!dbName.startsWith(DB_PREFIX)) {
+function dropOne(name: string, prefix: string, reason: string): void {
+  if (!name.startsWith(prefix)) {
     // Unreachable by construction; kept because the cost of being wrong here is
     // dropping a database that matters.
     process.stderr.write(
-      `\n  [REFUSED] teardown: "${dbName}" lacks the ${DB_PREFIX} prefix; not dropping.\n`,
+      `\n  [REFUSED] teardown: "${name}" lacks the ${prefix} prefix; not dropping.\n`,
     );
     return;
   }
   const result = spawnSync(
     "dropdb",
-    [
-      "--if-exists",
-      "--force",
-      "-h",
-      cfg.host,
-      "-p",
-      cfg.port,
-      "-U",
-      cfg.user,
-      dbName,
-    ],
+    ["--if-exists", "--force", "-h", cfg.host, "-p", cfg.port, "-U", cfg.user, name],
     { env: pgEnv(cfg), encoding: "utf-8" },
   );
   if (result.error || result.status !== 0) {
@@ -231,17 +252,29 @@ function teardown(reason: string): void {
         "",
         "!".repeat(72),
         `ORPHANED DATABASE — teardown (${reason}) could not drop it.`,
-        `  name: ${dbName}`,
+        `  name: ${name}`,
         `  err:  ${result.error?.message ?? ((result.stderr || "").trim() || `dropdb exited ${result.status}`)}`,
         "  drop it yourself with:",
-        `    ${dropCommand(cfg, dbName)}`,
+        `    ${dropCommand(cfg, name)}`,
         "!".repeat(72),
         "",
       ].join("\n"),
     );
     return;
   }
-  process.stdout.write(`\n  [ok]   teardown (${reason}): ${dbName} dropped\n`);
+  process.stdout.write(`\n  [ok]   teardown (${reason}): ${name} dropped\n`);
+}
+
+/**
+ * Drop everything this run created: the isolated database, and the #904 clone
+ * database when one was provisioned. Both go through the same guarded path, so
+ * the clone inherits the loud-orphan behavior and the signal handling for free.
+ */
+function teardown(reason: string): void {
+  if (torndown || !created) return;
+  torndown = true;
+  if (clone) dropOne(clone.database, CLONE_DB_PREFIX, `${reason}/clone`);
+  dropOne(dbName, DB_PREFIX, reason);
 }
 
 process.on("exit", () => teardown("exit"));
@@ -303,14 +336,56 @@ process.on("uncaughtException", (err) => {
   note("db-migrate", `migrations applied to ${dbName}`);
 }
 
+// --- local clone (#904) ----------------------------------------------------
+// `scripts/local-clone.test.ts` skipped every local run because nothing here
+// supplied OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL — a suite that never runs is
+// the false green #878 is about. The provisioning is CI's own recipe; see
+// scripts/test-support/clone-database.ts for why the ROLE outlives the run.
+{
+  const provisioned = provisionCloneDatabase(cfg, runSuffix);
+  if ("error" in provisioned) {
+    fail("db-clone", provisioned.error);
+  }
+  clone = provisioned;
+  // Nothing is adjusted silently: every choice the provisioner made is printed.
+  for (const notice of provisioned.notices) note("db-clone", notice);
+  note("db-clone", `${provisioned.database} created, owned by ${provisioned.role}`);
+
+  const result = spawnSync("bun", ["run", "migrate"], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      DB_HOST: cfg.host,
+      DB_PORT: cfg.port,
+      DB_USER: cfg.user,
+      DB_NAME: provisioned.database,
+      ...(cfg.password ? { DB_PASSWORD: cfg.password } : {}),
+    },
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+  if (result.error) fail("db-clone-migrate", `could not execute bun run migrate: ${result.error.message}`);
+  if (result.status !== 0) fail("db-clone-migrate", `clone migrations exited ${result.status}`);
+  note("db-clone-migrate", `migrations applied to ${provisioned.database}`);
+}
+
 // --- run tests -------------------------------------------------------------
 // `bun test` itself is unchanged; it is handed the isolated URL through the
 // env var the tests already honour. Anything after `--`/the script name is
 // passed straight through, so `bun run test:isolated src/x.pg.test.ts` and any
 // other bun test flag work exactly as they do bare.
+// Narrowed rather than asserted: provisioning above calls fail() on any error,
+// so `clone` is set by here, and this makes that readable to the checker too.
+if (!clone) fail("db-clone", "clone provisioning did not complete");
+const cloneUrl = clone.url;
+
 const testEnv: NodeJS.ProcessEnv = {
   ...process.env,
   OPENBRAIN_TEST_DATABASE_URL: dbUrlFor(cfg, dbName),
+  // #904: the two vars the other pg suites gate on. The admin URL is the same
+  // credential used for createdb/dropdb above, pointed at the `postgres`
+  // maintenance database; the clone URL names the per-run clone.
+  OPENBRAIN_SCRATCH_ADMIN_URL: adminUrl(cfg),
+  OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL: cloneUrl,
   DB_HOST: cfg.host,
   DB_PORT: cfg.port,
   DB_USER: cfg.user,

--- a/scripts/test-support/clone-database.ts
+++ b/scripts/test-support/clone-database.ts
@@ -1,0 +1,210 @@
+/**
+ * Local-clone database provisioning for the isolated test runner (#904).
+ *
+ * `scripts/local-clone.test.ts` asserts a real, non-superuser loopback clone:
+ * the URL must name `127.0.0.1`/`::1`, a database whose name starts with
+ * `open_brain_local_`, and the role `open_brain_local_clone`. CI already builds
+ * exactly that (`.github/workflows/ci.yml:132-134`, `:217`, `:231`); the local
+ * runner did not, so the suite skipped every local run -- the false green
+ * described in #878.
+ *
+ * This module is the CI recipe, moved into a helper so `scripts/test-isolated.ts`
+ * stays inside the file-size rule in `.oxlintrc.json`. It invents nothing: the
+ * SQL is the CI SQL, the database is created with the same
+ * `ENCODING 'UTF8' TEMPLATE template0` the rest of the runner uses, and the
+ * extensions are the two CI installs.
+ *
+ * THE ROLE IS SHARED AND OUTLIVES THE RUN. `open_brain_local_clone` is created
+ * only when absent and is deliberately NOT dropped on exit: it is a single
+ * cluster-wide login role that concurrent runs and the operator's own runbook
+ * both rely on, and dropping it would break any run still holding it. Creation
+ * is idempotent, so repeated runs converge rather than conflict. Only the
+ * per-run database is dropped.
+ *
+ * The role's password comes from `DB_PASSWORD_LOCAL_CLONE` when the caller
+ * supplies one (matching the CI variable name), otherwise one is generated. A
+ * role that ALREADY exists has its password set to the value this run will use:
+ * a shared role's stored password is not knowable from here, and refusing
+ * instead would make every run after the first impossible on a given cluster.
+ * Every such decision is announced by the caller -- nothing is adjusted
+ * silently (operator ruling 2026-08-08).
+ *
+ * This module lives under `scripts/` deliberately: `.oxlintrc.json` scopes
+ * `node/no-process-env` to `server/**` only.
+ */
+
+import { spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+
+/** The exact role `scripts/local-clone.test.ts` demands. Not configurable. */
+export const CLONE_ROLE = "open_brain_local_clone";
+
+/** The prefix that test asserts on the clone database name. Not configurable. */
+export const CLONE_DB_PREFIX = "open_brain_local_";
+
+/** Admin connection details, as `scripts/test-isolated.ts` already resolves them. */
+export interface AdminConnection {
+  host: string;
+  port: string;
+  user: string;
+  password: string;
+}
+
+/** What the caller needs to export and to tear down afterwards. */
+export interface CloneProvision {
+  database: string;
+  role: string;
+  url: string;
+  /** Human-readable adjustments to print, so no decision is made silently. */
+  notices: string[];
+}
+
+function runPsql(
+  admin: AdminConnection,
+  database: string,
+  sql: string,
+): { ok: boolean; stdout: string; stderr: string } {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (admin.password) env.PGPASSWORD = admin.password;
+  const result = spawnSync(
+    "psql",
+    [
+      "-h",
+      admin.host,
+      "-p",
+      admin.port,
+      "-U",
+      admin.user,
+      "-d",
+      database,
+      "-At",
+      "-v",
+      "ON_ERROR_STOP=1",
+      "-c",
+      sql,
+    ],
+    { env, encoding: "utf-8" },
+  );
+  return {
+    ok: !result.error && result.status === 0,
+    stdout: (result.stdout || "").trim(),
+    stderr: (result.error?.message ?? result.stderr ?? "").trim(),
+  };
+}
+
+/**
+ * The admin connection string the runner already holds, in URL form.
+ *
+ * `scripts/retire-collab-migration.test.ts` needs an admin connection that can
+ * `CREATE DATABASE`/`DROP DATABASE`; that is precisely the credential this
+ * runner uses for `createdb`/`dropdb`, so it is published rather than rebuilt.
+ * It points at the `postgres` maintenance database, never at a per-run one.
+ */
+export function adminUrl(admin: AdminConnection): string {
+  const auth = admin.password
+    ? `${encodeURIComponent(admin.user)}:${encodeURIComponent(admin.password)}`
+    : encodeURIComponent(admin.user);
+  return `postgres://${auth}@${admin.host}:${admin.port}/postgres`;
+}
+
+function ensureCloneRole(
+  admin: AdminConnection,
+  notices: string[],
+): { password: string } | { error: string } {
+  const existing = runPsql(
+    admin,
+    "postgres",
+    `select 1 from pg_roles where rolname = '${CLONE_ROLE}';`,
+  );
+  if (!existing.ok) {
+    return { error: `could not query pg_roles: ${existing.stderr}` };
+  }
+
+  const supplied = process.env.DB_PASSWORD_LOCAL_CLONE;
+  const password = supplied || randomBytes(18).toString("base64url");
+
+  if (existing.stdout === "1") {
+    // The role is shared and outlives every run, so its stored password is not
+    // knowable from here. Rather than fail -- which would make a second run on
+    // any cluster impossible -- the admin connection SETS the password it is
+    // about to use. This is announced, never silent: an operator who had their
+    // own password on this role needs to see that it changed.
+    const reset = runPsql(
+      admin,
+      "postgres",
+      `ALTER ROLE ${CLONE_ROLE} LOGIN PASSWORD '${password}';`,
+    );
+    if (!reset.ok) {
+      return { error: `role ${CLONE_ROLE} exists but its password could not be set: ${reset.stderr}` };
+    }
+    notices.push(
+      supplied
+        ? `role ${CLONE_ROLE} already existed; its password was RESET to the DB_PASSWORD_LOCAL_CLONE value so this run can log in (the role is shared and is never dropped here)`
+        : `role ${CLONE_ROLE} already existed; DB_PASSWORD_LOCAL_CLONE was unset, so its password was RESET to a freshly generated one for this run (the role is shared and is never dropped here). Export DB_PASSWORD_LOCAL_CLONE to keep a stable password instead`,
+    );
+    return { password };
+  }
+
+  const created = runPsql(
+    admin,
+    "postgres",
+    `CREATE ROLE ${CLONE_ROLE} LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE PASSWORD '${password}';`,
+  );
+  if (!created.ok) return { error: `could not create ${CLONE_ROLE}: ${created.stderr}` };
+
+  notices.push(
+    supplied
+      ? `role ${CLONE_ROLE} created with the DB_PASSWORD_LOCAL_CLONE password; it is shared and is NOT dropped on exit`
+      : `role ${CLONE_ROLE} created with a generated password; DB_PASSWORD_LOCAL_CLONE was unset. The role is shared and is NOT dropped on exit -- export that password on later runs, or reset it via ALTER ROLE`,
+  );
+  if (!supplied) {
+    notices.push(`generated ${CLONE_ROLE} password for this cluster: ${password}`);
+  }
+  return { password };
+}
+
+/**
+ * Create the clone role (if absent) and a per-run clone database owned by it.
+ *
+ * @param admin  the runner's own admin connection
+ * @param suffix the unique per-run suffix, so the clone shares the run's identity
+ * @returns the provisioned clone, or `{ error }` describing what stopped it
+ */
+export function provisionCloneDatabase(
+  admin: AdminConnection,
+  suffix: string,
+): CloneProvision | { error: string } {
+  const notices: string[] = [];
+  const role = ensureCloneRole(admin, notices);
+  if ("error" in role) return role;
+
+  const database = `${CLONE_DB_PREFIX}${suffix}`;
+  const created = runPsql(
+    admin,
+    "postgres",
+    `CREATE DATABASE ${database} OWNER ${CLONE_ROLE} ENCODING 'UTF8' TEMPLATE template0;`,
+  );
+  if (!created.ok) return { error: `could not create ${database}: ${created.stderr}` };
+
+  // Administrative bootstrap only, exactly as ci.yml:222-225 does it: the
+  // clone role stays a non-superuser and cannot install extensions itself.
+  const extensions = runPsql(
+    admin,
+    database,
+    "CREATE EXTENSION IF NOT EXISTS vector; CREATE EXTENSION IF NOT EXISTS pg_stat_statements;",
+  );
+  if (!extensions.ok) {
+    return { error: `could not install extensions in ${database}: ${extensions.stderr}` };
+  }
+
+  // The test asserts literal loopback, so the host is 127.0.0.1 regardless of
+  // how the admin connection spells it. Announced when they differ.
+  if (admin.host !== "127.0.0.1") {
+    notices.push(
+      `clone URL host set to 127.0.0.1 (admin host is ${admin.host}); the local-clone boundary requires literal loopback`,
+    );
+  }
+  const url = `postgres://${CLONE_ROLE}:${encodeURIComponent(role.password)}@127.0.0.1:${admin.port}/${database}`;
+
+  return { database, role: CLONE_ROLE, url, notices };
+}

--- a/scripts/test-support/print-env.test.ts
+++ b/scripts/test-support/print-env.test.ts
@@ -16,30 +16,44 @@
  * operator reading the transcript can see exactly what the child received.
  * Passwords are not printed.
  *
+ * A missing variable throws the same named error shape
+ * `scripts/test-support/require-test-database.ts` uses --
+ * `test_database_required: <VAR> is unset; run bun run test:isolated` -- rather
+ * than failing a bare `expect`. The distinction matters to whoever reads the
+ * failure: a bare assertion reads as "this test is wrong", while the named
+ * error names the actual cause, that the SUPPLIER did not export what the
+ * suite demands. `test_database_required` is the string to search for when it
+ * fires, in this file and in that one alike.
+ *
  * This file lives under `scripts/`, where `.oxlintrc.json` allows the
  * environment read and `console`.
  */
 
 import { describe, expect, it } from "bun:test";
 
+/**
+ * Returns the named environment variable, or throws when it is unset.
+ *
+ * @throws {Error} `test_database_required` when the variable is missing or empty.
+ */
+function requireSuppliedUrl(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`test_database_required: ${name} is unset; run bun run test:isolated`);
+  }
+  return value;
+}
+
 describe("isolated runner environment contract (#904)", () => {
   it("exports OPENBRAIN_SCRATCH_ADMIN_URL", () => {
-    const admin = process.env.OPENBRAIN_SCRATCH_ADMIN_URL;
-    expect(admin, "OPENBRAIN_SCRATCH_ADMIN_URL is unset; run bun run test:isolated").toBeTruthy();
-    if (!admin) throw new Error("OPENBRAIN_SCRATCH_ADMIN_URL is unset");
+    const admin = requireSuppliedUrl("OPENBRAIN_SCRATCH_ADMIN_URL");
     const url = new URL(admin);
     expect(["postgres:", "postgresql:"]).toContain(url.protocol);
     console.log(`OPENBRAIN_SCRATCH_ADMIN_URL -> ${url.username}@${url.host}${url.pathname}`);
   });
 
   it("exports a OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL the clone suite accepts", () => {
-    const raw = process.env.OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL;
-    expect(
-      raw,
-      "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL is unset; run bun run test:isolated",
-    ).toBeTruthy();
-
-    if (!raw) throw new Error("OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL is unset");
+    const raw = requireSuppliedUrl("OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL");
     const url = new URL(raw);
     const host = url.hostname === "[::1]" ? "::1" : url.hostname;
     const database = decodeURIComponent(url.pathname.replace(/^\//, ""));

--- a/scripts/test-support/print-env.test.ts
+++ b/scripts/test-support/print-env.test.ts
@@ -1,0 +1,55 @@
+/**
+ * The runner's contract with the pg suites, asserted (#904).
+ *
+ * `scripts/local-clone.test.ts` and `scripts/retire-collab-migration.test.ts`
+ * gate themselves on two variables the isolated runner did not used to set, so
+ * both skipped every local run -- the false green #878 is about. This file is
+ * the tripwire for the SUPPLY side: it fails when `bun run test:isolated` stops
+ * exporting them, or exports a clone URL those suites would reject.
+ *
+ * It deliberately asserts the same three properties `local-clone.test.ts`
+ * checks (loopback host, `open_brain_local_` database, `open_brain_local_clone`
+ * role) rather than merely that the string is non-empty: a URL that is set but
+ * wrong would let that suite throw at runtime instead of naming the cause here.
+ *
+ * It prints both values because the runner's job is to be inspectable -- an
+ * operator reading the transcript can see exactly what the child received.
+ * Passwords are not printed.
+ *
+ * This file lives under `scripts/`, where `.oxlintrc.json` allows the
+ * environment read and `console`.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+describe("isolated runner environment contract (#904)", () => {
+  it("exports OPENBRAIN_SCRATCH_ADMIN_URL", () => {
+    const admin = process.env.OPENBRAIN_SCRATCH_ADMIN_URL;
+    expect(admin, "OPENBRAIN_SCRATCH_ADMIN_URL is unset; run bun run test:isolated").toBeTruthy();
+    if (!admin) throw new Error("OPENBRAIN_SCRATCH_ADMIN_URL is unset");
+    const url = new URL(admin);
+    expect(["postgres:", "postgresql:"]).toContain(url.protocol);
+    console.log(`OPENBRAIN_SCRATCH_ADMIN_URL -> ${url.username}@${url.host}${url.pathname}`);
+  });
+
+  it("exports a OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL the clone suite accepts", () => {
+    const raw = process.env.OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL;
+    expect(
+      raw,
+      "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL is unset; run bun run test:isolated",
+    ).toBeTruthy();
+
+    if (!raw) throw new Error("OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL is unset");
+    const url = new URL(raw);
+    const host = url.hostname === "[::1]" ? "::1" : url.hostname;
+    const database = decodeURIComponent(url.pathname.replace(/^\//, ""));
+    const user = decodeURIComponent(url.username);
+
+    expect(["postgres:", "postgresql:"]).toContain(url.protocol);
+    expect(["127.0.0.1", "::1"]).toContain(host);
+    expect(user).toBe("open_brain_local_clone");
+    expect(database.startsWith("open_brain_local_")).toBe(true);
+
+    console.log(`OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL -> ${user}@${host}:${url.port}/${database}`);
+  });
+});


### PR DESCRIPTION
## Summary

Refs #904, #878

`scripts/local-clone.test.ts` gates its live-Postgres suite on `OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL`, and `scripts/retire-collab-migration.test.ts` gates its live half on `OPENBRAIN_SCRATCH_ADMIN_URL`. `bun run test:isolated` set neither, so both suites skipped every local run while reporting `0 fail` and exiting 0 — the false green #878 is about. CI already builds exactly what the clone suite wants (`.github/workflows/ci.yml:132-134`, `:217`, `:231`); only the local runner did not.

This is step 1 of #904: the runner now supplies both, extended at the boundary that already owns test-database lifecycle rather than in a new script.

- **`OPENBRAIN_SCRATCH_ADMIN_URL`** is the admin connection the runner *already holds* — the one it runs `createdb`/`dropdb` with — published in URL form against the `postgres` maintenance database. It is derived from the same `DB_*`/`PG*` reader the runner already uses, so no host is hardcoded.
- **`OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL`** names a per-run `open_brain_local_<suffix>` database owned by `open_brain_local_clone`, created with CI's own SQL and migrated through the existing `bun run migrate` path. It shares the run's unique suffix, so one run has one identity and two databases.

The clone **database** is dropped on exit through the same guarded, prefix-checked path as the main one, so it inherits the SIGINT/SIGTERM handling and the loud-orphan message for free. The clone **role** is deliberately *not* dropped: it is a single cluster-wide login role shared by concurrent runs and by the operator runbook, and dropping it would break any run still holding it. It is created when absent, and a pre-existing role has its password set to the value this run will use — a shared role's stored password is not knowable from the runner, and refusing instead would make every run after the first impossible on a given cluster. Every one of those decisions is printed as it is made, per the operator ruling of 2026-08-08: nothing is adjusted silently.

`makeDbName()` becomes `makeRunSuffix()` so both database names derive from one suffix, and the teardown body is extracted into `dropOne()` so the clone reuses it verbatim rather than growing a second drop path. Provisioning lives in `scripts/test-support/clone-database.ts` to keep the runner inside the file-size rule in `.oxlintrc.json`.

Steps 2 and 3 of #904 — the `require-test-database.ts` helpers and converting the two suites off their `skipIf`/`describe.skip` guards — are deliberately **not** here. Converting them before the runner supplied these variables would have made every local run fail on a missing variable. `scripts/local-clone.test.ts` and `scripts/retire-collab-migration.test.ts` are untouched by this PR.

## Verification

- Done-means: scripts/done-means/904-isolated-runner-supplies-clone-and-admin.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Measured on this cluster, 2026-08-27:

| check | RED at `origin/main` | GREEN on this branch |
|---|---|---|
| C1 `bun run test:isolated scripts/test-support/print-env.test.ts` | both vars unset in the child | 2 pass / 0 fail |
| C2 `bun run test:isolated scripts/local-clone.test.ts` | 19 pass / **1 skip** — boundary suite skipped | 20 pass / **0 skip** |

- `bash scripts/done-means/904-isolated-runner-supplies-clone-and-admin.sh` → `VERDICT: PASS`
- `bun run test:isolated` (full suite) → 3953 pass / 26 skip / 0 fail, exit 0; both databases dropped on exit
- `bunx tsc --noEmit` → clean
- `./node_modules/.bin/oxlint --deny-warnings` on all four touched files → clean
- Pre-commit gate (gitleaks, oxlint on staged content, tsc over the staged snapshot) and the full pre-push gate both passed without `--no-verify`.

## Critical Self-Review

- Highest-risk behavior: resetting the password of a pre-existing `open_brain_local_clone` role. It is a shared, cluster-wide login role, so a run changes state another run or an operator could be relying on. It affects that one role only, the role is non-superuser (`NOSUPERUSER NOCREATEDB NOCREATEROLE`), it owns only throwaway per-run databases, and the change is printed every time. Setting `DB_PASSWORD_LOCAL_CLONE` makes it a no-op in practice.
- Assumptions that could be wrong: that the runner's `DB_USER` can `CREATE ROLE` and `CREATE DATABASE`. On this cluster it can, and CI's admin user can. A cluster where it cannot now fails loudly at `db-clone` with the psql error rather than silently skipping — which is the intended direction, but it does convert a previously-green local run into a red one on such a cluster.
- Missing/weak tests: `scripts/test-support/print-env.test.ts` asserts the *shape* of what the runner exports, not the provisioning helper's branches directly — the "role already existed" path and the psql failure paths have no unit test, only the integration evidence of repeated local runs (the role existed on this cluster, so that branch is the one actually exercised above). `OPENBRAIN_SCRATCH_ADMIN_URL` is proven well-formed and proven to let `retire-collab-migration.test.ts` run, but this PR adds no test of its own for that suite.
- Security/permission risk: the clone role is created non-superuser exactly as CI creates it, so the boundary that suite is meant to prove stays real. Generated passwords use `randomBytes(18)`; one is printed to the local transcript when `DB_PASSWORD_LOCAL_CLONE` is unset, which is deliberate — otherwise the operator could not reuse the role — and it grants only access to throwaway loopback databases. gitleaks passed on both the staged content and the pushed commits. No production credential is read or written.
- Migration/deploy risk: none. Nothing here ships in the server; it is test tooling only. Migrations run through the unchanged `bun run migrate` path, against a new database.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface changes, so `docs/downstream-rollout.md` classifies this as not applicable.
- Rollback/cleanup concern: reverting the commit restores the previous runner exactly; the only residue would be the `open_brain_local_clone` role, which is idempotent, non-superuser, and owns nothing after teardown. Per-run clone databases are dropped on exit and on SIGINT/SIGTERM/SIGHUP, and a failed drop prints the name plus the `dropdb` line rather than leaking silently.
- Fixes made before PR: the first implementation *failed* the run when the clone role already existed with an unknown password, which made every second run on a cluster impossible — caught on the first real run and changed to an announced password set. Three `no-non-null-assertion` oxlint errors were replaced with real narrowing guards rather than suppressed.
- Known residual risk: the first push attempt failed the pre-push gate with 2 failures in `scripts/retire-collab-migration.test.ts` (`beforeAll` timeout, "Cannot use a pool after calling end on the pool" from `runMigrations`). That suite passes in isolation on both `origin/main` and this branch with the variable supplied (12 pass / 0 fail each), and two subsequent full `test:isolated` runs were clean (3953 and 3979 pass, 0 fail), so the observed failure is intermittent rather than deterministic. **Supplying `OPENBRAIN_SCRATCH_ADMIN_URL` is what makes that suite run at all, so this PR is what exposes that flake** — it does not introduce it, but it does make it reachable. That file is step 3's scope and is untouched here; the flake is worth its own issue under #904.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no new MEDIUM+ review finding about repo code — the failure it surfaced belongs to `scripts/retire-collab-migration.test.ts`, which is step 3 of #904 and is deliberately untouched here, so the lesson is recorded in the residual-risk field above and on the PR rather than as a new SME entry that a later step would immediately supersede.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this is test-harness tooling; it does not run in the served application and touches no live Open Brain surface.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, schema, or fixture surface is touched — the change is confined to the local test runner and its own support files.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- No MCP tool, schema, protocol, or client-facing surface changes, so every downstream step is not applicable by the classification in `docs/downstream-rollout.md`.
- Files touched: `scripts/test-isolated.ts`, `scripts/test-support/clone-database.ts` (new), `scripts/test-support/print-env.test.ts` (new), `scripts/done-means/904-isolated-runner-supplies-clone-and-admin.sh` (new).
