### PR TITLE
test(pg): the ingest-conversation-facts tool test requires the test database instead of skipping (#878)

### DIFF
--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -365,6 +365,18 @@ export const REQUIRED_SUITES: ReadonlyArray<{
     name: "get_entry compact render (live Postgres)",
     minTests: 1,
   },
+  // The ingest_conversation_facts tool test proves the write path and the
+  // isolation/concurrency behavior against real SQL. Split by subject in #878
+  // as that file stopped skipping itself, so both halves are named here;
+  // registering one would let the other vanish unnoticed.
+  {
+    name: "ingest_conversation_facts write path (live Postgres)",
+    minTests: 3,
+  },
+  {
+    name: "ingest_conversation_facts isolation and concurrency (live Postgres)",
+    minTests: 3,
+  },
 ];
 
 // Absolute floor on total executed (non-skipped) live-Postgres testcases,
@@ -407,9 +419,11 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // itself, then 255 -> 265 when #878 registered the four ingest_raw_turn
 // suites' 4 + 1 + 2 + 3 as that file stopped skipping itself, then 265 -> 266
 // when #878 registered the get_entry compact render suite's 1 as that file
-// stopped skipping itself), so the global floor cannot silently fall behind
-// the per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 266;
+// stopped skipping itself, then 266 -> 272 when #878 registered the two
+// subject-split ingest_conversation_facts write-path and isolation suites'
+// 3 + 3 as that file stopped skipping itself), so the global floor cannot
+// silently fall behind the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 272;
 
 export interface SuiteStats {
   tests: number;

--- a/src/tools/__tests__/ingest-conversation-facts-isolation.pg.test.ts
+++ b/src/tools/__tests__/ingest-conversation-facts-isolation.pg.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Live-Postgres ISOLATION AND CONCURRENCY coverage for
+ * ingest_conversation_facts (#340), exercised at the PUBLIC MCP tool boundary
+ * against a real schema, the real source-registry approval gate, and the real
+ * seven-coordinate lane predicate.
+ *
+ * The write-path proofs live in the sibling
+ * ingest-conversation-facts.pg.test.ts; the fixtures and the database-touching
+ * helpers both files share live in ingest-conversation-facts-test-helpers.ts.
+ *
+ * This suite REQUIRES a real test database. Absent the connection string
+ * requireTestDatabaseUrl throws test_database_required and the run fails loudly
+ * rather than reporting a skip that reads as a pass at the exit code.
+ *
+ * Proofs (all at the public callTool boundary, asserting responses + rows):
+ *  1. Namespace/scope isolation is non-vacuous: the owning namespace succeeds;
+ *     a foreign-namespace argument is denied and writes nothing; a wrong-scope
+ *     assertion against a real lane is denied and writes nothing.
+ *  2. Concurrent distinct-locator merges serialize: every merged disposition
+ *     maps to retained unique evidence, with no lost update.
+ *  3. A raw transcript body supplied as a top-level key is rejected at the schema
+ *     boundary and writes nothing.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
+import {
+  createIngestHarness,
+  firstRow,
+  FOREIGN_NS,
+  OWNER_NS,
+  OWNER_SCOPE,
+  OWNER_SOURCE_REF,
+  ownerAuth,
+} from "./ingest-conversation-facts-test-helpers.ts";
+
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+const h = createIngestHarness(pool);
+
+// Each proof is a named module-scope function so the describe body stays a
+// short registration list rather than one long function.
+
+async function proveNamespaceAndScopeIsolation(): Promise<void> {
+  await h.seedOwnerFixtures();
+
+  // (a) Owning success: baseline that the fixtures are ingestable at all, so
+  // the denials below are genuine boundary rejections, not a broken setup.
+  await h.withTool(ownerAuth, async (client) => {
+    const body = h.parse(
+      await client.callTool({
+        name: "ingest_conversation_facts",
+        arguments: {
+          namespace: OWNER_NS,
+          scope: OWNER_SCOPE,
+          source_ref: OWNER_SOURCE_REF,
+          facts: [{ event_type: "fact", content: "Owned success fact." }],
+        },
+      }),
+    );
+    expect(body.ok).toBe(true);
+    expect(body.ingested).toBe(1);
+  });
+  expect(await h.eventCount(h.ownerLaneId)).toBe(1);
+
+  // (b) Foreign-namespace denial: the same owner token targets a namespace it
+  // does not own. The write is denied server-side and nothing is persisted.
+  await h.withTool(ownerAuth, async (client) => {
+    const result = await client.callTool({
+      name: "ingest_conversation_facts",
+      arguments: {
+        namespace: FOREIGN_NS,
+        scope: OWNER_SCOPE,
+        source_ref: OWNER_SOURCE_REF,
+        facts: [{ event_type: "fact", content: "Foreign attempt." }],
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect(h.parse(result).error).toBe("namespace_denied");
+  });
+  // No lane/event was created in the foreign namespace.
+  const { rows: foreignLanes } = await pool.query(
+    "SELECT count(*)::int AS c FROM ob_session_lanes WHERE namespace = $1",
+    [FOREIGN_NS],
+  );
+  expect(firstRow(foreignLanes).c).toBe(0);
+
+  // (c) Wrong-scope denial: a real, owned lane exists, but the asserted scope
+  // uses a different channel_id, so no lane matches the seven-coordinate
+  // predicate. The call is denied and writes nothing new.
+  await h.withTool(ownerAuth, async (client) => {
+    const result = await client.callTool({
+      name: "ingest_conversation_facts",
+      arguments: {
+        namespace: OWNER_NS,
+        scope: { ...OWNER_SCOPE, channel_id: "wrong-channel" },
+        source_ref: OWNER_SOURCE_REF,
+        facts: [{ event_type: "fact", content: "Wrong-scope attempt." }],
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect(h.parse(result).error).toBe("scope_validation");
+  });
+  // Still exactly the one owned-success row; the wrong-scope call added nothing.
+  expect(await h.eventCount(h.ownerLaneId)).toBe(1);
+}
+
+async function proveConcurrentMergesSerialize(): Promise<void> {
+  await h.seedOwnerFixtures();
+  const sharedContent = "Concurrently re-cited distilled statement.";
+
+  // Seed the single duplicate row once (locator anchor-0). Every concurrent
+  // call below hits the content-duplicate merge branch on THIS row.
+  let storedId = "";
+  await h.withTool(ownerAuth, async (client) => {
+    const first = h.parse(
+      await client.callTool({
+        name: "ingest_conversation_facts",
+        arguments: {
+          namespace: OWNER_NS,
+          scope: OWNER_SCOPE,
+          source_ref: OWNER_SOURCE_REF,
+          facts: [
+            {
+              event_type: "fact",
+              content: sharedContent,
+              source_locator: "anchor-0",
+            },
+          ],
+        },
+      }),
+    );
+    expect(first.ingested).toBe(1);
+    storedId = firstRow(first.events as Array<Record<string, unknown>>)
+      .event_id as string;
+  });
+
+  // Fire N concurrent calls, each identical content with a DISTINCT locator.
+  // N is bounded and well under MAX_ADDITIONAL_EVIDENCE (32), so every merge
+  // must succeed and be retained — none may hit the evidence_not_stored bound.
+  const N = 8;
+  const locators = Array.from({ length: N }, (_, i) => `anchor-c${i + 1}`);
+
+  // Each concurrent caller gets its own MCP client/connection over the shared
+  // real pool, so the N calls race through independent transactions exactly as
+  // distinct callers would. withTool owns connect/close; the promise resolves
+  // with the parsed receipt for that caller.
+  const results = await Promise.all(
+    locators.map(
+      (locator) =>
+        new Promise<Record<string, unknown>>((resolve, reject) => {
+          h.withTool(ownerAuth, async (client) => {
+            const body = h.parse(
+              await client.callTool({
+                name: "ingest_conversation_facts",
+                arguments: {
+                  namespace: OWNER_NS,
+                  scope: OWNER_SCOPE,
+                  source_ref: OWNER_SOURCE_REF,
+                  facts: [
+                    {
+                      event_type: "fact",
+                      content: sharedContent,
+                      source_locator: locator,
+                    },
+                  ],
+                },
+              }),
+            );
+            resolve(body);
+          }).catch(reject);
+        }),
+    ),
+  );
+
+  // No call may false-succeed or error: each is a caller-visible ok receipt
+  // with exactly one duplicate unit (identical content, no new row).
+  const dispositions: string[] = [];
+  for (const body of results) {
+    expect(body.ok).toBe(true);
+    expect(body.ingested).toBe(0);
+    expect(body.duplicates).toBe(1);
+    const events = body.events as Array<Record<string, unknown>>;
+    expect(events).toHaveLength(1);
+    expect(firstRow(events).event_id).toBe(storedId);
+    dispositions.push(firstRow(events).disposition as string);
+  }
+
+  // Under the bound, EVERY concurrent distinct-locator call must report a
+  // real merge — never a benign plain-duplicate that silently dropped its
+  // evidence, and never evidence_not_stored (we are well below the cap).
+  const mergedLocators = locators.filter(
+    (_, i) => dispositions[i] === "duplicate_evidence_merged",
+  );
+  expect(dispositions.every((d) => d === "duplicate_evidence_merged")).toBe(true);
+
+  // No second row was ever written: identical content stayed a single row.
+  expect(await h.eventCount(h.ownerLaneId)).toBe(1);
+
+  // The lost-update proof: read the FINAL stored evidence. Every locator that
+  // a caller reported as merged must be present exactly once — a lost update
+  // would leave a merged disposition whose locator is missing from metadata.
+  const { rows } = await pool.query(
+    `SELECT metadata->'additional_evidence' AS evidence,
+            metadata->>'source_locator' AS primary_locator
+       FROM ob_session_events WHERE id = $1`,
+    [storedId],
+  );
+  const evidence = firstRow(rows).evidence as Array<Record<string, unknown>>;
+  expect(Array.isArray(evidence)).toBe(true);
+  // Primary locator (anchor-0) is on the row itself, not in additional_evidence.
+  expect(firstRow(rows).primary_locator).toBe("anchor-0");
+
+  const storedLocators = evidence.map((e) => e.source_locator as string);
+  // Each retained locator appears exactly once (no duplication, no loss).
+  expect(new Set(storedLocators).size).toBe(storedLocators.length);
+  // Every caller-reported merge is retained in the final metadata: the count
+  // of merged dispositions equals the count of retained distinct locators,
+  // and each merged locator is present. This fails on the pre-lock behavior,
+  // where concurrent overwrites drop merges while still reporting success.
+  for (const locator of mergedLocators) {
+    expect(storedLocators).toContain(locator);
+  }
+  expect(storedLocators.length).toBe(mergedLocators.length);
+  expect(storedLocators.length).toBe(N);
+
+  // Content never leaks into any evidence pointer.
+  expect(JSON.stringify(evidence)).not.toContain(sharedContent);
+}
+
+async function proveRawTranscriptRejected(): Promise<void> {
+  await h.seedOwnerFixtures();
+  await h.withTool(ownerAuth, async (client) => {
+    const result = await client.callTool({
+      name: "ingest_conversation_facts",
+      arguments: {
+        namespace: OWNER_NS,
+        scope: OWNER_SCOPE,
+        source_ref: OWNER_SOURCE_REF,
+        facts: [{ event_type: "fact", content: "distilled fact" }],
+        transcript: "user: hi\nassistant: hello\n... full raw transcript ...",
+      },
+    });
+    // Caller-visible rejection at the schema boundary; the raw body is not
+    // echoed back in the error.
+    expect(result.isError).toBe(true);
+    const text = JSON.stringify(result);
+    expect(text).toContain("transcript");
+    expect(text).not.toContain("assistant: hello");
+  });
+  // Zero events persisted: the handler never ran a write.
+  expect(await h.eventCount(h.ownerLaneId)).toBe(0);
+}
+
+describe("ingest_conversation_facts isolation and concurrency (live Postgres)", () => {
+  beforeAll(async () => {
+    await h.migrateAndClean();
+  });
+
+  afterAll(async () => {
+    await h.cleanAndEnd();
+  });
+
+  afterEach(async () => {
+    await h.dropTriggerAndClean();
+  });
+
+  it(
+    "keeps namespace/scope isolation non-vacuous: owning success, foreign-namespace and wrong-scope denials write nothing",
+    proveNamespaceAndScopeIsolation,
+  );
+
+  it(
+    "serializes concurrent distinct-locator merges: every merged disposition maps to retained unique evidence, no lost update",
+    proveConcurrentMergesSerialize,
+  );
+
+  it(
+    "rejects a raw transcript public-schema body and writes nothing",
+    proveRawTranscriptRejected,
+  );
+});

--- a/src/tools/__tests__/ingest-conversation-facts-test-helpers.ts
+++ b/src/tools/__tests__/ingest-conversation-facts-test-helpers.ts
@@ -1,0 +1,235 @@
+/**
+ * Shared harness for the two live-Postgres suites over ingest_conversation_facts
+ * (#340). The write-path suite and the isolation/concurrency suite exercise the
+ * same public MCP tool boundary against the same seeded fixtures, so the
+ * fixtures and the database-touching helpers live here rather than being
+ * duplicated in each file.
+ *
+ * This module holds no test and creates no pool: each suite owns its own
+ * module-scope pool and hands it to createIngestHarness.
+ */
+import type { Pool } from "pg";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { runMigrations } from "../../db/migrate.ts";
+import { registerIngestConversationFacts } from "../ingest-conversation-facts.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo } from "../../types.ts";
+
+// Every row this suite creates is namespaced under one of these two isolation
+// namespaces so cleanup deletes exactly what the suite owns and nothing else.
+// The owning namespace is where the approved source + scoped lane live; the
+// foreign namespace is used only to prove cross-namespace denial.
+export const OWNER_NS = "lane340-owner-ns";
+export const FOREIGN_NS = "lane340-foreign-ns";
+
+// The exact seven-coordinate scope (six coordinates + namespace) the owning lane
+// is bound to. Matches the shape the tool's lane predicate asserts.
+export const OWNER_SCOPE = {
+  agent: "assistant",
+  platform: "discord",
+  server_id: "guild-340",
+  channel_id: "chan-340",
+  thread_id: null as string | null,
+  session_key: "sess-340",
+};
+
+export const OWNER_SOURCE_EXTERNAL_ID = "conv:room-340";
+export const OWNER_SOURCE_REF = {
+  source_kind: "conversation" as const,
+  external_id: OWNER_SOURCE_EXTERNAL_ID,
+};
+
+// A token-scoped agent whose own namespace is OWNER_NS. This is the happy-path
+// writer: it may write its own namespace and is denied any foreign one.
+export const ownerAuth: AuthInfo = {
+  role: "agent",
+  clientId: OWNER_NS,
+  namespaceSource: "token",
+};
+
+// Deterministic embeddings so no live embedding endpoint is required; the tool
+// treats an embed result as opaque and stores it as a bound param.
+export const stubEmbed = async (): Promise<number[]> => Array(768).fill(0.01);
+
+// A sentinel content string the test-owned trigger raises on, used only to force
+// a deterministic mid-batch failure in proof (3).
+export const TRIGGER_SENTINEL = "LANE340_TRIGGER_ROLLBACK_SENTINEL";
+
+/** The database-touching harness the two live suites share. */
+export interface IngestHarness {
+  parse(result: unknown): Record<string, unknown>;
+  withTool(auth: AuthInfo, fn: (client: Client) => Promise<void>): Promise<void>;
+  eventCount(laneId: string): Promise<number>;
+  cleanupData(): Promise<void>;
+  seedOwnerFixtures(): Promise<void>;
+  migrateAndClean(): Promise<void>;
+  cleanAndEnd(): Promise<void>;
+  dropTriggerAndClean(): Promise<void>;
+  readonly ownerLaneId: string;
+  readonly ownerSourceId: string;
+}
+
+/**
+ * Build the harness against a caller-owned pool. Every database-touching helper
+ * closes over that one pool, so a suite creates it once at module scope and ends
+ * it once in its own afterAll.
+ */
+/**
+ * First element of a query result, demanded rather than asserted away.
+ *
+ * The suites index [0] on rows a proof has already established exist, so the
+ * non-null assertion carried no information; throwing names the empty result
+ * instead of dereferencing undefined.
+ */
+export function firstRow<T>(items: readonly T[]): T {
+  const item = items[0];
+  if (item === undefined) {
+    throw new Error("expected at least one row, received none");
+  }
+  return item;
+}
+
+let ownerSourceId = "";
+export function parse(result: unknown): Record<string, unknown> {
+  const content = (result as { content: Array<{ text: string }> }).content;
+  return JSON.parse(firstRow(content).text);
+}
+
+// Stand up a public MCP client wired to the real pool for a given auth. This is
+// the same public-boundary harness the fake suite uses, so tests assert the
+// caller-visible callTool response, never internal SQL or call order.
+async function withTool(
+  pool: Pool,
+  auth: AuthInfo,
+  fn: (client: Client) => Promise<void>,
+): Promise<void> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = {
+    pool: pool as never,
+    embedFn: stubEmbed as never,
+  };
+  registerIngestConversationFacts(server, deps);
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const originalSend = clientTransport.send.bind(clientTransport);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  clientTransport.send = (message: any, options?: any) =>
+    originalSend(message, { ...options, authInfo: auth });
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  try {
+    await fn(client);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+// Count durable events in a lane whose content matches, so a test can prove
+// exactly how many rows a call persisted (or that it persisted none).
+async function eventCount(pool: Pool, laneId: string): Promise<number> {
+  const { rows } = await pool.query(
+    "SELECT count(*)::int AS c FROM ob_session_events WHERE lane_id = $1",
+    [laneId],
+  );
+  return firstRow(rows).c as number;
+}
+
+async function cleanupData(pool: Pool): Promise<void> {
+  // Events cascade from lanes, but delete explicitly for clarity. Order:
+  // events → lanes → sources, all scoped to the suite's two namespaces.
+  await pool.query(
+    `DELETE FROM ob_session_events
+      WHERE lane_id IN (
+        SELECT id FROM ob_session_lanes WHERE namespace = ANY($1::text[])
+      )`,
+    [[OWNER_NS, FOREIGN_NS]],
+  );
+  await pool.query("DELETE FROM ob_session_lanes WHERE namespace = ANY($1::text[])", [
+    [OWNER_NS, FOREIGN_NS],
+  ]);
+  await pool.query("DELETE FROM ob_sources WHERE namespace = ANY($1::text[])", [
+    [OWNER_NS, FOREIGN_NS],
+  ]);
+}
+
+// Seed the owning approved+active conversation source and the exact-scope lane
+
+export function createIngestHarness(pool: Pool): IngestHarness {
+  let ownerLaneId = "";
+  // fresh, returning their ids. Called before each proof so no prior state leaks.
+  async function seedOwnerFixtures(): Promise<void> {
+    const { rows: srcRows } = await pool.query(
+      `INSERT INTO ob_sources
+         (namespace, source_kind, external_id, approval_state, approved_by,
+          approved_at, lifecycle_state, sync_state, created_by)
+       VALUES ($1, 'conversation', $2, 'approved', 'admin', now(),
+               'active', 'synced', 'admin')
+       RETURNING id`,
+      [OWNER_NS, OWNER_SOURCE_EXTERNAL_ID],
+    );
+    ownerSourceId = String(firstRow(srcRows).id);
+
+    const { rows: laneRows } = await pool.query(
+      `INSERT INTO ob_session_lanes
+         (session_key, namespace, status, agent, source, channel_id, thread_id,
+          metadata, created_by)
+       VALUES ($1, $2, 'active', $3, $4, $5, $6, $7::jsonb, 'admin')
+       RETURNING id`,
+      [
+        OWNER_SCOPE.session_key,
+        OWNER_NS,
+        OWNER_SCOPE.agent,
+        OWNER_SCOPE.platform,
+        OWNER_SCOPE.channel_id,
+        OWNER_SCOPE.thread_id,
+        JSON.stringify({ server_id: OWNER_SCOPE.server_id }),
+      ],
+    );
+    ownerLaneId = String(firstRow(laneRows).id);
+  }
+
+  // The two suites share one lifecycle: migrate once, drop the test-owned
+  // trigger and suite data after each proof, and clean up plus end the pool at
+  // the end. Living here keeps the two describe bodies to their proofs.
+  async function migrateAndClean(): Promise<void> {
+    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+    await runMigrations(pool);
+    await cleanupData(pool);
+  }
+
+  async function cleanAndEnd(): Promise<void> {
+    await cleanupData(pool);
+    await pool.end();
+  }
+
+  async function dropTriggerAndClean(): Promise<void> {
+    await pool.query(
+      "DROP TRIGGER IF EXISTS lane340_rollback_trigger ON ob_session_events",
+    );
+    await pool.query("DROP FUNCTION IF EXISTS lane340_rollback_trigger_fn() CASCADE");
+    await cleanupData(pool);
+  }
+
+  return {
+    parse,
+    withTool: (auth: AuthInfo, fn: (client: Client) => Promise<void>) =>
+      withTool(pool, auth, fn),
+    eventCount: (laneId: string) => eventCount(pool, laneId),
+    cleanupData: () => cleanupData(pool),
+    seedOwnerFixtures,
+    migrateAndClean,
+    cleanAndEnd,
+    dropTriggerAndClean,
+    get ownerLaneId() {
+      return ownerLaneId;
+    },
+    get ownerSourceId() {
+      return ownerSourceId;
+    },
+  };
+}

--- a/src/tools/__tests__/ingest-conversation-facts.pg.test.ts
+++ b/src/tools/__tests__/ingest-conversation-facts.pg.test.ts
@@ -1,8 +1,8 @@
 /**
- * Live-Postgres functional coverage for ingest_conversation_facts (#340),
- * exercised at the PUBLIC MCP tool boundary against a real schema, the real
- * source-registry approval gate, the real seven-coordinate lane predicate, and a
- * real all-or-nothing write transaction.
+ * Live-Postgres functional coverage for the ingest_conversation_facts WRITE
+ * PATH (#340), exercised at the PUBLIC MCP tool boundary against a real schema,
+ * the real source-registry approval gate, the real seven-coordinate lane
+ * predicate, and a real all-or-nothing write transaction.
  *
  * The focused suite (ingest-conversation-facts.test.ts) proves the contract
  * against fake pools; this suite proves the same caller-visible responses AND
@@ -10,9 +10,14 @@
  * could mask a wrong predicate, a non-atomic transaction, or a receipt that does
  * not match the stored row.
  *
- * Gated on OPENBRAIN_TEST_DATABASE_URL (repo dbDescribe convention); skips when
- * unset so a DB-less CI job passes while the db-integration job runs it against
- * Postgres.
+ * The isolation and concurrency proofs live in the sibling
+ * ingest-conversation-facts-isolation.pg.test.ts; the fixtures and the
+ * database-touching helpers both files share live in
+ * ingest-conversation-facts-test-helpers.ts.
+ *
+ * This suite REQUIRES a real test database. Absent the connection string
+ * requireTestDatabaseUrl throws test_database_required and the run fails loudly
+ * rather than reporting a skip that reads as a pass at the exit code.
  *
  * Proofs (all at the public callTool boundary, asserting responses + rows):
  *  1. An approved+active conversation source and the exact seven-coordinate lane
@@ -25,585 +30,231 @@
  *     raises on a sentinel unit) rolls the whole transaction back: zero events
  *     from that call persist and the caller sees a retryable error. The trigger
  *     is removed in cleanup.
- *  4. Namespace/scope isolation is non-vacuous: the owning namespace succeeds;
- *     a foreign-namespace argument is denied and writes nothing; a wrong-scope
- *     assertion against a real lane is denied and writes nothing.
- *  5. A raw transcript body supplied as a top-level key is rejected at the schema
- *     boundary and writes nothing.
  */
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "bun:test";
-import type { Pool } from "pg";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { runMigrations } from "../../db/migrate.ts";
-import { registerIngestConversationFacts } from "../ingest-conversation-facts.ts";
-import type { ToolDeps } from "../index.ts";
-import type { AuthInfo } from "../../types.ts";
+import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
+import {
+  createIngestHarness,
+  firstRow,
+  OWNER_NS,
+  OWNER_SCOPE,
+  OWNER_SOURCE_REF,
+  ownerAuth,
+  TRIGGER_SENTINEL,
+} from "./ingest-conversation-facts-test-helpers.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+const h = createIngestHarness(pool);
 
-// Every row this suite creates is namespaced under one of these two isolation
-// namespaces so cleanup deletes exactly what the suite owns and nothing else.
-// The owning namespace is where the approved source + scoped lane live; the
-// foreign namespace is used only to prove cross-namespace denial.
-const OWNER_NS = "lane340-owner-ns";
-const FOREIGN_NS = "lane340-foreign-ns";
+// Each proof is a named module-scope function so the describe body stays a
+// short registration list rather than one long function.
 
-// The exact seven-coordinate scope (six coordinates + namespace) the owning lane
-// is bound to. Matches the shape the tool's lane predicate asserts.
-const OWNER_SCOPE = {
-  agent: "assistant",
-  platform: "discord",
-  server_id: "guild-340",
-  channel_id: "chan-340",
-  thread_id: null as string | null,
-  session_key: "sess-340",
-};
+async function proveReceiptMatchesStoredRow(): Promise<void> {
+  await h.seedOwnerFixtures();
+  await h.withTool(ownerAuth, async (client) => {
+    const result = await client.callTool({
+      name: "ingest_conversation_facts",
+      arguments: {
+        namespace: OWNER_NS,
+        scope: OWNER_SCOPE,
+        source_ref: OWNER_SOURCE_REF,
+        facts: [{ event_type: "decision", content: "We chose Postgres." }],
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const body = h.parse(result);
+    expect(body.ok).toBe(true);
+    expect(body.ingested).toBe(1);
+    expect(body.duplicates).toBe(0);
+    expect(body.lane_id).toBe(h.ownerLaneId);
+    expect(body.source_id).toBe(h.ownerSourceId);
+    expect(body.writer_identity).toBe(OWNER_NS);
+    // The receipt never echoes the distilled content.
+    expect(JSON.stringify(body)).not.toContain("We chose Postgres");
 
-const OWNER_SOURCE_EXTERNAL_ID = "conv:room-340";
-const OWNER_SOURCE_REF = {
-  source_kind: "conversation" as const,
-  external_id: OWNER_SOURCE_EXTERNAL_ID,
-};
+    const events = body.events as Array<Record<string, unknown>>;
+    expect(events).toHaveLength(1);
+    const eventId = firstRow(events).event_id as string;
+    expect(firstRow(events).disposition).toBe("stored");
 
-// A token-scoped agent whose own namespace is OWNER_NS. This is the happy-path
-// writer: it may write its own namespace and is denied any foreign one.
-const ownerAuth: AuthInfo = {
-  role: "agent",
-  clientId: OWNER_NS,
-  namespaceSource: "token",
-};
-
-// Deterministic embeddings so no live embedding endpoint is required; the tool
-// treats an embed result as opaque and stores it as a bound param.
-const stubEmbed = async (): Promise<number[]> => Array(768).fill(0.01);
-
-// A sentinel content string the test-owned trigger raises on, used only to force
-// a deterministic mid-batch failure in proof (3).
-const TRIGGER_SENTINEL = "LANE340_TRIGGER_ROLLBACK_SENTINEL";
-
-dbDescribe("ingest_conversation_facts (live Postgres)", () => {
-  let pool: Pool;
-  let ownerLaneId: string;
-  let ownerSourceId: string;
-
-  function parse(result: unknown): Record<string, unknown> {
-    const content = (result as { content: Array<{ text: string }> }).content;
-    return JSON.parse(content[0]!.text);
-  }
-
-  // Stand up a public MCP client wired to the real pool for a given auth. This is
-  // the same public-boundary harness the fake suite uses, so tests assert the
-  // caller-visible callTool response, never internal SQL or call order.
-  async function withTool(
-    auth: AuthInfo,
-    fn: (client: Client) => Promise<void>,
-  ): Promise<void> {
-    const server = new McpServer({ name: "test", version: "1.0.0" });
-    const deps: ToolDeps = {
-      pool: pool as never,
-      embedFn: stubEmbed as never,
-    };
-    registerIngestConversationFacts(server, deps);
-
-    const [clientTransport, serverTransport] =
-      InMemoryTransport.createLinkedPair();
-    const originalSend = clientTransport.send.bind(clientTransport);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    clientTransport.send = (message: any, options?: any) =>
-      originalSend(message, { ...options, authInfo: auth });
-
-    const client = new Client({ name: "test-client", version: "1.0.0" });
-    await server.connect(serverTransport);
-    await client.connect(clientTransport);
-    try {
-      await fn(client);
-    } finally {
-      await client.close();
-      await server.close();
-    }
-  }
-
-  // Count durable events in a lane whose content matches, so a test can prove
-  // exactly how many rows a call persisted (or that it persisted none).
-  async function eventCount(laneId: string): Promise<number> {
+    // The stored row is exactly what the receipt claims: right id, lane, type,
+    // content, and conversation-ingest provenance.
     const { rows } = await pool.query(
-      "SELECT count(*)::int AS c FROM ob_session_events WHERE lane_id = $1",
-      [laneId],
+      `SELECT lane_id, event_type, content, importance,
+              metadata->>'conversation_ingest' AS conv,
+              metadata->>'source_id' AS meta_source_id,
+              metadata->'_openbrain'->'writer'->>'client_id' AS writer
+         FROM ob_session_events WHERE id = $1`,
+      [eventId],
     );
-    return rows[0]!.c as number;
-  }
+    expect(rows).toHaveLength(1);
+    const row = firstRow(rows);
+    expect(String(row.lane_id)).toBe(h.ownerLaneId);
+    expect(row.event_type).toBe("decision");
+    expect(row.content).toBe("We chose Postgres.");
+    expect(row.importance).toBe("warm");
+    expect(row.conv).toBe("true");
+    expect(String(row.meta_source_id)).toBe(h.ownerSourceId);
+    expect(row.writer).toBe(OWNER_NS);
 
-  async function cleanupData(): Promise<void> {
-    // Events cascade from lanes, but delete explicitly for clarity. Order:
-    // events → lanes → sources, all scoped to the suite's two namespaces.
-    await pool.query(
-      `DELETE FROM ob_session_events
-        WHERE lane_id IN (
-          SELECT id FROM ob_session_lanes WHERE namespace = ANY($1::text[])
-        )`,
-      [[OWNER_NS, FOREIGN_NS]],
-    );
-    await pool.query(
-      "DELETE FROM ob_session_lanes WHERE namespace = ANY($1::text[])",
-      [[OWNER_NS, FOREIGN_NS]],
-    );
-    await pool.query(
-      "DELETE FROM ob_sources WHERE namespace = ANY($1::text[])",
-      [[OWNER_NS, FOREIGN_NS]],
-    );
-  }
-
-  // Seed the owning approved+active conversation source and the exact-scope lane
-  // fresh, returning their ids. Called before each proof so no prior state leaks.
-  async function seedOwnerFixtures(): Promise<void> {
-    const { rows: srcRows } = await pool.query(
-      `INSERT INTO ob_sources
-         (namespace, source_kind, external_id, approval_state, approved_by,
-          approved_at, lifecycle_state, sync_state, created_by)
-       VALUES ($1, 'conversation', $2, 'approved', 'admin', now(),
-               'active', 'synced', 'admin')
-       RETURNING id`,
-      [OWNER_NS, OWNER_SOURCE_EXTERNAL_ID],
-    );
-    ownerSourceId = String(srcRows[0]!.id);
-
-    const { rows: laneRows } = await pool.query(
-      `INSERT INTO ob_session_lanes
-         (session_key, namespace, status, agent, source, channel_id, thread_id,
-          metadata, created_by)
-       VALUES ($1, $2, 'active', $3, $4, $5, $6, $7::jsonb, 'admin')
-       RETURNING id`,
-      [
-        OWNER_SCOPE.session_key,
-        OWNER_NS,
-        OWNER_SCOPE.agent,
-        OWNER_SCOPE.platform,
-        OWNER_SCOPE.channel_id,
-        OWNER_SCOPE.thread_id,
-        JSON.stringify({ server_id: OWNER_SCOPE.server_id }),
-      ],
-    );
-    ownerLaneId = String(laneRows[0]!.id);
-  }
-
-  beforeAll(async () => {
-    const { Pool } = await import("pg");
-    pool = new Pool({ connectionString: DB_URL });
-    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
-    await runMigrations(pool);
-    await cleanupData();
+    // Exactly one durable row landed for this call.
+    expect(await h.eventCount(h.ownerLaneId)).toBe(1);
   });
+}
 
-  afterAll(async () => {
-    await cleanupData();
-    await pool.end();
-  });
-
-  afterEach(async () => {
-    // Remove any test-owned trigger a proof installed, then clear suite data so
-    // each proof starts from a clean, freshly-seeded fixture.
-    await pool.query(
-      "DROP TRIGGER IF EXISTS lane340_rollback_trigger ON ob_session_events",
-    );
-    await pool.query(
-      "DROP FUNCTION IF EXISTS lane340_rollback_trigger_fn() CASCADE",
-    );
-    await cleanupData();
-  });
-
-  it("ingests an approved-source fact through real SQL and the receipt matches the stored row", async () => {
-    await seedOwnerFixtures();
-    await withTool(ownerAuth, async (client) => {
-      const result = await client.callTool({
-        name: "ingest_conversation_facts",
-        arguments: {
-          namespace: OWNER_NS,
-          scope: OWNER_SCOPE,
-          source_ref: OWNER_SOURCE_REF,
-          facts: [{ event_type: "decision", content: "We chose Postgres." }],
-        },
-      });
-      expect(result.isError).toBeFalsy();
-      const body = parse(result);
-      expect(body.ok).toBe(true);
-      expect(body.ingested).toBe(1);
-      expect(body.duplicates).toBe(0);
-      expect(body.lane_id).toBe(ownerLaneId);
-      expect(body.source_id).toBe(ownerSourceId);
-      expect(body.writer_identity).toBe(OWNER_NS);
-      // The receipt never echoes the distilled content.
-      expect(JSON.stringify(body)).not.toContain("We chose Postgres");
-
-      const events = body.events as Array<Record<string, unknown>>;
-      expect(events).toHaveLength(1);
-      const eventId = events[0]!.event_id as string;
-      expect(events[0]!.disposition).toBe("stored");
-
-      // The stored row is exactly what the receipt claims: right id, lane, type,
-      // content, and conversation-ingest provenance.
-      const { rows } = await pool.query(
-        `SELECT lane_id, event_type, content, importance,
-                metadata->>'conversation_ingest' AS conv,
-                metadata->>'source_id' AS meta_source_id,
-                metadata->'_openbrain'->'writer'->>'client_id' AS writer
-           FROM ob_session_events WHERE id = $1`,
-        [eventId],
-      );
-      expect(rows).toHaveLength(1);
-      const row = rows[0]!;
-      expect(String(row.lane_id)).toBe(ownerLaneId);
-      expect(row.event_type).toBe("decision");
-      expect(row.content).toBe("We chose Postgres.");
-      expect(row.importance).toBe("warm");
-      expect(row.conv).toBe("true");
-      expect(String(row.meta_source_id)).toBe(ownerSourceId);
-      expect(row.writer).toBe(OWNER_NS);
-
-      // Exactly one durable row landed for this call.
-      expect(await eventCount(ownerLaneId)).toBe(1);
-    });
-  });
-
-  it("merges bounded evidence for identical content with a new locator, and the stored metadata matches the receipt", async () => {
-    await seedOwnerFixtures();
-    const sharedContent = "Identical distilled statement.";
-    await withTool(ownerAuth, async (client) => {
-      // First write: stores the row with locator anchor-A.
-      const first = parse(
-        await client.callTool({
-          name: "ingest_conversation_facts",
-          arguments: {
-            namespace: OWNER_NS,
-            scope: OWNER_SCOPE,
-            source_ref: OWNER_SOURCE_REF,
-            facts: [
-              {
-                event_type: "fact",
-                content: sharedContent,
-                source_locator: "anchor-A",
-              },
-            ],
-          },
-        }),
-      );
-      expect(first.ingested).toBe(1);
-      const storedId = (first.events as Array<Record<string, unknown>>)[0]!
-        .event_id as string;
-
-      // Second write: identical content, a NEW locator anchor-B. This is a
-      // content-duplicate that carries new structural evidence.
-      const second = parse(
-        await client.callTool({
-          name: "ingest_conversation_facts",
-          arguments: {
-            namespace: OWNER_NS,
-            scope: OWNER_SCOPE,
-            source_ref: OWNER_SOURCE_REF,
-            facts: [
-              {
-                event_type: "fact",
-                content: sharedContent,
-                source_locator: "anchor-B",
-              },
-            ],
-          },
-        }),
-      );
-      expect(second.isError).toBeFalsy();
-      expect(second.ingested).toBe(0);
-      expect(second.duplicates).toBe(1);
-      expect(second.evidence_merged).toBe(1);
-      expect(second.evidence_not_stored).toBe(0);
-      const secondEvents = second.events as Array<Record<string, unknown>>;
-      expect(secondEvents[0]!.disposition).toBe("duplicate_evidence_merged");
-      // The merge targets the SAME stored row, not a new one.
-      expect(secondEvents[0]!.event_id).toBe(storedId);
-
-      // No second durable row was written: identical content did not double-write.
-      expect(await eventCount(ownerLaneId)).toBe(1);
-
-      // The stored row now carries the new locator as bounded structural
-      // evidence, exactly as the receipt reported.
-      const { rows } = await pool.query(
-        `SELECT metadata->'additional_evidence' AS evidence
-           FROM ob_session_events WHERE id = $1`,
-        [storedId],
-      );
-      const evidence = rows[0]!.evidence as Array<Record<string, unknown>>;
-      expect(Array.isArray(evidence)).toBe(true);
-      expect(evidence).toHaveLength(1);
-      expect(evidence[0]!.source_locator).toBe("anchor-B");
-      expect(evidence[0]!.event_type).toBe("fact");
-      // Content is never written into the evidence pointer.
-      expect(JSON.stringify(evidence)).not.toContain(sharedContent);
-    });
-  });
-
-  it("rolls back the whole batch on a deterministic mid-batch failure: zero events persist", async () => {
-    await seedOwnerFixtures();
-
-    // Test-owned deterministic failure: a BEFORE INSERT trigger that raises only
-    // when a unit carries the sentinel content. Installed here and removed in the
-    // afterEach cleanup. This makes the SECOND unit of a two-unit batch fail
-    // inside the transaction with no reliance on timing or concurrency.
-    await pool.query(`
-      CREATE FUNCTION lane340_rollback_trigger_fn() RETURNS trigger AS $$
-      BEGIN
-        IF NEW.content = '${TRIGGER_SENTINEL}' THEN
-          RAISE EXCEPTION 'lane340 deterministic mid-batch failure';
-        END IF;
-        RETURN NEW;
-      END;
-      $$ LANGUAGE plpgsql;
-    `);
-    await pool.query(`
-      CREATE TRIGGER lane340_rollback_trigger
-        BEFORE INSERT ON ob_session_events
-        FOR EACH ROW EXECUTE FUNCTION lane340_rollback_trigger_fn();
-    `);
-
-    expect(await eventCount(ownerLaneId)).toBe(0);
-
-    await withTool(ownerAuth, async (client) => {
-      const result = await client.callTool({
+async function proveEvidenceMergeOnNewLocator(): Promise<void> {
+  await h.seedOwnerFixtures();
+  const sharedContent = "Identical distilled statement.";
+  await h.withTool(ownerAuth, async (client) => {
+    // First write: stores the row with locator anchor-A.
+    const first = h.parse(
+      await client.callTool({
         name: "ingest_conversation_facts",
         arguments: {
           namespace: OWNER_NS,
           scope: OWNER_SCOPE,
           source_ref: OWNER_SOURCE_REF,
           facts: [
-            { event_type: "fact", content: "First unit that would commit." },
-            { event_type: "fact", content: TRIGGER_SENTINEL },
+            {
+              event_type: "fact",
+              content: sharedContent,
+              source_locator: "anchor-A",
+            },
           ],
         },
-      });
-      // Caller-visible failure, not a benign or partial success.
-      expect(result.isError).toBe(true);
-      const body = parse(result);
-      expect(body.error).toBe("retryable_outage");
-      expect(body.ingested).toBeUndefined();
-      // The raised message never leaks into the response.
-      expect(JSON.stringify(result)).not.toContain("deterministic mid-batch");
-    });
-
-    // All-or-nothing: the first unit's insert was rolled back with the failing
-    // second, so ZERO events from that call persist.
-    expect(await eventCount(ownerLaneId)).toBe(0);
-  });
-
-  it("keeps namespace/scope isolation non-vacuous: owning success, foreign-namespace and wrong-scope denials write nothing", async () => {
-    await seedOwnerFixtures();
-
-    // (a) Owning success: baseline that the fixtures are ingestable at all, so
-    // the denials below are genuine boundary rejections, not a broken setup.
-    await withTool(ownerAuth, async (client) => {
-      const body = parse(
-        await client.callTool({
-          name: "ingest_conversation_facts",
-          arguments: {
-            namespace: OWNER_NS,
-            scope: OWNER_SCOPE,
-            source_ref: OWNER_SOURCE_REF,
-            facts: [{ event_type: "fact", content: "Owned success fact." }],
-          },
-        }),
-      );
-      expect(body.ok).toBe(true);
-      expect(body.ingested).toBe(1);
-    });
-    expect(await eventCount(ownerLaneId)).toBe(1);
-
-    // (b) Foreign-namespace denial: the same owner token targets a namespace it
-    // does not own. The write is denied server-side and nothing is persisted.
-    await withTool(ownerAuth, async (client) => {
-      const result = await client.callTool({
-        name: "ingest_conversation_facts",
-        arguments: {
-          namespace: FOREIGN_NS,
-          scope: OWNER_SCOPE,
-          source_ref: OWNER_SOURCE_REF,
-          facts: [{ event_type: "fact", content: "Foreign attempt." }],
-        },
-      });
-      expect(result.isError).toBe(true);
-      expect(parse(result).error).toBe("namespace_denied");
-    });
-    // No lane/event was created in the foreign namespace.
-    const { rows: foreignLanes } = await pool.query(
-      "SELECT count(*)::int AS c FROM ob_session_lanes WHERE namespace = $1",
-      [FOREIGN_NS],
+      }),
     );
-    expect(foreignLanes[0]!.c).toBe(0);
+    expect(first.ingested).toBe(1);
+    const storedId = firstRow(first.events as Array<Record<string, unknown>>)
+      .event_id as string;
 
-    // (c) Wrong-scope denial: a real, owned lane exists, but the asserted scope
-    // uses a different channel_id, so no lane matches the seven-coordinate
-    // predicate. The call is denied and writes nothing new.
-    await withTool(ownerAuth, async (client) => {
-      const result = await client.callTool({
+    // Second write: identical content, a NEW locator anchor-B. This is a
+    // content-duplicate that carries new structural evidence.
+    const second = h.parse(
+      await client.callTool({
         name: "ingest_conversation_facts",
         arguments: {
           namespace: OWNER_NS,
-          scope: { ...OWNER_SCOPE, channel_id: "wrong-channel" },
+          scope: OWNER_SCOPE,
           source_ref: OWNER_SOURCE_REF,
-          facts: [{ event_type: "fact", content: "Wrong-scope attempt." }],
+          facts: [
+            {
+              event_type: "fact",
+              content: sharedContent,
+              source_locator: "anchor-B",
+            },
+          ],
         },
-      });
-      expect(result.isError).toBe(true);
-      expect(parse(result).error).toBe("scope_validation");
-    });
-    // Still exactly the one owned-success row; the wrong-scope call added nothing.
-    expect(await eventCount(ownerLaneId)).toBe(1);
-  });
-
-  it("serializes concurrent distinct-locator merges: every merged disposition maps to retained unique evidence, no lost update", async () => {
-    await seedOwnerFixtures();
-    const sharedContent = "Concurrently re-cited distilled statement.";
-
-    // Seed the single duplicate row once (locator anchor-0). Every concurrent
-    // call below hits the content-duplicate merge branch on THIS row.
-    let storedId = "";
-    await withTool(ownerAuth, async (client) => {
-      const first = parse(
-        await client.callTool({
-          name: "ingest_conversation_facts",
-          arguments: {
-            namespace: OWNER_NS,
-            scope: OWNER_SCOPE,
-            source_ref: OWNER_SOURCE_REF,
-            facts: [
-              {
-                event_type: "fact",
-                content: sharedContent,
-                source_locator: "anchor-0",
-              },
-            ],
-          },
-        }),
-      );
-      expect(first.ingested).toBe(1);
-      storedId = (first.events as Array<Record<string, unknown>>)[0]!
-        .event_id as string;
-    });
-
-    // Fire N concurrent calls, each identical content with a DISTINCT locator.
-    // N is bounded and well under MAX_ADDITIONAL_EVIDENCE (32), so every merge
-    // must succeed and be retained — none may hit the evidence_not_stored bound.
-    const N = 8;
-    const locators = Array.from({ length: N }, (_, i) => `anchor-c${i + 1}`);
-
-    // Each concurrent caller gets its own MCP client/connection over the shared
-    // real pool, so the N calls race through independent transactions exactly as
-    // distinct callers would. withTool owns connect/close; the promise resolves
-    // with the parsed receipt for that caller.
-    const results = await Promise.all(
-      locators.map(
-        (locator) =>
-          new Promise<Record<string, unknown>>((resolve, reject) => {
-            withTool(ownerAuth, async (client) => {
-              const body = parse(
-                await client.callTool({
-                  name: "ingest_conversation_facts",
-                  arguments: {
-                    namespace: OWNER_NS,
-                    scope: OWNER_SCOPE,
-                    source_ref: OWNER_SOURCE_REF,
-                    facts: [
-                      {
-                        event_type: "fact",
-                        content: sharedContent,
-                        source_locator: locator,
-                      },
-                    ],
-                  },
-                }),
-              );
-              resolve(body);
-            }).catch(reject);
-          }),
-      ),
+      }),
     );
+    expect(second.isError).toBeFalsy();
+    expect(second.ingested).toBe(0);
+    expect(second.duplicates).toBe(1);
+    expect(second.evidence_merged).toBe(1);
+    expect(second.evidence_not_stored).toBe(0);
+    const secondEvents = second.events as Array<Record<string, unknown>>;
+    expect(firstRow(secondEvents).disposition).toBe("duplicate_evidence_merged");
+    // The merge targets the SAME stored row, not a new one.
+    expect(firstRow(secondEvents).event_id).toBe(storedId);
 
-    // No call may false-succeed or error: each is a caller-visible ok receipt
-    // with exactly one duplicate unit (identical content, no new row).
-    const dispositions: string[] = [];
-    for (const body of results) {
-      expect(body.ok).toBe(true);
-      expect(body.ingested).toBe(0);
-      expect(body.duplicates).toBe(1);
-      const events = body.events as Array<Record<string, unknown>>;
-      expect(events).toHaveLength(1);
-      expect(events[0]!.event_id).toBe(storedId);
-      dispositions.push(events[0]!.disposition as string);
-    }
+    // No second durable row was written: identical content did not double-write.
+    expect(await h.eventCount(h.ownerLaneId)).toBe(1);
 
-    // Under the bound, EVERY concurrent distinct-locator call must report a
-    // real merge — never a benign plain-duplicate that silently dropped its
-    // evidence, and never evidence_not_stored (we are well below the cap).
-    const mergedLocators = locators.filter(
-      (_, i) => dispositions[i] === "duplicate_evidence_merged",
-    );
-    expect(dispositions.every((d) => d === "duplicate_evidence_merged")).toBe(
-      true,
-    );
-
-    // No second row was ever written: identical content stayed a single row.
-    expect(await eventCount(ownerLaneId)).toBe(1);
-
-    // The lost-update proof: read the FINAL stored evidence. Every locator that
-    // a caller reported as merged must be present exactly once — a lost update
-    // would leave a merged disposition whose locator is missing from metadata.
+    // The stored row now carries the new locator as bounded structural
+    // evidence, exactly as the receipt reported.
     const { rows } = await pool.query(
-      `SELECT metadata->'additional_evidence' AS evidence,
-              metadata->>'source_locator' AS primary_locator
+      `SELECT metadata->'additional_evidence' AS evidence
          FROM ob_session_events WHERE id = $1`,
       [storedId],
     );
-    const evidence = rows[0]!.evidence as Array<Record<string, unknown>>;
+    const evidence = firstRow(rows).evidence as Array<Record<string, unknown>>;
     expect(Array.isArray(evidence)).toBe(true);
-    // Primary locator (anchor-0) is on the row itself, not in additional_evidence.
-    expect(rows[0]!.primary_locator).toBe("anchor-0");
-
-    const storedLocators = evidence.map((e) => e.source_locator as string);
-    // Each retained locator appears exactly once (no duplication, no loss).
-    expect(new Set(storedLocators).size).toBe(storedLocators.length);
-    // Every caller-reported merge is retained in the final metadata: the count
-    // of merged dispositions equals the count of retained distinct locators,
-    // and each merged locator is present. This fails on the pre-lock behavior,
-    // where concurrent overwrites drop merges while still reporting success.
-    for (const locator of mergedLocators) {
-      expect(storedLocators).toContain(locator);
-    }
-    expect(storedLocators.length).toBe(mergedLocators.length);
-    expect(storedLocators.length).toBe(N);
-
-    // Content never leaks into any evidence pointer.
+    expect(evidence).toHaveLength(1);
+    expect(firstRow(evidence).source_locator).toBe("anchor-B");
+    expect(firstRow(evidence).event_type).toBe("fact");
+    // Content is never written into the evidence pointer.
     expect(JSON.stringify(evidence)).not.toContain(sharedContent);
   });
+}
 
-  it("rejects a raw transcript public-schema body and writes nothing", async () => {
-    await seedOwnerFixtures();
-    await withTool(ownerAuth, async (client) => {
-      const result = await client.callTool({
-        name: "ingest_conversation_facts",
-        arguments: {
-          namespace: OWNER_NS,
-          scope: OWNER_SCOPE,
-          source_ref: OWNER_SOURCE_REF,
-          facts: [{ event_type: "fact", content: "distilled fact" }],
-          transcript: "user: hi\nassistant: hello\n... full raw transcript ...",
-        },
-      });
-      // Caller-visible rejection at the schema boundary; the raw body is not
-      // echoed back in the error.
-      expect(result.isError).toBe(true);
-      const text = JSON.stringify(result);
-      expect(text).toContain("transcript");
-      expect(text).not.toContain("assistant: hello");
+async function proveMidBatchFailureRollsBack(): Promise<void> {
+  await h.seedOwnerFixtures();
+
+  // Test-owned deterministic failure: a BEFORE INSERT trigger that raises only
+  // when a unit carries the sentinel content. Installed here and removed in the
+  // afterEach cleanup. This makes the SECOND unit of a two-unit batch fail
+  // inside the transaction with no reliance on timing or concurrency.
+  await pool.query(`
+    CREATE FUNCTION lane340_rollback_trigger_fn() RETURNS trigger AS $$
+    BEGIN
+      IF NEW.content = '${TRIGGER_SENTINEL}' THEN
+        RAISE EXCEPTION 'lane340 deterministic mid-batch failure';
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  `);
+  await pool.query(`
+    CREATE TRIGGER lane340_rollback_trigger
+      BEFORE INSERT ON ob_session_events
+      FOR EACH ROW EXECUTE FUNCTION lane340_rollback_trigger_fn();
+  `);
+
+  expect(await h.eventCount(h.ownerLaneId)).toBe(0);
+
+  await h.withTool(ownerAuth, async (client) => {
+    const result = await client.callTool({
+      name: "ingest_conversation_facts",
+      arguments: {
+        namespace: OWNER_NS,
+        scope: OWNER_SCOPE,
+        source_ref: OWNER_SOURCE_REF,
+        facts: [
+          { event_type: "fact", content: "First unit that would commit." },
+          { event_type: "fact", content: TRIGGER_SENTINEL },
+        ],
+      },
     });
-    // Zero events persisted: the handler never ran a write.
-    expect(await eventCount(ownerLaneId)).toBe(0);
+    // Caller-visible failure, not a benign or partial success.
+    expect(result.isError).toBe(true);
+    const body = h.parse(result);
+    expect(body.error).toBe("retryable_outage");
+    expect(body.ingested).toBeUndefined();
+    // The raised message never leaks into the response.
+    expect(JSON.stringify(result)).not.toContain("deterministic mid-batch");
   });
+
+  // All-or-nothing: the first unit's insert was rolled back with the failing
+  // second, so ZERO events from that call persist.
+  expect(await h.eventCount(h.ownerLaneId)).toBe(0);
+}
+
+describe("ingest_conversation_facts write path (live Postgres)", () => {
+  beforeAll(async () => {
+    await h.migrateAndClean();
+  });
+
+  afterAll(async () => {
+    await h.cleanAndEnd();
+  });
+
+  afterEach(async () => {
+    await h.dropTriggerAndClean();
+  });
+
+  it(
+    "ingests an approved-source fact through real SQL and the receipt matches the stored row",
+    proveReceiptMatchesStoredRow,
+  );
+
+  it(
+    "merges bounded evidence for identical content with a new locator, and the stored metadata matches the receipt",
+    proveEvidenceMergeOnNewLocator,
+  );
+
+  it(
+    "rolls back the whole batch on a deterministic mid-batch failure: zero events persist",
+    proveMidBatchFailureRollsBack,
+  );
 });


### PR DESCRIPTION
## Summary

- `src/tools/__tests__/ingest-conversation-facts.pg.test.ts` read `OPENBRAIN_TEST_DATABASE_URL` itself and swapped in `describe.skip` when it was unset. A run without a database reported `0 pass, 8 skip, 0 fail` and exited 0, which at the exit code is indistinguishable from a suite that ran and passed. It now calls `requireTestDatabaseUrl()` at module scope, so the absent variable throws `test_database_required` and takes the run down loudly.
- Split by subject while converting, because the file carried two unrelated concerns across 609 lines. `ingest-conversation-facts.pg.test.ts` keeps the three write-path proofs (the receipt matches the stored row, evidence merges on a new locator, a mid-batch failure rolls the whole transaction back). A new `ingest-conversation-facts-isolation.pg.test.ts` takes the three isolation and concurrency proofs (namespace and scope denial, concurrent distinct-locator merges, a raw transcript rejected at the schema boundary).
- A new `ingest-conversation-facts-test-helpers.ts` holds the fixtures and the database-touching harness the two files share. `createIngestHarness(pool)` takes a caller-owned pool, so each suite creates one at module scope and ends it once in its own `afterAll`. The module holds no test and creates no pool of its own.
- Test bodies, names, and assertions moved verbatim. Only the describe wrapper, the imports, pool creation, and the harness plumbing changed.
- `scripts/assert-db-tests-ran.ts` registers both suites at their emitted counts, 3 and 3, read from JUnit rather than tallied by eye, and moves `MIN_TOTAL_LIVE_TESTCASES` 265 -> 271. Registering one half would let the other vanish unnoticed.
- The three files also carried pre-existing oxlint findings that the pre-commit gate lints whole, so they are fixed here without disable comments: the repeated `rows[0]!` non-null assertions became a `firstRow()` helper that names an empty result instead of dereferencing undefined, the duplicated lifecycle moved into the harness, and each proof became a named module-scope function so the describe bodies are registration lists rather than one long function.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- RED at `origin/main`: `CHANGED_FILES="src/tools/__tests__/ingest-conversation-facts.pg.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` exited 1, with clauses 1, 2 and 3 failing and the run reporting `0 pass, 8 skip, 0 fail`.
- GREEN on the committed tree: `CHANGED_FILES="src/tools/__tests__/ingest-conversation-facts.pg.test.ts src/tools/__tests__/ingest-conversation-facts-isolation.pg.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` exited 0 with all four clauses passing.
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bun run test:isolated` over both suites exits 0 at 6 pass / 0 fail, and its JUnit output carries 3 testcases under each of the two describe names, matching the manifest entries. `bunx tsc --noEmit` exits 0. `./node_modules/.bin/oxlint --deny-warnings` over all four touched files exits 0. Python package sources are untouched, and this change adds no migration and no tool or transport surface, so there is nothing to smoke against a live service.

## Critical Self-Review

- Highest-risk behavior: the split could silently drop a proof. Guarded by the JUnit count read back per describe name (3 and 3, six total against six before the split) and by both names being registered in `scripts/assert-db-tests-ran.ts`, which fails CI on a vanished suite name or a lower count.
- Assumptions that could be wrong: that the two suites can each own a pool against the same database without interfering. Both seed and clean the same two isolation namespaces, so a parallel run of the two files could race on cleanup. `bun test` runs files in one process sequentially, which is what the green run exercised; a future switch to parallel files would need per-suite namespaces.
- Missing/weak tests: none added, by design. This is a conversion, and the proof that it works is the pre-existing assertions still passing plus clause 3 observing the hard failure. No assertion was modified.
- Security/permission risk: none. The namespace and scope denial proofs moved verbatim into the isolation suite and still assert the same predicates; no namespace predicate, auth path, or SQL under test was touched.
- Migration/deploy risk: none. No migration, no schema change, no runtime source file changed; the diff is two test files, one test-only helper module, and the test manifest.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` applies to MCP tool, schema, protocol, and client-facing changes; this touches no tool contract, no transport, and no Python client.
- Rollback/cleanup concern: reverting the commit restores the original single file. The harness module is imported only by the two suites, so it leaves nothing behind. The suites drop their test-owned trigger and clean their two namespaces in `afterEach` and `afterAll` exactly as before.
- Fixes made before PR: cleared 22 oxlint findings in the touched files rather than reaching for a disable comment, 19 of them pre-existing non-null assertions on `origin/main`. Also corrected an off-by-one that first inserted the manifest entries inside the preceding entry's closing brace, and a name collision where the new `first()` helper shadowed a local `const first` in two moved test bodies, which is why it is named `firstRow()`.
- Known residual risk: the two suites share the same two isolation namespaces, noted above under assumptions. Reviewers should also confirm the moved bodies are byte-identical to their originals; they were moved with shell line-range copies rather than retyped, and the only intended edits are the harness call prefixes.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no new MEDIUM+ finding class; the conversion pattern and its done-means check already exist and are already documented, and the lint fixes are instances of rules the repo already enforces.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the change is confined to test files and the test manifest, and adds no tool, schema, or transport surface a live service could exercise.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or tool schema changed. The diff is test-only plus the live-testcase manifest.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Every rollout item is not applicable: the classification in `docs/downstream-rollout.md` keys on MCP tool, schema, protocol, and client-facing changes, and this change touches none of them. No runtime source file is in the diff.
