### PR TITLE
docs(handover): the authoring session drains; Retire is none (rule 47)

### DIFF
--- a/_DOCS/HANDOVER-RULES.md
+++ b/_DOCS/HANDOVER-RULES.md
@@ -316,3 +316,14 @@ only when a session actually needed it.
     `git grep -l 'describe.skip\|skipIf' origin/main -- '*.test.ts'` and
     read each hit; a comment mentioning the old guard is fine, a live
     `dbDescribe` is a lane.
+47. **The authoring session drains.** Sessions 3-8 each wrote cleanup into
+    the handover for the next session and none ran it: on
+    2026-08-27 origin carried 31 merged branches and eleven lane clones sat
+    on stale branches with stashes. Before writing State 2, run
+    `/opt/homebrew/bin/bash /Volumes/ThunderBolt/Development/_ob/skills/handover-author/scripts/check-drained.sh .`
+    until it exits 0: merged branches deleted on origin and in every clone
+    under `_worktrees/`, stashes dropped after their patch is archived under
+    `_archive/`, unmerged work landed or parked as a doc, no registered
+    worktree. `scripts/done-means/handover-validates.sh` runs the same check,
+    so a handover PR cannot merge while anything is left behind. A handover
+    never names cleanup for the next session.

--- a/_DOCS/_handover/2026-08-27-pg-tests-session9.md
+++ b/_DOCS/_handover/2026-08-27-pg-tests-session9.md
@@ -2,16 +2,17 @@
 
 ## State 0 — BASE
 Read /Volumes/ThunderBolt/Development/_DOCS/HANDOVER-BASE.md in full
-(181 lines). It is the standing contract for this session.
+(183 lines). It is the standing contract for this session.
 - Any question this document does not directly override → the rules layers
   answer it, nearest layer first.
 - Anything neither the base nor this document covers → ask Rico before acting.
 - Output discipline: minimum verbosity, only the context needed, output tokens
   low. If Rico wants more, he will ask.
-- Layer 0.1: read open-brain/_DOCS/HANDOVER-RULES.md in full (318 lines on
-  this branch). It overrides the base; this document overrides it. Rules 28-46
+- Layer 0.1: read open-brain/_DOCS/HANDOVER-RULES.md in full (329 lines on
+  this branch). It overrides the base; this document overrides it. Rules 28-47
   bind: head never works, own clones, FIVE lanes, no `rm`, no `--no-verify`,
