### PR TITLE
docs(lane-contract): graduate Tightenings rounds 11-26; the ratchet check passes

### DIFF
--- a/docs/lane-contract.md
+++ b/docs/lane-contract.md
@@ -701,6 +701,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   Rows of uncertain provenance, user data, and anything outside a
   provably-test prefix stay report-only.
 
+
+graduated: bullet 1 -> docs/sme/entries/2026-08-08-a-prefix-scoped-sql-delete-of-provable-test-residue-is-the-lanes-to-run.md (domain-backend order 83), and the FILESYSTEM half stands unchanged as standing contract clause 7 (no rm, ever, anywhere).
+provenance: operator ruling 2026-08-08, ledger item 31 (docs/issue-graph.md); no PR.
 ### 2026-08-08 (round 25) — harvest of the #653 final-sync lane (clause-e residue edit)
 
 - **When a gate has no clause-level seam, EXTRACT the clause from the
@@ -734,6 +737,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   joined the enumeration) — the briefed "8" is stale; brief the observed
   number or brief "the enumerated set," not a count.
 
+
+graduated: bullets 1, 2, 3 and 4 -> docs/sme/entries/2026-08-08-extract-the-clause-from-the-real-file-by-markers-and-prove-the-prover.md (correctness order 84); bullet 5 -> docs/sme/entries/2026-08-08-pipestatus-outside-the-pipelines-shell-prints-empty-and-reads-as-exit-0.md (write message files in a separate call before a guarded command); bullet 7 -> docs/sme/entries/2026-08-08-pipestatus-outside-the-pipelines-shell-prints-empty-and-reads-as-exit-0.md (brief the enumerated set, never a count); bullet 6 -> history-only, bootstrap continuation mode's first real run, shipped by scripts/done-means/667-lane-bootstrap-continuation.sh; bullet 8 -> history-only, one design-lookup payback already covered by round 17's payback rule.
+provenance: PR #653 final-sync lane.
 ### 2026-08-08 (round 24) — harvest of the #671 verdict-channel lane (PR #673)
 
 - **A driver that implements a changing interface can silently repair the
@@ -769,6 +775,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   fabricating. "NOT OBSERVED — structurally cannot observe" is a
   complete, correct answer.
 
+
+graduated: bullets 1, 2 and 4 -> docs/sme/entries/2026-08-08-a-driver-that-implements-a-changing-interface-can-repair-the-defect-it-exposes.md (correctness order 85); bullet 3 -> the same entry's residue-reader corollary, enforced by scripts/done-means/671-teardown-verdict-residue.sh; bullets 5 and 6 -> docs/sme/entries/2026-08-08-pipestatus-outside-the-pipelines-shell-prints-empty-and-reads-as-exit-0.md (quality order 88); bullet 7 -> the round-24 entry's structurally-cannot-observe corollary, and standing contract clause 8 (report shape).
+provenance: PR #673.
 ### 2026-08-08 (round 23) — harvest of the #667 bootstrap-continuation lane
 
 - **A negative-match clause on a crashing subject can go green off the
@@ -793,6 +802,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   announced, not refused** — lane judgment call, flagged in PR #669's
   assumptions field; stands unless the operator overrules.
 
+
+graduated: bullets 1, 3 and 4 -> docs/sme/entries/2026-08-08-a-negative-match-clause-can-go-green-off-the-subjects-own-error-text.md (adversarial order 86); bullet 2 -> the same entry's summary-line corollary; bullet 5 -> history-only, a lane judgment call flagged in PR #669's assumptions field and never overruled.
+provenance: PRs #668, #669.
 ### 2026-08-08 (round 22) — harvest of the #666 transport-delegation lane
 
 - **When the defect is "what does X pass to the boundary," stub the
@@ -816,6 +828,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   after a 120s+ hang is did-not-run.** The two are distinguishable and
   must be treated differently (rounds 11/17/20 refined).
 
+
+graduated: bullets 1 and 2 -> docs/sme/entries/2026-08-08-stub-the-boundary-do-not-extract-a-helper-for-observability.md (correctness order 87), enforced by scripts/done-means/666-transport-delegates-namespace.sh; bullets 3 and 4 -> the same entry's empty-result corollary, and docs/sme/entries/2026-08-08-includes-on-a-raw-log-line-is-a-substring-match-and-every-superset-satisfies-it.md (empty after a timeout is did-not-run).
+provenance: PR #666 lane; issue #666.
 ### 2026-08-08 (round 21) — harvest of the #653 branch-sync lane
 
 - **`lane-bootstrap` refuses a continuation lane on an EXISTING BRANCH,
@@ -840,6 +855,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   credentials fully exercises the refusal branch with zero harvest risk;
   the credentialed leg stays with the controller-dispatched verifier.
 
+
+graduated: bullets 1 and 4 -> docs/sme/entries/2026-08-08-pipestatus-outside-the-pipelines-shell-prints-empty-and-reads-as-exit-0.md (quality order 88), with the continuation-mode half now shipped by scripts/done-means/667-lane-bootstrap-continuation.sh; bullet 2 -> the same entry's record-the-negative-results corollary; bullet 3 -> the same entry's opening pattern.
+provenance: PR #653 branch-sync lane.
 ### 2026-08-08 (round 20) — harvest of the #661 five-keys lane (PR #663) and the hold-at-RED escalation
 
 - **An issue generated from a tool's own output inherits that tool's
@@ -869,6 +887,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   `qmd search` direct (~1s) as the standing fallback; empty output after
   a timeout is did-not-run.
 
+
+graduated: bullets 1, 2, 3 and 5 -> docs/sme/entries/2026-08-08-an-issue-generated-from-a-tools-output-inherits-that-tools-classification-errors.md (adversarial order 89), enforced by scripts/done-means/661-launcher-honors-six-keys.sh; bullet 4 -> docs/sme/entries/2026-08-08-includes-on-a-raw-log-line-is-a-substring-match-and-every-superset-satisfies-it.md (the two-runs-same-SHA corollary), with the collision itself filed as #665; bullet 6 -> the same entry's empty-after-a-timeout corollary.
+provenance: PR #663; operator ruling 29.2a.
 ### 2026-08-08 (round 19) — harvest of the #662 validator lane (PR #664) and the #653 credentialed verify
 
 - **A guard written as "key present AND value wrong" leaves the absent
@@ -906,6 +927,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   red gate as a broken gate; the verifier proved the fixed defects fixed
   (re-ran their checks live) before attributing the new failure.
 
+
+graduated: bullets 1, 2 and 3 -> docs/sme/entries/2026-08-08-a-guard-written-as-present-and-wrong-leaves-the-absent-branch-unguarded.md (security order 90), enforced by scripts/done-means/662-absent-namespace-scope-proof.sh; bullet 4 -> the same entry's rg -r corollary, and docs/sme/entries/2026-08-08-lane-tooling-gotchas-the-shell-the-validator-and-the-worktree.md; bullet 5 -> docs/sme/entries/2026-08-08-pipestatus-outside-the-pipelines-shell-prints-empty-and-reads-as-exit-0.md; bullets 6 and 7 -> the round-19 entry's gate-that-keeps-failing corollary.
+provenance: PR #664; the #653 credentialed verify.
 ### 2026-08-08 (round 18) — harvest of the #659 launcher-env lane (PR #660) and the controller-side discovery
 
 - **A revision proof is not a feature-live proof.** The clone redeploy
@@ -952,6 +976,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   otherwise-correct compound commands — which is exactly why the ban is
   unconditional and why `2>/dev/null` on cleanup steps deserves suspicion.
 
+
+graduated: bullets 1, 2, 3, 4, 5, 6 and 7 -> docs/sme/entries/2026-08-08-a-revision-proof-is-not-a-feature-live-proof.md (domain-backend order 91), enforced by scripts/done-means/659-launcher-env-passthrough.sh; bullet 8 -> the same entry's self-reported-violation section, and standing contract clause 7 (no rm, ever, anywhere) plus clause 8 (self-reported violations are harvested, never punished).
+provenance: PR #660.
 ### 2026-08-08 (round 17) — harvest of the #656 observer-wiring lane
 
 - **`includes("<event_name>")` on a raw log line is a substring match, and
@@ -981,6 +1008,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   so every PR gets this two-runs-same-SHA comparison for free; use it
   before concluding branch defect.
 
+
+graduated: bullets 1 and 2 -> docs/sme/entries/2026-08-08-includes-on-a-raw-log-line-is-a-substring-match-and-every-superset-satisfies-it.md (correctness order 92), enforced by scripts/done-means/656-capture-observer-wired.sh; bullets 3, 4 and 5 -> the same entry's payback, timeout, and two-runs-same-SHA corollaries.
+provenance: #656 observer-wiring lane.
 ### 2026-08-08 (round 16) — harvest of the #655 eval-teardown lane
 
 - **A teardown that reports success is not evidence of removal.** The RED
@@ -1004,6 +1034,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   and make a correct denial look spurious. Gate working as designed; know
   the shape before reporting it as a misfire.
 
+
+graduated: bullets 1, 3 and 4 -> docs/sme/entries/2026-08-08-red-by-breaking-the-import-is-a-false-red-use-a-skip-flag.md (correctness order 93), enforced by scripts/done-means/655-eval-teardown.sh; bullet 2 -> docs/sme/entries/2026-08-08-a-prefix-scoped-sql-delete-of-provable-test-residue-is-the-lanes-to-run.md (a namespace is an emergent property of its rows); bullet 5 -> the round-16 entry's session-scoped-window corollary.
+provenance: #655 eval-teardown lane.
 ### 2026-08-08 (round 15) — harvest of the #654 namespace-scope lane (PR #657) and its verify run
 
 - **A live-service check reads the SERVING process's credentials, never the
@@ -1036,6 +1069,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   (`recheck-head`). Any check whose RED lives on main and GREEN on the
   branch inherits this binding requirement.
 
+
+graduated: bullets 1, 2, 3, 4 and 5 -> docs/sme/entries/2026-08-08-a-live-service-check-reads-the-serving-processs-credentials.md (security order 94), enforced by scripts/done-means/654-namespace-scope-proof.sh; bullet 3 also -> ledger item 28 (identity-selecting config is required config, loud on absence).
+provenance: PR #657.
 ### 2026-08-08 (round 14) — harvest of the #652 capture-health composition lane
 
 - **A "compose it" lane must ask what the composer can actually SEE.** The
@@ -1064,6 +1100,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   same PR** — tsc found #648's `TransportCaptureHealth` declared but never
   barrel-exported; invisible until the first composer tried to import it.
 
+
+graduated: bullets 1, 2, 3 and 5 -> docs/sme/entries/2026-08-08-a-compose-it-lane-must-ask-what-the-composer-can-actually-see.md (domain-backend order 95), enforced by scripts/done-means/652-capture-health-composed.sh; bullet 4 -> the same entry's declare-your-own-gap corollary, and standing contract clause 5 (nothing silent).
+provenance: #652 capture-health composition lane.
 ### 2026-08-08 (round 13) — harvest of the #647 capture-liveness lane (PR #648)
 
 - **The design may already exist and simply never have been executed.** #647
@@ -1096,6 +1135,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   composition change ships. WRITTEN-not-RUNNING, stated in the PR rather
   than implied away.
 
