### PR TITLE
test(pg): the tier-lane tool test requires the test database instead of skipping (#878)

### DIFF
--- a/src/tools/__tests__/tier-lane.pg.test.ts
+++ b/src/tools/__tests__/tier-lane.pg.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Live-Postgres coverage for tier_lane, the graduation path that copies durable
+ * session-lane events into the namespace as thoughts.
+ *
+ * The mock-pool suite (tier-lane.test.ts) covers auth, argument validation, and
+ * response shape against a fake pool, which is right for all of those. It
+ * cannot cover what this file covers: real halfvec embeddings, the ON CONFLICT
+ * idempotency of a re-run, and cosine-distance near-duplicate detection are all
+ * supplied by the fixture in a fake and computed by Postgres here.
+ *
+ * The suite demands the test database through the shared helper rather than
+ * reading the environment itself, so a run without one fails loudly instead of
+ * reporting a silent green over a suite that never executed.
+ */
+import { describe, it, expect, afterAll } from "bun:test";
+import { Pool } from "pg";
+import { toSql } from "pgvector/pg";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
+import { registerTierLane } from "../tier-lane.ts";
+import { contentHash } from "../../embedding.ts";
+import {
+  createMockEmbed,
+  setupMcpClient,
+  parseToolResult,
+  type MockPool,
+} from "./test-helpers.ts";
+import type { AuthInfo } from "../../types.ts";
+
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+
+const ns = "test-tier-lane-live";
+const sessionKey = "live-tier-lane";
+// Deterministic embeddings so near-dup behavior is testable.
+const baseEmbedding = Array(768).fill(0.1);
+const embedFn = createMockEmbed(baseEmbedding);
+
+async function callTierLane(args: Record<string, unknown>, auth: AuthInfo) {
+  const { client, cleanup } = await setupMcpClient(
+    registerTierLane,
+    pool as unknown as MockPool,
+    embedFn,
+    auth,
+  );
+  try {
+    return await client.callTool({ name: "tier_lane", arguments: args });
+  } finally {
+    await cleanup();
+  }
+}
+
+async function seedLaneWithEvent(content: string, eventType = "fact") {
+  const { rows } = await pool.query(
+    `INSERT INTO ob_session_lanes (session_key, namespace, agent, created_by)
+       VALUES ($1, $2, $3, $3)
+       ON CONFLICT (namespace, session_key) DO UPDATE SET updated_at = NOW()
+       RETURNING id`,
+    [sessionKey, ns, ns],
+  );
+  const laneId = rows[0].id as string;
+  await pool.query(
+    `INSERT INTO ob_session_events
+         (lane_id, event_type, content, importance, content_hash, embedding, created_by)
+       VALUES ($1, $2, $3, 'warm', $4, $5, $6)
+       ON CONFLICT (lane_id, content_hash) WHERE content_hash IS NOT NULL
+       DO NOTHING`,
+    [laneId, eventType, content, contentHash(content), toSql(baseEmbedding), ns],
+  );
+  return laneId;
+}
+
+async function cleanup() {
+  await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [ns]);
+  await pool.query("DELETE FROM thoughts WHERE namespace = $1", [ns]);
+}
+
+describe("tier_lane (live Postgres)", () => {
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  it("graduates a fact into the namespace with provenance, idempotent on re-run", async () => {
+    await cleanup();
+    const content =
+      "Live durable fact about the open-brain tiering integration test path";
+    await seedLaneWithEvent(content);
+    const auth: AuthInfo = { role: "agent", clientId: ns };
+
+    const first = await callTierLane(
+      { session_key: sessionKey, namespace: ns, dry_run: false },
+      auth,
+    );
+    expect(first.isError).toBeFalsy();
+    expect(parseToolResult(first).graduated).toBe(1);
+
+    const { rows: afterFirst } = await pool.query(
+      "SELECT id, promoted_from, tags FROM thoughts WHERE namespace = $1",
+      [ns],
+    );
+    expect(afterFirst.length).toBe(1);
+    expect(afterFirst[0].promoted_from.source).toBe("session-lane");
+    expect(afterFirst[0].tags).toContain("tiered-from-lane");
+
+    // Re-run: ON CONFLICT idempotency — exact-hash dedup skips, no new row.
+    const second = await callTierLane(
+      { session_key: sessionKey, namespace: ns, dry_run: false },
+      auth,
+    );
+    expect(second.isError).toBeFalsy();
+    expect(parseToolResult(second).duplicates).toBe(1);
+
+    const { rows: afterSecond } = await pool.query(
+      "SELECT count(*)::int AS n FROM thoughts WHERE namespace = $1",
+      [ns],
+    );
+    expect(afterSecond[0].n).toBe(1);
+  });
+
+  it("skips a near-duplicate by embedding distance", async () => {
+    await cleanup();
+    const auth: AuthInfo = { role: "agent", clientId: ns };
+    // First event graduates.
+    await seedLaneWithEvent(
+      "Original durable statement that should graduate into thoughts cleanly",
+    );
+    await callTierLane(
+      { session_key: sessionKey, namespace: ns, dry_run: false },
+      auth,
+    );
+
+    // Second event: different text + hash but identical embedding → near-dup.
+    await seedLaneWithEvent(
+      "A slightly reworded but semantically identical durable statement here",
+    );
+    const res = await callTierLane(
+      { session_key: sessionKey, namespace: ns, dry_run: false },
+      auth,
+    );
+    const parsed = parseToolResult(res);
+    // The tool re-scans the whole lane, so BOTH events are now duplicates:
+    // event 1 by exact content_hash (already graduated), event 2 by near
+    // embedding distance. The point is that the near-dup event 2 did NOT
+    // graduate (no new row), proving embedding dedup works.
+    expect(parsed.graduated).toBe(0);
+    expect(parsed.duplicates).toBe(2);
+
+    const { rows } = await pool.query(
+      "SELECT count(*)::int AS n FROM thoughts WHERE namespace = $1",
+      [ns],
+    );
+    expect(rows[0].n).toBe(1);
+  });
+});

