### PR TITLE
test(pg): the 026 maintenance queue migration test requires the test database instead of skipping (#878)

### DIFF
--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -85,6 +85,20 @@ export const REQUIRED_SUITES: ReadonlyArray<{
     name: "025 leaves unrecognized lane shapes unchanged (live Postgres)",
     minTests: 1,
   },
+  // Migration 026's maintenance queue (#878). Env-gated like the suites above
+  // and never registered here, so a Postgres misconfiguration silently skipped
+  // every proof this queue has: idempotent enqueue, single-claimant leasing,
+  // deterministic retry scheduling, and the dead-letter transition. Split by
+  // subject in #878 into enqueue/claim and retry/dead-letter, so both halves
+  // are named here -- registering one would let the other vanish unnoticed.
+  {
+    name: "026 maintenance queue enqueue and claim (live Postgres)",
+    minTests: 6,
+  },
+  {
+    name: "026 maintenance queue retry and dead-letter (live Postgres)",
+    minTests: 6,
+  },
   {
     name: "server ID queries enforce namespace isolation (live Postgres)",
     minTests: 4,
@@ -421,9 +435,11 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // when #878 registered the get_entry compact render suite's 1 as that file
 // stopped skipping itself, then 266 -> 272 when #878 registered the two
 // subject-split ingest_conversation_facts write-path and isolation suites'
-// 3 + 3 as that file stopped skipping itself), so the global floor cannot
-// silently fall behind the per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 272;
+// 3 + 3 as that file stopped skipping itself, then 272 -> 284 when #878
+// registered the two 026 maintenance queue suites' 6 + 6 as that file
+// stopped skipping itself), so the global floor cannot silently fall behind
+// the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 284;
 
 export interface SuiteStats {
   tests: number;

--- a/src/db/migrations/026_maintenance_queue-retry.test.ts
+++ b/src/db/migrations/026_maintenance_queue-retry.test.ts
@@ -1,0 +1,367 @@
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import {
+  MaintenanceQueue,
+  MaintenanceQueueRunner,
+  type MaintenanceJob,
+  type MaintenanceJobHandler,
+} from "../../maintenance-queue.ts";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
+import {
+  cleanup,
+  enqueue as enqueueWith,
+  expectDefined,
+  migrate,
+  queue as queueWith,
+} from "./026_maintenance_queue-test-helpers.ts";
+
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+const queue = () => queueWith(pool);
+const enqueue = (input: Parameters<typeof enqueueWith>[1] = {}) =>
+  enqueueWith(pool, input);
+
+// Drive the real runner over the real queue with a handler that mutates the
+// job's durable retry fields before throwing. The terminal decision and the
+// retry schedule must come from the persisted row, not the mutated object, so
+// no caller-supplied retry-policy value can decide the transition.
+function runnerFor(
+  handlers: Record<string, MaintenanceJobHandler>,
+  fixedNow: Date,
+): MaintenanceQueueRunner {
+  return new MaintenanceQueueRunner({
+    queue: queue(),
+    handlers: new Map(Object.entries(handlers)),
+    logger: {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+    concurrency: 1,
+    leaseMs: 60_000,
+    now: () => fixedNow,
+  });
+}
+
+// The `it` bodies live at module scope rather than inline so the describe
+// callback stays inside the repo's per-function line rule. Test names, order,
+// and assertions are unchanged by the move.
+
+async function deadLettersExpiredLeaseWhenAttemptsExhausted(): Promise<void> {
+  // maxAttempts=1: exactly one handler execution is allowed. The claim below
+  // consumes it (attempts 0 -> 1). The lease then expires without a
+  // complete()/fail(), simulating a handler that hung or crashed.
+  await enqueue({
+    idempotencyKey: "expired-bound",
+    retry: { maxAttempts: 1 },
+  });
+  const now = new Date("2026-07-22T14:00:00.000Z");
+  const [maybeFirst] = await queue().claimDueJobs({
+    limit: 1,
+    now,
+    leaseMs: 1_000,
+  });
+  expect(maybeFirst).toBeDefined();
+  expect(maybeFirst?.attempts).toBe(1);
+  const first = expectDefined(maybeFirst, "first");
+
+  // Old behavior: the expired running row is reclaimed unconditionally,
+  // attempts -> 2, state stays running, and it is returned as a fresh claim —
+  // a second handler execution past the maxAttempts=1 bound. The bounded
+  // behavior returns nothing and terminates the row instead.
+  const afterExpiry = new Date(now.getTime() + 1_000);
+  const reclaimed = await queue().claimDueJobs({
+    limit: 1,
+    now: afterExpiry,
+    leaseMs: 1_000,
+  });
+  expect(reclaimed).toHaveLength(0);
+
+  const { rows } = await pool.query<{
+    state: string;
+    attempts: number;
+    lease_token: string | null;
+    lease_until: string | null;
+    last_error_category: string | null;
+    terminal_at: string | null;
+    dead_lettered_at: string | null;
+  }>(
+    `SELECT state, attempts, lease_token, lease_until, last_error_category,
+            terminal_at, dead_lettered_at
+       FROM maintenance_jobs WHERE id = $1`,
+    [first.id],
+  );
+  const row = rows[0];
+  expect(row?.state).toBe("dead_letter");
+  // attempts stays at the number of execution leases actually consumed (1),
+  // never inflated past max_attempts by the expiry sweep.
+  expect(row?.attempts).toBe(1);
+  expect(row?.lease_token).toBeNull();
+  expect(row?.lease_until).toBeNull();
+  expect(row?.last_error_category).toBe("lease_expired");
+  expect(row?.terminal_at).not.toBeNull();
+  expect(row?.dead_lettered_at).not.toBeNull();
+
+  // The terminated row cannot be reclaimed again on any later sweep.
+  const laterSweep = await queue().claimDueJobs({
+    limit: 1,
+    now: new Date(now.getTime() + 10_000),
+    leaseMs: 1_000,
+  });
+  expect(laterSweep).toHaveLength(0);
+}
+
+async function reclaimsExpiredLeaseWithAttemptsRemaining(): Promise<void> {
+  // maxAttempts=3: after one claim (attempts 1) an expired lease has budget,
+  // so the bounded sweep must still reclaim it rather than dead-letter it.
+  await enqueue({
+    idempotencyKey: "expired-with-budget",
+    retry: { maxAttempts: 3 },
+  });
+  const now = new Date("2026-07-22T15:00:00.000Z");
+  const [first] = await queue().claimDueJobs({
+    limit: 1,
+    now,
+    leaseMs: 1_000,
+  });
+  expect(first?.attempts).toBe(1);
+  const [reclaimed] = await queue().claimDueJobs({
+    limit: 1,
+    now: new Date(now.getTime() + 1_000),
+    leaseMs: 1_000,
+  });
+  expect(reclaimed?.id).toBe(first?.id);
+  expect(reclaimed?.attempts).toBe(2);
+  expect(reclaimed?.state).toBe("running");
+}
+
+async function retriesDeterministicallyAndRecoversAfterRestart(): Promise<void> {
+  const now = new Date("2026-07-22T13:00:00.000Z");
+  await enqueue({
+    idempotencyKey: "retry",
+    retry: { maxAttempts: 2, backoffBaseMs: 1_000, backoffMaxMs: 4_000 },
+  });
+  const [maybeFirst] = await queue().claimDueJobs({
+    limit: 1,
+    now,
+    leaseMs: 1_000,
+  });
+  const retry = await queue().fail({
+    job: expectDefined(maybeFirst, "first"),
+    error: new TypeError("content must not persist"),
+    now,
+  });
+  expect(retry).toMatchObject({
+    state: "queued",
+    lastErrorCategory: "type_error",
+  });
+  expect(retry?.runAfter.toISOString()).toBe("2026-07-22T13:00:01.000Z");
+
+  const retryRunAfter = expectDefined(retry, "retry").runAfter;
+  const [maybeSecond] = await queue().claimDueJobs({
+    limit: 1,
+    now: retryRunAfter,
+    leaseMs: 1_000,
+  });
+  const deadLetter = await queue().fail({
+    job: expectDefined(maybeSecond, "second"),
+    error: new Error("still private"),
+    now: retryRunAfter,
+  });
+  expect(deadLetter?.state).toBe("dead_letter");
+  expect(deadLetter?.terminalAt).toBeInstanceOf(Date);
+  expect(deadLetter?.deadLetteredAt).toBeInstanceOf(Date);
+
+  const recovered = await enqueue({ idempotencyKey: "restart" });
+  const [beforeRestart] = await queue().claimDueJobs({
+    limit: 1,
+    now,
+    leaseMs: 1_000,
+  });
+  expect(beforeRestart?.id).toBe(recovered.id);
+  const restartedQueue = new MaintenanceQueue(pool);
+  const [afterRestart] = await restartedQueue.claimDueJobs({
+    limit: 1,
+    now: new Date(now.getTime() + 1_000),
+    leaseMs: 1_000,
+  });
+  expect(afterRestart?.id).toBe(recovered.id);
+  expect(afterRestart?.attempts).toBe(2);
+}
+
+async function deadLettersWhenHandlerInflatesRetryPolicy(): Promise<void> {
+  // maxAttempts=1: exactly one execution is allowed, so a first failure must
+  // dead-letter. The handler tries to buy itself more attempts and a larger
+  // backoff by mutating the job it was handed. The durable row's max_attempts
+  // must still terminate it — the caller cannot override the terminal bound.
+  const created = await enqueue({
+    idempotencyKey: "mutating-terminal",
+    retry: { maxAttempts: 1, backoffBaseMs: 1_000, backoffMaxMs: 4_000 },
+  });
+  const fixedNow = new Date("2026-07-22T16:00:00.000Z");
+  let observed: MaintenanceJob | undefined;
+  const runner = runnerFor(
+    {
+      "maintenance.test": async (job) => {
+        observed = job;
+        // Handler mutates the in-memory retry policy, then throws.
+        job.maxAttempts = 99;
+        job.backoffBaseMs = 1;
+        job.backoffMaxMs = 1;
+        job.attempts = 0;
+        throw new Error("handler blew up after tampering with retry policy");
+      },
+    },
+    fixedNow,
+  );
+  await runner.runOnce();
+  await runner.stop();
+
+  expect(observed?.id).toBe(created.id);
+  const { rows } = await pool.query<{
+    state: string;
+    attempts: number;
+    max_attempts: number;
+    run_after: string;
+    lease_token: string | null;
+    terminal_at: string | null;
+    dead_lettered_at: string | null;
+  }>(
+    `SELECT state, attempts, max_attempts, run_after, lease_token,
+            terminal_at, dead_lettered_at
+       FROM maintenance_jobs WHERE id = $1`,
+    [created.id],
+  );
+  const row = rows[0];
+  // Persisted policy wins: one execution consumed, terminal at attempt 1.
+  expect(row?.state).toBe("dead_letter");
+  expect(row?.attempts).toBe(1);
+  expect(row?.max_attempts).toBe(1);
+  expect(row?.lease_token).toBeNull();
+  expect(row?.terminal_at).not.toBeNull();
+  expect(row?.dead_lettered_at).not.toBeNull();
+
+  // No requeue: the terminated row is never claimed again.
+  const later = await queue().claimDueJobs({
+    limit: 1,
+    now: new Date(fixedNow.getTime() + 60_000),
+    leaseMs: 1_000,
+  });
+  expect(later).toHaveLength(0);
+}
+
+async function schedulesRetryFromPersistedBackoff(): Promise<void> {
+  // maxAttempts=3 leaves budget after the first failure, so the row requeues.
+  // The handler shrinks backoff_base/max on the object before throwing; the
+  // persisted schedule (base 2000ms at attempt 1) must be used, so run_after
+  // is now + 2000ms, not now + 1ms.
+  const created = await enqueue({
+    idempotencyKey: "mutating-schedule",
+    retry: { maxAttempts: 3, backoffBaseMs: 2_000, backoffMaxMs: 8_000 },
+  });
+  const fixedNow = new Date("2026-07-22T17:00:00.000Z");
+  const runner = runnerFor(
+    {
+      "maintenance.test": async (job) => {
+        job.backoffBaseMs = 1;
+        job.backoffMaxMs = 1;
+        job.maxAttempts = 25;
+        throw new Error("handler blew up after shrinking its own backoff");
+      },
+    },
+    fixedNow,
+  );
+  await runner.runOnce();
+  await runner.stop();
+
+  const { rows } = await pool.query<{
+    state: string;
+    attempts: number;
+    run_after: string;
+  }>("SELECT state, attempts, run_after FROM maintenance_jobs WHERE id = $1", [
+    created.id,
+  ]);
+  const row = rows[0];
+  expect(row?.state).toBe("queued");
+  expect(row?.attempts).toBe(1);
+  // First retry uses the persisted base (2000ms), exponent semantics
+  // unchanged. A handler-mutated 1ms backoff would have scheduled +1ms.
+  expect(new Date(expectDefined(row, "row").run_after).toISOString()).toBe(
+    "2026-07-22T17:00:02.000Z",
+  );
+}
+
+async function failDerivesTransitionFromDurableRow(): Promise<void> {
+  // Direct-queue proof independent of the runner: claim, then tamper the
+  // returned job's retry fields exactly as a handler holding the reference
+  // could, and fail it. maxAttempts=1 on the row must still dead-letter.
+  const created = await enqueue({
+    idempotencyKey: "direct-tamper",
+    retry: { maxAttempts: 1, backoffBaseMs: 1_000, backoffMaxMs: 4_000 },
+  });
+  const now = new Date("2026-07-22T18:00:00.000Z");
+  const [maybeClaimed] = await queue().claimDueJobs({
+    limit: 1,
+    now,
+    leaseMs: 60_000,
+  });
+  expect(maybeClaimed?.attempts).toBe(1);
+  const claimed = expectDefined(maybeClaimed, "claimed");
+  // Tamper every retry-policy field the old code read from the object.
+  claimed.maxAttempts = 99;
+  claimed.attempts = 0;
+  claimed.backoffBaseMs = 1;
+  claimed.backoffMaxMs = 1;
+  const result = await queue().fail({
+    job: claimed,
+    error: new Error("still private"),
+    now,
+  });
+  expect(result?.state).toBe("dead_letter");
+  const { rows } = await pool.query<{ state: string; attempts: number }>(
+    "SELECT state, attempts FROM maintenance_jobs WHERE id = $1",
+    [created.id],
+  );
+  expect(rows[0]?.state).toBe("dead_letter");
+  expect(rows[0]?.attempts).toBe(1);
+}
+
+describe("026 maintenance queue retry and dead-letter (live Postgres)", () => {
+  beforeEach(async () => {
+    await migrate(pool);
+    await cleanup(pool);
+  });
+  afterAll(async () => {
+    await cleanup(pool);
+    await pool.end();
+  });
+
+  it(
+    "dead-letters an expired lease once its execution attempts are exhausted, not reclaims it forever",
+    deadLettersExpiredLeaseWhenAttemptsExhausted,
+  );
+
+  it(
+    "still reclaims an expired lease that has execution attempts remaining",
+    reclaimsExpiredLeaseWithAttemptsRemaining,
+  );
+
+  it(
+    "retries at a deterministic time, dead-letters terminal attempts, and recovers after a restart",
+    retriesDeterministicallyAndRecoversAfterRestart,
+  );
+
+  it(
+    "dead-letters at attempt 1 when a handler inflates maxAttempts/backoff before throwing",
+    deadLettersWhenHandlerInflatesRetryPolicy,
+  );
+
+  it(
+    "schedules the next retry from the persisted backoff, not a handler-mutated one",
+    schedulesRetryFromPersistedBackoff,
+  );
+
+  it(
+    "fail() derives the transition from the durable row when the passed job is tampered",
+    failDerivesTransitionFromDurableRow,
+  );
+});

--- a/src/db/migrations/026_maintenance_queue-test-helpers.ts
+++ b/src/db/migrations/026_maintenance_queue-test-helpers.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared fixtures for the two live suites over migration 026.
+ *
+ * The suites split by subject -- enqueue/claim in
+ * `026_maintenance_queue.test.ts`, retry/dead-letter in
+ * `026_maintenance_queue-retry.test.ts` -- and both need the same migration
+ * apply, the same namespace scrub, and the same enqueue defaults. This module
+ * holds no test and creates no pool: each suite owns one pool at module scope
+ * and passes it in, so neither file can end the other's connections.
+ *
+ * `src/db/migrate.ts:28` filters the migrations directory to `.sql` files, so
+ * these `.ts` siblings are inert to the migration runner.
+ */
+import type { Pool } from "pg";
+import { MaintenanceQueue } from "../../maintenance-queue.ts";
+
+const migrationUrl = new URL("026_maintenance_queue.sql", import.meta.url);
+
+/** Namespace both live suites scope their rows to. */
+export const namespace = "test-maintenance-queue-026";
+
+/** Applies migration 026 to the connected database. */
+export async function migrate(pool: Pool): Promise<void> {
+  await pool.query(await Bun.file(migrationUrl).text());
+}
+
+/** Removes every row this namespace owns. */
+export async function cleanup(pool: Pool): Promise<void> {
+  await pool.query("DELETE FROM maintenance_jobs WHERE namespace = $1", [namespace]);
+}
+
+/** A queue bound to the caller's pool. */
+export function queue(pool: Pool): MaintenanceQueue {
+  return new MaintenanceQueue(pool);
+}
+
+/** Enqueues a job carrying the suite defaults, overridden field by field. */
+export async function enqueue(
+  pool: Pool,
+  input: Partial<Parameters<MaintenanceQueue["enqueue"]>[0]> = {},
+) {
+  return queue(pool).enqueue({
+    kind: "maintenance.test",
+    version: 1,
+    payload: {},
+    idempotencyKey: crypto.randomUUID(),
+    scope: { namespace },
+    // Default to a far-past run_after so tests that claim with a fixed
+    // deterministic `now` see the job as due, instead of racing the DB's NOW().
+    runAfter: new Date("2000-01-01T00:00:00.000Z"),
+    ...input,
+  });
+}
+
+/**
+ * Narrows an optional value, throwing a labelled error when it is absent.
+ *
+ * Same assertion meaning as a non-null assertion -- a missing value still
+ * fails the test -- except the failure names which value went missing instead
+ * of surfacing as a bare TypeError on the next property read.
+ */
+export function expectDefined<T>(value: T | null | undefined, label: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(`${label} is undefined`);
+  }
+  return value;
+}

--- a/src/db/migrations/026_maintenance_queue.test.ts
+++ b/src/db/migrations/026_maintenance_queue.test.ts
@@ -1,520 +1,207 @@
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
 import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "bun:test";
-import type { Pool } from "pg";
-import {
-  MaintenanceQueue,
-  MaintenanceQueueRunner,
-  type MaintenanceJob,
-  type MaintenanceJobHandler,
-} from "../../maintenance-queue.ts";
+  cleanup,
+  enqueue as enqueueWith,
+  expectDefined,
+  migrate,
+  queue as queueWith,
+} from "./026_maintenance_queue-test-helpers.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-const migrationUrl = new URL("026_maintenance_queue.sql", import.meta.url);
-const namespace = "test-maintenance-queue-026";
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+const queue = () => queueWith(pool);
+const enqueue = (input: Parameters<typeof enqueueWith>[1] = {}) =>
+  enqueueWith(pool, input);
 
-dbDescribe("026 maintenance queue (live Postgres)", () => {
-  let pool: Pool;
+// The `it` bodies live at module scope rather than inline so the describe
+// callback stays inside the repo's per-function line rule. Test names, order,
+// and assertions are unchanged by the move.
 
-  beforeAll(async () => {
-    const { Pool } = await import("pg");
-    pool = new Pool({ connectionString: DB_URL });
+async function enforcesConstraintsAndIdempotentEnqueue(): Promise<void> {
+  const first = await enqueue({
+    idempotencyKey: "same-key",
+    payload: { a: 1 },
   });
+  // Identical semantics (key order aside) is a safe idempotent replay.
+  const second = await enqueue({
+    idempotencyKey: "same-key",
+    payload: { a: 1 },
+  });
+  expect(second.id).toBe(first.id);
 
-  async function migrate(): Promise<void> {
-    await pool.query(await Bun.file(migrationUrl).text());
-  }
+  // Reusing the key with a divergent payload must be rejected content-free,
+  // not silently return the stale job under the old contract.
+  await expect(
+    enqueue({ idempotencyKey: "same-key", payload: { a: 2 } }),
+  ).rejects.toThrow("divergent job semantics");
+  // Divergent retry semantics under the same key must also be rejected.
+  await expect(
+    enqueue({
+      idempotencyKey: "same-key",
+      payload: { a: 1 },
+      retry: { maxAttempts: 5 },
+    }),
+  ).rejects.toThrow("divergent job semantics");
 
-  async function cleanup(): Promise<void> {
-    await pool.query("DELETE FROM maintenance_jobs WHERE namespace = $1", [
-      namespace,
-    ]);
-  }
+  const { rows } = await pool.query<{ conname: string }>(
+    `SELECT conname
+       FROM pg_constraint
+      WHERE conrelid = 'maintenance_jobs'::regclass`,
+  );
+  expect(rows.map((row) => row.conname)).toContain("maintenance_jobs_lease_shape");
+  expect(rows.map((row) => row.conname)).toContain("maintenance_jobs_terminal_shape");
 
-  function queue(): MaintenanceQueue {
-    return new MaintenanceQueue(pool);
-  }
+  // Idempotency uniqueness is a PARTIAL UNIQUE INDEX since 047, not a table
+  // constraint, so it lives in pg_indexes and never appears above. 047
+  // scoped it to live states on purpose: a terminal row must stop reserving
+  // its key, or a recurring batch deadlocks forever (#747).
+  const { rows: indexes } = await pool.query<{
+    indexname: string;
+    indexdef: string;
+  }>(
+    `SELECT indexname, indexdef
+       FROM pg_indexes
+      WHERE tablename = 'maintenance_jobs'`,
+  );
+  const byName = new Map(indexes.map((row) => [row.indexname, row.indexdef]));
 
-  async function enqueue(
-    input: Partial<Parameters<MaintenanceQueue["enqueue"]>[0]> = {},
-  ) {
-    return queue().enqueue({
-      kind: "maintenance.test",
-      version: 1,
-      payload: {},
-      idempotencyKey: crypto.randomUUID(),
-      scope: { namespace },
-      // Default to a far-past run_after so tests that claim with a fixed
-      // deterministic `now` see the job as due, instead of racing the DB's NOW().
-      runAfter: new Date("2000-01-01T00:00:00.000Z"),
-      ...input,
-    });
-  }
+  expect([...byName.keys()]).not.toContain("maintenance_jobs_unique_kind_idempotency");
 
+  const live = byName.get("maintenance_jobs_live_idempotency");
+  expect(live).toBeDefined();
+  expect(live).toContain("UNIQUE");
+  // Only queued and running reserve the key.
+  expect(live).toContain("'queued'");
+  expect(live).toContain("'running'");
+  expect(live).not.toContain("'succeeded'");
+  expect(live).not.toContain("'dead_letter'");
+}
+
+async function persistsCallerForcedTerminalCategory(): Promise<void> {
+  await enqueue({ idempotencyKey: "unsupported", retry: { maxAttempts: 1 } });
+  const [maybeClaimed] = await queue().claimDueJobs({
+    limit: 1,
+    now: new Date(),
+    leaseMs: 60_000,
+  });
+  const claimed = expectDefined(maybeClaimed, "claimed");
+  const dead = await queue().fail({
+    job: claimed,
+    error: "unsupported_job_kind",
+    category: "unsupported_job_kind",
+  });
+  expect(dead?.state).toBe("dead_letter");
+  // Old behavior stored non_error because the sentinel is a plain string.
+  expect(dead?.lastErrorCategory).toBe("unsupported_job_kind");
+  const { rows } = await pool.query<{ last_error_category: string }>(
+    "SELECT last_error_category FROM maintenance_jobs WHERE id = $1",
+    [claimed.id],
+  );
+  expect(rows[0]?.last_error_category).toBe("unsupported_job_kind");
+}
+
+async function rejectsOutOfBoundsClaimLimit(): Promise<void> {
+  await expect(
+    queue().claimDueJobs({ limit: 1_000, now: new Date(), leaseMs: 60_000 }),
+  ).rejects.toThrow("claim limit exceeds the bound");
+}
+
+async function rejectsInvalidNamespaceToken(): Promise<void> {
+  await expect(
+    enqueue({
+      idempotencyKey: "bad-ns",
+      scope: { namespace: "not a valid namespace!" },
+    }),
+  ).rejects.toThrow("namespace is invalid");
+}
+
+async function allowsOnlyOneConcurrentClaim(): Promise<void> {
+  await enqueue({ idempotencyKey: "single-claim" });
+  const now = new Date();
+  const [first, second] = await Promise.all([
+    queue().claimDueJobs({ limit: 1, now, leaseMs: 60_000 }),
+    queue().claimDueJobs({ limit: 1, now, leaseMs: 60_000 }),
+  ]);
+  expect(first.length + second.length).toBe(1);
+}
+
+async function honorsLeaseExpiryAndRejectsStaleCompletion(): Promise<void> {
+  await enqueue({ idempotencyKey: "leases" });
+  const now = new Date("2026-07-22T12:00:00.000Z");
+  const [maybeFirst] = await queue().claimDueJobs({
+    limit: 1,
+    now,
+    leaseMs: 1_000,
+  });
+  expect(maybeFirst).toBeDefined();
+  expect(
+    await queue().claimDueJobs({
+      limit: 1,
+      now: new Date(now.getTime() + 999),
+      leaseMs: 1_000,
+    }),
+  ).toHaveLength(0);
+
+  const [maybeReclaimed] = await queue().claimDueJobs({
+    limit: 1,
+    now: new Date(now.getTime() + 1_000),
+    leaseMs: 1_000,
+  });
+  expect(maybeReclaimed?.id).toBe(maybeFirst?.id);
+  expect(maybeReclaimed?.attempts).toBe(2);
+  const first = expectDefined(maybeFirst, "first");
+  const reclaimed = expectDefined(maybeReclaimed, "reclaimed");
+  expect(
+    await queue().complete(
+      first.id,
+      expectDefined(first.leaseToken, "first.leaseToken"),
+      new Date(now.getTime() + 1_001),
+    ),
+  ).toBe(false);
+  expect(
+    await queue().complete(
+      reclaimed.id,
+      expectDefined(reclaimed.leaseToken, "reclaimed.leaseToken"),
+      new Date(now.getTime() + 1_001),
+    ),
+  ).toBe(true);
+}
+
+describe("026 maintenance queue enqueue and claim (live Postgres)", () => {
   beforeEach(async () => {
-    await migrate();
-    await cleanup();
+    await migrate(pool);
+    await cleanup(pool);
   });
   afterAll(async () => {
-    await cleanup();
+    await cleanup(pool);
     await pool.end();
   });
 
-  it("enforces live migration constraints and idempotent enqueue", async () => {
-    const first = await enqueue({
-      idempotencyKey: "same-key",
-      payload: { a: 1 },
-    });
-    // Identical semantics (key order aside) is a safe idempotent replay.
-    const second = await enqueue({
-      idempotencyKey: "same-key",
-      payload: { a: 1 },
-    });
-    expect(second.id).toBe(first.id);
+  it(
+    "enforces live migration constraints and idempotent enqueue",
+    enforcesConstraintsAndIdempotentEnqueue,
+  );
 
-    // Reusing the key with a divergent payload must be rejected content-free,
-    // not silently return the stale job under the old contract.
-    await expect(
-      enqueue({ idempotencyKey: "same-key", payload: { a: 2 } }),
-    ).rejects.toThrow("divergent job semantics");
-    // Divergent retry semantics under the same key must also be rejected.
-    await expect(
-      enqueue({
-        idempotencyKey: "same-key",
-        payload: { a: 1 },
-        retry: { maxAttempts: 5 },
-      }),
-    ).rejects.toThrow("divergent job semantics");
+  it(
+    "persists the caller-forced terminal category (unsupported kind is not non_error)",
+    persistsCallerForcedTerminalCategory,
+  );
 
-    const { rows } = await pool.query<{ conname: string }>(
-      `SELECT conname
-         FROM pg_constraint
-        WHERE conrelid = 'maintenance_jobs'::regclass`,
-    );
-    expect(rows.map((row) => row.conname)).toContain(
-      "maintenance_jobs_lease_shape",
-    );
-    expect(rows.map((row) => row.conname)).toContain(
-      "maintenance_jobs_terminal_shape",
-    );
+  it(
+    "rejects an out-of-bounds direct claim limit before touching the table",
+    rejectsOutOfBoundsClaimLimit,
+  );
 
-    // Idempotency uniqueness is a PARTIAL UNIQUE INDEX since 047, not a table
-    // constraint, so it lives in pg_indexes and never appears above. 047
-    // scoped it to live states on purpose: a terminal row must stop reserving
-    // its key, or a recurring batch deadlocks forever (#747).
-    const { rows: indexes } = await pool.query<{
-      indexname: string;
-      indexdef: string;
-    }>(
-      `SELECT indexname, indexdef
-         FROM pg_indexes
-        WHERE tablename = 'maintenance_jobs'`,
-    );
-    const byName = new Map(indexes.map((row) => [row.indexname, row.indexdef]));
+  it("rejects an invalid namespace token content-free", rejectsInvalidNamespaceToken);
 
-    expect([...byName.keys()]).not.toContain(
-      "maintenance_jobs_unique_kind_idempotency",
-    );
+  it(
+    "allows only one concurrent runner to claim a due job",
+    allowsOnlyOneConcurrentClaim,
+  );
 
-    const live = byName.get("maintenance_jobs_live_idempotency");
-    expect(live).toBeDefined();
-    expect(live).toContain("UNIQUE");
-    // Only queued and running reserve the key.
-    expect(live).toContain("'queued'");
-    expect(live).toContain("'running'");
-    expect(live).not.toContain("'succeeded'");
-    expect(live).not.toContain("'dead_letter'");
-  });
-
-  it("persists the caller-forced terminal category (unsupported kind is not non_error)", async () => {
-    await enqueue({ idempotencyKey: "unsupported", retry: { maxAttempts: 1 } });
-    const [claimed] = await queue().claimDueJobs({
-      limit: 1,
-      now: new Date(),
-      leaseMs: 60_000,
-    });
-    const dead = await queue().fail({
-      job: claimed!,
-      error: "unsupported_job_kind",
-      category: "unsupported_job_kind",
-    });
-    expect(dead?.state).toBe("dead_letter");
-    // Old behavior stored non_error because the sentinel is a plain string.
-    expect(dead?.lastErrorCategory).toBe("unsupported_job_kind");
-    const { rows } = await pool.query<{ last_error_category: string }>(
-      "SELECT last_error_category FROM maintenance_jobs WHERE id = $1",
-      [claimed!.id],
-    );
-    expect(rows[0]?.last_error_category).toBe("unsupported_job_kind");
-  });
-
-  it("rejects an out-of-bounds direct claim limit before touching the table", async () => {
-    await expect(
-      queue().claimDueJobs({ limit: 1_000, now: new Date(), leaseMs: 60_000 }),
-    ).rejects.toThrow("claim limit exceeds the bound");
-  });
-
-  it("rejects an invalid namespace token content-free", async () => {
-    await expect(
-      enqueue({
-        idempotencyKey: "bad-ns",
-        scope: { namespace: "not a valid namespace!" },
-      }),
-    ).rejects.toThrow("namespace is invalid");
-  });
-
-  it("allows only one concurrent runner to claim a due job", async () => {
-    await enqueue({ idempotencyKey: "single-claim" });
-    const now = new Date();
-    const [first, second] = await Promise.all([
-      queue().claimDueJobs({ limit: 1, now, leaseMs: 60_000 }),
-      queue().claimDueJobs({ limit: 1, now, leaseMs: 60_000 }),
-    ]);
-    expect(first.length + second.length).toBe(1);
-  });
-
-  it("does not steal an unexpired lease, reclaims an expired one, and rejects stale completion", async () => {
-    await enqueue({ idempotencyKey: "leases" });
-    const now = new Date("2026-07-22T12:00:00.000Z");
-    const [first] = await queue().claimDueJobs({
-      limit: 1,
-      now,
-      leaseMs: 1_000,
-    });
-    expect(first).toBeDefined();
-    expect(
-      await queue().claimDueJobs({
-        limit: 1,
-        now: new Date(now.getTime() + 999),
-        leaseMs: 1_000,
-      }),
-    ).toHaveLength(0);
-
-    const [reclaimed] = await queue().claimDueJobs({
-      limit: 1,
-      now: new Date(now.getTime() + 1_000),
-      leaseMs: 1_000,
-    });
-    expect(reclaimed?.id).toBe(first?.id);
-    expect(reclaimed?.attempts).toBe(2);
-    expect(
-      await queue().complete(
-        first!.id,
-        first!.leaseToken!,
-        new Date(now.getTime() + 1_001),
-      ),
-    ).toBe(false);
-    expect(
-      await queue().complete(
-        reclaimed!.id,
-        reclaimed!.leaseToken!,
-        new Date(now.getTime() + 1_001),
-      ),
-    ).toBe(true);
-  });
-
-  it("dead-letters an expired lease once its execution attempts are exhausted, not reclaims it forever", async () => {
-    // maxAttempts=1: exactly one handler execution is allowed. The claim below
-    // consumes it (attempts 0 -> 1). The lease then expires without a
-    // complete()/fail(), simulating a handler that hung or crashed.
-    await enqueue({
-      idempotencyKey: "expired-bound",
-      retry: { maxAttempts: 1 },
-    });
-    const now = new Date("2026-07-22T14:00:00.000Z");
-    const [first] = await queue().claimDueJobs({
-      limit: 1,
-      now,
-      leaseMs: 1_000,
-    });
-    expect(first).toBeDefined();
-    expect(first?.attempts).toBe(1);
-
-    // Old behavior: the expired running row is reclaimed unconditionally,
-    // attempts -> 2, state stays running, and it is returned as a fresh claim —
-    // a second handler execution past the maxAttempts=1 bound. The bounded
-    // behavior returns nothing and terminates the row instead.
-    const afterExpiry = new Date(now.getTime() + 1_000);
-    const reclaimed = await queue().claimDueJobs({
-      limit: 1,
-      now: afterExpiry,
-      leaseMs: 1_000,
-    });
-    expect(reclaimed).toHaveLength(0);
-
-    const { rows } = await pool.query<{
-      state: string;
-      attempts: number;
-      lease_token: string | null;
-      lease_until: string | null;
-      last_error_category: string | null;
-      terminal_at: string | null;
-      dead_lettered_at: string | null;
-    }>(
-      `SELECT state, attempts, lease_token, lease_until, last_error_category,
-              terminal_at, dead_lettered_at
-         FROM maintenance_jobs WHERE id = $1`,
-      [first!.id],
-    );
-    const row = rows[0];
-    expect(row?.state).toBe("dead_letter");
-    // attempts stays at the number of execution leases actually consumed (1),
-    // never inflated past max_attempts by the expiry sweep.
-    expect(row?.attempts).toBe(1);
-    expect(row?.lease_token).toBeNull();
-    expect(row?.lease_until).toBeNull();
-    expect(row?.last_error_category).toBe("lease_expired");
-    expect(row?.terminal_at).not.toBeNull();
-    expect(row?.dead_lettered_at).not.toBeNull();
-
-    // The terminated row cannot be reclaimed again on any later sweep.
-    const laterSweep = await queue().claimDueJobs({
-      limit: 1,
-      now: new Date(now.getTime() + 10_000),
-      leaseMs: 1_000,
-    });
-    expect(laterSweep).toHaveLength(0);
-  });
-
-  it("still reclaims an expired lease that has execution attempts remaining", async () => {
-    // maxAttempts=3: after one claim (attempts 1) an expired lease has budget,
-    // so the bounded sweep must still reclaim it rather than dead-letter it.
-    await enqueue({
-      idempotencyKey: "expired-with-budget",
-      retry: { maxAttempts: 3 },
-    });
-    const now = new Date("2026-07-22T15:00:00.000Z");
-    const [first] = await queue().claimDueJobs({
-      limit: 1,
-      now,
-      leaseMs: 1_000,
-    });
-    expect(first?.attempts).toBe(1);
-    const [reclaimed] = await queue().claimDueJobs({
-      limit: 1,
-      now: new Date(now.getTime() + 1_000),
-      leaseMs: 1_000,
-    });
-    expect(reclaimed?.id).toBe(first?.id);
-    expect(reclaimed?.attempts).toBe(2);
-    expect(reclaimed?.state).toBe("running");
-  });
-
-  it("retries at a deterministic time, dead-letters terminal attempts, and recovers after a restart", async () => {
-    const now = new Date("2026-07-22T13:00:00.000Z");
-    await enqueue({
-      idempotencyKey: "retry",
-      retry: { maxAttempts: 2, backoffBaseMs: 1_000, backoffMaxMs: 4_000 },
-    });
-    const [first] = await queue().claimDueJobs({
-      limit: 1,
-      now,
-      leaseMs: 1_000,
-    });
-    const retry = await queue().fail({
-      job: first!,
-      error: new TypeError("content must not persist"),
-      now,
-    });
-    expect(retry).toMatchObject({
-      state: "queued",
-      lastErrorCategory: "type_error",
-    });
-    expect(retry?.runAfter.toISOString()).toBe("2026-07-22T13:00:01.000Z");
-
-    const [second] = await queue().claimDueJobs({
-      limit: 1,
-      now: retry!.runAfter,
-      leaseMs: 1_000,
-    });
-    const deadLetter = await queue().fail({
-      job: second!,
-      error: new Error("still private"),
-      now: retry!.runAfter,
-    });
-    expect(deadLetter?.state).toBe("dead_letter");
-    expect(deadLetter?.terminalAt).toBeInstanceOf(Date);
-    expect(deadLetter?.deadLetteredAt).toBeInstanceOf(Date);
-
-    const recovered = await enqueue({ idempotencyKey: "restart" });
-    const [beforeRestart] = await queue().claimDueJobs({
-      limit: 1,
-      now,
-      leaseMs: 1_000,
-    });
-    expect(beforeRestart?.id).toBe(recovered.id);
-    const restartedQueue = new MaintenanceQueue(pool);
-    const [afterRestart] = await restartedQueue.claimDueJobs({
-      limit: 1,
-      now: new Date(now.getTime() + 1_000),
-      leaseMs: 1_000,
-    });
-    expect(afterRestart?.id).toBe(recovered.id);
-    expect(afterRestart?.attempts).toBe(2);
-  });
-
-  // Drive the real runner over the real queue with a handler that mutates the
-  // job's durable retry fields before throwing. The terminal decision and the
-  // retry schedule must come from the persisted row, not the mutated object, so
-  // no caller-supplied retry-policy value can decide the transition.
-  function runnerFor(
-    handlers: Record<string, MaintenanceJobHandler>,
-    fixedNow: Date,
-  ): MaintenanceQueueRunner {
-    return new MaintenanceQueueRunner({
-      queue: queue(),
-      handlers: new Map(Object.entries(handlers)),
-      logger: {
-        info: () => undefined,
-        warn: () => undefined,
-        error: () => undefined,
-      },
-      concurrency: 1,
-      leaseMs: 60_000,
-      now: () => fixedNow,
-    });
-  }
-
-  it("dead-letters at attempt 1 when a handler inflates maxAttempts/backoff before throwing", async () => {
-    // maxAttempts=1: exactly one execution is allowed, so a first failure must
-    // dead-letter. The handler tries to buy itself more attempts and a larger
-    // backoff by mutating the job it was handed. The durable row's max_attempts
-    // must still terminate it — the caller cannot override the terminal bound.
-    const created = await enqueue({
-      idempotencyKey: "mutating-terminal",
-      retry: { maxAttempts: 1, backoffBaseMs: 1_000, backoffMaxMs: 4_000 },
-    });
-    const fixedNow = new Date("2026-07-22T16:00:00.000Z");
-    let observed: MaintenanceJob | undefined;
-    const runner = runnerFor(
-      {
-        "maintenance.test": async (job) => {
-          observed = job;
-          // Handler mutates the in-memory retry policy, then throws.
-          job.maxAttempts = 99;
-          job.backoffBaseMs = 1;
-          job.backoffMaxMs = 1;
-          job.attempts = 0;
-          throw new Error("handler blew up after tampering with retry policy");
-        },
-      },
-      fixedNow,
-    );
-    await runner.runOnce();
-    await runner.stop();
-
-    expect(observed?.id).toBe(created.id);
-    const { rows } = await pool.query<{
-      state: string;
-      attempts: number;
-      max_attempts: number;
-      run_after: string;
-      lease_token: string | null;
-      terminal_at: string | null;
-      dead_lettered_at: string | null;
-    }>(
-      `SELECT state, attempts, max_attempts, run_after, lease_token,
-              terminal_at, dead_lettered_at
-         FROM maintenance_jobs WHERE id = $1`,
-      [created.id],
-    );
-    const row = rows[0];
-    // Persisted policy wins: one execution consumed, terminal at attempt 1.
-    expect(row?.state).toBe("dead_letter");
-    expect(row?.attempts).toBe(1);
-    expect(row?.max_attempts).toBe(1);
-    expect(row?.lease_token).toBeNull();
-    expect(row?.terminal_at).not.toBeNull();
-    expect(row?.dead_lettered_at).not.toBeNull();
-
-    // No requeue: the terminated row is never claimed again.
-    const later = await queue().claimDueJobs({
-      limit: 1,
-      now: new Date(fixedNow.getTime() + 60_000),
-      leaseMs: 1_000,
-    });
-    expect(later).toHaveLength(0);
-  });
-
-  it("schedules the next retry from the persisted backoff, not a handler-mutated one", async () => {
-    // maxAttempts=3 leaves budget after the first failure, so the row requeues.
-    // The handler shrinks backoff_base/max on the object before throwing; the
-    // persisted schedule (base 2000ms at attempt 1) must be used, so run_after
-    // is now + 2000ms, not now + 1ms.
-    const created = await enqueue({
-      idempotencyKey: "mutating-schedule",
-      retry: { maxAttempts: 3, backoffBaseMs: 2_000, backoffMaxMs: 8_000 },
-    });
-    const fixedNow = new Date("2026-07-22T17:00:00.000Z");
-    const runner = runnerFor(
-      {
-        "maintenance.test": async (job) => {
-          job.backoffBaseMs = 1;
-          job.backoffMaxMs = 1;
-          job.maxAttempts = 25;
-          throw new Error("handler blew up after shrinking its own backoff");
-        },
-      },
-      fixedNow,
-    );
-    await runner.runOnce();
-    await runner.stop();
-
-    const { rows } = await pool.query<{
-      state: string;
-      attempts: number;
-      run_after: string;
-    }>(
-      "SELECT state, attempts, run_after FROM maintenance_jobs WHERE id = $1",
-      [created.id],
-    );
-    const row = rows[0];
-    expect(row?.state).toBe("queued");
-    expect(row?.attempts).toBe(1);
-    // First retry uses the persisted base (2000ms), capped exponent semantics
-    // unchanged. A handler-mutated 1ms backoff would have scheduled +1ms.
-    expect(new Date(row!.run_after).toISOString()).toBe(
-      "2026-07-22T17:00:02.000Z",
-    );
-  });
-
-  it("fail() derives the transition from the durable row when the passed job is tampered", async () => {
-    // Direct-queue proof independent of the runner: claim, then tamper the
-    // returned job's retry fields exactly as a handler holding the reference
-    // could, and fail it. maxAttempts=1 on the row must still dead-letter.
-    const created = await enqueue({
-      idempotencyKey: "direct-tamper",
-      retry: { maxAttempts: 1, backoffBaseMs: 1_000, backoffMaxMs: 4_000 },
-    });
-    const now = new Date("2026-07-22T18:00:00.000Z");
-    const [claimed] = await queue().claimDueJobs({
-      limit: 1,
-      now,
-      leaseMs: 60_000,
-    });
-    expect(claimed?.attempts).toBe(1);
-    // Tamper every retry-policy field the old code read from the object.
-    claimed!.maxAttempts = 99;
-    claimed!.attempts = 0;
-    claimed!.backoffBaseMs = 1;
-    claimed!.backoffMaxMs = 1;
-    const result = await queue().fail({
-      job: claimed!,
-      error: new Error("still private"),
-      now,
-    });
-    expect(result?.state).toBe("dead_letter");
-    const { rows } = await pool.query<{ state: string; attempts: number }>(
-      "SELECT state, attempts FROM maintenance_jobs WHERE id = $1",
-      [created.id],
-    );
-    expect(rows[0]?.state).toBe("dead_letter");
-    expect(rows[0]?.attempts).toBe(1);
-  });
+  it(
+    "does not steal an unexpired lease, reclaims an expired one, and rejects stale completion",
+    honorsLeaseExpiryAndRejectsStaleCompletion,
+  );
 });


### PR DESCRIPTION
## Summary

- `src/db/migrations/026_maintenance_queue.test.ts` read `OPENBRAIN_TEST_DATABASE_URL` itself and swapped in a skipping describe when it was unset. Absent the variable it reported `0 pass, N skip, 0 fail` and exited 0, which at the exit code is indistinguishable from a suite that ran and passed. It now calls `requireTestDatabaseUrl()` at module scope, so a missing variable throws `test_database_required` and the run fails loudly.
- The suite is split by subject so each describe callback stays inside the repo's per-function line rule: enqueue/claim stays in `026_maintenance_queue.test.ts`, retry and dead-letter move to `026_maintenance_queue-retry.test.ts`. Test names, order, and assertions are unchanged by the split.
- `026_maintenance_queue-test-helpers.ts` holds the shared migration apply, namespace scrub, and enqueue defaults. It creates no pool: each suite owns one at module scope, so neither file can end the other's connections. `src/db/migrate.ts:28` filters the migrations directory to `.sql`, so the `.ts` siblings are inert to the migration runner.
- Each `it` body is a named module-scope function called as `it("<same name>", fn)`. Non-null assertions are replaced by a new `expectDefined(value, label)` in the helper module: same assertion meaning (a missing value still fails the test), with the failure naming which value went missing instead of surfacing as a bare TypeError on the next property read.
- `scripts/assert-db-tests-ran.ts` carries both describe names so the CI db-integration anti-skip guard still sees a suite name and a test count for each half.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh

Invocation: `CHANGED_FILES="src/db/migrations/026_maintenance_queue.test.ts src/db/migrations/026_maintenance_queue-retry.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` -> exit 0, all four clauses PASS for both files. RED at `origin/main`: the same invocation over the unsplit file exited 1 with clauses 1/2/3 FAIL, the file self-skipping.

- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bun run test:isolated src/db/migrations/026_maintenance_queue.test.ts src/db/migrations/026_maintenance_queue-retry.test.ts` -> exit 0, 12 pass / 0 fail / 62 expect() calls across 2 files, re-run on the committed tree. `bunx tsc --noEmit` -> exit 0. `./node_modules/.bin/oxlint --deny-warnings` over the four changed files -> exit 0, zero findings.

## Critical Self-Review

- Highest-risk behavior: the split could silently drop a test. Guarded two ways -- the isolated run reports 12 tests across the two files, matching the original suite's count, and `scripts/assert-db-tests-ran.ts` now names both describes with their own minimum counts, so a vanished suite fails CI rather than passing quietly.
- Assumptions that could be wrong: that two module-scope `Pool` instances against the same database do not interfere. Each suite ends only its own pool in its own `afterAll`, and the shared helper module deliberately creates no pool, which is what makes that hold; the isolated run over both files together is the evidence.
- Missing/weak tests: no new behavior is under test here -- this is a conversion plus a split. The one genuinely new unit is `expectDefined`, which has no direct test of its own; it is exercised indirectly by every assertion that now routes through it.
- Security/permission risk: none. No auth, namespace, or permission path is touched; the namespace used is a test-only literal scoped by the existing cleanup.
- Migration/deploy risk: none. `026_maintenance_queue.sql` is unchanged. The two new `.ts` files sit in the migrations directory, and `src/db/migrate.ts:28` filters that directory to `.sql`, so the runner never sees them.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md` -- no MCP tool, schema, transport, or Python client surface changes; the diff is test files plus the CI test manifest.
- Rollback/cleanup concern: reverting the commit restores the single file and the original manifest entry together, so there is no half state. The temp databases the isolated runner creates are dropped by its own teardown, confirmed in the run output.
- Fixes made before PR: replaced 19 non-null assertions with `expectDefined` and hoisted every `it` body to module scope, clearing 2 `max-lines-per-function` findings; both files were over the rule before the fix. Re-ran lint, typecheck, the tests, and the done-means check on the committed tree after prettier reformatted the staged files.
- Known residual risk: `expectDefined` throws rather than calling `expect`, so a missing value surfaces as a thrown error and not as a formatted assertion diff. The test still fails and the message names the value; the failure output shape differs from a matcher failure.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane produced no new MEDIUM+ review finding -- it is a conversion and a mechanical split with no behavior change, and the pattern it follows (`requireTestDatabaseUrl` over a self-skipping describe) is already the documented #878 convention that the done-means check enforces.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the change is test-side only and touches no served surface.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched -- the diff is two test files, a test-only helper module, and the CI test manifest.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Every downstream item is not applicable: no MCP tool, schema, protocol, or client-facing surface is in the diff.