+
+graduated: bullets 1, 3 and 4 -> docs/sme/entries/2026-08-08-ask-whether-the-design-already-exists-and-was-simply-never-run.md (quality order 96); bullet 2 -> docs/sme/entries/2026-08-08-a-top-level-await-driver-exits-0-when-it-throws-banking-a-false-green.md, already carried at order 67; bullets 5 and 6 -> the round-13 entry's gate-precision datapoints and its name-the-capability-state corollary.
+provenance: PR #648.
 ### 2026-08-08 (round 12) — harvest of the #646 provider-scope lane (PR #650)
 
 - **Verify which tree the process actually runs before reading source as
@@ -1127,6 +1169,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   on their next capture; no bulk repair was run, and the report says so —
   bulk-heal remains an operator option.
 
+
+graduated: bullets 1, 2, 3, 4 and 5 -> docs/sme/entries/2026-08-08-verify-which-tree-the-process-runs-before-reading-source-as-truth.md (domain-backend order 97), enforced by scripts/done-means/646-provider-scope.sh; bullets 6 and 7 -> the same entry's near-miss-discipline and lazy-heal corollaries, and standing contract clause 5 (nothing silent).
+provenance: PR #650.
 ### 2026-08-08 (round 11) — harvest of the #645 conflict lane, the ledger-25 retirement lane (PR #649), and the worker-48 pin failure
 
 - **A recorded ruling is not an implemented one, and the gap is invisible to
@@ -1171,6 +1216,9 @@ Newest first. Every entry: what changed, and the observation that forced it.
   variable in controller/verifier environments or teach the scripts the
   Development default.
 
+
+graduated: bullets 1, 3, 4, 5, 6 and 7 -> docs/sme/entries/2026-08-08-a-recorded-ruling-is-not-an-implemented-one-and-the-gap-is-invisible.md (gotcha-agent order 98), with the retirement half enforced by scripts/done-means/648-capture-gate-retired.sh; bullet 2 -> the same entry's model-pin corollary and _DOCS/MODEL_ROUTING.md (a worker launch pins its own model); bullet 8 -> the same entry's gate-defects section.
+provenance: PR #649; the #645 conflict lane; the worker-48 pin failure.
 ### 2026-08-08 (round 10) — harvest of the #636 neutrality-scrub lanes (PR #645, Sol + Claude continuation)
 
 - **A placeholder only neutralizes a value nothing compares to reality.** A

--- a/docs/sme/adversarial.md
+++ b/docs/sme/adversarial.md
@@ -1063,3 +1063,57 @@ Two adjacent shapes from the same lane:
 - Gate mutation clauses on a proven-green baseline; report INCONCLUSIVE otherwise.
 - Read exit codes from the command itself, never from `PIPESTATUS` evaluated in a different shell.
 - File the anomaly rather than absorbing it. Two runs of the same SHA disagreeing is the flake signal: identical `f0e135c` passed on `push` and failed on `pull_request`, and the local differential on clean `origin/main` versus the branch in separate worktrees (29 pass / 0 fail on both) is what proved it environment-owned. The same-SHA disagreement is the signal; the local differential is the proof.
+
+## [2026-08-08] A negative-match clause can go green off the subject's own error text
+
+**Severity:** HIGH
+**Source:** PRs #668, #669 (#667 bootstrap-continuation lane), Tightenings round 23
+**Scope:** `scripts/done-means/*.sh` announce-assertions; any clause matching prose the subject prints
+**Status:** active
+
+### Pattern
+
+A clause asserted that `lane-bootstrap` announced `already exists`. On the exact run where the script announced NOTHING and died, git's own `fatal: a branch named 'x' already exists` satisfied the match. The clause was green off the crash it was written to catch.
+
+Round-9/17 family, new spelling — and it was caught by round 18's read-WHY rule, not by the tally.
+
+### What to do
+
+- Anchor announce-assertions on a marker the script OWNS — its `[ok]` step prefix, a structured field it emits — never on prose that the failure mode also produces.
+- **When the subject IS a script, resolve the script from the check's OWN tree** (a `BASH_SOURCE`-derived root), so the check structurally cannot reach across trees into a different revision. Make this the default shape for tooling done-means; round 12's which-tree-runs rule, sharpened into a mechanism.
+- **Plant-and-survive on worktree refusals needs the REGISTRY check, not just the directory check.** A created-then-cleaned worktree leaves a `.git/worktrees` registration that a `-d` test alone would miss, so the refusal path reads as untested when it in fact fired.
+
+### Corollary: a summary line hardcoding one path's provenance
+
+`(from origin/main)` became a lie in the same commit that added a continuation path. When you add a branch to a function, search the REPORTING strings, not just the logic — a report that describes only the original path misreports the new one silently, from the first run.
+
+## [2026-08-08] An issue generated from a tool's output inherits that tool's classification errors
+
+**Severity:** HIGH
+**Source:** PR #663 (#661 five-keys lane), operator ruling 29.2a, Tightenings round 20
+**Scope:** issues filed from tool output; `scripts/done-means/661-launcher-honors-six-keys.sh`; launcher env handling
+**Status:** active
+
+### Pattern
+
+#659's drop reporter could not tell set-empty from set-valued, so its boot line named a PROHIBITED key, and the resulting ruling said "honor all six." A lane that simply obeyed would have shipped a change the source forbids.
+
+The lane validated each enumerated key against source, found the prohibition (`PROHIBITED_PATH_KEYS`, test-pinned), HELD AT PROVEN RED, and escalated with options rather than obeying or silently deviating. The operator amended the ruling.
+
+This is the no-variations rule's DESIGNED behavior. Brief it as the expectation, not as an exception a lane has to be brave to take.
+
+### What to do
+
+- Treat a briefed enumeration derived from tool output as a hypothesis. Validate each element against source before building on it.
+- Hold at proven RED and escalate with options. Never obey a briefing the source contradicts, and never deviate quietly.
+- **Empty-means-suppressed is repo precedent** (`QMD_PATH=`). A drop reporter distinguishes unset / set-empty / set-valued and SKIPS explicit suppressions rather than announcing them — a per-suppression boot line is exactly the noise the #659 scope rule exists to prevent.
+
+### Corollary: report equivalent mutants as equivalent, not as kills
+
+A survived mutant (`=== ""` versus `!configured` behind an undefined-guard) was provably UNREACHABLE, not a check gap. The first instinct — "fix" the check — would have shipped a false rationale into the repo.
+
+A survived mutant deserves the same why-analysis as a failed clause.
+
+### Corollary: prove new tests execute
+
+Assert the test COUNT went up (14 to 19). A green suite may simply never have loaded the new file, and green-because-absent is indistinguishable from green-because-passing at the summary line.

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -2179,3 +2179,138 @@ The second half compounded it. The wrong claim was made once from a bad search a
 - Verify "pre-existing" by stashing and re-running, not by asserting. The #609 full-suite differential applies cheaply at any scale.
 - An outage path is testable without an outage: a closed port in 7100-7199 yields a real connection refusal with no waiting and no wall-clock assertion. Reusable for any gate distinguishing unreachable from empty.
 - Wall-clock assertions (`toBeLessThan(1000)` ms) are CI flake generators — three runs produced three different unrelated timing failures, all proven main-owned via the #609 differential and filed (#632, #634) instead of absorbed.