-  manifest in the same commit, one rebase lane per PR, census by command.
+  manifest in the same commit, one rebase lane per PR, census by command, the
+  authoring session drains.
 
 ## State 1 — ORIENT
 - `origin/main` is `692900a2` (#919); session 8 merged #893-#919 — MERGED (`git log --oneline origin/main -1`)
@@ -27,10 +28,9 @@ Read /Volumes/ThunderBolt/Development/_DOCS/HANDOVER-BASE.md in full
 - #889 lease race CLOSED (#899); #912 drop time and #915 runner PG 17 OPEN,
   runner-side; #916 wall-clock test OPEN — RUNNING (`gh issue list --state open`)
 - #888 Forge migration is a planning item, not a build order — RUNNING (`gh issue view 888`)
-- Lane-7 `stash@{0}` (superseded by #873) and lane-8 `stash@{0}` (superseded by
-  #906-#908) await Rico's drop — RUNNING (`git -C <clone> stash list`)
-- Mac checkout `/Volumes/ThunderBolt/Development/open-brain` is DIRTY on
-  `sprint/standards-fmt` (Rico's); lanes never work there — RUNNING
+- Drained 2026-08-27: origin holds only `main` and the two open-PR heads, the
+  Mac checkout is clean on `main`, the eleven lane clones are detached at
+  `origin/main` with no stash — RUNNING (`check-drained.sh .` exits 0)
 - Reusable, temp: `/Volumes/ThunderBolt/_tmp/open-brain/_scratch/session7/{lane,recon,git}.workflow.js`, `collect.sh` — WRITTEN
 - Graph mode: converted — RUNNING (`ls scripts/done-means/` has `878-*.sh`)
 Re-probe before dispatching anything (live state beats this doc):
@@ -42,10 +42,6 @@ Re-probe before dispatching anything (live state beats this doc):
 Branch: `docs/pg-tests-session9` from `origin/main` — cut it once THIS
 document's PR merges; if the checkout is `main` or `docs/pg-tests-session8` is
 merged, switch first, never work there.
-Retire: `docs/pg-tests-session8` (this document's PR); lane clones 1-6, 9, 10
-sit on merged `chore/878-*` / `feat/904-*` branches (`git switch --detach
-origin/main` then `git branch -d`); lane-6 is detached already. Worktrees:
-`none`.
 Commit this handover: branch `docs/pg-tests-session8`, path
 `_DOCS/_handover/2026-08-27-pg-tests-session9.md` with `_DOCS/HANDOVER-RULES.md`,
 explicit-path staging, `git commit -F` message file. Done by the authoring session.
@@ -107,7 +103,7 @@ Invoke the handover-author skill; next handover passes the validator; `aqmd up`.
 - Q1, since session 3: `.claude/agents/tracking-scribe.md` writes ONLY to the root checkout (Rico's dirty branch); sessions 3-8 scribed via comments — Rico's call.
 - Q2: `server/main.ts` reads `process.env` under the door override; moving them into `server/config.ts` is Rico's decision.
 - Q5: `node/no-process-env` is scoped to `server/**`; 19 `src/` files still read env and retire at L6 — Rico confirms the scope.
-- Q7: lane-7 and lane-8 `stash@{0}` are superseded; dropping them is Rico's, not a lane's.
 - Q8: #888 Forge migration — Rico decides when planning starts and whether it displaces #878 work.
 - #915: the self-hosted `check` runner's PostgreSQL 17 versus the stack's 18 is a runner change (Rico's); `scripts/local-clone.test.ts` asserts `>= 17` until then.
 - Parked: dev#98 hook-env crossing checkpoint, `_DOCS/_parked/dev98-hook-env-crossing.md` (patch embedded, test fails at :326 on main); resume or drop is Rico's call.
+- `.qmd/index.yml`: every `aqmd up` rewrites its three `models:` lines from the committed hf paths to `https://llama-swap.rodaddy.live/v1#...`, so the checkout reads dirty after each wrap; committing the fleet endpoints or ignoring the file is Rico's call.

--- a/scripts/done-means/handover-validates.sh
+++ b/scripts/done-means/handover-validates.sh
@@ -70,4 +70,17 @@ if (( failed )); then
   echo "FAIL: a handover document does not conform"
   exit 1
 fi
-echo "PASS: ${#files[@]} handover document(s) conform"
+
+# HANDOVER-RULES rule 47: the authoring session drains. Merged branches on
+# origin or in a lane clone, a stash, a dirty clone, or a registered worktree
+# fail the handover PR here, on the Development machine that verifies it.
+DRAINED=/Volumes/ThunderBolt/Development/_ob/skills/handover-author/scripts/check-drained.sh
+if [[ ! -f $DRAINED ]]; then
+  echo "FAIL: drain check not found at $DRAINED"
+  exit 1
+fi
+if ! /opt/homebrew/bin/bash "$DRAINED" .; then
+  echo "FAIL: the repo is not drained (rule 47)"
+  exit 1
+fi
+echo "PASS: ${#files[@]} handover document(s) conform and the repo is drained"


### PR DESCRIPTION
## Summary

- Adds HANDOVER-RULES rule 47: the authoring session drains the repo (merged branches on origin and in lane clones, stashes, worktrees) and the State 2 `Retire:` line is `none`. `scripts/done-means/handover-validates.sh` now runs the handover-author skill's `check-drained.sh` after the document check, so a handover PR fails while anything is left behind. The session-9 handover records the drained state and drops Q7.

## Verification

- Done-means: scripts/done-means/handover-validates.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed — not applicable, docs-only; `_ob/skills/handover-author/scripts/validate-handover.sh` exits 0 (109 lines); `handover-validates.sh` PASS with the drain check; RED: `DONE_MEANS_HANDOVER_FILES=<fixtures/fail-retire-deferred.md>` exits 1, and a stale branch or stash planted in lane-1 made `check-drained.sh` exit 1
- [x] Python package checks passed or are not applicable — not applicable, no Python touched
- [x] Live Open Brain smoke passed or is not applicable — not applicable, no runtime surface touched

## Critical Self-Review

- Highest-risk behavior: the drain check depends on `gh pr list` for the open-PR heads; if `gh` fails it returns no heads and every open-PR branch on origin reads as leftover, which fails closed, not open.
- Assumptions that could be wrong: that every lane clone lives under `{temp}/open-brain/_worktrees/`; a clone elsewhere is not inspected.
- Missing/weak tests: the drain check has no fixture battery of its own; RED was shown by planting a stale branch and a stash in lane-1 and watching it exit 1.
- Security/permission risk: none, docs-only.
- Migration/deploy risk: none, docs-only.
- Downstream client/runtime risk: none, docs-only.
- Rollback/cleanup concern: the skill half (check-drained.sh, validator, fixtures) lives in Development at `9c28b8a7` on `wip/2026-08-27`; this repo's done-means FAILs if that file is absent.
- Fixes made before PR: the drain check first flagged `origin/HEAD` and the PR branch under authoring; both fixed and re-run.
- Known residual risk: the check runs on the Development machine through verify-lane, not in CI, like the validator it extends.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the lesson is rule 47 itself.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: docs-only change with no runtime surface

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, schema, or fixture is touched

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- `validate-handover.sh _DOCS/_handover/2026-08-27-pg-tests-session9.md` → `PASS ... (112 lines) [validator 2026-08-22.4]`, exit 0