--- a/src/tools/__tests__/tier-lane.test.ts
+++ b/src/tools/__tests__/tier-lane.test.ts
@@ -1,22 +1,19 @@
-import { describe, it, expect, afterAll } from "bun:test";
-import { Pool } from "pg";
-import { toSql } from "pgvector/pg";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, it, expect } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { registerTierLane } from "../tier-lane.ts";
 import { contentHash } from "../../embedding.ts";
-import type { ToolDeps } from "../index.ts";
+import {
+  createMockEmbed,
+  setupMcpClient,
+  parseToolResult,
+  getErrorText,
+  type MockPool,
+} from "./test-helpers.ts";
 import type { AuthInfo } from "../../types.ts";
-
-function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
-  return async (_text: string) => result;
-}
 
 /** A graduate-eligible event row joined with its lane. */
 function laneEventRow(overrides: Record<string, unknown> = {}) {
-  const content =
-    "This is a substantive durable fact that exceeds the minimum length";
+  const content = "This is a substantive durable fact that exceeds the minimum length";
   return {
     id: "evt-1",
     lane_id: "lane-1",
@@ -44,10 +41,10 @@ function createMockPool(opts: {
   exactDup?: boolean;
   nearDup?: boolean;
 }) {
-  const writes: Array<{ sql: string; params: any[] }> = [];
+  const writes: Array<{ sql: string; params: unknown[] }> = [];
   const pool = {
     writes,
-    query: async (sql: string, params: any[] = []) => {
+    query: async (sql: string, params: unknown[] = []) => {
       if (sql.includes("FROM ob_session_events")) {
         return { rows: opts.events };
       }
@@ -71,49 +68,25 @@ function createMockPool(opts: {
   return pool;
 }
 
-async function setupToolClient(
-  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
+function setupToolClient(
+  mockPool: MockPool,
   auth: AuthInfo,
-  embedFn?: (text: string) => Promise<number[] | null>,
+  embedFn?: ReturnType<typeof createMockEmbed>,
 ): Promise<{ client: Client; cleanup: () => Promise<void> }> {
-  const server = new McpServer({ name: "test", version: "1.0.0" });
-  const deps: ToolDeps = {
-    pool: mockPool as any,
-    embedFn: embedFn ?? createMockEmbed(),
-  };
-  registerTierLane(server, deps);
-
-  const [clientTransport, serverTransport] =
-    InMemoryTransport.createLinkedPair();
-  const originalSend = clientTransport.send.bind(clientTransport);
-  clientTransport.send = (message: any, options?: any) =>
-    originalSend(message, { ...options, authInfo: auth });
-
-  const client = new Client({ name: "test-client", version: "1.0.0" });
-  await server.connect(serverTransport);
-  await client.connect(clientTransport);
-
-  return {
-    client,
-    cleanup: async () => {
-      await client.close();
-      await server.close();
-    },
-  };
+  return setupMcpClient(registerTierLane, mockPool, embedFn ?? createMockEmbed(), auth);
 }
 
-describe("tier_lane", () => {
-  // ── AUTH ──
-
+describe("tier_lane AUTH", () => {
   it("denies when auth is missing entirely", async () => {
     const mockPool = { query: async () => ({ rows: [] }) };
-    const server = new McpServer({ name: "test", version: "1.0.0" });
-    const deps: ToolDeps = { pool: mockPool as any, embedFn: createMockEmbed() };
-    registerTierLane(server, deps);
-    const [ct, st] = InMemoryTransport.createLinkedPair();
-    const client = new Client({ name: "tc", version: "1.0.0" });
-    await server.connect(st);
-    await client.connect(ct);
+    // `auth: null` leaves the transport unwired, so the call arrives with no
+    // AuthInfo at all -- which is the case under test.
+    const { client, cleanup } = await setupMcpClient(
+      registerTierLane,
+      mockPool,
+      createMockEmbed(),
+      null,
+    );
 
     try {
       const res = await client.callTool({
@@ -121,10 +94,9 @@ describe("tier_lane", () => {
         arguments: { session_key: "task-42" },
       });
       expect(res.isError).toBe(true);
-      expect((res.content as any)[0].text).toContain("Permission denied");
+      expect(getErrorText(res)).toContain("Permission denied");
     } finally {
-      await client.close();
-      await server.close();
+      await cleanup();
     }
   });
 
@@ -138,7 +110,7 @@ describe("tier_lane", () => {
         arguments: { session_key: "task-42" },
       });
       expect(res.isError).toBe(true);
-      expect((res.content as any)[0].text).toContain("Permission denied");
+      expect(getErrorText(res)).toContain("Permission denied");
     } finally {
       await cleanup();
     }
@@ -169,7 +141,7 @@ describe("tier_lane", () => {
         arguments: { session_key: "task-42", namespace: "skippy" },
       });
       expect(res.isError).toBe(true);
-      expect((res.content as any)[0].text).toContain("Permission denied");
+      expect(getErrorText(res)).toContain("Permission denied");
     } finally {
       await cleanup();
     }
@@ -189,14 +161,14 @@ describe("tier_lane", () => {
         arguments: { session_key: "task-42", namespace: "other" },
       });
       expect(res.isError).toBe(true);
-      expect((res.content as any)[0].text).toContain("Permission denied");
+      expect(getErrorText(res)).toContain("Permission denied");
     } finally {
       await cleanup();
     }
   });
+});
 
-  // ── DRY RUN ──
-
+describe("tier_lane DRY RUN", () => {
   it("dry-run (default) performs NO writes and reports would-graduate", async () => {
     const mockPool = createMockPool({ events: [laneEventRow()] });
     const auth: AuthInfo = { role: "agent", clientId: "bilby" };
@@ -207,7 +179,7 @@ describe("tier_lane", () => {
         arguments: { session_key: "task-42", namespace: "bilby" },
       });
       expect(res.isError).toBeFalsy();
-      const parsed = JSON.parse((res.content as any)[0].text);
+      const parsed = parseToolResult(res);
       expect(parsed.dry_run).toBe(true);
       expect(parsed.scanned).toBe(1);
       expect(parsed.graduated).toBe(1);
@@ -216,9 +188,9 @@ describe("tier_lane", () => {
       await cleanup();
     }
   });
+});
 
-  // ── APPLY ──
-
+describe("tier_lane APPLY", () => {
   it("apply mode writes a graduated thought", async () => {
     const mockPool = createMockPool({ events: [laneEventRow()] });
     const auth: AuthInfo = { role: "agent", clientId: "bilby" };
@@ -233,25 +205,26 @@ describe("tier_lane", () => {
         },
       });
       expect(res.isError).toBeFalsy();
-      const parsed = JSON.parse((res.content as any)[0].text);
+      const parsed = parseToolResult(res);
       expect(parsed.graduated).toBe(1);
       expect(mockPool.writes.length).toBe(1);
       // provenance + tags carried into the INSERT params
-      const write = mockPool.writes[0]!;
-      const provenance = JSON.parse(write.params[8]);
+      const write = mockPool.writes[0];
+      expect(write).toBeDefined();
+      const provenance = JSON.parse(String(write?.params[8]));
       expect(provenance.source).toBe("session-lane");
       expect(provenance.lane_id).toBe("lane-1");
       expect(provenance.event_id).toBe("evt-1");
-      const tags = write.params[1];
+      const tags = write?.params[1];
       expect(tags).toContain("tiered-from-lane");
       expect(tags).toContain("lane:task-42");
     } finally {
       await cleanup();
     }
   });
+});
 
-  // ── DEDUP ──
-
+describe("tier_lane DEDUP", () => {
   it("skips an exact-hash duplicate (no write)", async () => {
     const mockPool = createMockPool({
       events: [laneEventRow()],
@@ -268,7 +241,7 @@ describe("tier_lane", () => {
           dry_run: false,
         },
       });
-      const parsed = JSON.parse((res.content as any)[0].text);
+      const parsed = parseToolResult(res);
       expect(parsed.duplicates).toBe(1);
       expect(parsed.graduated).toBe(0);
       expect(mockPool.writes.length).toBe(0);
@@ -293,7 +266,7 @@ describe("tier_lane", () => {
           dry_run: false,
         },
       });
-      const parsed = JSON.parse((res.content as any)[0].text);
+      const parsed = parseToolResult(res);
       expect(parsed.duplicates).toBe(1);
       expect(parsed.graduated).toBe(0);
       expect(mockPool.writes.length).toBe(0);
@@ -301,9 +274,9 @@ describe("tier_lane", () => {
       await cleanup();
     }
   });
+});
 
-  // ── RECEIPT SHAPE / CLASSIFICATION ──
-
+describe("tier_lane RECEIPT SHAPE / CLASSIFICATION", () => {
   it("returns the full receipt shape across mixed event types", async () => {
     const long = "x".repeat(40);
     const mockPool = createMockPool({
@@ -343,7 +316,7 @@ describe("tier_lane", () => {
         name: "tier_lane",
         arguments: { session_key: "task-42", namespace: "bilby" },
       });
-      const parsed = JSON.parse((res.content as any)[0].text);
+      const parsed = parseToolResult(res);
       expect(parsed.scanned).toBe(5);
       expect(parsed.graduated).toBe(1); // fact/warm/long
       expect(parsed.archived).toBe(2); // question + cold handoff
@@ -365,7 +338,7 @@ describe("tier_lane", () => {
         name: "tier_lane",
         arguments: { session_key: "task-42" },
       });
-      const parsed = JSON.parse((res.content as any)[0].text);
+      const parsed = parseToolResult(res);
       expect(parsed.namespace).toBe("bilby");
     } finally {
       await cleanup();
@@ -379,150 +352,16 @@ describe("tier_lane", () => {
       },
     };
     const auth: AuthInfo = { role: "agent", clientId: "bilby" };
-    const { client, cleanup } = await setupToolClient(mockPool as any, auth);
+    const { client, cleanup } = await setupToolClient(mockPool as MockPool, auth);
     try {
       const res = await client.callTool({
         name: "tier_lane",
         arguments: { session_key: "task-42", namespace: "bilby" },
       });
       expect(res.isError).toBe(true);
-      expect((res.content as any)[0].text).toContain("connection refused");
+      expect(getErrorText(res)).toContain("connection refused");
     } finally {
       await cleanup();
     }
-  });
-});
-
-// ── DB-BACKED INTEGRATION ──
-// Mocks can't catch real Postgres halfvec/embedding behavior, the ON CONFLICT
-// idempotency, or cosine-distance dedup. Gated on OPENBRAIN_TEST_DATABASE_URL.
-//   OPENBRAIN_TEST_DATABASE_URL=postgres://... bun test src/tools/__tests__/tier-lane.test.ts
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-
-dbDescribe("tier_lane (live Postgres)", () => {
-  const pool = new Pool({ connectionString: DB_URL });
-  const ns = "test-tier-lane-live";
-  const sessionKey = "live-tier-lane";
-  // Deterministic embeddings so near-dup behavior is testable.
-  const baseEmbedding = Array(768).fill(0.1);
-  const embedFn = createMockEmbed(baseEmbedding);
-
-  async function callTierLane(args: Record<string, unknown>, auth: AuthInfo) {
-    const server = new McpServer({ name: "test", version: "1.0.0" });
-    const deps: ToolDeps = { pool: pool as any, embedFn };
-    registerTierLane(server, deps);
-    const [ct, st] = InMemoryTransport.createLinkedPair();
-    const original = ct.send.bind(ct);
-    ct.send = (m: any, o?: any) => original(m, { ...o, authInfo: auth });
-    const client = new Client({ name: "tc", version: "1.0.0" });
-    await server.connect(st);
-    await client.connect(ct);
-    const res = await client.callTool({ name: "tier_lane", arguments: args });
-    await client.close();
-    await server.close();
-    return res;
-  }
-
-  async function seedLaneWithEvent(content: string, eventType = "fact") {
-    const { rows } = await pool.query(
-      `INSERT INTO ob_session_lanes (session_key, namespace, agent, created_by)
-       VALUES ($1, $2, $3, $3)
-       ON CONFLICT (namespace, session_key) DO UPDATE SET updated_at = NOW()
-       RETURNING id`,
-      [sessionKey, ns, ns],
-    );
-    const laneId = rows[0].id as string;
-    await pool.query(
-      `INSERT INTO ob_session_events
-         (lane_id, event_type, content, importance, content_hash, embedding, created_by)
-       VALUES ($1, $2, $3, 'warm', $4, $5, $6)
-       ON CONFLICT (lane_id, content_hash) WHERE content_hash IS NOT NULL
-       DO NOTHING`,
-      [laneId, eventType, content, contentHash(content), toSql(baseEmbedding), ns],
-    );
-    return laneId;
-  }
-
-  async function cleanup() {
-    await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [ns]);
-    await pool.query("DELETE FROM thoughts WHERE namespace = $1", [ns]);
-  }
-
-  afterAll(async () => {
-    await cleanup();
-    await pool.end();
-  });
-
-  it("graduates a fact into the namespace with provenance, idempotent on re-run", async () => {
-    await cleanup();
-    const content =
-      "Live durable fact about the open-brain tiering integration test path";
-    await seedLaneWithEvent(content);
-    const auth: AuthInfo = { role: "agent", clientId: ns };
-
-    const first = await callTierLane(
-      { session_key: sessionKey, namespace: ns, dry_run: false },
-      auth,
-    );
-    expect(first.isError).toBeFalsy();
-    expect(JSON.parse((first.content as any)[0].text).graduated).toBe(1);
-
-    const { rows: afterFirst } = await pool.query(
-      "SELECT id, promoted_from, tags FROM thoughts WHERE namespace = $1",
-      [ns],
-    );
-    expect(afterFirst.length).toBe(1);
-    expect(afterFirst[0].promoted_from.source).toBe("session-lane");
-    expect(afterFirst[0].tags).toContain("tiered-from-lane");
-
-    // Re-run: ON CONFLICT idempotency — exact-hash dedup skips, no new row.
-    const second = await callTierLane(
-      { session_key: sessionKey, namespace: ns, dry_run: false },
-      auth,
-    );
-    expect(second.isError).toBeFalsy();
-    expect(JSON.parse((second.content as any)[0].text).duplicates).toBe(1);
-
-    const { rows: afterSecond } = await pool.query(
-      "SELECT count(*)::int AS n FROM thoughts WHERE namespace = $1",
-      [ns],
-    );
-    expect(afterSecond[0].n).toBe(1);
-  });
-
-  it("skips a near-duplicate by embedding distance", async () => {
-    await cleanup();
-    const auth: AuthInfo = { role: "agent", clientId: ns };
-    // First event graduates.
-    await seedLaneWithEvent(
-      "Original durable statement that should graduate into thoughts cleanly",
-    );
-    await callTierLane(
-      { session_key: sessionKey, namespace: ns, dry_run: false },
-      auth,
-    );
-
-    // Second event: different text + hash but identical embedding → near-dup.
-    await seedLaneWithEvent(
-      "A slightly reworded but semantically identical durable statement here",
-    );
-    const res = await callTierLane(
-      { session_key: sessionKey, namespace: ns, dry_run: false },
-      auth,
-    );
-    const parsed = JSON.parse((res.content as any)[0].text);
-    // The tool re-scans the whole lane, so BOTH events are now duplicates:
-    // event 1 by exact content_hash (already graduated), event 2 by near
-    // embedding distance. The point is that the near-dup event 2 did NOT
-    // graduate (no new row), proving embedding dedup works.
-    expect(parsed.graduated).toBe(0);
-    expect(parsed.duplicates).toBe(2);
-
-    const { rows } = await pool.query(
-      "SELECT count(*)::int AS n FROM thoughts WHERE namespace = $1",
-      [ns],
-    );
-    expect(rows[0].n).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- The live-Postgres half of `src/tools/__tests__/tier-lane.test.ts` read `OPENBRAIN_TEST_DATABASE_URL` itself and swapped in `describe.skip` when it was unset. A run without a database reported `12 pass, 3 skip, 0 fail` and exited 0 — at the exit code that is indistinguishable from a suite that ran and passed, which is the false green #878 exists to close.
- Split by subject: `tier-lane.test.ts` keeps the mock-pool suites and the fake-pool helpers; new `src/tools/__tests__/tier-lane.pg.test.ts` holds the live suite as a plain `describe("tier_lane (live Postgres)")` with a module-scope `new Pool({ connectionString: requireTestDatabaseUrl() })`, ended once in its own `afterAll`. Absent the variable the helper throws `test_database_required` and the run fails loudly.
- `createMockEmbed` was defined locally and is now needed by both halves. `src/tools/__tests__/test-helpers.ts` already exported an identical function (same `Array(768).fill(0.1)` default, same returned closure), so both files import that rather than introducing a new helper module.
- Test bodies, names, and assertions moved verbatim. Only the describe wrappers, imports, pool creation, and helper plumbing changed.
- `scripts/assert-db-tests-ran.ts` needs no edit: the live describe string is unchanged and JUnit still reports 2 testcases under `tier_lane (live Postgres)`, matching the existing `minTests: 2` entry, so `MIN_TOTAL_LIVE_TESTCASES` stays at 265. Verified from JUnit rather than tallied by eye.
- The pre-commit gate lints staged files whole, so touching this file made its 29 pre-existing oxlint findings this change's to clear, with no disable comments. Most were cleared by reuse: `test-helpers.ts` already exported `setupMcpClient`, `parseToolResult`, `getErrorText`, and `MockPool`, and both halves were hand-rolling the same MCP client wiring and the same `JSON.parse((res.content as any)[0].text)`. That removed 26 `no-explicit-any` sites and both hand-rolled clients. The no-auth case now calls `setupMcpClient` with `auth: null`, which is exactly what that argument is for — it leaves the transport unwired so the call arrives with no AuthInfo. The remaining three: `writes[0]!` became an explicit `expect(write).toBeDefined()` plus optional access; the 266-line `describe("tier_lane")` was split along its own five section comments into sibling top-level describes (nesting does not satisfy the rule, which counts the outer body); and the live file's fixture constants and seed/cleanup helpers moved to module scope.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- RED at `origin/main`, before any edit: `CHANGED_FILES="src/tools/__tests__/tier-lane.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` -> exit 1, clauses 1, 2 and 3 FAIL (clause 4 PASS).
- GREEN after the change: `CHANGED_FILES="src/tools/__tests__/tier-lane.pg.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` -> exit 0, all four clauses PASS.
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bun run test:isolated src/tools/__tests__/tier-lane.pg.test.ts src/tools/__tests__/tier-lane.test.ts` -> exit 0, 14 pass / 0 fail / 0 skip (was 12 pass / 3 skip). `bunx tsc --noEmit` -> exit 0. `./node_modules/.bin/oxlint --deny-warnings` over both files -> exit 0. Python package and live smoke are not applicable: this change touches two test files and no runtime, schema, or client code.

## Critical Self-Review

- Highest-risk behavior: the live suite silently ceasing to run under a different name. The describe string is byte-identical to the manifest entry it feeds, and JUnit was read back to confirm 2 testcases still carry `tier_lane (live Postgres)` — the anti-skip guard in `scripts/assert-db-tests-ran.ts` is the thing that would otherwise go quiet.
- Assumptions that could be wrong: that `test-helpers.ts`'s `createMockEmbed` is equivalent to the local one it replaces. Checked by reading both bodies — same default argument and same returned closure — rather than by name. Likewise `setupMcpClient`, whose body was read to confirm it registers the tool and wires auth identically, and that `auth: null` skips the transport wrapper rather than passing a null AuthInfo.
- Missing/weak tests: no test was added; this is a conversion, and the existing assertions moved verbatim. The proof that the conversion works is clause 3 of the done-means, which observes the hard failure rather than arranging it.
- Security/permission risk: none. No namespace predicate, auth path, or SQL was touched. The permission assertions in the mock suites moved unmodified.
- Migration/deploy risk: none. No migration, no runtime file, no config.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classifies by MCP tool/schema/protocol/client-facing surface; two test files touch none of them.
- Rollback/cleanup concern: reverting the commit restores the single file as it was. The isolated test database is created and dropped by `test:isolated` itself; the run reported both teardowns ok.
- Fixes made before PR: the 29 pre-existing oxlint findings the whole-file gate surfaced, described in the summary. The `writes[0]!` change is the only one that alters what is asserted, and it strengthens it — the non-null assertion was claiming something the test never checked, and now the test checks it.
- Known residual risk: the mock suites now live under five top-level describe names instead of one. Nothing indexes those names — they are absent from `scripts/assert-db-tests-ran.ts`, which tracks live suites only — but a future filter matching `describe("tier_lane")` exactly would no longer match them.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the lessons here are a conversion pattern already covered by the #878 done-means check itself and by the existing lane-contract Tightenings on whole-file lint scope (PR #806); no new MEDIUM+ finding surfaced that the next swarm would miss.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, schema, or client-facing surface changed; the live-Postgres coverage in this PR runs against the isolated test database, not the hosted service.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, schema, or client surface is touched — the diff is two TypeScript test files.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Every downstream item is not applicable. The gate applies to MCP tool, schema, protocol, or client-facing changes; this PR changes two test files and no shipped surface. `src/tools/tier-lane.ts` itself is untouched.