+
+## [2026-08-08] Extract the clause from the real file by markers, and prove the prover
+
+**Severity:** HIGH
+**Source:** PR #653 final-sync lane (clause-e residue edit), Tightenings round 25
+**Scope:** `scripts/done-means/*.sh` and their `.driver.ts`; any check that exercises a fragment of a larger gate
+**Status:** active
+
+### Pattern
+
+When a gate has no clause-level seam, the tempting move is to retype the clause into the driver. A retyped copy proves the COPY. The gate can drift one character and the check keeps reporting on text nobody ships.
+
+Extract the clause from the real file by markers instead — and then the extractor becomes the new place a vacuous green hides.
+
+### What to do
+
+- **Extract, never retype.** Pull the clause out of the shipped file by START/END markers so the check reads the same bytes the gate runs.
+- **Fail hard on empty or unrecognisable extraction.** "0 lines extracted, all cases as expected" is a vacuous green: the extractor found nothing and the comparison loop ran zero times.
+- **Gate the END pattern on the state variable** (`on &&`). An END regex that also matches EARLIER than START turns the block off before it turns on, and silently yields nothing — the same vacuous green by a different route.
+- **Prove the prover.** "All cases behaved as expected" is a claim about the AUTHOR'S expectations until one deliberate driver mutation (`elif false`) makes the harness report MISMATCH. Until that run exists, an expectation table that agrees with itself is indistinguishable from one that compares nothing.
+
+### Corollary: zero has two meanings and a receipt has three worlds
+
+`rows=0` means both "clean" and "never looked." A companion `checked` field, read SEPARATELY, is mandatory.
+
+And a receipt MISSING the field entirely is a THIRD world that must ERROR, never default. Defaulting it means a stale pre-fix receipt — written before the field existed — silently satisfies the very clause added to read it.
+
+## [2026-08-08] A driver that implements a changing interface can repair the defect it exposes
+
+**Severity:** HIGH
+**Source:** PR #673 (#671 verdict-channel lane), Tightenings round 24
+**Scope:** `scripts/done-means/*.driver.ts` where the driver implements an interface the fix changes; residue and leak readers
+**Status:** active
+
+### Pattern
+
+The #671 driver returned only the POST-fix shape. Handed to the pre-fix gate, that object had no `failed` field, and `undefined > 0` is false — so the broken gate reported PASS and the RED was false.
+
+This is a new spelling of the false-RED family (round 18's broken import, round 22's env mutant): a CONTRACT-SHAPE mismatch that reads as legitimate green rather than as an error.
+
+### What to do
+
+- When a fix changes a driver-implemented signature, return BOTH shapes, and assert the RED went red for the defect's OWN reason — not merely that it went red.
+- **When a fix changes WHICH SIGNAL produces a failure, the control clause must assert the SIGNAL, not the outcome.** "Gate failed" was satisfied pre-fix by the old tally verdict, certifying a mechanism that did not exist yet. Round 9/17's negative-match family, extended.
+- **"Not observed" must fail closed.** A verdict moved onto a query inherits that query's failure modes; unchecked and partially-read readings both fail, or the false-red fix becomes a false-green one.
+
+### Corollary: a residue reader shares the remover's resource list
+
+A residue or leak reader must read the REMOVER'S list of tables, never a parallel copy. Two lists drift, and the drift fails GREEN: the table the purge stops clearing also stops being counted, so the leak becomes invisible at exactly the moment it starts.
+
+Enforce with a unit test asserting the reader names exactly the remover's tables.
+
+### Corollary: a lane that cannot see the live path says so
+
+The #671 lane was constrained away from the live path and could only observe its own stub label. It reported instrumentation shipped, not findings observed, and filed #672 for the real one. "NOT OBSERVED — structurally cannot observe" is a complete, correct answer; a fabricated observation is not.
+
+## [2026-08-08] Stub the boundary; do not extract a helper for observability
+
+**Severity:** HIGH
+**Source:** #666 transport-delegation lane, Tightenings round 22
+**Scope:** `scripts/done-means/*.sh` where the defect is "what does X pass across a boundary"; `src/transport.ts`, provider spawn paths
+**Status:** active
+
+### Pattern
+
+When the defect is "what does X pass to the boundary," extracting a helper (`buildProviderEnv()`) to make the value observable invents a SEAM, and the check then proves the seam instead of the real call site. That is the same gap class that let #655's stubbed green miss #666 entirely.
+
+Monkeypatch the BOUNDARY instead. The existing repo convention is `Bun.spawn` monkeypatching (`src/tools/__tests__/search-all.test.ts:85`): the SHIPPED method runs unmodified while the check reads what the real spawn actually received.
+
+### What to do
+
+- Stub at the boundary the code already crosses; do not create a new one for the check's convenience.
+- **A single-key presence assertion most needs a mutant, and an ENV-level mutant beats a source-level one.** Stripping the key from the OBSERVED env keeps RED regenerable forever with the fix in place — round 16's SKIP-flag idea in its env spelling.
+- Report what the mutant proves honestly: the clause reads that key and fails on its absence. Not more.
+
+### Corollary: an empty search result is neither permission nor a defect
+
+The design-lookup gate's window EXPIRES mid-lane by plain time decay — distinct from round 20's sibling-contention shape. Long lanes get gated twice on unrelated writes.
+
+When a legitimate lookup returns nothing, declare UNVERIFIED and source the convention elsewhere (`git log` is the standing fallback). And distinguish the two empties: fast-and-explicit "No results found" is a genuine miss, while empty output after a 120s+ hang is DID-NOT-RUN. Treating the second as the first is how a lane records a lookup it never performed.
+
+## [2026-08-08] `includes()` on a raw log line is a substring match, and every superset satisfies it
+
+**Severity:** HIGH
+**Source:** #656 observer-wiring lane, Tightenings round 17
+**Scope:** `scripts/done-means/656-capture-observer-wired.sh` and any clause reading structured logs as text
+**Status:** active
+
+### Pattern
+
+`includes("<event_name>")` against a raw log line matches every SUPERSET of that name. A renamed event (`x_MUTED`) kept two clauses green — the clause passed both when the notice existed AND when it had been renamed away.
+
+Round-9 negative-match family, new spelling.
+
+### What to do
+
+- Parse the line and compare the `msg` field for EQUALITY (`findEvent()`), then mutation-test the rename to prove the clause discriminates.
+- **A "loud on absence" claim asserts BOTH halves in ONE clause** — loud in the log AND quiet in the health verdict. Split into two clauses and each half passes for the wrong reason: silence-on-absence is the status quo, and a verdict-on-absence violates absence-is-not-staleness. Two audiences, one clause.
+
+### Corollary: record gate paybacks as deliberately as gate taxes
+
+The design-lookup gate fired on the exact edit where the lane was about to hand-roll shutdown teardown in a catch block. The surfaced doc showed `backgroundRuntimes` already owns ordered shutdown, and the delta collapsed to one runtime registration instead of a whole new mechanism.
+
+If only the TAXES get recorded, the ledger only ever argues for retirement.
+
+### Corollary: two CI runs of one identical SHA
+
+The `push` and `pull_request` workflows both run `check` on the same commit, so every PR gets a two-runs-same-SHA comparison for free. Use it before concluding a branch defect — #643's shape recurred and was settled this way.
+
+### Corollary: empty after a timeout is DID-NOT-RUN
+
+`aqmd search` returning EMPTY after a 120s+ timeout is worse than slow: it reads as "no results." Wrap it in `timeout` AND treat empty output as did-not-run; `qmd search` direct is the roughly one-second fallback.
+
+## [2026-08-08] RED by breaking the import is a false RED — use a SKIP flag
+
+**Severity:** HIGH
+**Source:** #655 eval-teardown lane, Tightenings round 16
+**Scope:** `scripts/done-means/655-eval-teardown.sh` and every check whose RED must stay regenerable after the fix ships
+**Status:** active
+
+### Pattern
+
+Moving a module aside to produce RED killed the driver AT IMPORT. Clause (a) measured nothing, and the transcript was indistinguishable from a real RED.
+
+A `SKIP_*` env flag reproduces the pre-fix world with everything else intact, and keeps RED regenerable FOREVER without deleting the fix.
+
+### What to do
+
+- Reproduce the pre-fix world by an env flag the shipped code reads, not by damaging the module graph.
+- **A guard needs a CANARY, not just an exception.** "Throws on a bad name" and "refuses BEFORE mutating" are different claims. Only planting a row under each refused name and checking it SURVIVES distinguishes them — an exception thrown after the mutation looks identical from the outside.
+- **Assert a row COUNT from OUTSIDE the run.** A teardown that reports success is not evidence of removal: the RED run showed `failed=0` while two rows leaked, because the tally is the thing under test and can never be its own proof.
+
+### Corollary: the design-lookup window is session-scoped, not lane-scoped
+
+A sibling CONCURRENT lane's lookup can occupy the recent-lookup window and make a correct denial look spurious. The gate is working as designed. Know the shape before reporting it as a misfire — a false gate-defect report costs the operator loop more than the denial cost the lane.

--- a/docs/sme/domain-backend.md
+++ b/docs/sme/domain-backend.md
@@ -783,3 +783,107 @@ Reusable review check for any queue/sweep design: name the producer explicitly. 
 Verbatim, from the source:
 
 > `src/maintenance-bootstrap.ts` states it as intent, not accident: "The bootstrap enqueues nothing and defines no recurring sweep: the maintenance runner is a consumer." So the runner consumes a queue that no producer fills.
