### PR TITLE
docs(lane-contract): graduate the 16 oldest Tightenings rounds into SME entries and standing rules

### DIFF
--- a/docs/lane-contract.md
+++ b/docs/lane-contract.md
@@ -1207,6 +1207,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   work; the finding to check is whether the HOST half is real, not the
   fake secret.
 
+
+graduated: bullets 1, 2, 4 and 7 -> docs/sme/entries/2026-08-08-a-placeholder-only-neutralises-a-value-nothing-compares-to-reality.md (gotcha-agent order 66); bullet 3 -> docs/sme/entries/2026-08-08-a-repaired-or-rewritten-check-has-never-failed-in-its-current-form.md; bullet 5 -> standing contract clause 1 (worker output is PROPOSED until the controller re-runs); bullet 6 -> history-only, the deploy-runner variable is required with no fallback and was ratified in the same session.
+provenance: PR #645.
 ### 2026-08-08 (round 9) — harvest of the #451 tiered-coverage lane (PR #642)
 
 - **`rg -E` can manufacture a false GREEN, not just an error.** Inside an
@@ -1237,6 +1240,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   outage shape untested; session_id/session_key equivalence assumed, enforced
   nowhere.
 
+
+graduated: bullets 1 and 2 -> docs/sme/entries/2026-08-08-a-repaired-or-rewritten-check-has-never-failed-in-its-current-form.md; bullets 3, 4 and 5 -> docs/sme/entries/2026-08-08-prove-absence-by-the-variable-the-code-reads-and-re-run-never-re-quote.md; bullet 6 -> history-only, gaps named in PR #642 and carried by done-means 451-tiered-coverage.sh.
+provenance: PR #642.
 ### 2026-08-08 (round 8) — harvest of the #625 (PR #640) and #563 (PR #639) lanes
 
 - **A done-means clause can silently measure its own harness — optional
@@ -1280,6 +1286,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   control clause get added alongside (the #384/#612 checks drive the live
   clone)?
 
+
+graduated: bullets 1, 2 and 3 -> docs/sme/entries/2026-08-08-a-repaired-or-rewritten-check-has-never-failed-in-its-current-form.md; bullet 4 -> AGENTS.md Coding Standards (nothing is adjusted silently) and docs/sme/entries/2026-08-08-nothing-is-adjusted-silently-tools-announce-every-self-made-decision.md; bullet 5 -> done-means 625-sweep-heartbeat.sh; bullet 6 -> docs/sme/entries/2026-08-09-a-gate-that-judges-from-a-tree-other-than-the-one-under-review.md; bullet 7 -> docs/sme/entries/2026-08-09-an-exit-code-is-not-a-verdict-until-you-know-the-subject-ran.md; bullets 8 and 9 -> history-only, resolved by done-means 637-gate-precision.sh and the #625 ruling.
+provenance: PRs #640, #639.
 ### 2026-08-08 (round 7) — harvest of the #637 gate-precision lane (PR #638) and the Sol runtime failures
 
 - **A guard's own repair is the hardest thing to write past it.** The #637 lane
@@ -1312,6 +1321,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   flagged it as known residual risk rather than silently narrowing or keeping
   it. Needs a ruling at the next decisions pass.
 
+
+graduated: bullets 1, 2 and 3 -> docs/sme/entries/2026-08-08-name-the-layer-that-produced-the-symptom-before-writing-the-fix.md; bullet 4 -> docs/sme/entries/2026-08-09-a-gate-that-judges-from-a-tree-other-than-the-one-under-review.md; bullet 5 -> standing contract clause 1 (inherited work is PROPOSED until re-verified); bullet 6 -> history-only, the PR #638 exemption was carried to the decisions pass.
+provenance: PR #638.
 ### 2026-08-08 (round 6) — harvest of the #629 clause-8 fix (the check that measured its own guard)
 
 - **A done-means check that exercises its own tooling inherits that tooling's
@@ -1337,6 +1349,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   missing-.env failure the script exists to prevent, and no receipt was
   posted. Copy `.env` into any bare worktree you run verify-lane from.
 
+
+graduated: bullets 1, 2, 3 and 4 -> docs/sme/entries/2026-08-08-name-the-layer-that-produced-the-symptom-before-writing-the-fix.md.
+provenance: PR #629.
 ### 2026-08-08 (round 5) — harvest of the merge-gate lane (PR #629) and the Terra ruling
 
 - **A repo guard cannot protect a run that checks out an older commit of the
@@ -1363,6 +1378,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   constraint appears only in a secondary copy, check the canonical source
   before repeating it.
 
+
+graduated: bullets 1 and 2 -> docs/sme/entries/2026-08-09-a-gate-that-judges-from-a-tree-other-than-the-one-under-review.md and docs/sme/entries/2026-08-08-name-the-layer-that-produced-the-symptom-before-writing-the-fix.md; bullet 3 -> docs/sme/entries/2026-08-08-prove-absence-by-the-variable-the-code-reads-and-re-run-never-re-quote.md; bullet 4 -> standing contract clause 9 (refusals are rules working; report, do not fight); bullet 5 -> _DOCS/MODEL_ROUTING.md is canonical, secondary copies are not.
+provenance: PR #629.
 ### 2026-08-08 (round 4) — harvest of a CONTROLLER defect (Langfuse false-absence claim)
 
 - **Prove absence by the variable the CODE reads, never the product name.**
@@ -1379,6 +1397,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   nothing; re-run it. Controller reports are subject to this exactly as lane
   reports are.
 
+
+graduated: both bullets -> docs/sme/entries/2026-08-08-prove-absence-by-the-variable-the-code-reads-and-re-run-never-re-quote.md.
+provenance: PR #629 round-4 harvest.
 ### 2026-08-08 (round 3) — harvest of the enforcement-build lanes (PRs #628, #630, #631)
 
 - **`lane-bootstrap` prints the worktree path but does not change your
