### PR TITLE
test(pg): the get-entry tool test requires the test database instead of skipping (#878)

### DIFF
--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -357,6 +357,14 @@ export const REQUIRED_SUITES: ReadonlyArray<{
     name: "ingest_raw_turn namespace and auth boundary (live Postgres)",
     minTests: 3,
   },
+  // The get_entry tool test's live suite proves the compact render reads the
+  // full stored content through real Postgres, which the mock-pool suite in
+  // the sibling file cannot execute. Split into its own file in #878 as that
+  // file stopped skipping itself.
+  {
+    name: "get_entry compact render (live Postgres)",
+    minTests: 1,
+  },
 ];
 
 // Absolute floor on total executed (non-skipped) live-Postgres testcases,
@@ -397,9 +405,11 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // that file stopped skipping itself, then 249 -> 255 when #904 registered the
 // retire-collab scratch-migration suite's 6 as that file stopped skipping
 // itself, then 255 -> 265 when #878 registered the four ingest_raw_turn
-// suites' 4 + 1 + 2 + 3 as that file stopped skipping itself), so the global
-// floor cannot silently fall behind the per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 265;
+// suites' 4 + 1 + 2 + 3 as that file stopped skipping itself, then 265 -> 266
+// when #878 registered the get_entry compact render suite's 1 as that file
+// stopped skipping itself), so the global floor cannot silently fall behind
+// the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 266;
 
 export interface SuiteStats {
   tests: number;
@@ -458,8 +468,7 @@ function executedLiveSuiteName(block: string): string | undefined {
   const open = block.match(/<testcase\b[^>]*>/)?.[0] ?? block;
   const classname = attr(open, "classname") ?? "";
   if (!classname.includes("(live Postgres)")) return undefined;
-  const isSkipped =
-    /<skipped\b/.test(block) || attr(open, "skipped") === "true";
+  const isSkipped = /<skipped\b/.test(block) || attr(open, "skipped") === "true";
   return isSkipped ? undefined : classname;
 }
 
@@ -516,8 +525,7 @@ function checkRequiredSuite(
     }
     if (s.tests < req.minTests) {
       errors.push(
-        `"${req.name}" ran ${s.tests} tests, expected at least ` +
-          `${req.minTests}.`,
+        `"${req.name}" ran ${s.tests} tests, expected at least ` + `${req.minTests}.`,
       );
     }
     const executed = executedLiveTestcasesBySuite.get(req.name) ?? 0;
@@ -533,18 +541,13 @@ function checkRequiredSuite(
 
 export function evaluateJunit(xml: string): GuardResult {
   const suiteStats = collectSuiteStats(xml);
-  const {
-    executedLiveTestcases,
-    erroredLiveTestcases,
-    executedLiveTestcasesBySuite,
-  } = tallyTestcases(xml);
+  const { executedLiveTestcases, erroredLiveTestcases, executedLiveTestcasesBySuite } =
+    tallyTestcases(xml);
 
   const errors: string[] = [];
 
   for (const req of REQUIRED_SUITES) {
-    errors.push(
-      ...checkRequiredSuite(req, suiteStats, executedLiveTestcasesBySuite),
-    );
+    errors.push(...checkRequiredSuite(req, suiteStats, executedLiveTestcasesBySuite));
   }
 
   if (erroredLiveTestcases > 0) {

--- a/src/tools/__tests__/get-entry.pg.test.ts
+++ b/src/tools/__tests__/get-entry.pg.test.ts
@@ -1,0 +1,66 @@
+// This suite requires OPENBRAIN_TEST_DATABASE_URL and fails loudly without it.
+import { afterAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
+import { registerGetEntry } from "../get-entry.ts";
+import {
+  createMockEmbed,
+  type MockPool,
+  parseToolResult,
+  setupMcpClient,
+} from "./test-helpers.ts";
+
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+
+describe("get_entry compact render (live Postgres)", () => {
+  const ns = "test-get-entry-compact";
+  const sessionId = "550e8400-e29b-41d4-a716-446655440099";
+
+  async function cleanupNs() {
+    await pool.query("DELETE FROM sessions WHERE namespace = $1", [ns]);
+  }
+
+  afterAll(async () => {
+    await cleanupNs();
+    await pool.end();
+  });
+
+  it("reports session length and truncation from the full readable content", async () => {
+    await cleanupNs();
+    const longSummary = "x".repeat(450);
+    await pool.query(
+      `INSERT INTO sessions (id, namespace, project, summary, created_by, tags)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [sessionId, ns, "proj", longSummary, "codex", ["compact"]],
+    );
+
+    const { client, cleanup } = await setupMcpClient(
+      registerGetEntry,
+      pool as unknown as MockPool,
+      createMockEmbed(),
+      { role: "agent", clientId: ns },
+    );
+
+    try {
+      const result = await client.callTool({
+        name: "get_entry",
+        arguments: {
+          table: "sessions",
+          id: sessionId,
+          render: "compact",
+          max_chars: 80,
+        },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const parsed = parseToolResult(result);
+      expect(parsed.content_preview).toBe(`proj: ${"x".repeat(74)}`);
+      expect(parsed.content_length).toBe(456);
+      expect(parsed.content_truncated).toBe(true);
+      expect(parsed.content_preview).toHaveLength(80);
+    } finally {
+      await cleanup();
+      await cleanupNs();
+    }
+  });
+});

--- a/src/tools/__tests__/get-entry.test.ts
+++ b/src/tools/__tests__/get-entry.test.ts
@@ -1,5 +1,4 @@
-import { afterAll, describe, expect, it } from "bun:test";
-import { Pool } from "pg";
+import { describe, expect, it } from "bun:test";
 import { registerGetEntry } from "../get-entry.ts";
 import type { AuthInfo } from "../../types.ts";
 import {
@@ -9,7 +8,7 @@ import {
   setupMcpClient,
 } from "./test-helpers.ts";
 
-describe("get_entry", () => {
+describe("get_entry full reads and source scope", () => {
   it("filters scoped callers to readable namespaces", async () => {
     const queries: Array<{ sql: string; params?: unknown[] }> = [];
     const mockPool = {
@@ -92,7 +91,9 @@ describe("get_entry", () => {
       await cleanup();
     }
   });
+});
 
+describe("get_entry source ref redaction", () => {
   it("requires matching source scope before returning source refs", async () => {
     const queries: Array<{ sql: string; params?: unknown[] }> = [];
     const sourceRefs = [
@@ -154,9 +155,7 @@ describe("get_entry", () => {
       expect(parseToolResult(result).source_refs).toEqual([
         { ...sourceRefs[0], source_type: "file" },
       ]);
-      expect(queries[0]?.sql).toContain(
-        "COALESCE(t.source_refs, '[]'::jsonb)",
-      );
+      expect(queries[0]?.sql).toContain("COALESCE(t.source_refs, '[]'::jsonb)");
       expect(queries[0]?.params).toEqual([
         "550e8400-e29b-41d4-a716-446655440021",
         JSON.stringify({
@@ -169,7 +168,9 @@ describe("get_entry", () => {
       await cleanup();
     }
   });
+});
 
+describe("get_entry source scope authorization", () => {
   it("denies source scope for non-admin callers before querying", async () => {
     let queried = false;
     const mockPool = {
@@ -234,7 +235,9 @@ describe("get_entry", () => {
       await cleanup();
     }
   });
+});
 
+describe("get_entry compact render", () => {
   it("denies compact render before querying when the role cannot read the table", async () => {
     let queried = false;
     const mockPool = {
@@ -307,7 +310,9 @@ describe("get_entry", () => {
       await cleanup();
     }
   });
+});
 
+describe("get_entry compact envelope", () => {
   it("returns a bounded compact envelope without emitting the full row", async () => {
     const queries: Array<{ sql: string; params?: unknown[] }> = [];
     const mockPool = {
@@ -392,7 +397,9 @@ describe("get_entry", () => {
       await cleanup();
     }
   });
+});
 
+describe("get_entry session compact content", () => {
   it("builds session compact content from the full summary, not the clipped search preview", async () => {
     const queries: Array<{ sql: string; params?: unknown[] }> = [];
     const mockPool = {
@@ -442,65 +449,6 @@ describe("get_entry", () => {
       expect(queries[0]?.sql).toContain("length(entry.content_text)");
     } finally {
       await cleanup();
-    }
-  });
-});
-
-// Gated on OPENBRAIN_TEST_DATABASE_URL. CI's db-integration job sets this and
-// catches real Postgres SQL failures that mock-pool tests cannot execute.
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-
-dbDescribe("get_entry compact render (live Postgres)", () => {
-  const pool = new Pool({ connectionString: DB_URL });
-  const ns = "test-get-entry-compact";
-  const sessionId = "550e8400-e29b-41d4-a716-446655440099";
-
-  async function cleanupNs() {
-    await pool.query("DELETE FROM sessions WHERE namespace = $1", [ns]);
-  }
-
-  afterAll(async () => {
-    await cleanupNs();
-    await pool.end();
-  });
-
-  it("reports session length and truncation from the full readable content", async () => {
-    await cleanupNs();
-    const longSummary = "x".repeat(450);
-    await pool.query(
-      `INSERT INTO sessions (id, namespace, project, summary, created_by, tags)
-       VALUES ($1, $2, $3, $4, $5, $6)`,
-      [sessionId, ns, "proj", longSummary, "codex", ["compact"]],
-    );
-
-    const { client, cleanup } = await setupMcpClient(
-      registerGetEntry,
-      pool as any,
-      createMockEmbed(),
-      { role: "agent", clientId: ns },
-    );
-
-    try {
-      const result = await client.callTool({
-        name: "get_entry",
-        arguments: {
-          table: "sessions",
-          id: sessionId,
-          render: "compact",
-          max_chars: 80,
-        },
-      });
-
-      expect(result.isError).toBeFalsy();
-      const parsed = parseToolResult(result);
-      expect(parsed.content_preview).toBe(`proj: ${"x".repeat(74)}`);
-      expect(parsed.content_length).toBe(456);
-      expect(parsed.content_truncated).toBe(true);
-      expect(parsed.content_preview).toHaveLength(80);
-    } finally {
-      await cleanup();
-      await cleanupNs();
     }
   });
 });


### PR DESCRIPTION
## Summary

- The live suite in `src/tools/__tests__/get-entry.test.ts` read `OPENBRAIN_TEST_DATABASE_URL` itself and swapped in `describe.skip` when it was unset, so a run without a database reported `0 pass, 2 skip, 0 fail` and exited 0 -- at the exit code, indistinguishable from a suite that ran and passed.
- Split by subject: the mock-pool tests stay in `get-entry.test.ts`; the live suite moves verbatim into a new `src/tools/__tests__/get-entry.pg.test.ts` as a plain `describe("get_entry compact render (live Postgres)")` with one module-scope pool built from `requireTestDatabaseUrl()`. Absent the variable the helper throws `test_database_required` and the run fails loudly.
- `scripts/assert-db-tests-ran.ts` registers the suite (`minTests: 1`) and `MIN_TOTAL_LIVE_TESTCASES` moves 265 -> 266, so CI's anti-skip guard notices if it ever vanishes again.
- The pre-commit gate lints staged files whole, and the remaining mock-pool `describe` carried a pre-existing `max-lines-per-function` finding (410 lines) that survived the move. `.oxlintrc.json` declines that exemption on purpose -- the debt is paid per file as tests are touched -- so the mock suite is split by subject into six describes, each under the rule value. No test body, name, or assertion changed; only the `describe` wrappers they sit in. These are mock suites, so no `assert-db-tests-ran` entry names them.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- Invocation on the committed tree: `CHANGED_FILES="src/tools/__tests__/get-entry.pg.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` -> exit 0, all four clauses PASS. RED before any edit, at `origin/main`: `CHANGED_FILES="src/tools/__tests__/get-entry.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` -> exit 1, clause 1 naming `dbDescribe` on line 450.
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bunx tsc --noEmit` -> exit 0. `./node_modules/.bin/oxlint --deny-warnings` over all three touched files -> exit 0, no findings. `bun run test:isolated src/tools/__tests__/get-entry.test.ts` -> 9 pass, 0 fail, 0 skip (the 2 skips on `main` were the live suite, which now lives in its own file and runs). `bun run test:isolated src/tools/__tests__/get-entry.pg.test.ts --reporter=junit` -> 1 testcase, which is the count registered in the manifest. Python package untouched; no migration, no schema, no tool contract change.

## Critical Self-Review

- Highest-risk behavior: the compact-render read path against real Postgres. It was previously skipped whenever the variable was unset, which on a developer machine is the default; it now runs or takes the run down.
- Assumptions that could be wrong: that the single live testcase is the whole live coverage of `get_entry`. Read from JUnit rather than tallied by eye -- `<testcase>` count 1 -- but if a future test is added to that file without moving `minTests`, the floor understates it. The floor is a lower one by design, so that direction is safe.
- Missing/weak tests: none added. This lane moves existing coverage from conditionally-skipped to always-executed; writing a new assertion here would hide whether the move preserved the old one.
- Security/permission risk: none. No auth path, no namespace predicate, and no SQL was touched. The moved suite's namespace scoping is byte-for-byte what it was.
- Migration/deploy risk: none. Test files and one CI guard script; no migration, no runtime code, nothing that ships.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classifies by MCP tool/schema/protocol/client-facing change; this is none of those, so no rtech-mcps, mcp2cli, or Hermes step applies.
- Rollback/cleanup concern: reverting the commit restores the self-skipping suite and the 265 floor together, so the manifest cannot be left ahead of the tests it counts. The temporary clone artifacts from `test:isolated` drop themselves; the run printed its teardown receipts.
- Fixes made before PR: the `any` cast that moved with the suite is now `as unknown as MockPool`, since `--deny-warnings` over a file I touched is mine to satisfy without a disable comment. The mock describe's pre-existing size finding is fixed by splitting rather than exempted.
- Known residual risk: the mock suite's six describe names are new, so any future manifest entry or external tooling matching the old `"get_entry"` string would not find it. Checked: no entry in `scripts/assert-db-tests-ran.ts` names it, because the manifest tracks live-Postgres suites only and these are mock-pool ones.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the defect class -- an env-gated suite that self-skips and reports green -- is already the subject of the #878 done-means check and its recorded rationale, and this lane surfaced no new pattern beyond it.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, tool, or transport code changed; the suite runs against an isolated per-run database created by `test:isolated`.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, tool schema, or response shape changed -- only which describe wrapper existing assertions sit in, and whether the live one is allowed to skip.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Rollout does not apply: the gate keys on MCP tool, schema, protocol, or client-facing changes. This diff is two test files and one CI guard script; `src/tools/get-entry.ts` is untouched.