+
+## [2026-08-08] A prefix-scoped SQL DELETE of provable test residue is the lane's to run
+
+**Severity:** MEDIUM
+**Source:** operator ruling 2026-08-08 (ledger item 31), Tightenings round 26
+**Scope:** `scripts/done-means/*.sh` teardown clauses, eval and fixture cleanup, any lane that seeds rows into the dogfood database
+**Status:** active
+
+### Pattern
+
+Lanes seed rows and then hesitate to remove them, reading the unconditional no-`rm` rule as covering the database. It does not. The operator ruling is explicit: "It's a database, not an RM-RF" — the filesystem rule governs the FILESYSTEM and is unchanged.
+
+A lane may DELETE rows it can PROVE are its own test residue, scoped by a prefix it created.
+
+### What to do
+
+- Prove ownership first: the rows sit under a prefix the lane itself wrote, not merely a prefix that looks test-shaped.
+- Count before. Delete in ONE transaction, children before parents. Verify zero after. Announce all three counts in the report — a silent cleanup is the adjusted-silently failure in a different costume.
+- Rows of uncertain provenance, user data, and anything outside a provably-test prefix stay REPORT-ONLY. Name them in the report and let the operator decide.
+- In this schema a namespace is an emergent property of its rows: there is no registry table, so `archive_entry` soft-delete can never retire one. Twenty-four archived-only eval namespaces are what that looks like after months of teardown that only soft-deleted.
+
+### Why it matters
+
+A teardown that reports success is not evidence of removal — the tally is the thing under test, never the proof. Assert a row COUNT read from OUTSIDE the run, and the count is what the DELETE clause exists to drive to zero.
+
+## [2026-08-08] A revision proof is not a feature-live proof
+
+**Severity:** HIGH
+**Source:** PR #660 (#659 launcher-env lane) and the controller-side discovery, Tightenings round 18
+**Scope:** deploys to core01 and the local clone; launcher env allowlists; `scripts/done-means/659-launcher-env-passthrough.sh`
+**Status:** active
+
+### Pattern
+
+The clone redeploy PASSED its revision proof at the right SHA while the merged feature stayed DARK: the launcher's env allowlist dropped the new config keys. #659 exists because the two were conflated for about ten minutes.
+
+After any deploy meant to light up a feature, read the FEATURE'S OWN signal — a `/health` block, a log event — never just the revision.
+
+### What to do
+
+- **When a merged feature fails in deployment, ask which SEAM the passing check could not see.** #656's done-means drove `createShadowApplication` directly, so the entire launcher spawn chain sat outside its vantage. The check was honest about its seam, and the seam was exactly where the defect lived. Chain-level clauses driving the real launcher through its injected boundaries were cheap, and were the ONLY ones that reproduced the live symptom.
+- **An env allowlist between launcher and child is a standing drop hazard** — third instance of the class (#530 tracing, then `AUTH_TOKEN_USER_`, now capture-health). The fix is ANNOUNCE-ON-DROP, not abolishing the allowlist: six more silently-dropped configured keys surfaced the moment drops became visible.
+- **A done-means check for a NEW export must import it DYNAMICALLY.** A static import at the pre-fix tree dies at module resolution before any clause prints — a false RED identical in shape to a real one, reached by the ORDINARY act of writing a check for a function that does not exist yet. This is the default path, not an edge case.
+- **A scope rule needs both halves in ONE clause, and only a mutation proves it.** "Ambient vars NOT announced AND configured key IS" was the only clause that caught an announce-everything filter. An unscoped drop report is boot noise an operator learns to skip — silence with extra steps. Companion rule: a drop report names KEYS, never values, because the dropped set contains secrets in the general case.
+- **Read WHY each RED clause failed, not just the tally.** Three fixture defects (WAL path, clone root, `QMD_PATH`) failed IDENTICALLY to the defect under test at the shell. A false RED banks confidence in a check that measured nothing.
+- **Suspect your own formatting before a known gate defect.** #641 being real made it the attractive explanation for a validator refusal that was in fact the lane's own backticks-in-a-field-value. Reading the validator's five lines of path resolution beat another workaround attempt.
+
+### Self-reported violation, harvested not punished
+
+A reflexive bare `rm -rf` — argument-less, deleted nothing, its error swallowed by `2>/dev/null` — ran inside an otherwise-correct clean-clone command. The reflex fires INSIDE correct compound commands, which is precisely why the ban is unconditional, and why `2>/dev/null` on a cleanup step deserves suspicion on sight.
+
+## [2026-08-08] A "compose it" lane must ask what the composer can actually see
+
+**Severity:** HIGH
+**Source:** #652 capture-health composition lane, Tightenings round 14
+**Scope:** `/health` inputs, `server/main.ts` composition, `scripts/done-means/652-capture-health-composed.sh`
+**Status:** active
+
+### Pattern
+
+The reader wanted watermark bytes and spool depth — client-side per-hook files a SERVER cannot enumerate. Passing an honest-looking `0` for an unobservable count is not neutral: zero-while-sessions-ran IS the wedged fault, so a hardcoded zero would degrade EVERY healthy deployment into a permanent false alarm.
+
+Substitute a value that preserves the PROPERTY (turns arriving is approximately watermark advancing), and publish which faults the vantage point can actually raise. Round 10's TEST-NET lesson in the counts domain.
+
+### What to do
+
+- **A per-role check must SEED the expected roles before folding rows.** `GROUP BY role` returns no group for the dead speaker — the exact entity the check exists to find. A fold over returned rows reports a busy lane and rebuilds #447.
+- **Late-binding needs its own clause.** Two requests against one composed app, with the observation CHANGED between them, was the only clause that caught a boot-captured reading. Any health input composed as a closure carries this clause.
+- **A type added for a future composer is exported at the boundary in the SAME PR.** `tsc` found #648's `TransportCaptureHealth` declared but never barrel-exported — invisible until the first composer tried to import it.
+
+### Corollary: declare your own remaining gap
+
+A WRITTEN-not-RUNNING declaration that names its own missing piece makes the NEXT lane cheap. #648's residual-risk field pointed straight at the composition root, and this lane declared its own gap the same way — `server/main.ts` wiring awaiting an operator config ruling on namespace, window, and refresh cadence.
+
+Hardcoding defaults to satisfy a dispatch expectation would have been the adjusted-silently failure.
+
+## [2026-08-08] Verify which tree the process runs before reading source as truth
+
+**Severity:** HIGH
+**Source:** PR #650 (#646 provider-scope lane), Tightenings round 12
+**Scope:** any lane reasoning about live behavior; `src/` versus `server/main.ts`; `package.json` `start`
+**Status:** active
+
+### Pattern
+
+The lane reasoned about correct-looking code in `src/` while the service was in fact running `server/main.ts`. One call answers it — `lsof -nP -iTCP:<port>` plus `ps -o command` — and `package.json`'s `start` STILL points at the non-serving tree.
+
+A source file that contradicts observed behavior is evidence you are reading the WRONG FILE, not evidence of a mystery.
+
+### What to do
+
+- Resolve the serving tree before treating any source file as the explanation for a live symptom.
+- **A done-means fixture encodes a world-assumption that can be wrong in EITHER direction — query the real distribution before inventing a fixture shape.** The lane's first fixture seeded a conflicting `agent` and read the server's contract-CORRECT refusal as a failure; it nearly "fixed" correct code. All 2011 real lanes carried the matching agent.
+- **A shared test resource closed by an earlier suite's `afterAll` fakes a red.** Distinguish by ASSERTION COUNT: 23 assertions executing means the subject failed; a harness error executes near zero.
+- **`git stash push` on already-committed work stashes NOTHING**, and the follow-up pop grabs someone else's stash. Read the stash output before popping. Second foreign-stash incident; the first was #624.
+- **A live-service-bound receipt is not portable.** A check proving behavior against `127.0.0.1:3100` at revision X proves nothing about any other host or revision, and goes stale on redeploy. Name the binding IN the receipt.
+
+### Corollary: near-miss discipline runs both directions
+
+A phantom finding (a nonexistent import) was re-checked and RETRACTED before reporting. A wrong fixture was corrected and RED re-proven against the pre-fix revision. Both belong in the report — they are the report's job, not its shame.
+
+### Corollary: lazy-heal is a decision, not a default
+
+2011 scope-broken lanes heal on their next capture. No bulk repair was run, and the report SAYS so — bulk-heal remains an operator option rather than a silently-taken default.

--- a/docs/sme/entries/2026-08-08-a-compose-it-lane-must-ask-what-the-composer-can-actually-see.md
+++ b/docs/sme/entries/2026-08-08-a-compose-it-lane-must-ask-what-the-composer-can-actually-see.md
@@ -1,0 +1,28 @@
+---
+lane: domain-backend
+order: 95
+---
+## [2026-08-08] A "compose it" lane must ask what the composer can actually see
+
+**Severity:** HIGH
+**Source:** #652 capture-health composition lane, Tightenings round 14
+**Scope:** `/health` inputs, `server/main.ts` composition, `scripts/done-means/652-capture-health-composed.sh`
+**Status:** active
+
+### Pattern
+
+The reader wanted watermark bytes and spool depth — client-side per-hook files a SERVER cannot enumerate. Passing an honest-looking `0` for an unobservable count is not neutral: zero-while-sessions-ran IS the wedged fault, so a hardcoded zero would degrade EVERY healthy deployment into a permanent false alarm.
+
+Substitute a value that preserves the PROPERTY (turns arriving is approximately watermark advancing), and publish which faults the vantage point can actually raise. Round 10's TEST-NET lesson in the counts domain.
+
+### What to do
+
+- **A per-role check must SEED the expected roles before folding rows.** `GROUP BY role` returns no group for the dead speaker — the exact entity the check exists to find. A fold over returned rows reports a busy lane and rebuilds #447.
+- **Late-binding needs its own clause.** Two requests against one composed app, with the observation CHANGED between them, was the only clause that caught a boot-captured reading. Any health input composed as a closure carries this clause.
+- **A type added for a future composer is exported at the boundary in the SAME PR.** `tsc` found #648's `TransportCaptureHealth` declared but never barrel-exported — invisible until the first composer tried to import it.
+
+### Corollary: declare your own remaining gap
+
+A WRITTEN-not-RUNNING declaration that names its own missing piece makes the NEXT lane cheap. #648's residual-risk field pointed straight at the composition root, and this lane declared its own gap the same way — `server/main.ts` wiring awaiting an operator config ruling on namespace, window, and refresh cadence.
+
+Hardcoding defaults to satisfy a dispatch expectation would have been the adjusted-silently failure.

--- a/docs/sme/entries/2026-08-08-a-driver-that-implements-a-changing-interface-can-repair-the-defect-it-exposes.md
+++ b/docs/sme/entries/2026-08-08-a-driver-that-implements-a-changing-interface-can-repair-the-defect-it-exposes.md
@@ -1,0 +1,32 @@
+---
+lane: correctness
+order: 85
+---
+## [2026-08-08] A driver that implements a changing interface can repair the defect it exposes
+
+**Severity:** HIGH
+**Source:** PR #673 (#671 verdict-channel lane), Tightenings round 24
+**Scope:** `scripts/done-means/*.driver.ts` where the driver implements an interface the fix changes; residue and leak readers
+**Status:** active
+
+### Pattern
+
+The #671 driver returned only the POST-fix shape. Handed to the pre-fix gate, that object had no `failed` field, and `undefined > 0` is false — so the broken gate reported PASS and the RED was false.
+
+This is a new spelling of the false-RED family (round 18's broken import, round 22's env mutant): a CONTRACT-SHAPE mismatch that reads as legitimate green rather than as an error.
+
+### What to do
+
+- When a fix changes a driver-implemented signature, return BOTH shapes, and assert the RED went red for the defect's OWN reason — not merely that it went red.
+- **When a fix changes WHICH SIGNAL produces a failure, the control clause must assert the SIGNAL, not the outcome.** "Gate failed" was satisfied pre-fix by the old tally verdict, certifying a mechanism that did not exist yet. Round 9/17's negative-match family, extended.
+- **"Not observed" must fail closed.** A verdict moved onto a query inherits that query's failure modes; unchecked and partially-read readings both fail, or the false-red fix becomes a false-green one.
+
+### Corollary: a residue reader shares the remover's resource list
+
+A residue or leak reader must read the REMOVER'S list of tables, never a parallel copy. Two lists drift, and the drift fails GREEN: the table the purge stops clearing also stops being counted, so the leak becomes invisible at exactly the moment it starts.
+
+Enforce with a unit test asserting the reader names exactly the remover's tables.
+
+### Corollary: a lane that cannot see the live path says so
+
+The #671 lane was constrained away from the live path and could only observe its own stub label. It reported instrumentation shipped, not findings observed, and filed #672 for the real one. "NOT OBSERVED — structurally cannot observe" is a complete, correct answer; a fabricated observation is not.

--- a/docs/sme/entries/2026-08-08-a-guard-written-as-present-and-wrong-leaves-the-absent-branch-unguarded.md
+++ b/docs/sme/entries/2026-08-08-a-guard-written-as-present-and-wrong-leaves-the-absent-branch-unguarded.md
@@ -1,0 +1,30 @@
+---
+lane: security
+order: 90
+---
+## [2026-08-08] A guard written as "present AND wrong" leaves the absent branch unguarded
+
+**Severity:** HIGH
+**Source:** PR #664 (#662 validator lane), the #653 credentialed verify, Tightenings round 19
+**Scope:** `src/` validators and scope guards; `scripts/done-means/662-absent-namespace-scope-proof.sh`
+**Status:** active
+
+### Pattern
+
+A guard spelled "key present AND value wrong" never runs for the ABSENT case — and the absent branch inherits the exact dead end the guard was added to remove. #654 and #662 are ONE defect on two sides of one `if`.
+
+### What to do
+
+- When a fix special-cases a key, ENUMERATE the key's states — present-correct, present-wrong, absent — and say in the check header which branch handles each. A state you cannot name is a state nothing guards.
+- **"The server always sends it" is not a reason to leave a validator's hostile-input branch dead-ended.** The lane object is the untrusted thing being validated. The dispatch's server-side hypothesis was reasonable and wrong; one live `tools/call` plus reading the column lists settled it in minutes. A lane rejects a briefed hypothesis ON EVIDENCE and writes the reasoning into the check header — never decides silently.
+- **Absence and mismatch need DIFFERENT messages, because only one has a remedy.** Reusing the delegation advice for the absent case would pass a naive "mentions namespace" assertion while remaining a dead end with more words. Clauses assert what the message SAYS, not that a message exists.
+
+### Corollary: `rg -r` is the REPLACE flag, not recursive
+
+It silently emits mangled replacement text that reads as a single real hit. It joins the `rg -E` family: the failure mode is a plausible-looking WRONG ANSWER, not an error, which is why neither is caught by checking the exit code.
+
+### Corollary: a gate that keeps failing on real defects is doing its job
+
+The #578 gate's first credentialed run found the THIRD live defect in the very path it composes (#654's absent-case sibling). Resist reading a red gate as a broken gate: the verifier re-ran the fixed defects' own checks live, proved them fixed, and only then attributed the new failure.
+
+Also observed: a per-run tally can UNDER-report entity creation — `attempted=1` while two namespaces appeared. Count the entities, not the attempts.

--- a/docs/sme/entries/2026-08-08-a-live-service-check-reads-the-serving-processs-credentials.md
+++ b/docs/sme/entries/2026-08-08-a-live-service-check-reads-the-serving-processs-credentials.md
@@ -1,0 +1,36 @@
+---
+lane: security
+order: 94
+---
+## [2026-08-08] A live-service check reads the serving process's credentials, never the checkout's
+
+**Severity:** HIGH
+**Source:** PR #657 (#654 namespace-scope lane) and its verify run, Tightenings round 15
+**Scope:** `scripts/done-means/654-namespace-scope-proof.sh`, live-service clauses, `python/openbrain-memory` delegation
+**Status:** active
+
+### Pattern
+
+The repo `.env` has carried an empty `AUTH_TOKEN_ADMIN` since the #645 scrub, so a check built on it 401s BY DESIGN — and the transcript reads as a service fault.
+
+Round 12's which-tree-runs rule, extended to IDENTITY: name where the credential comes from in the check header, and refuse LOUDLY when it is absent instead of falling through to a misleading auth failure.
+
+### Corollary: a security control is unproven until something REQUESTS the dangerous thing
+
+The server role-gates `X-Namespace`, but the Python client had `delegate_namespace=False` hardcoded since #294 — the header was never sent, so the 403 path had NEVER executed in any run. A refusal branch that has never refused is decoration.
+
+The done-means now sends the forbidden request and asserts both the refusal (clause c) and that the refusal NAMES the actionable cause (clause d).
+
+### Corollary: silent-default identity is tenant mis-scope, not cosmetics
+
+With delegation hardcoded off, every delegated-intent session landed in namespace `admin` — a real cross-tenant landing, STRONGER than the issue as filed.
+
+Any config key that selects identity is REQUIRED config: loud on absence, never silently defaulted (ledger item 28).
+
+### Corollary: errors must name what the caller can change
+
+#646 (scope errors naming response vocabulary the validator rejects) and #654 (a silent wrong-namespace landing with no signal at all) are the same dead-end-error defect at different volumes. A refusal that does not name the acting cause, and a mis-scope that says nothing, both strand the caller. Checks assert the error TEXT, not just the status.
+
+### Corollary: a red anchor that inverts at the fix must be bound to the PR head
+
+Clause (a)'s PASS proves the fix ONLY because verify-lane pinned the worktree to the head SHA and re-read it after the run (`recheck-head`). Any check whose RED lives on main and whose GREEN lives on the branch inherits this binding requirement — without it, the inversion could come from either tree.

--- a/docs/sme/entries/2026-08-08-a-negative-match-clause-can-go-green-off-the-subjects-own-error-text.md
+++ b/docs/sme/entries/2026-08-08-a-negative-match-clause-can-go-green-off-the-subjects-own-error-text.md
@@ -1,0 +1,26 @@
+---
+lane: adversarial
+order: 86
+---
+## [2026-08-08] A negative-match clause can go green off the subject's own error text
+
+**Severity:** HIGH
+**Source:** PRs #668, #669 (#667 bootstrap-continuation lane), Tightenings round 23
+**Scope:** `scripts/done-means/*.sh` announce-assertions; any clause matching prose the subject prints
+**Status:** active
+
+### Pattern
+
+A clause asserted that `lane-bootstrap` announced `already exists`. On the exact run where the script announced NOTHING and died, git's own `fatal: a branch named 'x' already exists` satisfied the match. The clause was green off the crash it was written to catch.
+
+Round-9/17 family, new spelling — and it was caught by round 18's read-WHY rule, not by the tally.
+
+### What to do
+
+- Anchor announce-assertions on a marker the script OWNS — its `[ok]` step prefix, a structured field it emits — never on prose that the failure mode also produces.
+- **When the subject IS a script, resolve the script from the check's OWN tree** (a `BASH_SOURCE`-derived root), so the check structurally cannot reach across trees into a different revision. Make this the default shape for tooling done-means; round 12's which-tree-runs rule, sharpened into a mechanism.
+- **Plant-and-survive on worktree refusals needs the REGISTRY check, not just the directory check.** A created-then-cleaned worktree leaves a `.git/worktrees` registration that a `-d` test alone would miss, so the refusal path reads as untested when it in fact fired.
+
+### Corollary: a summary line hardcoding one path's provenance
+
+`(from origin/main)` became a lie in the same commit that added a continuation path. When you add a branch to a function, search the REPORTING strings, not just the logic — a report that describes only the original path misreports the new one silently, from the first run.

--- a/docs/sme/entries/2026-08-08-a-prefix-scoped-sql-delete-of-provable-test-residue-is-the-lanes-to-run.md
+++ b/docs/sme/entries/2026-08-08-a-prefix-scoped-sql-delete-of-provable-test-residue-is-the-lanes-to-run.md
@@ -1,0 +1,27 @@
+---
+lane: domain-backend
+order: 83
+---
+## [2026-08-08] A prefix-scoped SQL DELETE of provable test residue is the lane's to run
+
+**Severity:** MEDIUM
+**Source:** operator ruling 2026-08-08 (ledger item 31), Tightenings round 26
+**Scope:** `scripts/done-means/*.sh` teardown clauses, eval and fixture cleanup, any lane that seeds rows into the dogfood database
+**Status:** active
+
+### Pattern
+
+Lanes seed rows and then hesitate to remove them, reading the unconditional no-`rm` rule as covering the database. It does not. The operator ruling is explicit: "It's a database, not an RM-RF" — the filesystem rule governs the FILESYSTEM and is unchanged.
+
+A lane may DELETE rows it can PROVE are its own test residue, scoped by a prefix it created.
+
+### What to do
+
+- Prove ownership first: the rows sit under a prefix the lane itself wrote, not merely a prefix that looks test-shaped.
+- Count before. Delete in ONE transaction, children before parents. Verify zero after. Announce all three counts in the report — a silent cleanup is the adjusted-silently failure in a different costume.
+- Rows of uncertain provenance, user data, and anything outside a provably-test prefix stay REPORT-ONLY. Name them in the report and let the operator decide.
+- In this schema a namespace is an emergent property of its rows: there is no registry table, so `archive_entry` soft-delete can never retire one. Twenty-four archived-only eval namespaces are what that looks like after months of teardown that only soft-deleted.
+
+### Why it matters
+
+A teardown that reports success is not evidence of removal — the tally is the thing under test, never the proof. Assert a row COUNT read from OUTSIDE the run, and the count is what the DELETE clause exists to drive to zero.

--- a/docs/sme/entries/2026-08-08-a-recorded-ruling-is-not-an-implemented-one-and-the-gap-is-invisible.md
+++ b/docs/sme/entries/2026-08-08-a-recorded-ruling-is-not-an-implemented-one-and-the-gap-is-invisible.md
@@ -1,0 +1,36 @@
+---
+lane: gotcha-agent
+order: 98
+---
+## [2026-08-08] A recorded ruling is not an implemented one, and the gap is invisible
+
+**Severity:** HIGH
+**Source:** PR #649 (ledger-25 retirement lane), the #645 conflict lane, the worker-48 pin failure; Tightenings round 11
+**Scope:** `docs/issue-graph.md` ledger items, `scripts/done-means/648-capture-gate-retired.sh`, merge procedure, model-pinned dispatch
+**Status:** active
+
+### Pattern
+
+Ledger item 25 retired the capture gate. `main` kept it REGISTERED, and nothing failed — because no check asserted the retirement, and every check predating the ruling is structurally blind to it.
+
+A ruling that retires a mechanism needs its OWN done-means check on the same pass, or the ledger and the tree drift silently and neither side reports it.
+
+### What to do
+
+- **A conflict-free merge is not a clean merge.** A merge is a fresh RED opportunity for every gate the branch owns: the neutrality gate caught a literal #642 introduced AFTER the branch cut — correct on each side, wrong only in combination. Re-run the branch's own checks AFTER merging the upstream default branch.
+- **A generated file in conflict is REGENERATED, never hand-merged.** The conflict lives in the inputs and usually is not one at all (the SME index rebuilt from entries; both sides' entries survived).
+- **Inverting a done-means clause needs its own RED**, extending round 9's rewritten-clause rule. And **retired-versus-deleted must be distinguished BY THE CHECK** — the 451 clauses now fail loudly if a cleanup deletes the #647 prior art instead of retiring it.
+- **A hook-set assertion needs both directions.** "None missing" passes happily while a sixth hook creeps in; the "none extra" half is what catches config drift.
+- **`FETCH_HEAD` is per-worktree** — fetch inside the worktree you merge in.
+
+### Corollary: a model pin does not bind through direct Agent dispatch
+
+The lane self-reported `claude-fable-5` — the HEAD's model — despite the agent definition pinning `claude-opus-4-8`. Requested-model provenance recorded what was ASKED, not what ANSWERED: the ledger-18 provenance warning, proven live.
+
+The A/B comparison therefore had ZERO valid 4.8 samples. Model-pinned dispatch must go through the route that actually PLACES the model.
+
+### Gate defects and announced adjustments
+
+The git guard fires on the word "main" in commit-message PROSE on a correctly-named branch — say "the default branch"; the guard should read `git branch --show-current`. The design-lookup gate fires on a gitignored scratch PR-body file. The PRE-PUSH hook runs the suite against the shared dogfood database — the exact inadmissible path of the #614 ruling (1 fail then 0 fail on an identical tree, skip counts 485 apart). `aqmd search` can exceed 120s; wrap it in `timeout`.
+
+Announced by tooling and needing a home: verify-lane and lane-bootstrap print `ADJUSTED: neither OPENBRAIN_TEMP_WORKSPACE nor DEV_TMP is set` and place worktrees under `~/.cache` instead of the configured temp workspace. Set the variable in controller and verifier environments, or teach the scripts the Development default.

--- a/docs/sme/entries/2026-08-08-a-revision-proof-is-not-a-feature-live-proof.md
+++ b/docs/sme/entries/2026-08-08-a-revision-proof-is-not-a-feature-live-proof.md
@@ -1,0 +1,29 @@
+---
+lane: domain-backend
+order: 91
+---
+## [2026-08-08] A revision proof is not a feature-live proof
+
+**Severity:** HIGH
+**Source:** PR #660 (#659 launcher-env lane) and the controller-side discovery, Tightenings round 18
+**Scope:** deploys to core01 and the local clone; launcher env allowlists; `scripts/done-means/659-launcher-env-passthrough.sh`
+**Status:** active
+
+### Pattern
+
+The clone redeploy PASSED its revision proof at the right SHA while the merged feature stayed DARK: the launcher's env allowlist dropped the new config keys. #659 exists because the two were conflated for about ten minutes.
+
+After any deploy meant to light up a feature, read the FEATURE'S OWN signal — a `/health` block, a log event — never just the revision.
+
+### What to do
+
+- **When a merged feature fails in deployment, ask which SEAM the passing check could not see.** #656's done-means drove `createShadowApplication` directly, so the entire launcher spawn chain sat outside its vantage. The check was honest about its seam, and the seam was exactly where the defect lived. Chain-level clauses driving the real launcher through its injected boundaries were cheap, and were the ONLY ones that reproduced the live symptom.
+- **An env allowlist between launcher and child is a standing drop hazard** — third instance of the class (#530 tracing, then `AUTH_TOKEN_USER_`, now capture-health). The fix is ANNOUNCE-ON-DROP, not abolishing the allowlist: six more silently-dropped configured keys surfaced the moment drops became visible.
+- **A done-means check for a NEW export must import it DYNAMICALLY.** A static import at the pre-fix tree dies at module resolution before any clause prints — a false RED identical in shape to a real one, reached by the ORDINARY act of writing a check for a function that does not exist yet. This is the default path, not an edge case.
+- **A scope rule needs both halves in ONE clause, and only a mutation proves it.** "Ambient vars NOT announced AND configured key IS" was the only clause that caught an announce-everything filter. An unscoped drop report is boot noise an operator learns to skip — silence with extra steps. Companion rule: a drop report names KEYS, never values, because the dropped set contains secrets in the general case.
+- **Read WHY each RED clause failed, not just the tally.** Three fixture defects (WAL path, clone root, `QMD_PATH`) failed IDENTICALLY to the defect under test at the shell. A false RED banks confidence in a check that measured nothing.
+- **Suspect your own formatting before a known gate defect.** #641 being real made it the attractive explanation for a validator refusal that was in fact the lane's own backticks-in-a-field-value. Reading the validator's five lines of path resolution beat another workaround attempt.
+
+### Self-reported violation, harvested not punished
+
+A reflexive bare `rm -rf` — argument-less, deleted nothing, its error swallowed by `2>/dev/null` — ran inside an otherwise-correct clean-clone command. The reflex fires INSIDE correct compound commands, which is precisely why the ban is unconditional, and why `2>/dev/null` on a cleanup step deserves suspicion on sight.

--- a/docs/sme/entries/2026-08-08-an-issue-generated-from-a-tools-output-inherits-that-tools-classification-errors.md
+++ b/docs/sme/entries/2026-08-08-an-issue-generated-from-a-tools-output-inherits-that-tools-classification-errors.md
@@ -1,0 +1,34 @@
+---
+lane: adversarial
+order: 89
+---
+## [2026-08-08] An issue generated from a tool's output inherits that tool's classification errors
+
+**Severity:** HIGH
+**Source:** PR #663 (#661 five-keys lane), operator ruling 29.2a, Tightenings round 20
+**Scope:** issues filed from tool output; `scripts/done-means/661-launcher-honors-six-keys.sh`; launcher env handling
+**Status:** active
+
+### Pattern
+
+#659's drop reporter could not tell set-empty from set-valued, so its boot line named a PROHIBITED key, and the resulting ruling said "honor all six." A lane that simply obeyed would have shipped a change the source forbids.
+
+The lane validated each enumerated key against source, found the prohibition (`PROHIBITED_PATH_KEYS`, test-pinned), HELD AT PROVEN RED, and escalated with options rather than obeying or silently deviating. The operator amended the ruling.
+
+This is the no-variations rule's DESIGNED behavior. Brief it as the expectation, not as an exception a lane has to be brave to take.
+
+### What to do
+
+- Treat a briefed enumeration derived from tool output as a hypothesis. Validate each element against source before building on it.
+- Hold at proven RED and escalate with options. Never obey a briefing the source contradicts, and never deviate quietly.
+- **Empty-means-suppressed is repo precedent** (`QMD_PATH=`). A drop reporter distinguishes unset / set-empty / set-valued and SKIPS explicit suppressions rather than announcing them — a per-suppression boot line is exactly the noise the #659 scope rule exists to prevent.
+
+### Corollary: report equivalent mutants as equivalent, not as kills
+
+A survived mutant (`=== ""` versus `!configured` behind an undefined-guard) was provably UNREACHABLE, not a check gap. The first instinct — "fix" the check — would have shipped a false rationale into the repo.
+
+A survived mutant deserves the same why-analysis as a failed clause.
+
+### Corollary: prove new tests execute
+
+Assert the test COUNT went up (14 to 19). A green suite may simply never have loaded the new file, and green-because-absent is indistinguishable from green-because-passing at the summary line.

--- a/docs/sme/entries/2026-08-08-ask-whether-the-design-already-exists-and-was-simply-never-run.md
+++ b/docs/sme/entries/2026-08-08-ask-whether-the-design-already-exists-and-was-simply-never-run.md
@@ -1,0 +1,30 @@
+---
+lane: quality
+order: 96
+---
+## [2026-08-08] Ask whether the design already exists and was simply never run
+
+**Severity:** MEDIUM
+**Source:** PR #648 (#647 capture-liveness lane), Tightenings round 13
+**Scope:** every build lane's first move; `docs/decisions/`, `docs/sme/entries/`
+**Status:** active
+
+### Pattern
+
+#647 read as "invent a liveness check." `docs/decisions/capture-never-drops-a-turn.md:182-200` had SPECIFIED it — per-role, count-based — for eleven days, carrying its own record that it "was never run."
+
+"Has this been specified and left unrun?" is the FIRST question of any build lane, not a formality. Here the lookup materially changed the deliverable and avoided rebuilding the #447 per-role blind spot.
+
+### What to do
+
+- Search decisions and SME entries for the thing you are about to invent, BEFORE inventing it. A design that exists and was never executed looks exactly like a design that does not exist, from inside the issue text.
+- **A control clause that passes PRE-fix is the signal the check discriminates.** Ten of thirteen clauses red with the two CONTROLS green is stronger evidence than thirteen of thirteen red: a check that fails everywhere proves only that it fails.
+- **Lanes do not use `git stash` for red/green proofs — file-copy instead.** The stash stack is SHARED even when the worktree is exclusively yours. This was the second lane in one session to pop a foreign stash from a bootstrapped worktree, third incident overall; the round-1 "checkout you don't own" wording under-scoped the hazard.
+
+### Corollary: name the capability state honestly
+
+The liveness reader was MERGED code with no process composing it — no live `/health` reported capture until a composition change shipped. WRITTEN-not-RUNNING, stated in the PR rather than implied away.
+
+### Gate-precision datapoints
+
+The design-lookup gate accepted `aqmd` but refused a direct `sqlite3` query of the same index (#637 corpus). The git guard fired on a protected-branch name inside a MERGE-COMMIT MESSAGE — the fifth shape of #618; say "upstream default branch" in prose instead.

--- a/docs/sme/entries/2026-08-08-extract-the-clause-from-the-real-file-by-markers-and-prove-the-prover.md
+++ b/docs/sme/entries/2026-08-08-extract-the-clause-from-the-real-file-by-markers-and-prove-the-prover.md
@@ -1,0 +1,29 @@
+---
+lane: correctness
+order: 84
+---
+## [2026-08-08] Extract the clause from the real file by markers, and prove the prover
+
+**Severity:** HIGH
+**Source:** PR #653 final-sync lane (clause-e residue edit), Tightenings round 25
+**Scope:** `scripts/done-means/*.sh` and their `.driver.ts`; any check that exercises a fragment of a larger gate
+**Status:** active
+
+### Pattern
+
+When a gate has no clause-level seam, the tempting move is to retype the clause into the driver. A retyped copy proves the COPY. The gate can drift one character and the check keeps reporting on text nobody ships.
+
+Extract the clause from the real file by markers instead — and then the extractor becomes the new place a vacuous green hides.
+
+### What to do
+
+- **Extract, never retype.** Pull the clause out of the shipped file by START/END markers so the check reads the same bytes the gate runs.
+- **Fail hard on empty or unrecognisable extraction.** "0 lines extracted, all cases as expected" is a vacuous green: the extractor found nothing and the comparison loop ran zero times.
+- **Gate the END pattern on the state variable** (`on &&`). An END regex that also matches EARLIER than START turns the block off before it turns on, and silently yields nothing — the same vacuous green by a different route.
+- **Prove the prover.** "All cases behaved as expected" is a claim about the AUTHOR'S expectations until one deliberate driver mutation (`elif false`) makes the harness report MISMATCH. Until that run exists, an expectation table that agrees with itself is indistinguishable from one that compares nothing.
+
+### Corollary: zero has two meanings and a receipt has three worlds
+
+`rows=0` means both "clean" and "never looked." A companion `checked` field, read SEPARATELY, is mandatory.
+
+And a receipt MISSING the field entirely is a THIRD world that must ERROR, never default. Defaulting it means a stale pre-fix receipt — written before the field existed — silently satisfies the very clause added to read it.

--- a/docs/sme/entries/2026-08-08-includes-on-a-raw-log-line-is-a-substring-match-and-every-superset-satisfies-it.md
+++ b/docs/sme/entries/2026-08-08-includes-on-a-raw-log-line-is-a-substring-match-and-every-superset-satisfies-it.md
@@ -1,0 +1,35 @@
+---
+lane: correctness
+order: 92
+---
+## [2026-08-08] `includes()` on a raw log line is a substring match, and every superset satisfies it
+
+**Severity:** HIGH
+**Source:** #656 observer-wiring lane, Tightenings round 17
+**Scope:** `scripts/done-means/656-capture-observer-wired.sh` and any clause reading structured logs as text
+**Status:** active
+
+### Pattern
+
+`includes("<event_name>")` against a raw log line matches every SUPERSET of that name. A renamed event (`x_MUTED`) kept two clauses green — the clause passed both when the notice existed AND when it had been renamed away.
+
+Round-9 negative-match family, new spelling.
+
+### What to do
+
+- Parse the line and compare the `msg` field for EQUALITY (`findEvent()`), then mutation-test the rename to prove the clause discriminates.
+- **A "loud on absence" claim asserts BOTH halves in ONE clause** — loud in the log AND quiet in the health verdict. Split into two clauses and each half passes for the wrong reason: silence-on-absence is the status quo, and a verdict-on-absence violates absence-is-not-staleness. Two audiences, one clause.
+
+### Corollary: record gate paybacks as deliberately as gate taxes
+
+The design-lookup gate fired on the exact edit where the lane was about to hand-roll shutdown teardown in a catch block. The surfaced doc showed `backgroundRuntimes` already owns ordered shutdown, and the delta collapsed to one runtime registration instead of a whole new mechanism.
+
+If only the TAXES get recorded, the ledger only ever argues for retirement.
+
+### Corollary: two CI runs of one identical SHA
+
+The `push` and `pull_request` workflows both run `check` on the same commit, so every PR gets a two-runs-same-SHA comparison for free. Use it before concluding a branch defect — #643's shape recurred and was settled this way.
+
+### Corollary: empty after a timeout is DID-NOT-RUN
+
+`aqmd search` returning EMPTY after a 120s+ timeout is worse than slow: it reads as "no results." Wrap it in `timeout` AND treat empty output as did-not-run; `qmd search` direct is the roughly one-second fallback.

--- a/docs/sme/entries/2026-08-08-pipestatus-outside-the-pipelines-shell-prints-empty-and-reads-as-exit-0.md
+++ b/docs/sme/entries/2026-08-08-pipestatus-outside-the-pipelines-shell-prints-empty-and-reads-as-exit-0.md
@@ -1,0 +1,30 @@
+---
+lane: quality
+order: 88
+---
+## [2026-08-08] PIPESTATUS outside the pipeline's shell prints empty and reads as exit 0
+
+**Severity:** MEDIUM
+**Source:** #653 branch-sync lane, Tightenings round 21; sibling of round 19's tee-masking finding
+**Scope:** `scripts/done-means/*.sh`, verify-lane runs, any clause whose whole claim is a non-zero exit
+**Status:** active
+
+### Pattern
+
+`PIPESTATUS` evaluated OUTSIDE the pipeline's own shell prints EMPTY. At a glance that is indistinguishable from exit 0, so a clause whose entire claim is "this refusal exits non-zero" reports success on a run that captured nothing.
+
+It bit twice in one lane: once on a refusal path and once on `tsc`. It is the second spelling of round 19's finding that piping a driver through `tee` masks the exit code.
+
+### What to do
+
+- Redirect to a file and read `$?` directly, or set `pipefail` and re-run clean. Do not read a status through a pipeline you did not construct in the same shell.
+- **Guard the arithmetic.** Empty shell variables in numeric tests abort under `set -u` and truncate every remaining clause, producing a transcript that reads as a crash rather than a verdict. Give JSON reads a sentinel value and test against it.
+- **Write message files in a SEPARATE tool call before a guarded command.** A git-guard refusal aborts the ENTIRE compound command, so heredocs and file writes earlier in the chain never execute — the next step then fails on a missing file and reads as an unrelated bug. Verified as standing practice one round later, with no compound-chain aborts.
+
+### Corollary: record the NEGATIVE results of a rule too
+
+Round 11's "a conflict-free merge is not a clean merge" re-run cost about a minute and came back clean. Reporting only the CATCHES makes a cheap rule look expensive, and a rule that looks expensive gets retired. Log the clean re-runs as deliberately as the ones that found something.
+
+### Corollary: prove the refusal, never the credentialed path
+
+For an uncredentialed continuation lane this is a viable standing split. The gate's refusal enumerates every missing coordinate BY NAME, so a lane with no credentials fully exercises the refusal branch at zero harvest risk; the credentialed leg stays with the controller-dispatched verifier. Brief the ENUMERATED SET, never a count — the briefed "8" went stale the moment two capture fallbacks joined the enumeration and made it 10.

--- a/docs/sme/entries/2026-08-08-red-by-breaking-the-import-is-a-false-red-use-a-skip-flag.md
+++ b/docs/sme/entries/2026-08-08-red-by-breaking-the-import-is-a-false-red-use-a-skip-flag.md
@@ -1,0 +1,26 @@
+---
+lane: correctness
+order: 93
+---
+## [2026-08-08] RED by breaking the import is a false RED — use a SKIP flag
+
+**Severity:** HIGH
+**Source:** #655 eval-teardown lane, Tightenings round 16
+**Scope:** `scripts/done-means/655-eval-teardown.sh` and every check whose RED must stay regenerable after the fix ships
+**Status:** active
+
+### Pattern
+
+Moving a module aside to produce RED killed the driver AT IMPORT. Clause (a) measured nothing, and the transcript was indistinguishable from a real RED.
+
+A `SKIP_*` env flag reproduces the pre-fix world with everything else intact, and keeps RED regenerable FOREVER without deleting the fix.
+
+### What to do
+
+- Reproduce the pre-fix world by an env flag the shipped code reads, not by damaging the module graph.
+- **A guard needs a CANARY, not just an exception.** "Throws on a bad name" and "refuses BEFORE mutating" are different claims. Only planting a row under each refused name and checking it SURVIVES distinguishes them — an exception thrown after the mutation looks identical from the outside.
+- **Assert a row COUNT from OUTSIDE the run.** A teardown that reports success is not evidence of removal: the RED run showed `failed=0` while two rows leaked, because the tally is the thing under test and can never be its own proof.
+
+### Corollary: the design-lookup window is session-scoped, not lane-scoped
+
+A sibling CONCURRENT lane's lookup can occupy the recent-lookup window and make a correct denial look spurious. The gate is working as designed. Know the shape before reporting it as a misfire — a false gate-defect report costs the operator loop more than the denial cost the lane.

--- a/docs/sme/entries/2026-08-08-stub-the-boundary-do-not-extract-a-helper-for-observability.md
+++ b/docs/sme/entries/2026-08-08-stub-the-boundary-do-not-extract-a-helper-for-observability.md
@@ -1,0 +1,28 @@
+---
+lane: correctness
+order: 87
+---
+## [2026-08-08] Stub the boundary; do not extract a helper for observability
+
+**Severity:** HIGH
+**Source:** #666 transport-delegation lane, Tightenings round 22
+**Scope:** `scripts/done-means/*.sh` where the defect is "what does X pass across a boundary"; `src/transport.ts`, provider spawn paths
+**Status:** active
+
+### Pattern
+
+When the defect is "what does X pass to the boundary," extracting a helper (`buildProviderEnv()`) to make the value observable invents a SEAM, and the check then proves the seam instead of the real call site. That is the same gap class that let #655's stubbed green miss #666 entirely.
+
+Monkeypatch the BOUNDARY instead. The existing repo convention is `Bun.spawn` monkeypatching (`src/tools/__tests__/search-all.test.ts:85`): the SHIPPED method runs unmodified while the check reads what the real spawn actually received.
+
+### What to do
+
+- Stub at the boundary the code already crosses; do not create a new one for the check's convenience.
+- **A single-key presence assertion most needs a mutant, and an ENV-level mutant beats a source-level one.** Stripping the key from the OBSERVED env keeps RED regenerable forever with the fix in place — round 16's SKIP-flag idea in its env spelling.
+- Report what the mutant proves honestly: the clause reads that key and fails on its absence. Not more.
+
+### Corollary: an empty search result is neither permission nor a defect
+
+The design-lookup gate's window EXPIRES mid-lane by plain time decay — distinct from round 20's sibling-contention shape. Long lanes get gated twice on unrelated writes.
+
+When a legitimate lookup returns nothing, declare UNVERIFIED and source the convention elsewhere (`git log` is the standing fallback). And distinguish the two empties: fast-and-explicit "No results found" is a genuine miss, while empty output after a 120s+ hang is DID-NOT-RUN. Treating the second as the first is how a lane records a lookup it never performed.

--- a/docs/sme/entries/2026-08-08-verify-which-tree-the-process-runs-before-reading-source-as-truth.md
+++ b/docs/sme/entries/2026-08-08-verify-which-tree-the-process-runs-before-reading-source-as-truth.md
@@ -1,0 +1,32 @@
+---
+lane: domain-backend
+order: 97
+---
+## [2026-08-08] Verify which tree the process runs before reading source as truth
+
+**Severity:** HIGH
+**Source:** PR #650 (#646 provider-scope lane), Tightenings round 12
+**Scope:** any lane reasoning about live behavior; `src/` versus `server/main.ts`; `package.json` `start`
+**Status:** active
+
+### Pattern
+
+The lane reasoned about correct-looking code in `src/` while the service was in fact running `server/main.ts`. One call answers it — `lsof -nP -iTCP:<port>` plus `ps -o command` — and `package.json`'s `start` STILL points at the non-serving tree.
+
+A source file that contradicts observed behavior is evidence you are reading the WRONG FILE, not evidence of a mystery.
+
+### What to do
+
+- Resolve the serving tree before treating any source file as the explanation for a live symptom.
+- **A done-means fixture encodes a world-assumption that can be wrong in EITHER direction — query the real distribution before inventing a fixture shape.** The lane's first fixture seeded a conflicting `agent` and read the server's contract-CORRECT refusal as a failure; it nearly "fixed" correct code. All 2011 real lanes carried the matching agent.
+- **A shared test resource closed by an earlier suite's `afterAll` fakes a red.** Distinguish by ASSERTION COUNT: 23 assertions executing means the subject failed; a harness error executes near zero.
+- **`git stash push` on already-committed work stashes NOTHING**, and the follow-up pop grabs someone else's stash. Read the stash output before popping. Second foreign-stash incident; the first was #624.
+- **A live-service-bound receipt is not portable.** A check proving behavior against `127.0.0.1:3100` at revision X proves nothing about any other host or revision, and goes stale on redeploy. Name the binding IN the receipt.
+
+### Corollary: near-miss discipline runs both directions
+
+A phantom finding (a nonexistent import) was re-checked and RETRACTED before reporting. A wrong fixture was corrected and RED re-proven against the pre-fix revision. Both belong in the report — they are the report's job, not its shame.
+
+### Corollary: lazy-heal is a decision, not a default
+
+2011 scope-broken lanes heal on their next capture. No bulk repair was run, and the report SAYS so — bulk-heal remains an operator option rather than a silently-taken default.

--- a/docs/sme/gotcha-agent.md
+++ b/docs/sme/gotcha-agent.md
@@ -2164,3 +2164,36 @@ git -C <d> rev-parse HEAD
 - **Would a stray write land somewhere the repo ignores?** Fixtures inside
   `_scratch/` bound the blast radius even when the other rules are followed;
   fixtures outside the repo do not.
+
+## [2026-08-08] A recorded ruling is not an implemented one, and the gap is invisible
+
+**Severity:** HIGH
+**Source:** PR #649 (ledger-25 retirement lane), the #645 conflict lane, the worker-48 pin failure; Tightenings round 11
+**Scope:** `docs/issue-graph.md` ledger items, `scripts/done-means/648-capture-gate-retired.sh`, merge procedure, model-pinned dispatch
+**Status:** active
+
+### Pattern
+
+Ledger item 25 retired the capture gate. `main` kept it REGISTERED, and nothing failed — because no check asserted the retirement, and every check predating the ruling is structurally blind to it.
+
+A ruling that retires a mechanism needs its OWN done-means check on the same pass, or the ledger and the tree drift silently and neither side reports it.
+
+### What to do
+
+- **A conflict-free merge is not a clean merge.** A merge is a fresh RED opportunity for every gate the branch owns: the neutrality gate caught a literal #642 introduced AFTER the branch cut — correct on each side, wrong only in combination. Re-run the branch's own checks AFTER merging the upstream default branch.
+- **A generated file in conflict is REGENERATED, never hand-merged.** The conflict lives in the inputs and usually is not one at all (the SME index rebuilt from entries; both sides' entries survived).
+- **Inverting a done-means clause needs its own RED**, extending round 9's rewritten-clause rule. And **retired-versus-deleted must be distinguished BY THE CHECK** — the 451 clauses now fail loudly if a cleanup deletes the #647 prior art instead of retiring it.
+- **A hook-set assertion needs both directions.** "None missing" passes happily while a sixth hook creeps in; the "none extra" half is what catches config drift.
+- **`FETCH_HEAD` is per-worktree** — fetch inside the worktree you merge in.
+
+### Corollary: a model pin does not bind through direct Agent dispatch
+
+The lane self-reported `claude-fable-5` — the HEAD's model — despite the agent definition pinning `claude-opus-4-8`. Requested-model provenance recorded what was ASKED, not what ANSWERED: the ledger-18 provenance warning, proven live.
+
+The A/B comparison therefore had ZERO valid 4.8 samples. Model-pinned dispatch must go through the route that actually PLACES the model.
+
+### Gate defects and announced adjustments
+
+The git guard fires on the word "main" in commit-message PROSE on a correctly-named branch — say "the default branch"; the guard should read `git branch --show-current`. The design-lookup gate fires on a gitignored scratch PR-body file. The PRE-PUSH hook runs the suite against the shared dogfood database — the exact inadmissible path of the #614 ruling (1 fail then 0 fail on an identical tree, skip counts 485 apart). `aqmd search` can exceed 120s; wrap it in `timeout`.
+
+Announced by tooling and needing a home: verify-lane and lane-bootstrap print `ADJUSTED: neither OPENBRAIN_TEMP_WORKSPACE nor DEV_TMP is set` and place worktrees under `~/.cache` instead of the configured temp workspace. Set the variable in controller and verifier environments, or teach the scripts the Development default.

--- a/docs/sme/quality.md
+++ b/docs/sme/quality.md
@@ -494,3 +494,57 @@ A cluster of tooling behaviours that each produced a false green or a lost after
 **Citations to artifacts that do not exist yet are fabrications.** A PR number guessed before `gh pr create` is a guess in the grammar of a fact. Write the reference after the artifact exists.
 
 **Mutation-test the gate itself when the PR's claim IS the gate.** Reintroduce each real failure mode and watch the gate fail; a gate observed only green is decoration.
+
+## [2026-08-08] PIPESTATUS outside the pipeline's shell prints empty and reads as exit 0
+
+**Severity:** MEDIUM
+**Source:** #653 branch-sync lane, Tightenings round 21; sibling of round 19's tee-masking finding
+**Scope:** `scripts/done-means/*.sh`, verify-lane runs, any clause whose whole claim is a non-zero exit
+**Status:** active
+
+### Pattern
+
+`PIPESTATUS` evaluated OUTSIDE the pipeline's own shell prints EMPTY. At a glance that is indistinguishable from exit 0, so a clause whose entire claim is "this refusal exits non-zero" reports success on a run that captured nothing.
+
+It bit twice in one lane: once on a refusal path and once on `tsc`. It is the second spelling of round 19's finding that piping a driver through `tee` masks the exit code.
+
+### What to do
+
+- Redirect to a file and read `$?` directly, or set `pipefail` and re-run clean. Do not read a status through a pipeline you did not construct in the same shell.
+- **Guard the arithmetic.** Empty shell variables in numeric tests abort under `set -u` and truncate every remaining clause, producing a transcript that reads as a crash rather than a verdict. Give JSON reads a sentinel value and test against it.
+- **Write message files in a SEPARATE tool call before a guarded command.** A git-guard refusal aborts the ENTIRE compound command, so heredocs and file writes earlier in the chain never execute — the next step then fails on a missing file and reads as an unrelated bug. Verified as standing practice one round later, with no compound-chain aborts.
+
+### Corollary: record the NEGATIVE results of a rule too
+
+Round 11's "a conflict-free merge is not a clean merge" re-run cost about a minute and came back clean. Reporting only the CATCHES makes a cheap rule look expensive, and a rule that looks expensive gets retired. Log the clean re-runs as deliberately as the ones that found something.
+
+### Corollary: prove the refusal, never the credentialed path
+
+For an uncredentialed continuation lane this is a viable standing split. The gate's refusal enumerates every missing coordinate BY NAME, so a lane with no credentials fully exercises the refusal branch at zero harvest risk; the credentialed leg stays with the controller-dispatched verifier. Brief the ENUMERATED SET, never a count — the briefed "8" went stale the moment two capture fallbacks joined the enumeration and made it 10.
+
+## [2026-08-08] Ask whether the design already exists and was simply never run
+
+**Severity:** MEDIUM
+**Source:** PR #648 (#647 capture-liveness lane), Tightenings round 13
+**Scope:** every build lane's first move; `docs/decisions/`, `docs/sme/entries/`
+**Status:** active
+
+### Pattern
+
+#647 read as "invent a liveness check." `docs/decisions/capture-never-drops-a-turn.md:182-200` had SPECIFIED it — per-role, count-based — for eleven days, carrying its own record that it "was never run."
+
+"Has this been specified and left unrun?" is the FIRST question of any build lane, not a formality. Here the lookup materially changed the deliverable and avoided rebuilding the #447 per-role blind spot.
+
+### What to do
+
+- Search decisions and SME entries for the thing you are about to invent, BEFORE inventing it. A design that exists and was never executed looks exactly like a design that does not exist, from inside the issue text.
+- **A control clause that passes PRE-fix is the signal the check discriminates.** Ten of thirteen clauses red with the two CONTROLS green is stronger evidence than thirteen of thirteen red: a check that fails everywhere proves only that it fails.
+- **Lanes do not use `git stash` for red/green proofs — file-copy instead.** The stash stack is SHARED even when the worktree is exclusively yours. This was the second lane in one session to pop a foreign stash from a bootstrapped worktree, third incident overall; the round-1 "checkout you don't own" wording under-scoped the hazard.
+
+### Corollary: name the capability state honestly
+
+The liveness reader was MERGED code with no process composing it — no live `/health` reported capture until a composition change shipped. WRITTEN-not-RUNNING, stated in the PR rather than implied away.
+
+### Gate-precision datapoints
+
+The design-lookup gate accepted `aqmd` but refused a direct `sqlite3` query of the same index (#637 corpus). The git guard fired on a protected-branch name inside a MERGE-COMMIT MESSAGE — the fifth shape of #618; say "upstream default branch" in prose instead.

--- a/docs/sme/security.md
+++ b/docs/sme/security.md
@@ -1129,3 +1129,63 @@ Any observability record that carries a session/user identity must derive it AFT
 ### Pattern
 
 A maintenance/dream/distill job that sweeps with `namespace IS NULL` touches every tenant; joining its trace to a job-supplied `session_key` renders all tenants' row identities and content inside one session's timeline — a namespace-isolation breach in the observability lane even though the data path is unchanged. Honour a job's session key only when the job is namespace-scoped; a global sweep emits no sessionId, and each observation stamps its own resolved namespace so cross-namespace evidence is visibly attributed. "No current enqueuer sets it" is not a defense — the job-row field is durable and the sweep is global by design.
+
+## [2026-08-08] A guard written as "present AND wrong" leaves the absent branch unguarded
+
+**Severity:** HIGH
+**Source:** PR #664 (#662 validator lane), the #653 credentialed verify, Tightenings round 19
+**Scope:** `src/` validators and scope guards; `scripts/done-means/662-absent-namespace-scope-proof.sh`
+**Status:** active
+
+### Pattern
+
+A guard spelled "key present AND value wrong" never runs for the ABSENT case — and the absent branch inherits the exact dead end the guard was added to remove. #654 and #662 are ONE defect on two sides of one `if`.
+
+### What to do
+
+- When a fix special-cases a key, ENUMERATE the key's states — present-correct, present-wrong, absent — and say in the check header which branch handles each. A state you cannot name is a state nothing guards.
+- **"The server always sends it" is not a reason to leave a validator's hostile-input branch dead-ended.** The lane object is the untrusted thing being validated. The dispatch's server-side hypothesis was reasonable and wrong; one live `tools/call` plus reading the column lists settled it in minutes. A lane rejects a briefed hypothesis ON EVIDENCE and writes the reasoning into the check header — never decides silently.
+- **Absence and mismatch need DIFFERENT messages, because only one has a remedy.** Reusing the delegation advice for the absent case would pass a naive "mentions namespace" assertion while remaining a dead end with more words. Clauses assert what the message SAYS, not that a message exists.
+
+### Corollary: `rg -r` is the REPLACE flag, not recursive
+
+It silently emits mangled replacement text that reads as a single real hit. It joins the `rg -E` family: the failure mode is a plausible-looking WRONG ANSWER, not an error, which is why neither is caught by checking the exit code.
+
+### Corollary: a gate that keeps failing on real defects is doing its job
+
+The #578 gate's first credentialed run found the THIRD live defect in the very path it composes (#654's absent-case sibling). Resist reading a red gate as a broken gate: the verifier re-ran the fixed defects' own checks live, proved them fixed, and only then attributed the new failure.
+
+Also observed: a per-run tally can UNDER-report entity creation — `attempted=1` while two namespaces appeared. Count the entities, not the attempts.
+
+## [2026-08-08] A live-service check reads the serving process's credentials, never the checkout's
+
+**Severity:** HIGH
+**Source:** PR #657 (#654 namespace-scope lane) and its verify run, Tightenings round 15
+**Scope:** `scripts/done-means/654-namespace-scope-proof.sh`, live-service clauses, `python/openbrain-memory` delegation
+**Status:** active
+
+### Pattern
+
+The repo `.env` has carried an empty `AUTH_TOKEN_ADMIN` since the #645 scrub, so a check built on it 401s BY DESIGN — and the transcript reads as a service fault.
+
+Round 12's which-tree-runs rule, extended to IDENTITY: name where the credential comes from in the check header, and refuse LOUDLY when it is absent instead of falling through to a misleading auth failure.
+
+### Corollary: a security control is unproven until something REQUESTS the dangerous thing
+
+The server role-gates `X-Namespace`, but the Python client had `delegate_namespace=False` hardcoded since #294 — the header was never sent, so the 403 path had NEVER executed in any run. A refusal branch that has never refused is decoration.
+
+The done-means now sends the forbidden request and asserts both the refusal (clause c) and that the refusal NAMES the actionable cause (clause d).
+
+### Corollary: silent-default identity is tenant mis-scope, not cosmetics
+
+With delegation hardcoded off, every delegated-intent session landed in namespace `admin` — a real cross-tenant landing, STRONGER than the issue as filed.
+
+Any config key that selects identity is REQUIRED config: loud on absence, never silently defaulted (ledger item 28).
+
+### Corollary: errors must name what the caller can change
+
+#646 (scope errors naming response vocabulary the validator rejects) and #654 (a silent wrong-namespace landing with no signal at all) are the same dead-end-error defect at different volumes. A refusal that does not name the acting cause, and a mis-scope that says nothing, both strand the caller. Checks assert the error TEXT, not just the status.
+
+### Corollary: a red anchor that inverts at the fix must be bound to the PR head
+
+Clause (a)'s PASS proves the fix ONLY because verify-lane pinned the worktree to the head SHA and re-read it after the run (`recheck-head`). Any check whose RED lives on main and whose GREEN lives on the branch inherits this binding requirement — without it, the inversion could come from either tree.


### PR DESCRIPTION
## Summary

- Second graduation pass on the Tightenings ratchet. Batch 1 (#926) graduated the 16 oldest rounds and left 29 live against a declared 15; this pass graduates rounds 26 down through 11 — sixteen more, all dated 2026-08-08 — and the bound clause the ratchet exists to enforce now holds.
- Each round's bullets were read individually and routed the way batch 1 routed its own: to the standing contract where the rule is already a numbered clause, to a `scripts/done-means/*.sh` check where one already enforces it, to one of sixteen new SME entries where the rule was live and had no home, or marked history-only where the bullet recorded a one-off carrying no reusable rule.
- No round text is deleted or rewritten. Each graduated round gains a trailing `graduated:` line naming where every bullet went, plus a `provenance:` line — all sixteen carried their PR numbers only in the heading, which the check cannot read.
- Sixteen new `docs/sme/entries/*.md` at orders 83 through 98, one per round, each with lane, source, scope, and status. The six generated lane files are rebuilt by `bun scripts/build-sme-indexes.ts` and staged.

## Verification

- Done-means: scripts/done-means/750-precommit-lint-gate-fires.sh
- Ratchet check before: `live=29 graduated=16 bound=15 source=default shape=heading` — exit 1, `FAIL bound: 29 live > 15`
- Ratchet check after: `live=13 graduated=32 bound=15 source=default shape=heading` — the `FAIL bound` line is gone
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

The pre-push hook ran the Bun suite green and skipped the Python, openbrain-package, and contract-parity gates as unchanged. Pre-commit skipped lint and typecheck: no TypeScript or JavaScript is staged. `placeholders/check.sh` exits 0 on each of the sixteen new entries.

## Critical Self-Review

- Highest-risk behavior: a `graduated:` line that misroutes a bullet — claiming a rule has a home it does not actually have. That would retire a live rule from the ratchet into nowhere, and the check cannot detect it because it reads markdown shape, not meaning. Mitigated by naming the exact destination file and lane order for every bullet, and by writing the destination entries in the same commit.
- Assumptions that could be wrong: that a bullet I marked history-only carries no reusable rule. Five bullets are marked that way; each records a one-off outcome already shipped as a done-means check or already covered by a sibling entry, and each names which.
- Missing/weak tests: none added; this is a documentation change with an executable check over it. The ratchet check is the test, and it moved from `FAIL bound: 29 live > 15` to no bound failure.
- Security/permission risk: none. No source, config, credential, or namespace path is touched.
- Migration/deploy risk: none. No schema, no runtime code.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface changes, so `docs/downstream-rollout.md` classifies this as not applicable.
- Rollback/cleanup concern: a plain revert restores the prior file. The generated lane files rebuild deterministically from `entries/`, so a revert plus one `bun scripts/build-sme-indexes.ts` returns the tree exactly.
- Fixes made before PR: the first order-scan used an unanchored pattern and matched dates rather than `order:` values, which is batch 1's own recorded lesson; re-scanned with `^order: [0-9]+$` and confirmed 82 as the true maximum before numbering 83 through 98.
- Known residual risk: the check still exits 1, on a DIFFERENT clause than the one this pass addresses. The 13 remaining live rounds (27 through 38) carry no literal `provenance:` token — their PR numbers sit in the heading, and the check reads markdown shape rather than meaning, so the heading does not satisfy it. Those rounds are outside this change's scope and were deliberately not edited. Closing that clause is a separate pass over rounds 27 through 38.
- SME review-memory update: [x] `docs/sme/` updated

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [x] not applicable because: no runtime, transport, or service behavior changes; the change is documentation plus its generated indexes.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract surface is touched, so there is no fixture to update.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Documentation-only change under `docs/`. No MCP tool, schema, protocol, or client-facing surface is modified, so every downstream step is not applicable.