@@ -1397,8 +1418,13 @@ Newest first. Every entry: what changed, and the observation that forced it.
 - **Process canon now lives on `main`** (PR #631): lanes read
   `docs/lane-contract.md` and `docs/controller-contract.md` from their own
   worktree; the absolute-path bridge is retired.
+
+graduated: bullets 1, 2 and 3 -> docs/sme/entries/2026-08-08-lane-tooling-gotchas-the-shell-the-validator-and-the-worktree.md; bullet 4 -> standing contract clause 3 and scripts/validate-pr-body.ts (the Done-means field is enforced, not forward-compliance); bullet 5 -> history-only, docs/lane-contract.md and docs/controller-contract.md now live on main and lanes read them from their own worktree.
+provenance: PRs #628, #630, #631.
 ### 2026-08-08 (round 10b, lane-authored) — the #636 continuation lane's own harvest (detail companion to round 10; overlapping bullets kept for their specifics)
 
+
+graduated: bullets 1 through 8 -> docs/sme/entries/2026-08-08-a-placeholder-only-neutralises-a-value-nothing-compares-to-reality.md (the full seven-instance taxonomy) and done-means 636-neutrality.sh with its allowlist and line-exception files; the negative-control bullet also -> docs/sme/entries/2026-08-08-a-repaired-or-rewritten-check-has-never-failed-in-its-current-form.md; the closing gate-refusal bullet -> standing contract clause 9. provenance: PR #645.
 ### NOTE (2026-08-18 rotation merge) — the round numbering forked
 
 Between 2026-08-09 and 2026-08-18 two integration lines advanced in parallel:
@@ -1438,6 +1464,8 @@ global; numbering is unified from round 30 up.
   duplicate to the next free number" the correct resolution instead of
   renumbering by date.
 
+
+graduated: bullets 1, 2 and 4 -> docs/sme/entries/2026-08-09-a-pin-derived-before-integration-is-stale-the-moment-anything-else-merges.md; bullet 3 (per-worktree FETCH_HEAD) -> the same entry's closing note. provenance: PR #688.
 ### 2026-08-09 (round 28) — harvest of the #681 integration (PR #687), a merge-order collision
 
 - **Two branches can each derive a pinned count HONESTLY and still be wrong
@@ -1466,6 +1494,8 @@ global; numbering is unified from round 30 up.
   scheme is the root cause and it will keep colliding as long as lanes run in
   parallel. Flagged for the decisions pass, not worked around here.
 
+
+graduated: all three bullets -> docs/sme/entries/2026-08-09-a-pin-derived-before-integration-is-stale-the-moment-anything-else-merges.md. provenance: PR #687.
 ### 2026-08-09 (round 27) — harvest of the #271 tripwire heal (PR #701), a CONTROLLER merge defect
 
 - **A failing assertion turns off every clause after it in the same test, and
@@ -1561,6 +1591,8 @@ global; numbering is unified from round 30 up.
   (`docs/CONFIG_REFERENCE.md`, "Host identity in /health") is what confirmed
   the RFC1918 root cause. The gate paid for itself.
 
+
+graduated: bullets 1 and 2 -> docs/sme/entries/2026-08-09-a-failing-assertion-turns-off-every-clause-after-it-in-the-same-test.md and done-means 271-tripwire-acknowledges-contract-moves.sh; bullets 4, 5, 6 and 7 -> docs/sme/entries/2026-08-09-an-exit-code-is-not-a-verdict-until-you-know-the-subject-ran.md; bullets 3 and 8 -> docs/sme/entries/2026-08-09-a-pin-derived-before-integration-is-stale-the-moment-anything-else-merges.md. provenance: PR #701.
 ### 2026-08-08 (latest) — harvest of the #612 lane (PR #624)
 
 - **`rm` of ANY spelling is banned — including single-file `rm -f`.** The
@@ -1588,6 +1620,8 @@ global; numbering is unified from round 30 up.
   the default transport that was the defect. Exercise the production default
   path at least once.
 
+
+graduated: bullets 1 and 2 -> standing contract clause 7 (teardown; no rm, ever, anywhere) and docs/sme/entries/2026-08-08-lane-tooling-gotchas-the-shell-the-validator-and-the-worktree.md; bullet 3 -> the same tooling entry (no absolute machine paths); bullets 4 and 5 -> done-means 612-component-lines-reach-logs.sh, whose control clause z is the live-window proof; bullet 6 -> docs/sme/entries/2026-08-06-instrumentation-on-a-tree-whose-wrapper-is-never-installed-is-dead-code.md and docs/sme/entries/2026-08-08-injecting-a-test-destination-can-bypass-the-composition-that-is-broken.md. provenance: PR #624.
 ### 2026-08-08 (later) — harvest of the #614 lane (PR #623) and its ruling
 
 - **Deviating from a recorded decision is allowed exactly one way: implement
@@ -1605,6 +1639,8 @@ global; numbering is unified from round 30 up.
   when the git guard (#618) rejects `push -u` — more specific, not a variant
   retry.
 
+
+graduated: bullet 1 -> standing contract clause 5 (nothing silent) and clause 8 (self-reported violations are harvested, never punished); bullet 2 -> history-only, ledger item 20 records the narrow auto-removal exception; bullet 3 -> docs/sme/entries/2026-08-08-lane-tooling-gotchas-the-shell-the-validator-and-the-worktree.md. provenance: PR #623.
 ### 2026-08-08 — harvest of the tooling + fixture lanes (PRs #615, #616, #617, #619, #620, #621)
 
 - **`validate-pr-body.ts` reads `PR_BODY`/`PR_TITLE` from ENV, not argv or
@@ -1649,6 +1685,8 @@ global; numbering is unified from round 30 up.
   only green is decoration. (#615, #620 practice; SME
   `sme.duplicated_selection_lists_diverge` corollary.)
 
+
+graduated: bullets 1, 2, 3, 4, 5, 8, 9, 10 and 11 -> docs/sme/entries/2026-08-08-lane-tooling-gotchas-the-shell-the-validator-and-the-worktree.md; bullets 6 and 7 (git-guard and design-lookup false positives) -> standing contract clause 9, refusals are rules working and each firing is reported. provenance: PRs #615, #616, #617, #619, #620, #621.
 ### 2026-08-07 — founding round (PRs #609, #610, #611 and the decisions pass)
 
 - Red-first done-means checks with controller re-verification became the
@@ -1664,3 +1702,5 @@ global; numbering is unified from round 30 up.
 - SME capture moved to one-file-per-entry (item 13) after three same-file
   union merges in one night; additions raise the pinned count in the same
   commit, on purpose.
+
+graduated: bullet 1 -> standing contract clause 1 (RLVR shape) and clause 6 (the #609 differential); bullet 2 -> standing contract clause 3, superseded by the template plus local validation and enforced by .claude/hooks/pr-body-gate.ts; bullet 3 -> standing contract clause 2 (scripts/lane-bootstrap.ts); bullet 4 -> docs/sme/README.md capture rules and scripts/build-sme-indexes.ts. provenance: PRs #609, #610, #611.

--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -1039,3 +1039,27 @@ Verbatim, from the source:
 ### Pattern
 
 Selection evidence built by re-matching candidates against results via a derived key (`row.id ?? "qmd:" + path`) lies whenever the key collapses: qmd rows carry no id, chunks share paths, and absent paths collapse to one literal key — so a dropped candidate is reported `chosen: true`, answering "why wasn't this returned" with an affirmative falsehood. Key selection by pre-sort array index (or have the selecting code RETURN its classification) rather than re-deriving identity, and distinguish drop REASONS the branch structure knows (pagination offset vs ranking window vs limit). Test shape: two candidates that collapse to one key where only one survives; assert exactly one chosen.
+
+## [2026-08-09] An exit code is not a verdict until you know the subject ran
+
+**Severity:** HIGH
+**Source:** PR #701 (#271 tripwire heal, five CI failures); filed as #702
+**Scope:** every clause asserting a specific nonzero exit; shell pipelines in `scripts/done-means/*.sh`; mutation clauses
+**Status:** active
+
+### Pattern
+
+Exit 127 is the shell's command-not-found. It means the script under test NEVER RAN. Five CI failures in the #271 lane asserted `toBe(1)` for a refusal and received 127 — "did not execute" and "refused correctly" were distinguishable only by the number's luck. Had the assertion been `toBe(127)` for some other reason, or had the refusal path happened to exit 127, the clause would have banked a non-execution as a proof of refusal.
+
+Two adjacent shapes from the same lane:
+
+- **`PIPESTATUS` printed empty when read outside the pipeline's own shell**, which reads as exit 0 at a glance. Every verdict in that lane was re-read directly from the command instead.
+- **A mutation clause written against an ALREADY-RED subject banks the pre-existing failure as a kill.** Clause c passed on the pre-fix tree in its first form: a survived mutant was reported as a discriminating check. This was found only by reading WHY each RED clause failed, rather than accepting a satisfying 4/4 red.
+
+### What to do
+
+- Any clause asserting a specific nonzero exit must reject 127 explicitly.
+- Prove a guard test by its executed-assertion COUNT, not by its exit code. A floor on `expect()` calls is the only clause that can express "the body ran to the end" — green/red structurally cannot. Pin a FLOOR, not an equality, so adding assertions does not fail the gate. (37 red vs 44 healed on the #271 tripwire.)
+- Gate mutation clauses on a proven-green baseline; report INCONCLUSIVE otherwise.
+- Read exit codes from the command itself, never from `PIPESTATUS` evaluated in a different shell.
+- File the anomaly rather than absorbing it. Two runs of the same SHA disagreeing is the flake signal: identical `f0e135c` passed on `push` and failed on `pull_request`, and the local differential on clean `origin/main` versus the branch in separate worktrees (29 pass / 0 fail on both) is what proved it environment-owned. The same-SHA disagreement is the signal; the local differential is the proof.

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -2075,3 +2075,107 @@ This is the second instance of the same defect in the same module: #447 was the 
 - **Where a copy genuinely cannot be folded in — a separate deployment tree, an applied migration's `CHECK` (immutable history), another language — the drift test IS the enforcement.** Copies that agree because something asserts they agree are a different world from copies that agree because nobody has touched one yet.
 - **Check the fold for `GROUP BY`-shaped blindness generally.** Any aggregate that reports per-category health from returned rows alone cannot see a category with no rows. The expected categories must be seeded before the fold, and the seed must come from the authority that defines them.
 - **When widening such a seed, read the existing test fixtures as evidence of the old world.** Two tests here encoded the two-role assumption and failed on the corrected behaviour — the failures were the fix working, not a regression, but a lane that "fixed" the fixtures without reading them would have narrowed the seed back.
+
+## [2026-08-08] A repaired or rewritten check has never failed in its current form
+
+**Severity:** HIGH
+**Source:** PR #640 (#625 sweep-heartbeat lane), PR #639 (#563 bounded-recall lane), PR #642 (#451 tiered-coverage lane)
+**Scope:** every `scripts/done-means/*.sh` and its `.driver.ts`; any acceptance clause edited after its first RED run
+**Status:** active
+
+### Pattern
+
+RED is a property of a specific version of a check, not of the check's name. Edit a clause — repair it, rewrite its instrument, swap a matcher — and the RED transcript you captured belongs to the old text. The new text has never been observed failing, so nothing distinguishes "this clause discriminates" from "this clause measures nothing and reports PASS."
+
+Three independent lanes hit this in one week, each by a different mechanism:
+
+- **Optional chaining on an API that does not exist.** #625's clause (a) called `sweep.runOnce?.()` on a method the subject never defined. The call short-circuited to `undefined`, the clause attempted nothing, and the aggregate verdict would have read PASS while proving zero.
+- **A rewritten instrument.** #563's clause 5 was rewritten after its first RED and re-run only green. A correct-looking aggregate FAIL from the other clauses hid the fact that clause 5 measured nothing.
+- **A negative match whose command was broken.** #451's clause used `rg -E`, which is `--encoding` and errors out. Inside an `if/elif` verdict chain the non-zero exit is indistinguishable from "pattern not found," so the chain advanced to PASS. This is the second `rg -E` incident in the ratchet and the first that manufactured a false GREEN rather than a visible error.
+
+### What to do
+
+- Re-prove RED after ANY edit to a check, including a one-line repair. The clause is new; treat it as new.
+- When a clause drives a subject, assert that the drive actually happened — a return value, a counter, an observable side effect — not merely that nothing threw.
+- Mutation-test every clause whose PASS comes from a NEGATIVE match. Such a clause passes both when the thing is genuinely absent and when the check itself is broken; only injecting the violation separates the two.
+- Never read an aggregate FAIL as evidence that each clause ran. Read WHY each individual clause reported what it reported.
+
+### Corollary
+
+Every check with an exception or allowlist mechanism needs a negative control: inject a real violation into an excepted path and confirm the check still fails. The #636 gate piped violations into `| while read`, which cannot count across the subshell — it printed its own VIOLATION lines and exited 0. A gate that reports failure and passes anyway is worse than no gate.
+
+## [2026-08-08] Name the layer that produced the symptom before writing the fix
+
+**Severity:** HIGH
+**Source:** PR #629 (merge-gate lane and the clause-8 repair), PR #638 (#637 gate-precision lane)
+**Scope:** verify-lane, done-means clauses that invoke repo tooling, recursion and re-entry guards, any fix aimed at a guard
+**Status:** active
+
+### Pattern
+
+A RED transcript proves a symptom, not a cause. Five distinct fixes across two lanes were aimed at the wrong layer, and every one of them looked justified from the failure text alone.
+
+- **A clause that measures its own guard.** #629's clause 8 ran verify-lane nested inside verify-lane. The re-entry guard (`MGVL_VERIFY_LANE_PRS`) fired BEFORE done-means resolution, so the nested probe died at the guard and never reached the error text the clause asserted on. The RED was real and its stated cause was wrong — which sent the next agent to fix code that was never broken. The misdirection is the dangerous half, worse than the failure.
+- **Two guard fixes against a selection defect.** The #629 lane burned two recursion-guard attempts before seeing the live clause was picking "whatever PR is open" — which was the PR containing the clause itself. The defect was SELECTION, not recursion.
+- **A message-text fix against a pre-emption defect**, in the same lane.
+- **An assertion that was itself the bug.** #637's first driver asserted a specific refusal banner; RED revealed a sibling clause already refusing those cases correctly. Satisfying the naive assertion would have weakened a layer that was never broken.
+
+### What to do
+
+- Before writing a fix, state in one sentence which layer produced the observed symptom and what evidence places it there. If the evidence is only "the clause said so," that is not evidence of a layer.
+- A clause must CLEAR the ambient state its subject reacts to, or it measures the guard. Named-env coupling is the residual risk: clause 8's correctness now depends on clearing two specifically named variables, and a future guard reading a different name silently regresses it to measuring the guard again. No test enforces the coupling.
+- When a tool tests repo state at a pinned SHA, ask which VERSION of every involved script actually executes. verify-lane runs the done-means check FROM the PR-head worktree, so a fix committed after that head does not exist where the check runs.
+- When an assertion fails, check whether the assertion is the defect before changing the subject.
+- Hold precision-check fixtures in DATA FILES, never inline in code or in commands. The #637 lane was refused twelve times by the very hook it was repairing — on an `import` path, a file rename, and a read-only `rg` — because the fixture text lived inline. Every agent editing a checker is otherwise refused by the guard under repair.
+- Copy `.env` into any bare worktree you run verify-lane from; bootstrap refuses loudly without it and posts no receipt.
+
+## [2026-08-09] A pin derived before integration is stale the moment anything else merges
+
+**Severity:** HIGH
+**Source:** PR #687 (#681 integration), PR #688 (#675 integration), PR #701 (#271 tripwire heal) — three consecutive integrations, same two collisions
+**Scope:** `EXPECTED_ENTRY_COUNT` and every hand-derived pin; `order:` in `docs/sme/entries/*.md`; `scripts/build-sme-indexes.ts`
+**Status:** active
+
+### Pattern
+
+Two branches can each derive a pinned count HONESTLY and both still be wrong after the merge. PR #687 measured `EXPECTED_ENTRY_COUNT` as 235 on its own tree and was correct there; PR #701 then landed its own entry and main became 235 too. The merged truth is 236.
+
+The freshness of a measurement is not a property of how carefully it was taken. It is a property of WHEN. A lane working alone cannot see this at all.
+
+The companion failure is worse, because git reports it as success. Both branches independently chose `order: 68`, in two DIFFERENT entry files, so there was nothing for a textual merge to conflict on. The tree merged clean and the duplicate surfaced only when `build-sme-indexes.ts` was run by hand and warned. Three integrations in a row hit both collisions, which makes them a PROPERTY of running lanes in parallel, not an unlucky merge.
+
+Root cause of the `order` half: it is a shared sequential ID allocated by reading the current maximum, which every concurrent lane reads identically. It will keep colliding as long as lanes run in parallel.
+
+### What to do
+
+- **Re-measure every pin AFTER integrating the upstream default branch.** Never carry a branch's own derivation across a merge, and never sum two branches' numbers.
+- **Re-run the branch's own tooling after integrating**, even on a conflict-free merge. The class of defect a merge introduces is precisely the class no textual merge can see. A generated-file conflict is regenerated; a generated-file NON-conflict still needs the build.
+- **A PR that moves a pinned value must re-run the other assertions of that value, including in files its diff never touches.** #691 bumped a tool contract 2 -> 3 with all its own gates green; the pin-holder was a test in an untouched file, so the branch was green and the merge was red. That is a controller defect — the cross-file pin check belongs in the merge pass.
+- Resolve a duplicate `order` by moving it to the next free number, not by renumbering by date: `order` is an explicit sort field independent of the entry's date, and the corpus is deliberately not date-sorted.
+- Enforcement gap, still open: `build-sme-indexes.ts` warns on a duplicate `order` and exits 0. A warning is the right severity for merge-time discovery and the wrong one for a gate — a merge that never runs the build ships the duplicate.
+- `FETCH_HEAD` is per-worktree. `git merge FETCH_HEAD` in a freshly-added worktree dies with `could not open .git/worktrees/<name>/FETCH_HEAD` when the fetch ran elsewhere. Fetch inside the worktree you merge in; note the error names a missing FILE, which reads as a broken repository at a glance.
+
+## [2026-08-08] Prove absence by the variable the code reads, and re-run rather than re-quote
+
+**Severity:** HIGH
+**Source:** PR #629 round-4 harvest — a CONTROLLER defect, the Langfuse false-absence claim; same class as #618
+**Scope:** `server/observability/langfuse-tracing.ts`, every configuration-absence claim, controller reports
+**Status:** active
+
+### Pattern
+
+The controller asserted "Langfuse unconfigured" after searching the environment files for `LANGFUSE_*`. The sink reads `OPENBRAIN_TRACING_*` (`server/observability/langfuse-tracing.ts:601-604`), which was set and ENABLED the entire time — 806 traces landed in the window claimed dark.
+
+Searching for the PRODUCT NAME instead of the variable the code actually reads is the same defect class as #618 (matching vocabulary instead of the operation). Committed by the head, not by a lane, which is the part worth naming: controller reports are subject to this exactly as lane reports are.
+
+The second half compounded it. The wrong claim was made once from a bad search and then REPEATED hours later by quoting the earlier conclusion rather than re-running the check. A verification conclusion is only as fresh as its last EXECUTION.
+
+### What to do
+
+- To claim a configuration is absent: find the `process.env.X` read in source FIRST, then search for `X`. Never search for the product, service, or vendor name.
+- Re-quote nothing. Re-run it. An earlier conclusion in your own transcript is not evidence; it is a memory of evidence.
+- A green clause is not evidence until it has been seen to fail. Both self-caught defects in the #451 lane were invisible in a fully-green run and surfaced only under deliberate mutation.
+- Check the enum and the database CHECK constraint before designing a new dimension: `usage_kind="recall"` would have required a Zod enum change AND a migration, and two searches found the pin before any code was written. Read the constraint, not just the field.
+- Verify "pre-existing" by stashing and re-running, not by asserting. The #609 full-suite differential applies cheaply at any scale.
+- An outage path is testable without an outage: a closed port in 7100-7199 yields a real connection refusal with no waiting and no wall-clock assertion. Reusable for any gate distinguishing unreachable from empty.
+- Wall-clock assertions (`toBeLessThan(1000)` ms) are CI flake generators — three runs produced three different unrelated timing failures, all proven main-owned via the #609 differential and filed (#632, #634) instead of absorbed.

--- a/docs/sme/entries/2026-08-08-a-repaired-or-rewritten-check-has-never-failed-in-its-current-form.md
+++ b/docs/sme/entries/2026-08-08-a-repaired-or-rewritten-check-has-never-failed-in-its-current-form.md
@@ -1,0 +1,31 @@
+---
+lane: correctness
+order: 77
+---
+## [2026-08-08] A repaired or rewritten check has never failed in its current form
+
+**Severity:** HIGH
+**Source:** PR #640 (#625 sweep-heartbeat lane), PR #639 (#563 bounded-recall lane), PR #642 (#451 tiered-coverage lane)
+**Scope:** every `scripts/done-means/*.sh` and its `.driver.ts`; any acceptance clause edited after its first RED run
+**Status:** active
+
+### Pattern
+
+RED is a property of a specific version of a check, not of the check's name. Edit a clause — repair it, rewrite its instrument, swap a matcher — and the RED transcript you captured belongs to the old text. The new text has never been observed failing, so nothing distinguishes "this clause discriminates" from "this clause measures nothing and reports PASS."
+
+Three independent lanes hit this in one week, each by a different mechanism:
+
+- **Optional chaining on an API that does not exist.** #625's clause (a) called `sweep.runOnce?.()` on a method the subject never defined. The call short-circuited to `undefined`, the clause attempted nothing, and the aggregate verdict would have read PASS while proving zero.
+- **A rewritten instrument.** #563's clause 5 was rewritten after its first RED and re-run only green. A correct-looking aggregate FAIL from the other clauses hid the fact that clause 5 measured nothing.
+- **A negative match whose command was broken.** #451's clause used `rg -E`, which is `--encoding` and errors out. Inside an `if/elif` verdict chain the non-zero exit is indistinguishable from "pattern not found," so the chain advanced to PASS. This is the second `rg -E` incident in the ratchet and the first that manufactured a false GREEN rather than a visible error.
+
+### What to do
+
+- Re-prove RED after ANY edit to a check, including a one-line repair. The clause is new; treat it as new.
+- When a clause drives a subject, assert that the drive actually happened — a return value, a counter, an observable side effect — not merely that nothing threw.
+- Mutation-test every clause whose PASS comes from a NEGATIVE match. Such a clause passes both when the thing is genuinely absent and when the check itself is broken; only injecting the violation separates the two.
+- Never read an aggregate FAIL as evidence that each clause ran. Read WHY each individual clause reported what it reported.
+
+### Corollary
+
+Every check with an exception or allowlist mechanism needs a negative control: inject a real violation into an excepted path and confirm the check still fails. The #636 gate piped violations into `| while read`, which cannot count across the subshell — it printed its own VIOLATION lines and exited 0. A gate that reports failure and passes anyway is worse than no gate.

--- a/docs/sme/entries/2026-08-08-lane-tooling-gotchas-the-shell-the-validator-and-the-worktree.md
+++ b/docs/sme/entries/2026-08-08-lane-tooling-gotchas-the-shell-the-validator-and-the-worktree.md
@@ -1,0 +1,38 @@
+---
+lane: quality
+order: 81
+---
+## [2026-08-08] Lane tooling gotchas: the shell, the validator, and the worktree
+
+**Severity:** MEDIUM
+**Source:** PRs #615, #616, #617, #619, #620, #621 (tooling + fixture lanes); PRs #623, #624 (#614 and #612 lanes); PRs #628, #630, #631 (enforcement-build lanes)
+**Scope:** `scripts/validate-pr-body.ts`, `scripts/lane-bootstrap.ts`, `scripts/done-means/*.sh`, PR bodies, `.gitignore`
+**Status:** active
+
+### Pattern
+
+A cluster of tooling behaviours that each produced a false green or a lost afternoon, collected because they recur and none is guessable from the tool's surface.
+
+**`validate-pr-body.ts` reads `PR_BODY`/`PR_TITLE` from the ENVIRONMENT — not argv, not stdin.** Run it with neither set and it validates the empty string; in one observed path it printed failures and exited 0. Always confirm the literal `PR body validation passed` line, never the exit code alone. Found independently by the controller and the #613 lane.
+
+**No `###` subheadings inside validator-required PR-body sections.** The section parser terminates on `startsWith("## ")`, which `### x` satisfies, so an h3 silently truncates the section. Use bold text instead.
+
+**Bun names tests only on failure.** A gate that searches the suite log for a test name to prove execution false-negatives on a fully-passing run. Prove execution by asserting a non-zero pass count.
+
+**`rg -E` is `--encoding`, not extended-regex.** Use `rg -e`.
+
+**`sed -i` is not portable between this shell's GNU sed and the BSD examples**, and in-place sed has burned two lanes. Prefer the Edit tool, `awk` to a new file, or `> file && cp`.
+
+**`lane-bootstrap` prints the worktree path but does not change your directory.** Relative commands after it still target the primary checkout — enter the printed absolute path explicitly. Also, `bunx --cwd` is not a thing; run `bunx` from inside the worktree.
+
+**Never `git stash` in a checkout you do not exclusively own.** One `stash pop` popped ANOTHER session's pre-existing stash and left a `UU` conflict. Worktrees from `lane-bootstrap` are exclusively yours; the primary checkout never is.
+
+**No absolute machine paths in tests or defaults.** A hardcoded `/Volumes/...` default died with `EACCES` on the Linux CI runner. Use repo-relative `_scratch/` (gitignored), as `src/operator-doctor.test.ts:32` does.
+
+**Verify `.gitignore` outcomes by `git ls-files`, not by reading patterns** — a later rule can override the one you read. `.claude/*` nearly ate the pr-scribe agent. The clean-clone or fresh-worktree run of the done-means check is the only thing that catches this class; always finish with one.
+
+**A suite that exits 0 can still leak rows.** The parity harness passed green for its whole life while seeding nine tables. Gates read the database, not the exit code — and clean up by the dimension the PRODUCER uses, not the dimension the test seeds, preferring the owning shared helper over per-suite patches.
+
+**Citations to artifacts that do not exist yet are fabrications.** A PR number guessed before `gh pr create` is a guess in the grammar of a fact. Write the reference after the artifact exists.
+
+**Mutation-test the gate itself when the PR's claim IS the gate.** Reintroduce each real failure mode and watch the gate fail; a gate observed only green is decoration.

--- a/docs/sme/entries/2026-08-08-name-the-layer-that-produced-the-symptom-before-writing-the-fix.md
+++ b/docs/sme/entries/2026-08-08-name-the-layer-that-produced-the-symptom-before-writing-the-fix.md
@@ -1,0 +1,28 @@
+---
+lane: correctness
+order: 78
+---
+## [2026-08-08] Name the layer that produced the symptom before writing the fix
+
+**Severity:** HIGH
+**Source:** PR #629 (merge-gate lane and the clause-8 repair), PR #638 (#637 gate-precision lane)
+**Scope:** verify-lane, done-means clauses that invoke repo tooling, recursion and re-entry guards, any fix aimed at a guard
+**Status:** active
+
+### Pattern
+
+A RED transcript proves a symptom, not a cause. Five distinct fixes across two lanes were aimed at the wrong layer, and every one of them looked justified from the failure text alone.
+
+- **A clause that measures its own guard.** #629's clause 8 ran verify-lane nested inside verify-lane. The re-entry guard (`MGVL_VERIFY_LANE_PRS`) fired BEFORE done-means resolution, so the nested probe died at the guard and never reached the error text the clause asserted on. The RED was real and its stated cause was wrong — which sent the next agent to fix code that was never broken. The misdirection is the dangerous half, worse than the failure.
+- **Two guard fixes against a selection defect.** The #629 lane burned two recursion-guard attempts before seeing the live clause was picking "whatever PR is open" — which was the PR containing the clause itself. The defect was SELECTION, not recursion.
+- **A message-text fix against a pre-emption defect**, in the same lane.
+- **An assertion that was itself the bug.** #637's first driver asserted a specific refusal banner; RED revealed a sibling clause already refusing those cases correctly. Satisfying the naive assertion would have weakened a layer that was never broken.
+
+### What to do
+
+- Before writing a fix, state in one sentence which layer produced the observed symptom and what evidence places it there. If the evidence is only "the clause said so," that is not evidence of a layer.
+- A clause must CLEAR the ambient state its subject reacts to, or it measures the guard. Named-env coupling is the residual risk: clause 8's correctness now depends on clearing two specifically named variables, and a future guard reading a different name silently regresses it to measuring the guard again. No test enforces the coupling.
+- When a tool tests repo state at a pinned SHA, ask which VERSION of every involved script actually executes. verify-lane runs the done-means check FROM the PR-head worktree, so a fix committed after that head does not exist where the check runs.
+- When an assertion fails, check whether the assertion is the defect before changing the subject.
+- Hold precision-check fixtures in DATA FILES, never inline in code or in commands. The #637 lane was refused twelve times by the very hook it was repairing — on an `import` path, a file rename, and a read-only `rg` — because the fixture text lived inline. Every agent editing a checker is otherwise refused by the guard under repair.
+- Copy `.env` into any bare worktree you run verify-lane from; bootstrap refuses loudly without it and posts no receipt.

--- a/docs/sme/entries/2026-08-08-prove-absence-by-the-variable-the-code-reads-and-re-run-never-re-quote.md
+++ b/docs/sme/entries/2026-08-08-prove-absence-by-the-variable-the-code-reads-and-re-run-never-re-quote.md
@@ -1,0 +1,28 @@
+---
+lane: correctness
+order: 82
+---
+## [2026-08-08] Prove absence by the variable the code reads, and re-run rather than re-quote
+
+**Severity:** HIGH
+**Source:** PR #629 round-4 harvest — a CONTROLLER defect, the Langfuse false-absence claim; same class as #618
+**Scope:** `server/observability/langfuse-tracing.ts`, every configuration-absence claim, controller reports
+**Status:** active
+
+### Pattern
+
+The controller asserted "Langfuse unconfigured" after searching the environment files for `LANGFUSE_*`. The sink reads `OPENBRAIN_TRACING_*` (`server/observability/langfuse-tracing.ts:601-604`), which was set and ENABLED the entire time — 806 traces landed in the window claimed dark.
+
+Searching for the PRODUCT NAME instead of the variable the code actually reads is the same defect class as #618 (matching vocabulary instead of the operation). Committed by the head, not by a lane, which is the part worth naming: controller reports are subject to this exactly as lane reports are.
+
+The second half compounded it. The wrong claim was made once from a bad search and then REPEATED hours later by quoting the earlier conclusion rather than re-running the check. A verification conclusion is only as fresh as its last EXECUTION.
+
+### What to do
+
+- To claim a configuration is absent: find the `process.env.X` read in source FIRST, then search for `X`. Never search for the product, service, or vendor name.
+- Re-quote nothing. Re-run it. An earlier conclusion in your own transcript is not evidence; it is a memory of evidence.
+- A green clause is not evidence until it has been seen to fail. Both self-caught defects in the #451 lane were invisible in a fully-green run and surfaced only under deliberate mutation.
+- Check the enum and the database CHECK constraint before designing a new dimension: `usage_kind="recall"` would have required a Zod enum change AND a migration, and two searches found the pin before any code was written. Read the constraint, not just the field.
+- Verify "pre-existing" by stashing and re-running, not by asserting. The #609 full-suite differential applies cheaply at any scale.
+- An outage path is testable without an outage: a closed port in 7100-7199 yields a real connection refusal with no waiting and no wall-clock assertion. Reusable for any gate distinguishing unreachable from empty.
+- Wall-clock assertions (`toBeLessThan(1000)` ms) are CI flake generators — three runs produced three different unrelated timing failures, all proven main-owned via the #609 differential and filed (#632, #634) instead of absorbed.

--- a/docs/sme/entries/2026-08-09-a-pin-derived-before-integration-is-stale-the-moment-anything-else-merges.md
+++ b/docs/sme/entries/2026-08-09-a-pin-derived-before-integration-is-stale-the-moment-anything-else-merges.md
@@ -1,0 +1,29 @@
+---
+lane: correctness
+order: 79
+---
+## [2026-08-09] A pin derived before integration is stale the moment anything else merges
+
+**Severity:** HIGH
+**Source:** PR #687 (#681 integration), PR #688 (#675 integration), PR #701 (#271 tripwire heal) — three consecutive integrations, same two collisions
+**Scope:** `EXPECTED_ENTRY_COUNT` and every hand-derived pin; `order:` in `docs/sme/entries/*.md`; `scripts/build-sme-indexes.ts`
+**Status:** active
+
+### Pattern
+
+Two branches can each derive a pinned count HONESTLY and both still be wrong after the merge. PR #687 measured `EXPECTED_ENTRY_COUNT` as 235 on its own tree and was correct there; PR #701 then landed its own entry and main became 235 too. The merged truth is 236.
+
+The freshness of a measurement is not a property of how carefully it was taken. It is a property of WHEN. A lane working alone cannot see this at all.
+
+The companion failure is worse, because git reports it as success. Both branches independently chose `order: 68`, in two DIFFERENT entry files, so there was nothing for a textual merge to conflict on. The tree merged clean and the duplicate surfaced only when `build-sme-indexes.ts` was run by hand and warned. Three integrations in a row hit both collisions, which makes them a PROPERTY of running lanes in parallel, not an unlucky merge.
+
+Root cause of the `order` half: it is a shared sequential ID allocated by reading the current maximum, which every concurrent lane reads identically. It will keep colliding as long as lanes run in parallel.
+
+### What to do
+
+- **Re-measure every pin AFTER integrating the upstream default branch.** Never carry a branch's own derivation across a merge, and never sum two branches' numbers.
+- **Re-run the branch's own tooling after integrating**, even on a conflict-free merge. The class of defect a merge introduces is precisely the class no textual merge can see. A generated-file conflict is regenerated; a generated-file NON-conflict still needs the build.
+- **A PR that moves a pinned value must re-run the other assertions of that value, including in files its diff never touches.** #691 bumped a tool contract 2 -> 3 with all its own gates green; the pin-holder was a test in an untouched file, so the branch was green and the merge was red. That is a controller defect — the cross-file pin check belongs in the merge pass.
+- Resolve a duplicate `order` by moving it to the next free number, not by renumbering by date: `order` is an explicit sort field independent of the entry's date, and the corpus is deliberately not date-sorted.
+- Enforcement gap, still open: `build-sme-indexes.ts` warns on a duplicate `order` and exits 0. A warning is the right severity for merge-time discovery and the wrong one for a gate — a merge that never runs the build ships the duplicate.
+- `FETCH_HEAD` is per-worktree. `git merge FETCH_HEAD` in a freshly-added worktree dies with `could not open .git/worktrees/<name>/FETCH_HEAD` when the fetch ran elsewhere. Fetch inside the worktree you merge in; note the error names a missing FILE, which reads as a broken repository at a glance.

--- a/docs/sme/entries/2026-08-09-an-exit-code-is-not-a-verdict-until-you-know-the-subject-ran.md
+++ b/docs/sme/entries/2026-08-09-an-exit-code-is-not-a-verdict-until-you-know-the-subject-ran.md
@@ -1,0 +1,27 @@
+---
+lane: adversarial
+order: 80
+---
+## [2026-08-09] An exit code is not a verdict until you know the subject ran
+
+**Severity:** HIGH
+**Source:** PR #701 (#271 tripwire heal, five CI failures); filed as #702
+**Scope:** every clause asserting a specific nonzero exit; shell pipelines in `scripts/done-means/*.sh`; mutation clauses
+**Status:** active
+
+### Pattern
+
+Exit 127 is the shell's command-not-found. It means the script under test NEVER RAN. Five CI failures in the #271 lane asserted `toBe(1)` for a refusal and received 127 — "did not execute" and "refused correctly" were distinguishable only by the number's luck. Had the assertion been `toBe(127)` for some other reason, or had the refusal path happened to exit 127, the clause would have banked a non-execution as a proof of refusal.
+
+Two adjacent shapes from the same lane:
+
+- **`PIPESTATUS` printed empty when read outside the pipeline's own shell**, which reads as exit 0 at a glance. Every verdict in that lane was re-read directly from the command instead.
+- **A mutation clause written against an ALREADY-RED subject banks the pre-existing failure as a kill.** Clause c passed on the pre-fix tree in its first form: a survived mutant was reported as a discriminating check. This was found only by reading WHY each RED clause failed, rather than accepting a satisfying 4/4 red.
+
+### What to do
+
+- Any clause asserting a specific nonzero exit must reject 127 explicitly.
+- Prove a guard test by its executed-assertion COUNT, not by its exit code. A floor on `expect()` calls is the only clause that can express "the body ran to the end" — green/red structurally cannot. Pin a FLOOR, not an equality, so adding assertions does not fail the gate. (37 red vs 44 healed on the #271 tripwire.)
+- Gate mutation clauses on a proven-green baseline; report INCONCLUSIVE otherwise.
+- Read exit codes from the command itself, never from `PIPESTATUS` evaluated in a different shell.
+- File the anomaly rather than absorbing it. Two runs of the same SHA disagreeing is the flake signal: identical `f0e135c` passed on `push` and failed on `pull_request`, and the local differential on clean `origin/main` versus the branch in separate worktrees (29 pass / 0 fail on both) is what proved it environment-owned. The same-SHA disagreement is the signal; the local differential is the proof.

--- a/docs/sme/quality.md
+++ b/docs/sme/quality.md
@@ -459,3 +459,38 @@ non-equivalent nested conditional, and the existing suite did not catch it. A
 refactor claimed to be behavior-free is verified by reading each extraction back
 against its original, not only by a green run — the tests cover the
 combinations someone already thought of.
+
+## [2026-08-08] Lane tooling gotchas: the shell, the validator, and the worktree
+
+**Severity:** MEDIUM
+**Source:** PRs #615, #616, #617, #619, #620, #621 (tooling + fixture lanes); PRs #623, #624 (#614 and #612 lanes); PRs #628, #630, #631 (enforcement-build lanes)
+**Scope:** `scripts/validate-pr-body.ts`, `scripts/lane-bootstrap.ts`, `scripts/done-means/*.sh`, PR bodies, `.gitignore`
+**Status:** active
+
+### Pattern
+
+A cluster of tooling behaviours that each produced a false green or a lost afternoon, collected because they recur and none is guessable from the tool's surface.
+
+**`validate-pr-body.ts` reads `PR_BODY`/`PR_TITLE` from the ENVIRONMENT — not argv, not stdin.** Run it with neither set and it validates the empty string; in one observed path it printed failures and exited 0. Always confirm the literal `PR body validation passed` line, never the exit code alone. Found independently by the controller and the #613 lane.
+
+**No `###` subheadings inside validator-required PR-body sections.** The section parser terminates on `startsWith("## ")`, which `### x` satisfies, so an h3 silently truncates the section. Use bold text instead.
+
+**Bun names tests only on failure.** A gate that searches the suite log for a test name to prove execution false-negatives on a fully-passing run. Prove execution by asserting a non-zero pass count.
+
+**`rg -E` is `--encoding`, not extended-regex.** Use `rg -e`.
+
+**`sed -i` is not portable between this shell's GNU sed and the BSD examples**, and in-place sed has burned two lanes. Prefer the Edit tool, `awk` to a new file, or `> file && cp`.
+
+**`lane-bootstrap` prints the worktree path but does not change your directory.** Relative commands after it still target the primary checkout — enter the printed absolute path explicitly. Also, `bunx --cwd` is not a thing; run `bunx` from inside the worktree.
+
+**Never `git stash` in a checkout you do not exclusively own.** One `stash pop` popped ANOTHER session's pre-existing stash and left a `UU` conflict. Worktrees from `lane-bootstrap` are exclusively yours; the primary checkout never is.
+
+**No absolute machine paths in tests or defaults.** A hardcoded `/Volumes/...` default died with `EACCES` on the Linux CI runner. Use repo-relative `_scratch/` (gitignored), as `src/operator-doctor.test.ts:32` does.
+
+**Verify `.gitignore` outcomes by `git ls-files`, not by reading patterns** — a later rule can override the one you read. `.claude/*` nearly ate the pr-scribe agent. The clean-clone or fresh-worktree run of the done-means check is the only thing that catches this class; always finish with one.
+
+**A suite that exits 0 can still leak rows.** The parity harness passed green for its whole life while seeding nine tables. Gates read the database, not the exit code — and clean up by the dimension the PRODUCER uses, not the dimension the test seeds, preferring the owning shared helper over per-suite patches.
+
+**Citations to artifacts that do not exist yet are fabrications.** A PR number guessed before `gh pr create` is a guess in the grammar of a fact. Write the reference after the artifact exists.
+
+**Mutation-test the gate itself when the PR's claim IS the gate.** Reintroduce each real failure mode and watch the gate fail; a gate observed only green is decoration.


### PR DESCRIPTION
## Summary

- The `## Tightenings` ratchet in `docs/lane-contract.md` declares a graduation valve — overflow entries are meant to graduate into a done-means check or an SME entry — and nothing had ever used it. Every round since the 2026-08-07 founding round was still live: 45 live entries against a declared 15.
- Graduate the 16 OLDEST rounds: round 10 down through round 3, round 10b, the three main-line rounds 29/28/27, the three 2026-08-08 latest/later/tooling rounds, and the 2026-08-07 founding round.
- Every bullet in those 16 rounds was read and routed to one of four destinations: an existing numbered clause of `## Standing contract`; an existing `docs/sme/entries/*.md` file or a `scripts/done-means/*.sh` check that already enforces it; one of six NEW SME entries written here for rules that were still live with no home; or marked history-only where the bullet recorded a one-off with no reusable rule.
- **No round text is deleted or rewritten.** The diff is 384 insertions and zero deletions. Each graduated round gains a trailing `graduated:` line naming where each of its bullets went, and the eight rounds carrying PR numbers only in their headings gain an explicit `provenance:` line.
- Six new SME entries (`order` 77-82, allocated from the observed maximum of 76): a repaired or rewritten check has never failed in its current form; name the layer that produced the symptom before writing the fix; a pin derived before integration is stale the moment anything else merges; an exit code is not a verdict until you know the subject ran; lane tooling gotchas (the shell, the validator, and the worktree); prove absence by the variable the code reads, and re-run rather than re-quote.
- `docs/sme/correctness.md`, `docs/sme/adversarial.md`, and `docs/sme/quality.md` are regenerated by `bun scripts/build-sme-indexes.ts` — they are generated files and were not hand-edited.

## Verification

- Done-means: scripts/done-means/750-precommit-lint-gate-fires.sh

The graduation itself is measured by the ratchet-bound beta check, which counts live versus graduated entries in the Tightenings section.

Before, on `origin/main`:

```
FAIL bound: 45 live > 15
live=45 graduated=0 bound=15 source=default shape=heading
```

After, on this branch:

```
FAIL bound: 29 live > 15
live=29 graduated=16 bound=15 source=default shape=heading
```

Exit 1 both times, and that is the honest result for this batch rather than a failure of the change: 29 live is down from 45 and still above the declared 15, so a second graduation pass is needed before the check reaches exit 0. The graduated count moving 0 -> 16 and the live count moving 45 -> 29 is what this PR claims. The 16 graduated rounds also no longer report `FAIL provenance`; the remaining provenance failures all belong to rounds newer than round 10, which this PR does not touch.

The placeholders beta check passes on each of the six new entries (exit 0, six for six).

- [x] Relevant Open Brain tests/typecheck/migrations passed — the pre-push gate ran the Bun suite green; no TypeScript or JavaScript is staged, so the pre-commit lint and typecheck steps reported themselves skipped rather than silently passing.
- [x] Python package checks passed or are not applicable — not applicable: `python/openbrain-memory/` is untouched, and the pre-push gate skipped that gate for the same reason.
- [x] Live Open Brain smoke passed or is not applicable — not applicable: documentation only, no runtime, schema, or transport surface changes.

## Critical Self-Review

- Highest-risk behavior: mis-routing a bullet — claiming a rule already lives in the standing contract or an SME entry when it does not, which would retire a live review rule into a citation that leads nowhere. Mitigated by citing a specific clause number, entry filename, or check filename for every bullet rather than a general gesture, and by keeping the original bullet text intact so a wrong citation is recoverable by reading the round.
- Assumptions that could be wrong: that the ratchet's intent is satisfied by an entry marked `graduated:` whose rule has a durable home, rather than by deleting the round. The section's own header says "Newest first. Every entry: what changed, and the observation that forced it," and the check's README (rule 4) treats `graduated:` as the mechanism that removes an entry from the live count, so retention plus a routing line is the reading I acted on. If the operator intended deletion, this PR is the wrong shape and the rounds are still all present to redo.
- Missing/weak tests: the ratchet check is markdown-shape only. It cannot verify that a `graduated:` line's cited entry file or done-means check actually exists, nor that the cited standing-contract clause says what the bullet said. Every citation in this PR was written by reading the target, but nothing executable enforces that, and a later rename of an SME entry would silently rot these lines.
- Security/permission risk: none. Documentation only; no auth, namespace, token, or SQL surface is touched, and gitleaks scanned the staged changes clean.
- Migration/deploy risk: none. No schema, no migration, no runtime file.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classification is not applicable — no MCP tool, schema, protocol, or client-facing contract changes, so rtech-mcps, mcp2cli, and rtech-hermes are unaffected.
- Rollback/cleanup concern: a straight revert restores the prior file exactly, since the change is insertion-only. The six new entry files would revert with it and the generated lane indexes would need `bun scripts/build-sme-indexes.ts` re-run after a revert, the same as after any entry change.
- Fixes made before PR: the first pass added `graduated:` lines only, and the check still reported `FAIL provenance` for eight of the sixteen rounds because their PR numbers lived in the heading text rather than the body. An explicit `provenance:` line was added to those eight before committing. Also confirmed the `order` allocation against the true maximum: a first attempt read `order` values with a pattern that also matched four-digit dates and reported 2026, which would have opened a large gap in the sequence; anchoring the pattern gave the real maximum of 76.
- Known residual risk: round 10b's body is empty in the current file — its bullets are orphaned further down, under round 27, from the 2026-08-18 rotation merge. Its `graduated:` line therefore cites the bullets as they appear under round 27 and sits directly after its own heading. That is faithful to what the file holds today, but a future reader following round 10b's heading alone will find only the routing line. I did not move the orphaned bullets, because relocating text is outside "do not rewrite any round."
- SME review-memory update: [x] `docs/sme/` updated

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] not applicable because: this change touches only documentation under `docs/`, with no runtime, transport, or database surface to smoke.

## Contract Parity

- Contract parity: [x] runtime-specific because: no contract, fixture, or cross-runtime surface is touched — the pre-push gate skipped the contract parity subset for the same reason.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Documentation-only change; the rollout gate classifies as not applicable on every downstream surface because no MCP tool, schema, protocol, or client-facing behavior moves.
- `bun scripts/build-sme-indexes.ts` reported `correctness.md (74 entries)`, `adversarial.md (37 entries)`, `quality.md (20 entries)` with no duplicate-`order` warning.
