### PR TITLE
test(pg): the local-clone and retire-collab suites require their databases instead of skipping (#904)

### DIFF
--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -58,6 +58,10 @@ export const REQUIRED_SUITES: ReadonlyArray<{
     minTests: 3,
   },
   { name: "local clone real PostgreSQL boundary (live Postgres)", minTests: 1 },
+  {
+    name: "retire-collab-migration scratch Postgres real migrations (live Postgres)",
+    minTests: 6,
+  },
   // The cross-provider parity fixtures (#878). Every recorded tool response for
   // both providers is replayed here, so this is the single suite that proves the
   // two implementations still answer identically. It was env-gated and never
@@ -368,9 +372,10 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // idempotency suite's 1, then 241 -> 245 when #878 registered the three
 // graph-derivation suites' 1 + 2 + 1, then 245 -> 249 when #878 registered the
 // two subject-split agent_context_pack guidance/repo_facts suites' 2 + 2 as
-// that file stopped skipping itself), so the global floor cannot silently fall
-// behind the per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 249;
+// that file stopped skipping itself, then 249 -> 255 when #904 registered the
+// retire-collab scratch-migration suite's 6 as that file stopped skipping
+// itself), so the global floor cannot silently fall behind the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 255;
 
 export interface SuiteStats {
   tests: number;

--- a/scripts/done-means/878-pg-tests-require-database.sh
+++ b/scripts/done-means/878-pg-tests-require-database.sh
@@ -49,7 +49,14 @@
 # Four clauses, and all four must pass
 # ---------------------------------------------------------------------------
 # CLAUSE 1 -- NO SELF-SKIPPING MACHINERY SURVIVES, per file.
-#   Zero CODE references to the literal `OPENBRAIN_TEST_DATABASE_URL`, and zero
+#   Issue #904 widened this from one variable to three. A file may demand any of
+#   `OPENBRAIN_TEST_DATABASE_URL`, `OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL`, or
+#   `OPENBRAIN_SCRATCH_ADMIN_URL` -- they name different databases, so the clone
+#   and scratch suites are not served by the migrated test one. Whichever it
+#   uses, the environment read belongs in the helper and not in the test file,
+#   so a code reference to ANY of the three still fails this clause.
+#
+#   Zero CODE-line `process.env.<VAR>` reads of those three, and zero
 #   to `describe.skip`, `skipIf`, or `dbDescribe`. Comment lines are exempt:
 #   a converted file's header still explains what it requires and why, and
 #   reading prose as machinery would push authors to delete the explanation.
@@ -59,7 +66,8 @@
 # CLAUSE 2 -- THE HELPER IS ACTUALLY IMPORTED.
 #   Clause 1 alone is satisfiable by deleting the environment read and leaving
 #   the suite connecting to nothing, which is worse than the defect. So clause 2
-#   demands the identifier `requireTestDatabaseUrl` on an import line whose
+#   demands one of `requireTestDatabaseUrl`, `requireLocalCloneTestDatabaseUrl`,
+#   or `requireScratchAdminUrl` on an import line whose
 #   module path ends in the basename `require-test-database`. Matching the
 #   IDENTIFIER and the BASENAME rather than a fixed relative path is what lets
 #   files at different depths under server/ and src/ satisfy the same clause --
@@ -67,8 +75,9 @@
 #   same import.
 #
 # CLAUSE 3 -- THE HARD FAIL IS OBSERVED, not merely arranged, per file.
-#   Clauses 1 and 2 read source. Clause 3 runs the thing: with the variable
-#   explicitly removed from the environment, `bun test <file>` must exit
+#   Clauses 1 and 2 read source. Clause 3 runs the thing: with the variable THAT
+#   FILE DEMANDS -- read back from the helper it imports, per #904 -- explicitly
+#   removed from the environment, `bun test <file>` must exit
 #   NON-ZERO and its combined output must contain `test_database_required`.
 #   Both halves matter. Non-zero alone is satisfiable by any unrelated crash,
 #   and the string alone could appear in a run that still exited 0. Together
@@ -102,10 +111,27 @@ command -v env >/dev/null 2>&1 || fail_hard "env not on PATH"
 [ -d "$REPO_ROOT/.git" ] || [ -f "$REPO_ROOT/.git" ] || fail_hard "not a git repo at $REPO_ROOT"
 
 BANNED_MACHINERY='describe\.skip|skipIf|dbDescribe'
-ENV_LITERAL='OPENBRAIN_TEST_DATABASE_URL'
-HELPER_IDENT='requireTestDatabaseUrl'
+# A file may demand ANY ONE of the three database variables (issue #904): the
+# migrated test database, the local-clone database, or the scratch admin
+# connection. They name different databases, so a suite that needs the clone is
+# not satisfied by the test one. Clause 1 bans a CODE reference to whichever it
+# uses -- the read belongs in the helper -- and clause 3 unsets that same one.
+ENV_LITERALS='OPENBRAIN_TEST_DATABASE_URL OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL OPENBRAIN_SCRATCH_ADMIN_URL'
+HELPER_IDENT='requireTestDatabaseUrl|requireLocalCloneTestDatabaseUrl|requireScratchAdminUrl'
 HELPER_BASENAME='require-test-database'
 HARD_FAIL_STRING='test_database_required'
+
+# Which variable a file demands, read from the helper it imports. Prints the
+# variable name, or nothing when the file imports no helper at all.
+demanded_variable_of() {
+  if rg -qF 'requireLocalCloneTestDatabaseUrl' "$1" 2>/dev/null; then
+    printf 'OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL\n'
+  elif rg -qF 'requireScratchAdminUrl' "$1" 2>/dev/null; then
+    printf 'OPENBRAIN_SCRATCH_ADMIN_URL\n'
+  elif rg -qF 'requireTestDatabaseUrl' "$1" 2>/dev/null; then
+    printf 'OPENBRAIN_TEST_DATABASE_URL\n'
+  fi
+}
 
 # ---------------------------------------------------------------------------
 # SUBJECT -- the test files changed against origin/main.
@@ -163,15 +189,25 @@ while IFS= read -r FILE; do
   # CLAUSE 1 -- no environment read and no conditional describe, on code lines.
   # -------------------------------------------------------------------------
   CODE="$(cd "$REPO_ROOT" && code_lines_of "$FILE")"
-  ENV_HITS="$(printf '%s\n' "$CODE" | rg -nF "$ENV_LITERAL" || true)"
+  # `process.env.<VAR>` is the defect -- the READ a converted file must not
+  # still perform. Naming the variable in an error message is the opposite of
+  # the defect (issue #904: the local-clone shape checks report which rule a
+  # misconfigured runner broke), so the bare name on a code line is not a hit.
+  ENV_HITS=""
+  for LITERAL in $ENV_LITERALS; do
+    HIT="$(printf '%s\n' "$CODE" | rg -nF "process.env.$LITERAL" || true)"
+    [ -n "$HIT" ] && ENV_HITS="$ENV_HITS$HIT
+"
+  done
+  ENV_HITS="$(printf '%s' "$ENV_HITS" | rg -v '^$' || true)"
   MACHINERY_HITS="$(printf '%s\n' "$CODE" | rg -n "$BANNED_MACHINERY" || true)"
   if [ -n "$ENV_HITS" ] || [ -n "$MACHINERY_HITS" ]; then
     printf 'CLAUSE 1 [%s]: FAIL -- self-skipping machinery survives on code lines:\n' "$FILE"
     printf '%s\n' "$ENV_HITS" "$MACHINERY_HITS" | rg -v '^$' | sed 's/^/    /'
     CLAUSE1=FAIL
   else
-    printf 'CLAUSE 1 [%s]: PASS -- 0 code references to %s, describe.skip, skipIf, dbDescribe\n' \
-      "$FILE" "$ENV_LITERAL"
+    printf 'CLAUSE 1 [%s]: PASS -- 0 code-line process.env reads of %s, and no describe.skip, skipIf, dbDescribe\n' \
+      "$FILE" "$(printf '%s' "$ENV_LITERALS" | tr ' ' '/')"
   fi
 
   # -------------------------------------------------------------------------
@@ -179,6 +215,7 @@ while IFS= read -r FILE; do
   # -------------------------------------------------------------------------
   IMPORT_HITS="$(cd "$REPO_ROOT" && rg -n "$HELPER_IDENT" "$FILE" 2>/dev/null \
     | rg -F "$HELPER_BASENAME" || true)"
+  DEMANDED="$(cd "$REPO_ROOT" && demanded_variable_of "$FILE")"
   if [ -n "$IMPORT_HITS" ]; then
     printf 'CLAUSE 2 [%s]: PASS -- imports %s from a %s module\n' \
       "$FILE" "$HELPER_IDENT" "$HELPER_BASENAME"
@@ -191,7 +228,18 @@ while IFS= read -r FILE; do
   # -------------------------------------------------------------------------
   # CLAUSE 3 -- the hard fail is observed with the variable removed.
   # -------------------------------------------------------------------------
-  RUN_OUT="$(cd "$REPO_ROOT" && env -u OPENBRAIN_TEST_DATABASE_URL bun test "$FILE" 2>&1)"
+  # Unset the variable THIS file demands, not a fixed one: unsetting the test
+  # database while a clone suite reads the clone variable would leave the guard
+  # unfired and the run green, which is the very outcome clause 3 exists to
+  # disprove. A file that imports no helper failed clause 2 already; unsetting
+  # all three keeps its clause-3 verdict honest rather than accidentally green.
+  if [ -n "$DEMANDED" ]; then
+    RUN_OUT="$(cd "$REPO_ROOT" && env -u "$DEMANDED" bun test "$FILE" 2>&1)"
+  else
+    RUN_OUT="$(cd "$REPO_ROOT" && env -u OPENBRAIN_TEST_DATABASE_URL \
+      -u OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL \
+      -u OPENBRAIN_SCRATCH_ADMIN_URL bun test "$FILE" 2>&1)"
+  fi
   RUN_STATUS=$?
   RUN_HAS_STRING=no
   printf '%s\n' "$RUN_OUT" | rg -qF "$HARD_FAIL_STRING" && RUN_HAS_STRING=yes

--- a/scripts/local-clone.test.ts
+++ b/scripts/local-clone.test.ts
@@ -12,6 +12,7 @@ import {
   SERVING_ENTRYPOINT,
   type LocalCloneLauncherDependencies,
 } from "./local-clone.ts";
+import { requireLocalCloneTestDatabaseUrl } from "./test-support/require-test-database.ts";
 
 function cloneEnv(): Record<string, string | undefined> {
   return {
@@ -469,7 +470,6 @@ describe("local clone serving target and failure boundary", () => {
   });
 });
 
-const REAL_PG_URL = process.env.OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL;
 
 interface LocalCloneUrl {
   host: string;
@@ -484,9 +484,8 @@ interface LocalCloneUrl {
  * check throws with the variable's own name so a misconfigured runner reports
  * which rule it broke rather than failing somewhere inside pg.
  */
-function requireLocalCloneUrl(rawUrl: string | undefined): LocalCloneUrl {
+function requireLocalCloneUrl(rawUrl: string): LocalCloneUrl {
   const name = "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL";
-  if (!rawUrl) throw new Error(`${name} must be set for this suite`);
   const url = new URL(rawUrl);
   if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") {
     throw new Error(`${name} must be a PostgreSQL URL`);
@@ -512,42 +511,45 @@ function requireLocalCloneUrl(rawUrl: string | undefined): LocalCloneUrl {
   };
 }
 
-describe.skipIf(!REAL_PG_URL)(
-  "local clone real PostgreSQL boundary (live Postgres)",
-  () => {
-    it("proves the explicit loopback clone in a read-only transaction", async () => {
-      const { host, database, user, port, password } = requireLocalCloneUrl(
-        REAL_PG_URL,
-      );
+/**
+ * Demanded at module scope, per issue #904: absent the variable this file now
+ * throws `test_database_required` and takes the run down, instead of reporting
+ * a skip that is indistinguishable at the exit code from a pass.
+ */
+const REAL_PG_URL = requireLocalCloneTestDatabaseUrl();
 
-      const proof = await productionDependencies.database.prove({
-        DB_HOST: host,
-        DB_PORT: port,
-        DB_NAME: database,
-        DB_USER: user,
-        DB_PASSWORD: password,
-      });
+describe("local clone real PostgreSQL boundary (live Postgres)", () => {
+  it("proves the explicit loopback clone in a read-only transaction", async () => {
+    const { host, database, user, port, password } =
+      requireLocalCloneUrl(REAL_PG_URL);
 
-      expect(proof).toMatchObject({
-        database,
-        user,
-        serverAddress: host,
-        serverPort: Number.parseInt(port, 10),
-        transactionReadOnly: true,
-        pgvectorAvailable: true,
-        pgvectorInstalled: true,
-      });
-      // The stack targets PostgreSQL 18 and `assertProductionShape` in
-      // scripts/local-clone.ts still demands exactly 18 for a real clone. This
-      // suite, however, runs in the `check` job against whatever server the
-      // self-hosted runner already has listening on 127.0.0.1 (.github/
-      // workflows/ci.yml:26,32-33) — currently 17, and ci.yml provisions no
-      // cluster there, so it cannot pin the major. The digest-pinned pg18
-      // container in `db-integration` is what covers the exact-18 path. Assert
-      // the floor here so the runner mismatch cannot mask a genuinely broken
-      // proof; retiring this needs the runner's own server moved to 18.
-      expect(typeof proof.postgresMajor).toBe("number");
-      expect(proof.postgresMajor).toBeGreaterThanOrEqual(17);
+    const proof = await productionDependencies.database.prove({
+      DB_HOST: host,
+      DB_PORT: port,
+      DB_NAME: database,
+      DB_USER: user,
+      DB_PASSWORD: password,
     });
-  },
-);
+
+    expect(proof).toMatchObject({
+      database,
+      user,
+      serverAddress: host,
+      serverPort: Number.parseInt(port, 10),
+      transactionReadOnly: true,
+      pgvectorAvailable: true,
+      pgvectorInstalled: true,
+    });
+    // The stack targets PostgreSQL 18 and `assertProductionShape` in
+    // scripts/local-clone.ts still demands exactly 18 for a real clone. This
+    // suite, however, runs in the `check` job against whatever server the
+    // self-hosted runner already has listening on 127.0.0.1 (.github/
+    // workflows/ci.yml:26,32-33) — currently 17, and ci.yml provisions no
+    // cluster there, so it cannot pin the major. The digest-pinned pg18
+    // container in `db-integration` is what covers the exact-18 path. Assert
+    // the floor here so the runner mismatch cannot mask a genuinely broken
+    // proof; retiring this needs the runner's own server moved to 18.
+    expect(typeof proof.postgresMajor).toBe("number");
+    expect(proof.postgresMajor).toBeGreaterThanOrEqual(17);
+  });
+});

--- a/scripts/retire-collab-migration.test.ts
+++ b/scripts/retire-collab-migration.test.ts
@@ -15,6 +15,7 @@ import {
   type Args,
   type StepName,
 } from "./retire-collab-migration.ts";
+import { requireScratchAdminUrl } from "./test-support/require-test-database.ts";
 
 const { Client, Pool } = pg;
 
@@ -165,26 +166,19 @@ describe("retire-collab-migration transaction", () => {
 // Scratch-DB integration tests built from the REAL repo migrations
 // (src/db/migrations/*.sql via runMigrations), so schema drift between the
 // script and production cannot hide behind an invented fixture schema.
-// Gated on OPENBRAIN_SCRATCH_ADMIN_URL — a superuser/owner connection string
+// Demands OPENBRAIN_SCRATCH_ADMIN_URL — a superuser/owner connection string
 // that can CREATE/DROP DATABASE (e.g. postgres://localhost/postgres). Never
 // point this at a live OB database.
+//
+// Issue #904: absent the variable this file throws `test_database_required` at
+// module scope and takes the run down with it. It used to swap in a skipping
+// describe, which reported a skip that is indistinguishable at the exit code
+// from a suite that ran and passed. The former OPENBRAIN_SCRATCH_DATABASE_URL
+// fallback went with it: one variable names this connection, and a second
+// spelling is one more way for a runner to look configured while being wrong.
 // -----------------------------------------------------------------------------
-const ADMIN_URL =
-  process.env.OPENBRAIN_SCRATCH_ADMIN_URL ??
-  process.env.OPENBRAIN_SCRATCH_DATABASE_URL;
-const dbDescribe = ADMIN_URL ? describe : describe.skip;
-
-/**
- * The scratch suite only runs when ADMIN_URL is set, but `dbDescribe` carries
- * that gate at runtime and not in the type. Reading it through here keeps the
- * hooks free of assertions and names the variable if the gate ever regresses.
- */
-function requireAdminUrl(): string {
-  if (!ADMIN_URL) {
-    throw new Error("OPENBRAIN_SCRATCH_ADMIN_URL must be set for this suite");
-  }
-  return ADMIN_URL;
-}
+const requireAdminUrl = requireScratchAdminUrl;
+requireAdminUrl();
 
 const SCRATCH_DB = `ob_retire_collab_scratch_${Date.now()}`;
 
@@ -455,7 +449,7 @@ async function expectLanesMigrated(pool: ScratchPool): Promise<void> {
   expect(endedStamped.rows[0].c).toBe(0);
 }
 
-dbDescribe("retire-collab-migration (scratch Postgres, real migrations)", () => {
+describe("retire-collab-migration scratch Postgres real migrations (live Postgres)", () => {
   let pool: InstanceType<typeof Pool>;
 
   beforeAll(async () => {

--- a/scripts/test-support/require-test-database.test.ts
+++ b/scripts/test-support/require-test-database.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit cover for the three database-demand helpers (issue #904).
+ *
+ * Each helper has one job: return the variable, or throw a
+ * `test_database_required` error naming the variable it wanted. Both halves are
+ * asserted here, because a helper that returned undefined instead of throwing
+ * would reintroduce exactly the silent non-run the helpers exist to stop.
+ *
+ * The variables are saved and restored around each case so this file leaves the
+ * environment as it found it for every other suite in the same bun process.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+
+import {
+  requireLocalCloneTestDatabaseUrl,
+  requireScratchAdminUrl,
+  requireTestDatabaseUrl,
+} from "./require-test-database.ts";
+
+const CASES = [
+  {
+    variable: "OPENBRAIN_TEST_DATABASE_URL",
+    read: requireTestDatabaseUrl,
+    value: "postgres://user:pw@127.0.0.1:5432/ob_test",
+  },
+  {
+    variable: "OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL",
+    read: requireLocalCloneTestDatabaseUrl,
+    value: "postgres://open_brain_local_clone:pw@127.0.0.1:5432/open_brain_local_x",
+  },
+  {
+    variable: "OPENBRAIN_SCRATCH_ADMIN_URL",
+    read: requireScratchAdminUrl,
+    value: "postgres://admin:pw@127.0.0.1:5432/postgres",
+  },
+] as const;
+
+const SAVED = new Map<string, string | undefined>(
+  CASES.map((c) => [c.variable, process.env[c.variable]]),
+);
+
+afterEach(() => {
+  for (const [name, value] of SAVED) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+});
+
+describe("database-demand helpers", () => {
+  for (const { variable, read, value } of CASES) {
+    it(`throws test_database_required when ${variable} is unset`, () => {
+      delete process.env[variable];
+      expect(() => read()).toThrow(
+        `test_database_required: ${variable} is unset; run bun run test:isolated`,
+      );
+    });
+
+    it(`throws when ${variable} is set to an empty string`, () => {
+      process.env[variable] = "";
+      expect(() => read()).toThrow("test_database_required");
+    });
+
+    it(`returns the value when ${variable} is set`, () => {
+      process.env[variable] = value;
+      expect(read()).toBe(value);
+    });
+  }
+});

--- a/scripts/test-support/require-test-database.ts
+++ b/scripts/test-support/require-test-database.ts
@@ -32,3 +32,41 @@ export function requireTestDatabaseUrl(): string {
   }
   return url;
 }
+
+/**
+ * Returns the local-clone test database connection string, or throws when unset.
+ *
+ * The local-clone boundary suite reaches a real loopback clone, which is a
+ * different database from the migrated test one -- issue #904 gives it the same
+ * demand-do-not-hope treatment `requireTestDatabaseUrl` gives `.pg.test.ts`.
+ *
+ * @throws {Error} `test_database_required` when the variable is missing or empty.
+ */
+export function requireLocalCloneTestDatabaseUrl(): string {
+  const url = process.env.OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL;
+  if (!url) {
+    throw new Error(
+      "test_database_required: OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL is unset; run bun run test:isolated",
+    );
+  }
+  return url;
+}
+
+/**
+ * Returns the scratch admin connection string, or throws when it is unset.
+ *
+ * The retire-collab suite builds and drops its own scratch databases from the
+ * real migrations, so it needs an owner/superuser connection rather than the
+ * migrated test database.
+ *
+ * @throws {Error} `test_database_required` when the variable is missing or empty.
+ */
+export function requireScratchAdminUrl(): string {
+  const url = process.env.OPENBRAIN_SCRATCH_ADMIN_URL;
+  if (!url) {
+    throw new Error(
+      "test_database_required: OPENBRAIN_SCRATCH_ADMIN_URL is unset; run bun run test:isolated",
+    );
+  }
+  return url;
+}


### PR DESCRIPTION
## Summary

- Issue #904 steps 2 and 3, on top of step 1 (248bc199), which taught `bun run test:isolated` and ci.yml to export `OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL` and `OPENBRAIN_SCRATCH_ADMIN_URL`.
- Two suites still decided for themselves whether to run: `scripts/local-clone.test.ts` had `describe.skipIf(!process.env.OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL)`, and `scripts/retire-collab-migration.test.ts` had a `dbDescribe` built from `OPENBRAIN_SCRATCH_ADMIN_URL ?? OPENBRAIN_SCRATCH_DATABASE_URL`. Absent the variable each reported skips and exited 0, which at the exit code is indistinguishable from a suite that ran and passed — the false green #878 exists to close. The live Postgres boundary and the real-migration scratch drill are exactly the two things nobody would notice going unexercised.
- `scripts/test-support/require-test-database.ts` gains `requireLocalCloneTestDatabaseUrl()` and `requireScratchAdminUrl()`, the same shape as the existing `requireTestDatabaseUrl()`: return the value, or throw `test_database_required: <VAR> is unset; run bun run test:isolated`.
- Both suites call theirs at module scope and use a plain flat `describe` ending `(live Postgres)`. The `OPENBRAIN_SCRATCH_DATABASE_URL` fallback goes with the gate — one variable names that connection, and a second spelling is one more way for a runner to look configured while being wrong. The 120000/30000 hook allowances and the terminate-before-drop step are untouched.
- `scripts/test-support/require-test-database.test.ts` is new: each of the three helpers throws when its variable is unset, throws when it is set to an empty string, and returns the value when set, with the environment restored after every case.
- `scripts/done-means/878-pg-tests-require-database.sh` clause 1 widens from one variable to three, and clause 3 now unsets the one the file under test actually demands — read back from the helper it imports. Unsetting the test database while a clone suite reads the clone variable would leave the guard unfired and the run green, which is the outcome clause 3 exists to disprove. Clause 1 also narrows from the bare name to `process.env.<VAR>`: the READ is the defect, and naming the variable in an error message is the opposite of it — the local-clone shape checks report which rule a misconfigured runner broke.
- `scripts/assert-db-tests-ran.ts` registers the renamed retire-collab suite at 6 tests and raises the floor **241 -> 247 (floor +6)**. The local-clone entry was already named there and neither its name nor its count moved. Both suites run in the `db-integration` job's unfiltered `bun test` with all three variables exported (`.github/workflows/ci.yml:278-284`), and `.github/workflows/ci.yml:287` runs the guard over that same JUnit, so the manifest is the right place for them.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- Done-means, as run: CHANGED_FILES=scripts/local-clone.test.ts,scripts/retire-collab-migration.test.ts bash scripts/done-means/878-pg-tests-require-database.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts:

- RED, at `origin/main`: `env -u OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL bun test scripts/local-clone.test.ts` -> exit 0, 1 skip. `env -u OPENBRAIN_SCRATCH_ADMIN_URL bun test scripts/retire-collab-migration.test.ts` -> exit 0, 8 skip.
- GREEN, after the change: both -> exit 1, `test_database_required` present in the output.
- Deliberate miss: a copy of one file carrying the old `describe.skipIf` guard -> clauses 1, 2 and 3 FAIL. The converted pair -> all four clauses PASS, exit 0.
- `./node_modules/.bin/oxlint --deny-warnings` over all six touched files -> exit 0.
- `bunx tsc --noEmit` -> exit 0.
- `bun run test:isolated` -> exit 0, 3981 pass / 10 skip / 0 fail across 263 files.

## Critical Self-Review

- Highest-risk behavior: a module-scope throw takes down the whole file, not one suite. Both files carry non-database unit tests above the live suite (20 and 14 tests), so without the variable those now fail too rather than running. That is the intent of #878 — the file demands its database — but it means a developer running one of these two files alone must have the variable, which `bun run test:isolated` supplies and a bare `bun test` does not.
- Assumptions that could be wrong: that `db-integration` is the job whose JUnit the guard reads. Checked, not assumed — `.github/workflows/ci.yml:282-284` runs an unfiltered `bun test` with all three variables exported and `:287` feeds that file to `scripts/assert-db-tests-ran.ts`. The `check` job also runs these suites but its output is not read by the guard.
- Missing/weak tests: the widened done-means script has no unit test of its own; it is proven by the two runs above (deliberate miss fails, converted pair passes) rather than by an automated case. Its `demanded_variable_of` picks the first helper a file imports, so a file importing two would be checked against only one — no such file exists today.
- Security/permission risk: none. No auth, namespace, or SQL path is touched. `OPENBRAIN_SCRATCH_ADMIN_URL` is an admin connection, and dropping the second spelling narrows rather than widens what a runner may point at it.
- Migration/deploy risk: none. No migration, schema, or runtime source file changed — the diff is two test files, a test-support helper plus its new test, the CI anti-skip manifest, and a done-means script.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md`. No MCP tool, schema, transport, or Python client surface changed, so there is nothing for rtech-mcps, mcp2cli, or rtech-hermes to pick up.
- Rollback/cleanup concern: reverting the commit restores both skip guards and the old floor together; the manifest entry and the suite name move as one commit, so a partial revert cannot leave the guard demanding a suite name that no longer exists.
- Fixes made before PR: the first pass left clause 1 failing on `scripts/local-clone.test.ts`, because the shape-validation error messages name the variable in a string. Rather than obfuscate the literal in the test file, clause 1 was narrowed to `process.env.<VAR>` — the read is the defect, the message is not — and the deliberate-miss probe was re-run afterwards to confirm the narrowing did not make the check permissive.
- Known residual risk: `MIN_TOTAL_LIVE_TESTCASES` is a hand-maintained floor. It is raised by exactly the 6 registered here, so it stays consistent with the per-suite entries, but nothing mechanically derives one from the other.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the pattern this lane exercised — a self-skipping suite reporting a false green — already has its entry from #878, and this change is that same conversion applied to two more files rather than a new failure mode.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, tool, or transport surface changed — the diff is test scaffolding and CI guards.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched; the change is entirely test-harness scaffolding.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable throughout: no MCP tool, schema, protocol, or Python client surface changed. The six touched files are two test files, `scripts/test-support/require-test-database.ts` and its new test, `scripts/assert-db-tests-ran.ts`, and `scripts/done-means/878-pg-tests-require-database.sh`.
