### PR TITLE
test(pg): the search-brain FTS language tests require the test database instead of skipping (#878)

### DIFF
--- a/src/tools/__tests__/search-brain-fts-language-config.pg.test.ts
+++ b/src/tools/__tests__/search-brain-fts-language-config.pg.test.ts
@@ -1,0 +1,218 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { executeSearch } from "../search-brain.ts";
+import type { ToolDeps } from "../index.ts";
+import { requestFtsConfig, resolveFtsConfig } from "../fts-config.ts";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
+import {
+  assertUtf8Harness,
+  embed,
+  THOUGHTS_ONLY,
+} from "./search-brain-fts-language-test-helpers.ts";
+
+/**
+ * Live-PostgreSQL coverage that a corpus's declared language selects the real
+ * search config through an explicit request setting (#341), split out of
+ * search-brain-fts-language.pg.test.ts so each live suite owns one file.
+ *
+ * HONEST SCOPE. There is NO thought->ob_sources linkage in the schema
+ * (`thoughts` has no source_id), so an ob_sources.language value cannot, on its
+ * own, control the config a search analyzes with. The truthful causal chain is:
+ * a corpus's declared language -> an explicit request `fts_config` setting ->
+ * the regconfig the real search path actually uses. The block below exercises
+ * exactly that chain (resolveFtsConfig(language) fed as the explicit request
+ * config), and does NOT pretend an unlinked source row drives retrieval by
+ * itself.
+ *
+ * The imported helper demands a real Postgres at module scope rather than
+ * letting the suite skip itself when the harness is absent (#878).
+ */
+
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+
+const deps = { pool: pool as never, embedFn: embed };
+const ns = "test-fts-language-e2e";
+
+async function cleanup(): Promise<void> {
+  await pool.query("DELETE FROM thoughts WHERE namespace = $1", [ns]);
+  await pool.query(
+    "DELETE FROM ob_sources WHERE namespace = $1 AND external_id LIKE $2",
+    [ns, "fts-lang-e2e/%"],
+  );
+}
+
+// One representative supported-language corpus per approved source kind:
+// synchronized file source (directory), approved drop-folder (drop), and
+// approved conversation content (conversation). Each declares a language on
+// its ob_sources row; that declared language is fed as the explicit request
+// `fts_config` (via requestFtsConfig) -- the same knob a caller uses -- and
+// that is what selects the config the real search path analyzes with.
+const sources = [
+  {
+    kind: "directory" as const,
+    externalId: "fts-lang-e2e/repo-de",
+    language: "de-DE",
+    expectConfig: "german" as const,
+    thoughtId: "21000000-0000-4000-8000-000000000001",
+    content: "Die Häuser wurden im Repository dokumentiert",
+    query: "Haus",
+    missUnder: "english" as const,
+  },
+  {
+    kind: "drop" as const,
+    externalId: "fts-lang-e2e/drop-es",
+    language: "es",
+    expectConfig: "spanish" as const,
+    thoughtId: "21000000-0000-4000-8000-000000000002",
+    content: "El documento describe atletas corriendo",
+    query: "corrió",
+    missUnder: "english" as const,
+  },
+  {
+    kind: "conversation" as const,
+    externalId: "fts-lang-e2e/convo-en",
+    language: "en-US",
+    expectConfig: "english" as const,
+    thoughtId: "21000000-0000-4000-8000-000000000003",
+    content: "The teams were running the deployment",
+    query: "runs",
+    missUnder: null,
+  },
+];
+
+/** Seed the approved source row AND read its stored language back. */
+async function seedSource(s: (typeof sources)[number]): Promise<string> {
+  const { rows } = await pool.query(
+    `INSERT INTO ob_sources
+       (namespace, source_kind, external_id, approval_state, approved_by,
+        approved_at, lifecycle_state, language, created_by)
+     VALUES ($1, $2, $3, 'approved', 'test-approver', now(), 'active', $4, 'test')
+     ON CONFLICT (namespace, source_kind, external_id)
+     DO UPDATE SET language = EXCLUDED.language, approval_state = 'approved'
+     RETURNING language`,
+    [ns, s.kind, s.externalId, s.language],
+  );
+  await pool.query(
+    `INSERT INTO thoughts (id, content, namespace, created_by, content_hash)
+     VALUES ($1, $2, $3, 'test', $4)
+     ON CONFLICT (id) DO UPDATE SET content = EXCLUDED.content`,
+    [s.thoughtId, s.content, ns, `fts-lang-e2e-${s.thoughtId}`],
+  );
+  return rows[0].language as string;
+}
+
+/**
+ * Run the real search path. `declaredLanguage` is the value stored on the
+ * source row; it flows through requestFtsConfig exactly as the public
+ * `search_brain` handler routes its `fts_config` argument -- there is no
+ * hand-picked internal config literal here.
+ */
+async function keywordIdsForLanguage(
+  query: string,
+  declaredLanguage: string,
+): Promise<string[]> {
+  const rows = await executeSearch(
+    deps as ToolDeps,
+    THOUGHTS_ONLY,
+    query,
+    10,
+    "keyword",
+    undefined,
+    0,
+    ns,
+    false,
+    undefined,
+    // requestFtsConfig(declaredLanguage) is the caller-visible selection;
+    // pass an empty env so ONLY the declared language can drive the config.
+    { ftsConfig: requestFtsConfig(declaredLanguage, {}) },
+  );
+  return rows.map((r) => r.id);
+}
+describe("declared source language selects the real search config via explicit request (live Postgres)", () => {
+  beforeAll(async () => {
+    await assertUtf8Harness(pool);
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  it("each source's stored language maps to the expected config (metadata only)", async () => {
+    // Pure metadata-mapping check: the stored ob_sources.language round-trips
+    // to the right regconfig. This does NOT by itself drive retrieval -- the
+    // ranking test below proves the retrieval effect via the explicit request.
+    await cleanup();
+    for (const s of sources) {
+      const stored = await seedSource(s);
+      expect(resolveFtsConfig(stored)).toBe(s.expectConfig);
+    }
+  });
+
+  it("declared source language, fed as the explicit request config, drives ranking", async () => {
+    await cleanup();
+    for (const s of sources) {
+      const declaredLanguage = await seedSource(s);
+      const underOwn = await keywordIdsForLanguage(s.query, declaredLanguage);
+      expect(underOwn).toContain(s.thoughtId);
+      if (s.missUnder) {
+        // Same query, but english (the mismatched config) misses it.
+        const underMismatch = await keywordIdsForLanguage(s.query, "en");
+        expect(underMismatch).not.toContain(s.thoughtId);
+      }
+    }
+  });
+
+  it("deterministic before/after comparison across the three source kinds", async () => {
+    await cleanup();
+    // Structured, order-stable table: for each representative fixture, record
+    // whether its document is found under (a) english = the pre-#341 baseline
+    // and (b) its declared language config. english-content fixtures must
+    // show NO regression; non-english fixtures show the language-aware gain.
+    const comparison = [];
+    for (const s of sources) {
+      const declaredLanguage = await seedSource(s);
+      const foundUnderEnglish = (await keywordIdsForLanguage(s.query, "en")).includes(
+        s.thoughtId,
+      );
+      const foundUnderDeclared = (
+        await keywordIdsForLanguage(s.query, declaredLanguage)
+      ).includes(s.thoughtId);
+      comparison.push({
+        kind: s.kind,
+        declaredLanguage,
+        config: s.expectConfig,
+        query: s.query,
+        before_english: foundUnderEnglish,
+        after_declared: foundUnderDeclared,
+      });
+    }
+
+    expect(comparison).toEqual([
+      {
+        kind: "directory",
+        declaredLanguage: "de-DE",
+        config: "german",
+        query: "Haus",
+        before_english: false, // english analysis misses the german inflection
+        after_declared: true, // german stemming finds it
+      },
+      {
+        kind: "drop",
+        declaredLanguage: "es",
+        config: "spanish",
+        query: "corrió",
+        before_english: false,
+        after_declared: true,
+      },
+      {
+        kind: "conversation",
+        declaredLanguage: "en-US",
+        config: "english",
+        query: "runs",
+        before_english: true, // english content: no regression
+        after_declared: true, // declared english == baseline
+      },
+    ]);
+  });
+});

--- a/src/tools/__tests__/search-brain-fts-language-fields.pg.test.ts
+++ b/src/tools/__tests__/search-brain-fts-language-fields.pg.test.ts
@@ -1,0 +1,171 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { executeSearch } from "../search-brain.ts";
+import type { ToolDeps } from "../index.ts";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
+import { assertUtf8Harness, embed } from "./search-brain-fts-language-test-helpers.ts";
+
+/**
+ * Live-PostgreSQL coverage that language-aware FTS reaches every source field
+ * migration 007 indexes (#341), split out of search-brain-fts-language.pg.test.ts
+ * so each live suite owns one file.
+ *
+ * The imported helper demands a real Postgres at module scope rather than
+ * letting the suite skip itself when the harness is absent (#878).
+ */
+
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+
+const deps = { pool: pool as never, embedFn: embed };
+const ns = "test-fts-language-all-tables";
+
+const tableCases = [
+  {
+    table: "decisions" as const,
+    ids: [
+      "22000000-0000-4000-8000-000000000001",
+      "22000000-0000-4000-8000-000000000002",
+      "22000000-0000-4000-8000-000000000003",
+      "22000000-0000-4000-8000-000000000004",
+    ],
+    seed: () =>
+      pool.query(
+        `INSERT INTO decisions
+           (id, title, rationale, context, tags, namespace, created_by)
+         VALUES
+           ($2, 'Häuser', 'neutral rationale', NULL, '{}', $1, 'test'),
+           ($3, 'neutral title 2', 'Häuser', NULL, '{}', $1, 'test'),
+           ($4, 'neutral title 3', 'neutral rationale', 'Häuser', '{}', $1, 'test'),
+           ($5, 'neutral title 4', 'neutral rationale', NULL, ARRAY['Häuser'], $1, 'test')`,
+        [
+          ns,
+          "22000000-0000-4000-8000-000000000001",
+          "22000000-0000-4000-8000-000000000002",
+          "22000000-0000-4000-8000-000000000003",
+          "22000000-0000-4000-8000-000000000004",
+        ],
+      ),
+  },
+  {
+    table: "relationships" as const,
+    ids: [
+      "22000000-0000-4000-8000-000000000011",
+      "22000000-0000-4000-8000-000000000012",
+      "22000000-0000-4000-8000-000000000013",
+    ],
+    seed: () =>
+      pool.query(
+        `INSERT INTO relationships
+           (id, person_name, context, tags, namespace, created_by)
+         VALUES
+           ($2, 'Häuser', NULL, '{}', $1, 'test'),
+           ($3, 'neutral person 12', 'Häuser', '{}', $1, 'test'),
+           ($4, 'neutral person 13', NULL, ARRAY['Häuser'], $1, 'test')`,
+        [
+          ns,
+          "22000000-0000-4000-8000-000000000011",
+          "22000000-0000-4000-8000-000000000012",
+          "22000000-0000-4000-8000-000000000013",
+        ],
+      ),
+  },
+  {
+    table: "projects" as const,
+    ids: [
+      "22000000-0000-4000-8000-000000000021",
+      "22000000-0000-4000-8000-000000000022",
+      "22000000-0000-4000-8000-000000000023",
+    ],
+    seed: () =>
+      pool.query(
+        `INSERT INTO projects
+           (id, name, description, tags, namespace, created_by)
+         VALUES
+           ($2, 'Häuser', NULL, '{}', $1, 'test'),
+           ($3, 'neutral project 22', 'Häuser', '{}', $1, 'test'),
+           ($4, 'neutral project 23', NULL, ARRAY['Häuser'], $1, 'test')`,
+        [
+          ns,
+          "22000000-0000-4000-8000-000000000021",
+          "22000000-0000-4000-8000-000000000022",
+          "22000000-0000-4000-8000-000000000023",
+        ],
+      ),
+  },
+  {
+    table: "sessions" as const,
+    ids: [
+      "22000000-0000-4000-8000-000000000031",
+      "22000000-0000-4000-8000-000000000032",
+      "22000000-0000-4000-8000-000000000033",
+      "22000000-0000-4000-8000-000000000034",
+    ],
+    seed: () =>
+      pool.query(
+        `INSERT INTO sessions
+           (id, summary, next_steps, key_decisions, tags, namespace, created_by)
+         VALUES
+           ($2, 'Häuser', '{}', '{}', '{}', $1, 'test'),
+           ($3, 'neutral summary 32', ARRAY['Häuser'], '{}', '{}', $1, 'test'),
+           ($4, 'neutral summary 33', '{}', ARRAY['Häuser'], '{}', $1, 'test'),
+           ($5, 'neutral summary 34', '{}', '{}', ARRAY['Häuser'], $1, 'test')`,
+        [
+          ns,
+          "22000000-0000-4000-8000-000000000031",
+          "22000000-0000-4000-8000-000000000032",
+          "22000000-0000-4000-8000-000000000033",
+          "22000000-0000-4000-8000-000000000034",
+        ],
+      ),
+  },
+];
+
+async function cleanup(): Promise<void> {
+  for (const { table } of tableCases.toReversed()) {
+    await pool.query(`DELETE FROM ${table} WHERE namespace = $1`, [ns]);
+  }
+}
+
+async function keywordIds(
+  table: (typeof tableCases)[number]["table"],
+  ftsConfig: "english" | "german",
+): Promise<string[]> {
+  const rows = await executeSearch(
+    deps as ToolDeps,
+    [table],
+    "Haus",
+    10,
+    "keyword",
+    undefined,
+    0,
+    ns,
+    false,
+    undefined,
+    { ftsConfig },
+  );
+  return rows.map((row) => row.id);
+}
+describe("language-aware FTS covers every migration-007 source field (live Postgres)", () => {
+  beforeAll(async () => {
+    await assertUtf8Harness(pool);
+  });
+
+  afterAll(async () => {
+    await cleanup();
+    await pool.end();
+  });
+
+  it("finds an isolated German inflection in every indexed field", async () => {
+    await cleanup();
+
+    for (const tableCase of tableCases) {
+      await tableCase.seed();
+
+      const underGerman = await keywordIds(tableCase.table, "german");
+      const underEnglish = await keywordIds(tableCase.table, "english");
+
+      expect(underGerman.toSorted()).toEqual(tableCase.ids.toSorted());
+      expect(underEnglish).toEqual([]);
+    }
+  });
+});

--- a/src/tools/__tests__/search-brain-fts-language-test-helpers.ts
+++ b/src/tools/__tests__/search-brain-fts-language-test-helpers.ts
@@ -1,0 +1,31 @@
+import { Pool } from "pg";
+import { createMockEmbed } from "./test-helpers.ts";
+/**
+ * Fail loudly on a non-UTF8 test harness. Under SQL_ASCII (or any non-UTF8
+ * encoding) the snowball stemmers split the multibyte bytes of accented
+ * characters (ä -> two single-byte chars), so "Häuser" never stems to "haus"
+ * and every non-english ranking assertion below returns []. That looks like a
+ * product bug but is purely an invalid harness -- Open Brain is UTF8 in
+ * production. This turns the confusing empty-ranking failure into a clear
+ * "test DB must be UTF8" signal. See .github/workflows/ci.yml (`createdb
+ * -E UTF8 -T template0`).
+ */
+export async function assertUtf8Harness(pool: Pool): Promise<void> {
+  const { rows } = await pool.query<{ server_encoding: string }>(
+    "SHOW server_encoding",
+  );
+  const encoding = rows[0]?.server_encoding;
+  if (encoding !== "UTF8") {
+    throw new Error(
+      `language-aware FTS tests require a UTF8 test database; server_encoding is ` +
+        `${encoding ?? "unknown"}. Snowball stemming of accented multibyte text ` +
+        `is broken under non-UTF8 encodings. Recreate the DB with ` +
+        `\`createdb -E UTF8 -T template0\`.`,
+    );
+  }
+}
+
+// Vector arm is irrelevant here; force keyword mode so we isolate the lexical
+// FTS config behavior deterministically.
+export const embed = createMockEmbed(null);
+export const THOUGHTS_ONLY: "thoughts"[] = ["thoughts"];

--- a/src/tools/__tests__/search-brain-fts-language.pg.test.ts
+++ b/src/tools/__tests__/search-brain-fts-language.pg.test.ts
@@ -1,67 +1,95 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
 import { executeSearch } from "../search-brain.ts";
-import { requestFtsConfig, resolveFtsConfig } from "../fts-config.ts";
-import { createMockEmbed } from "./test-helpers.ts";
+import type { ToolDeps } from "../index.ts";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
+import {
+  assertUtf8Harness,
+  embed,
+  THOUGHTS_ONLY,
+} from "./search-brain-fts-language-test-helpers.ts";
 
 /**
  * Live-PostgreSQL functional ranking coverage for language-aware FTS (#341).
  *
- * These run only when OPENBRAIN_TEST_DATABASE_URL points at a real Postgres
- * with the migrations applied (the stored english search_vector column and the
- * bundled snowball text-search configs). They prove the actual retrieval
- * benefit: content that only matches once its language is stemmed correctly is
- * found under the language-aware config and NOT under a mismatched english
- * config -- the before/after that motivates the change.
+ * These require a real Postgres with the migrations applied (the stored english
+ * search_vector column and the bundled snowball text-search configs), which the
+ * imported helper demands at module scope rather than skipping the suite when
+ * the harness is absent (#878). They prove the actual retrieval benefit:
+ * content that only matches once its language is stemmed correctly is found
+ * under the language-aware config and NOT under a mismatched english config --
+ * the before/after that motivates the change.
  *
- * HONEST SCOPE. There is NO thought->ob_sources linkage in the schema
- * (`thoughts` has no source_id), so an ob_sources.language value cannot, on its
- * own, control the config a search analyzes with. The truthful causal chain is:
- * a corpus's declared language -> an explicit request `fts_config` setting ->
- * the regconfig the real search path actually uses. The per-source-kind block
- * below exercises exactly that chain (resolveFtsConfig(language) fed as the
- * explicit request config), and does NOT pretend an unlinked source row drives
- * retrieval by itself.
+ * The two sibling files hold the other halves of the original suite: the
+ * migration-007 source-field coverage and the declared-language end-to-end
+ * chain.
  */
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+const deps = { pool: pool as never, embedFn: embed } as ToolDeps;
+const ns = "test-fts-language";
 
-/**
- * Fail loudly on a non-UTF8 test harness. Under SQL_ASCII (or any non-UTF8
- * encoding) the snowball stemmers split the multibyte bytes of accented
- * characters (ä -> two single-byte chars), so "Häuser" never stems to "haus"
- * and every non-english ranking assertion below returns []. That looks like a
- * product bug but is purely an invalid harness -- Open Brain is UTF8 in
- * production. This turns the confusing empty-ranking failure into a clear
- * "test DB must be UTF8" signal. See .github/workflows/ci.yml (`createdb
- * -E UTF8 -T template0`).
- */
-async function assertUtf8Harness(pool: Pool): Promise<void> {
-  const { rows } = await pool.query<{ server_encoding: string }>(
-    "SHOW server_encoding",
+async function cleanup(): Promise<void> {
+  await pool.query("DELETE FROM entry_access_log WHERE query_text LIKE $1", [
+    "%__fts_lang_probe__%",
+  ]);
+  await pool.query("DELETE FROM thoughts WHERE namespace = $1", [ns]);
+  await pool.query(
+    "DELETE FROM ob_sources WHERE namespace = $1 AND external_id LIKE $2",
+    [ns, "fts-lang/%"],
   );
-  const encoding = rows[0]?.server_encoding;
-  if (encoding !== "UTF8") {
-    throw new Error(
-      `language-aware FTS tests require a UTF8 test database; server_encoding is ` +
-        `${encoding ?? "unknown"}. Snowball stemming of accented multibyte text ` +
-        `is broken under non-UTF8 encodings. Recreate the DB with ` +
-        `\`createdb -E UTF8 -T template0\`.`,
-    );
-  }
 }
 
-// Vector arm is irrelevant here; force keyword mode so we isolate the lexical
-// FTS config behavior deterministically.
-const embed = createMockEmbed(null);
-const THOUGHTS_ONLY: "thoughts"[] = ["thoughts"];
+async function seedThought(id: string, content: string): Promise<void> {
+  await pool.query(
+    `INSERT INTO thoughts (id, content, namespace, created_by, content_hash)
+     VALUES ($1, $2, $3, 'test', $4)
+     ON CONFLICT (id) DO UPDATE SET content = EXCLUDED.content`,
+    [id, content, ns, `fts-lang-${id}`],
+  );
+}
 
-dbDescribe("search_brain language-aware FTS ranking (live Postgres)", () => {
-  const pool = new Pool({ connectionString: DB_URL });
-  const deps = { pool: pool as any, embedFn: embed };
-  const ns = "test-fts-language";
+/**
+ * Seed a thought whose matchable non-english token lives ONLY in `tags`, not
+ * in `content`. Both FTS paths fold tags into the analyzed text (english via
+ * the stored generated `search_vector`, non-english via the on-the-fly
+ * to_tsvector over FTS_SOURCE_TEXT), so this isolates tag-token stemming.
+ */
+async function seedThoughtWithTags(
+  id: string,
+  content: string,
+  tags: string[],
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO thoughts (id, content, tags, namespace, created_by, content_hash)
+     VALUES ($1, $2, $3, $4, 'test', $5)
+     ON CONFLICT (id) DO UPDATE
+       SET content = EXCLUDED.content, tags = EXCLUDED.tags`,
+    [id, content, tags, ns, `fts-lang-${id}`],
+  );
+}
 
+async function keywordIds(
+  query: string,
+  ftsConfig: "english" | "german" | "spanish",
+): Promise<string[]> {
+  const rows = await executeSearch(
+    deps as ToolDeps,
+    THOUGHTS_ONLY,
+    query,
+    10,
+    "keyword",
+    undefined,
+    0,
+    ns,
+    false,
+    undefined,
+    { ftsConfig },
+  );
+  return rows.map((r) => r.id);
+}
+
+describe("search_brain language-aware FTS ranking (live Postgres)", () => {
   beforeAll(async () => {
     await assertUtf8Harness(pool);
   });
@@ -71,75 +99,12 @@ dbDescribe("search_brain language-aware FTS ranking (live Postgres)", () => {
     await pool.end();
   });
 
-  async function cleanup(): Promise<void> {
-    await pool.query("DELETE FROM entry_access_log WHERE query_text LIKE $1", [
-      "%__fts_lang_probe__%",
-    ]);
-    await pool.query("DELETE FROM thoughts WHERE namespace = $1", [ns]);
-    await pool.query(
-      "DELETE FROM ob_sources WHERE namespace = $1 AND external_id LIKE $2",
-      [ns, "fts-lang/%"],
-    );
-  }
-
-  async function seedThought(id: string, content: string): Promise<void> {
-    await pool.query(
-      `INSERT INTO thoughts (id, content, namespace, created_by, content_hash)
-       VALUES ($1, $2, $3, 'test', $4)
-       ON CONFLICT (id) DO UPDATE SET content = EXCLUDED.content`,
-      [id, content, ns, `fts-lang-${id}`],
-    );
-  }
-
-  /**
-   * Seed a thought whose matchable non-english token lives ONLY in `tags`, not
-   * in `content`. Both FTS paths fold tags into the analyzed text (english via
-   * the stored generated `search_vector`, non-english via the on-the-fly
-   * to_tsvector over FTS_SOURCE_TEXT), so this isolates tag-token stemming.
-   */
-  async function seedThoughtWithTags(
-    id: string,
-    content: string,
-    tags: string[],
-  ): Promise<void> {
-    await pool.query(
-      `INSERT INTO thoughts (id, content, tags, namespace, created_by, content_hash)
-       VALUES ($1, $2, $3, $4, 'test', $5)
-       ON CONFLICT (id) DO UPDATE
-         SET content = EXCLUDED.content, tags = EXCLUDED.tags`,
-      [id, content, tags, ns, `fts-lang-${id}`],
-    );
-  }
-
-  async function keywordIds(
-    query: string,
-    ftsConfig: "english" | "german" | "spanish",
-  ): Promise<string[]> {
-    const rows = await executeSearch(
-      deps as any,
-      THOUGHTS_ONLY,
-      query,
-      10,
-      "keyword",
-      undefined,
-      0,
-      ns,
-      false,
-      undefined,
-      { ftsConfig },
-    );
-    return rows.map((r) => r.id);
-  }
-
   it("german stemming finds a document english analysis misses (before/after)", async () => {
     await cleanup();
     // "Häuser" (houses) stems to "haus" under german; english leaves it intact,
     // so an english analysis of the query "Haus" never matches the document.
     const doc = "20000000-0000-4000-8000-000000000001";
-    await seedThought(
-      doc,
-      "Die Häuser in der Stadt sind alt __fts_lang_probe__",
-    );
+    await seedThought(doc, "Die Häuser in der Stadt sind alt __fts_lang_probe__");
 
     const underGerman = await keywordIds("Haus", "german");
     const underEnglish = await keywordIds("Haus", "english");
@@ -199,354 +164,3 @@ dbDescribe("search_brain language-aware FTS ranking (live Postgres)", () => {
     expect(ids).toContain(doc);
   });
 });
-
-dbDescribe(
-  "language-aware FTS covers every migration-007 source field (live Postgres)",
-  () => {
-    const pool = new Pool({ connectionString: DB_URL });
-    const deps = { pool: pool as any, embedFn: embed };
-    const ns = "test-fts-language-all-tables";
-
-    const tableCases = [
-      {
-        table: "decisions" as const,
-        ids: [
-          "22000000-0000-4000-8000-000000000001",
-          "22000000-0000-4000-8000-000000000002",
-          "22000000-0000-4000-8000-000000000003",
-          "22000000-0000-4000-8000-000000000004",
-        ],
-        seed: () =>
-          pool.query(
-            `INSERT INTO decisions
-               (id, title, rationale, context, tags, namespace, created_by)
-             VALUES
-               ($2, 'Häuser', 'neutral rationale', NULL, '{}', $1, 'test'),
-               ($3, 'neutral title 2', 'Häuser', NULL, '{}', $1, 'test'),
-               ($4, 'neutral title 3', 'neutral rationale', 'Häuser', '{}', $1, 'test'),
-               ($5, 'neutral title 4', 'neutral rationale', NULL, ARRAY['Häuser'], $1, 'test')`,
-            [
-              ns,
-              "22000000-0000-4000-8000-000000000001",
-              "22000000-0000-4000-8000-000000000002",
-              "22000000-0000-4000-8000-000000000003",
-              "22000000-0000-4000-8000-000000000004",
-            ],
-          ),
-      },
-      {
-        table: "relationships" as const,
-        ids: [
-          "22000000-0000-4000-8000-000000000011",
-          "22000000-0000-4000-8000-000000000012",
-          "22000000-0000-4000-8000-000000000013",
-        ],
-        seed: () =>
-          pool.query(
-            `INSERT INTO relationships
-               (id, person_name, context, tags, namespace, created_by)
-             VALUES
-               ($2, 'Häuser', NULL, '{}', $1, 'test'),
-               ($3, 'neutral person 12', 'Häuser', '{}', $1, 'test'),
-               ($4, 'neutral person 13', NULL, ARRAY['Häuser'], $1, 'test')`,
-            [
-              ns,
-              "22000000-0000-4000-8000-000000000011",
-              "22000000-0000-4000-8000-000000000012",
-              "22000000-0000-4000-8000-000000000013",
-            ],
-          ),
-      },
-      {
-        table: "projects" as const,
-        ids: [
-          "22000000-0000-4000-8000-000000000021",
-          "22000000-0000-4000-8000-000000000022",
-          "22000000-0000-4000-8000-000000000023",
-        ],
-        seed: () =>
-          pool.query(
-            `INSERT INTO projects
-               (id, name, description, tags, namespace, created_by)
-             VALUES
-               ($2, 'Häuser', NULL, '{}', $1, 'test'),
-               ($3, 'neutral project 22', 'Häuser', '{}', $1, 'test'),
-               ($4, 'neutral project 23', NULL, ARRAY['Häuser'], $1, 'test')`,
-            [
-              ns,
-              "22000000-0000-4000-8000-000000000021",
-              "22000000-0000-4000-8000-000000000022",
-              "22000000-0000-4000-8000-000000000023",
-            ],
-          ),
-      },
-      {
-        table: "sessions" as const,
-        ids: [
-          "22000000-0000-4000-8000-000000000031",
-          "22000000-0000-4000-8000-000000000032",
-          "22000000-0000-4000-8000-000000000033",
-          "22000000-0000-4000-8000-000000000034",
-        ],
-        seed: () =>
-          pool.query(
-            `INSERT INTO sessions
-               (id, summary, next_steps, key_decisions, tags, namespace, created_by)
-             VALUES
-               ($2, 'Häuser', '{}', '{}', '{}', $1, 'test'),
-               ($3, 'neutral summary 32', ARRAY['Häuser'], '{}', '{}', $1, 'test'),
-               ($4, 'neutral summary 33', '{}', ARRAY['Häuser'], '{}', $1, 'test'),
-               ($5, 'neutral summary 34', '{}', '{}', ARRAY['Häuser'], $1, 'test')`,
-            [
-              ns,
-              "22000000-0000-4000-8000-000000000031",
-              "22000000-0000-4000-8000-000000000032",
-              "22000000-0000-4000-8000-000000000033",
-              "22000000-0000-4000-8000-000000000034",
-            ],
-          ),
-      },
-    ];
-
-    beforeAll(async () => {
-      await assertUtf8Harness(pool);
-    });
-
-    afterAll(async () => {
-      await cleanup();
-      await pool.end();
-    });
-
-    async function cleanup(): Promise<void> {
-      for (const { table } of tableCases.toReversed()) {
-        await pool.query(`DELETE FROM ${table} WHERE namespace = $1`, [ns]);
-      }
-    }
-
-    async function keywordIds(
-      table: (typeof tableCases)[number]["table"],
-      ftsConfig: "english" | "german",
-    ): Promise<string[]> {
-      const rows = await executeSearch(
-        deps as any,
-        [table],
-        "Haus",
-        10,
-        "keyword",
-        undefined,
-        0,
-        ns,
-        false,
-        undefined,
-        { ftsConfig },
-      );
-      return rows.map((row) => row.id);
-    }
-
-    it("finds an isolated German inflection in every indexed field", async () => {
-      await cleanup();
-
-      for (const tableCase of tableCases) {
-        await tableCase.seed();
-
-        const underGerman = await keywordIds(tableCase.table, "german");
-        const underEnglish = await keywordIds(tableCase.table, "english");
-
-        expect(underGerman.toSorted()).toEqual(tableCase.ids.toSorted());
-        expect(underEnglish).toEqual([]);
-      }
-    });
-  },
-);
-
-dbDescribe(
-  "declared source language selects the real search config via explicit request (live Postgres)",
-  () => {
-    const pool = new Pool({ connectionString: DB_URL });
-    const deps = { pool: pool as any, embedFn: embed };
-    const ns = "test-fts-language-e2e";
-
-    beforeAll(async () => {
-      await assertUtf8Harness(pool);
-    });
-
-    afterAll(async () => {
-      await cleanup();
-      await pool.end();
-    });
-
-    async function cleanup(): Promise<void> {
-      await pool.query("DELETE FROM thoughts WHERE namespace = $1", [ns]);
-      await pool.query(
-        "DELETE FROM ob_sources WHERE namespace = $1 AND external_id LIKE $2",
-        [ns, "fts-lang-e2e/%"],
-      );
-    }
-
-    // One representative supported-language corpus per approved source kind:
-    // synchronized file source (directory), approved drop-folder (drop), and
-    // approved conversation content (conversation). Each declares a language on
-    // its ob_sources row; that declared language is fed as the explicit request
-    // `fts_config` (via requestFtsConfig) -- the same knob a caller uses -- and
-    // that is what selects the config the real search path analyzes with.
-    const sources = [
-      {
-        kind: "directory" as const,
-        externalId: "fts-lang-e2e/repo-de",
-        language: "de-DE",
-        expectConfig: "german" as const,
-        thoughtId: "21000000-0000-4000-8000-000000000001",
-        content: "Die Häuser wurden im Repository dokumentiert",
-        query: "Haus",
-        missUnder: "english" as const,
-      },
-      {
-        kind: "drop" as const,
-        externalId: "fts-lang-e2e/drop-es",
-        language: "es",
-        expectConfig: "spanish" as const,
-        thoughtId: "21000000-0000-4000-8000-000000000002",
-        content: "El documento describe atletas corriendo",
-        query: "corrió",
-        missUnder: "english" as const,
-      },
-      {
-        kind: "conversation" as const,
-        externalId: "fts-lang-e2e/convo-en",
-        language: "en-US",
-        expectConfig: "english" as const,
-        thoughtId: "21000000-0000-4000-8000-000000000003",
-        content: "The teams were running the deployment",
-        query: "runs",
-        missUnder: null,
-      },
-    ];
-
-    /** Seed the approved source row AND read its stored language back. */
-    async function seedSource(s: (typeof sources)[number]): Promise<string> {
-      const { rows } = await pool.query(
-        `INSERT INTO ob_sources
-           (namespace, source_kind, external_id, approval_state, approved_by,
-            approved_at, lifecycle_state, language, created_by)
-         VALUES ($1, $2, $3, 'approved', 'test-approver', now(), 'active', $4, 'test')
-         ON CONFLICT (namespace, source_kind, external_id)
-         DO UPDATE SET language = EXCLUDED.language, approval_state = 'approved'
-         RETURNING language`,
-        [ns, s.kind, s.externalId, s.language],
-      );
-      await pool.query(
-        `INSERT INTO thoughts (id, content, namespace, created_by, content_hash)
-         VALUES ($1, $2, $3, 'test', $4)
-         ON CONFLICT (id) DO UPDATE SET content = EXCLUDED.content`,
-        [s.thoughtId, s.content, ns, `fts-lang-e2e-${s.thoughtId}`],
-      );
-      return rows[0].language as string;
-    }
-
-    /**
-     * Run the real search path. `declaredLanguage` is the value stored on the
-     * source row; it flows through requestFtsConfig exactly as the public
-     * `search_brain` handler routes its `fts_config` argument -- there is no
-     * hand-picked internal config literal here.
-     */
-    async function keywordIdsForLanguage(
-      query: string,
-      declaredLanguage: string,
-    ): Promise<string[]> {
-      const rows = await executeSearch(
-        deps as any,
-        THOUGHTS_ONLY,
-        query,
-        10,
-        "keyword",
-        undefined,
-        0,
-        ns,
-        false,
-        undefined,
-        // requestFtsConfig(declaredLanguage) is the caller-visible selection;
-        // pass an empty env so ONLY the declared language can drive the config.
-        { ftsConfig: requestFtsConfig(declaredLanguage, {}) },
-      );
-      return rows.map((r) => r.id);
-    }
-
-    it("each source's stored language maps to the expected config (metadata only)", async () => {
-      // Pure metadata-mapping check: the stored ob_sources.language round-trips
-      // to the right regconfig. This does NOT by itself drive retrieval -- the
-      // ranking test below proves the retrieval effect via the explicit request.
-      await cleanup();
-      for (const s of sources) {
-        const stored = await seedSource(s);
-        expect(resolveFtsConfig(stored)).toBe(s.expectConfig);
-      }
-    });
-
-    it("declared source language, fed as the explicit request config, drives ranking", async () => {
-      await cleanup();
-      for (const s of sources) {
-        const declaredLanguage = await seedSource(s);
-        const underOwn = await keywordIdsForLanguage(s.query, declaredLanguage);
-        expect(underOwn).toContain(s.thoughtId);
-        if (s.missUnder) {
-          // Same query, but english (the mismatched config) misses it.
-          const underMismatch = await keywordIdsForLanguage(s.query, "en");
-          expect(underMismatch).not.toContain(s.thoughtId);
-        }
-      }
-    });
-
-    it("deterministic before/after comparison across the three source kinds", async () => {
-      await cleanup();
-      // Structured, order-stable table: for each representative fixture, record
-      // whether its document is found under (a) english = the pre-#341 baseline
-      // and (b) its declared language config. english-content fixtures must
-      // show NO regression; non-english fixtures show the language-aware gain.
-      const comparison = [];
-      for (const s of sources) {
-        const declaredLanguage = await seedSource(s);
-        const foundUnderEnglish = (
-          await keywordIdsForLanguage(s.query, "en")
-        ).includes(s.thoughtId);
-        const foundUnderDeclared = (
-          await keywordIdsForLanguage(s.query, declaredLanguage)
-        ).includes(s.thoughtId);
-        comparison.push({
-          kind: s.kind,
-          declaredLanguage,
-          config: s.expectConfig,
-          query: s.query,
-          before_english: foundUnderEnglish,
-          after_declared: foundUnderDeclared,
-        });
-      }
-
-      expect(comparison).toEqual([
-        {
-          kind: "directory",
-          declaredLanguage: "de-DE",
-          config: "german",
-          query: "Haus",
-          before_english: false, // english analysis misses the german inflection
-          after_declared: true, // german stemming finds it
-        },
-        {
-          kind: "drop",
-          declaredLanguage: "es",
-          config: "spanish",
-          query: "corrió",
-          before_english: false,
-          after_declared: true,
-        },
-        {
-          kind: "conversation",
-          declaredLanguage: "en-US",
-          config: "english",
-          query: "runs",
-          before_english: true, // english content: no regression
-          after_declared: true, // declared english == baseline
-        },
-      ]);
-    });
-  },
-);


### PR DESCRIPTION
## Summary

- `src/tools/__tests__/search-brain-fts-language.pg.test.ts` read `OPENBRAIN_TEST_DATABASE_URL` itself and swapped in `describe.skip` when it was unset. A run without a database reported `0 pass, 14 skip, 0 fail` and exited 0 — at the exit code indistinguishable from three suites that ran and passed, while the Postgres behavior nobody exercised drifted underneath it. All three live suites now call `requireTestDatabaseUrl()` at module scope; absent the variable the helper throws `test_database_required` and the run fails loudly (#878).
- The file also carried three independent live suites in 552 lines, so it is split one live suite per file, each with its own module-scope `Pool` ended once in that file's `afterAll`: `search-brain-fts-language.pg.test.ts` keeps the ranking suite, `search-brain-fts-language-fields.pg.test.ts` holds the migration-007 source-field coverage, and `search-brain-fts-language-config.pg.test.ts` holds the declared-language explicit-request chain.
- New sibling `src/tools/__tests__/search-brain-fts-language-test-helpers.ts` holds the helpers shared by all three (`assertUtf8Harness`, `embed`, `THOUGHTS_ONLY`). It holds no test and creates no pool; `assertUtf8Harness` takes the `Pool` as its first parameter.
- Test bodies, names, and assertions moved verbatim by line-range copy. Only the `describe` wrappers, imports, pool creation, and helper plumbing changed. Each file's per-suite fixtures and query helpers moved from inside the `describe` callback to module scope alongside the pool they already used, which is what keeps the three callbacks inside the repo oxlint function-length rule now that the pre-commit gate lints each staged file whole. The `pool as any` / `deps as any` casts the original carried became `pool as never` (the existing repo pattern at `src/tools/__tests__/ingest-conversation-facts.pg.test.ts:106`) and a real `ToolDeps` annotation, clearing `no-explicit-any` in the same pass.
- All three `describe` names are unchanged, so all three `scripts/assert-db-tests-ran.ts` entries keep their lines. JUnit confirms each emitted count still matches its recorded minimum (4 / 1 / 3), so `MIN_TOTAL_LIVE_TESTCASES` is unchanged at 265.
- No tool, migration, or script under test changed. No assertion changed. No other test file was touched.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
  `CHANGED_FILES="src/tools/__tests__/search-brain-fts-language.pg.test.ts src/tools/__tests__/search-brain-fts-language-fields.pg.test.ts src/tools/__tests__/search-brain-fts-language-config.pg.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` — exit 0 on the committed tree, all four clauses PASS. RED before the change, at `origin/main` with `CHANGED_FILES="src/tools/__tests__/search-brain-fts-language.pg.test.ts"`: exit 1, clauses 1/2/3 FAIL (clause 3 recorded `exit 0, test_database_required present: no` over `0 pass, 14 skip`).
- [x] Relevant Open Brain tests/typecheck/migrations passed
  `bun run test:isolated` over the three live files: 8 pass, 0 fail, 24 expect() calls. `bunx tsc --noEmit`: exit 0. `./node_modules/.bin/oxlint --config .oxlintrc.json --deny-warnings` over all four files: exit 0, zero findings. Pre-commit ran oxlint, prettier --check, and tsc over the staged snapshot and passed; pre-push ran the Bun tests and passed.
- [x] Python package checks passed or are not applicable — not applicable, `python/openbrain-memory/` is untouched.
- [x] Live Open Brain smoke passed or is not applicable — not applicable, this is a test-harness change with no runtime, schema, or contract surface.

## Critical Self-Review

- Highest-risk behavior: the split silently dropping a test. Guarded two ways — the JUnit per-suite counts are 4 / 1 / 3, exactly the minimums already recorded in `scripts/assert-db-tests-ran.ts:49-58`, and the CI db-integration anti-skip guard fails on a vanished suite name or a lower count. 8 testcases across 3 files matches the 8 non-skipped cases the original file declared.
- Assumptions that could be wrong: that lifting per-suite fixtures to module scope preserves ordering semantics. It does here because every lifted binding is a `const` fixture or an `async function` closing over the module-scope `pool` and `ns`, and none ran at describe-collection time in the original either — the database work all sits inside `beforeAll`/`it`. The suites still pass against a real database, which is the check that would catch a mistake.
- Missing/weak tests: none added; this is a conversion, and the four done-means clauses are the test of the conversion itself. Clause 3 is the load-bearing one — it removes the demanded variable from the child environment and requires a non-zero exit AND the `test_database_required` string, so a pass cannot be an unrelated crash.
- Security/permission risk: none. No auth, namespace predicate, SQL construction, or token path is touched; the moved queries are the original parameterized statements, byte for byte.
- Migration/deploy risk: none. No migration, no schema, nothing deployed.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md`. No MCP tool, schema, transport, protocol, or Python client surface changes; these are test files and a test-only helper module.
- Rollback/cleanup concern: a plain revert restores the single 552-line file. The three new files and the helper module are new paths, so a revert leaves nothing orphaned. Each file ends its own pool in its own `afterAll`, so the split does not leak connections; the isolated-database runner reported both teardowns clean.
- Fixes made before PR: removed imports left unused by the split (`resolveFtsConfig` from two files, `requestFtsConfig` and `THOUGHTS_ONLY` from one each); replaced the inherited `any` casts with `never` plus a real `ToolDeps` type; lifted per-suite fixtures to module scope so each file passes oxlint whole rather than reaching for a disable comment; moved two stray scratch files that a shell expansion mistake had written into `src/tools/` out of the repo before staging.
- Known residual risk: the three `describe` bodies are near the function-length rule rather than far under it, so a future test added to one of them may push it over and require another extraction. The manifest counts are pinned as minimums, not equalities, so adding a test does not fail the guard.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the lane surfaced no new MEDIUM+ defect pattern — the conversion mechanics, the manifest-count rule, and the whole-file lint behavior of the pre-commit gate are all already recorded in `docs/lane-contract.md` Tightenings and in the done-means script's own header.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or hosted surface changes; the suites run against an ephemeral isolated test database, not the dogfood or core01 service.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched — the diff is three TypeScript test files and one test-only helper module.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable — not applicable, no MCP tool or schema change.
- [x] mcp2cli cache/skill refresh is complete or not applicable — not applicable, no tool surface change to cache.
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable — not applicable, no Python or plugin surface change.
- [x] Hermes live rollout/canaries are complete or not applicable — not applicable, nothing is deployed by this change.

Notes/evidence:

- RED at `origin/main`: exit 1 — `CLAUSE 1 FAIL` (`dbDescribe`/`describe.skip`/`process.env.OPENBRAIN_TEST_DATABASE_URL` on code lines 9, 29, 155, 314), `CLAUSE 2 FAIL` (no `requireTestDatabaseUrl` import), `CLAUSE 3 FAIL` (`exit 0, test_database_required present: no`, over `0 pass, 14 skip, 0 fail`).
- GREEN on the committed tree: exit 0 — clauses 1-4 all PASS, clause 3 observed per file, e.g. `CLAUSE 3 [src/tools/__tests__/search-brain-fts-language-config.pg.test.ts]: PASS -- exited 1 and printed test_database_required`.
- JUnit `classname` tally from the isolated run: 4 `search_brain language-aware FTS ranking (live Postgres)`, 1 `language-aware FTS covers every migration-007 source field (live Postgres)`, 3 `declared source language selects the real search config via explicit request (live Postgres)` — each equal to its existing `minTests`, so `scripts/assert-db-tests-ran.ts` needs no edit.
