### PR TITLE
test(ob-backfill): assert the sanitize scan's growth shape instead of a wall-clock count (#916)

### DIFF
--- a/scripts/done-means/916-sanitize-scan-growth-shape.sh
+++ b/scripts/done-means/916-sanitize-scan-growth-shape.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #916 -- the sanitize scan tests in
+# scripts/ob-backfill.test.ts assert growth shape, not wall-clock seconds.
+#
+#   bash scripts/done-means/916-sanitize-scan-growth-shape.sh
+#
+# ---------------------------------------------------------------------------
+# The defect this gates
+# ---------------------------------------------------------------------------
+# At origin/main the two sanitize scan tests assert that one scan finishes
+# under an absolute millisecond count -- `toBeLessThan(1_000)` on the
+# token-dense scan and `toBeLessThan(2_000)` on the URL-dense one, each applied
+# to a `performance.now()` difference. On the shared self-hosted runner that is
+# a distribution tail rather than a regression: 1024ms was observed on run
+# 33053849804 with the file untouched (#916; the same class as #834 and #912).
+# The suite then fails on a slow runner while the code under test is fine, and
+# a red check that carries no information is how a genuine red stops being
+# believed.
+#
+# The shape the property actually has is growth: sanitize should scale about
+# linearly with input size. Measuring the same input shape at N and at 4N and
+# asserting the RATIO is under 8 keeps the quadratic-blowup property under test
+# (quadratic is about 16, linear about 4) while cancelling out how fast the
+# machine happens to be that minute -- both measurements ride the same tail.
+#
+# ---------------------------------------------------------------------------
+# NO ARGUMENTS
+# ---------------------------------------------------------------------------
+# The subject is fixed: scripts/ob-backfill.test.ts. This check gates one file,
+# so discovery would add nothing and would let an empty subject read as a pass.
+#
+# CLAUSE 1 -- SHAPE. In scripts/ob-backfill.test.ts, zero `toBeLessThan(`
+#   whose subject is a `performance.now()` difference, and at least two
+#   assertions comparing a measured duration at size 4N against size N as a
+#   ratio.
+# CLAUSE 2 -- RUN. `bun test scripts/ob-backfill.test.ts` exits 0.
+#
+# Exit 0 when both clauses pass, 1 when either fails, 3 on a harness error
+# (missing rg, missing bun, or the test file absent).
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SUBJECT="scripts/ob-backfill.test.ts"
+
+fail_hard() {
+  printf 'HARNESS-ERROR: %s\n' "$1" >&2
+  exit 3
+}
+
+command -v rg >/dev/null 2>&1 || fail_hard "rg (ripgrep) not on PATH"
+command -v bun >/dev/null 2>&1 || fail_hard "bun not on PATH"
+[ -f "$REPO_ROOT/$SUBJECT" ] || fail_hard "$SUBJECT does not exist under $REPO_ROOT"
+
+printf 'SUBJECT: %s\n\n' "$SUBJECT"
+
+# ---------------------------------------------------------------------------
+# CLAUSE 1 -- shape.
+# ---------------------------------------------------------------------------
+# Half a: no wall-clock assertion survives. The defect's spelling is a
+# `toBeLessThan(` applied to a `performance.now()` difference, which prettier
+# keeps on one line here; the multiline spelling is caught by pairing the
+# expect line with the toBeLessThan on the following line.
+CLAUSE1=PASS
+WALLCLOCK_HITS="$(cd "$REPO_ROOT" && rg -n 'performance\.now\(\)[^\n]*toBeLessThan\(' "$SUBJECT" || true)"
+MULTILINE_HITS="$(cd "$REPO_ROOT" && rg -n -U 'expect\(\s*performance\.now\(\)[^;]*?\)\s*\.\s*toBeLessThan\(' "$SUBJECT" || true)"
+if [ -n "$WALLCLOCK_HITS" ] || [ -n "$MULTILINE_HITS" ]; then
+  printf 'CLAUSE 1a: FAIL -- wall-clock assertions on a performance.now() difference survive:\n'
+  printf '%s\n' "$WALLCLOCK_HITS" "$MULTILINE_HITS" | rg -v '^$' | sed 's/^/    /'
+  CLAUSE1=FAIL
+else
+  printf 'CLAUSE 1a: PASS -- 0 toBeLessThan assertions on a performance.now() difference\n'
+fi
+
+# Half b: at least two ratio assertions exist. A ratio assertion divides the
+# large-size measurement by the small-size one and bounds the quotient; the
+# `/ Math.max(` denominator guard is part of the agreed shape, so matching it
+# keeps a bare subtraction from reading as a ratio.
+RATIO_HITS="$(cd "$REPO_ROOT" && rg -c 'Math\.max\(' "$SUBJECT" || true)"
+RATIO_ASSERTS="$(cd "$REPO_ROOT" && rg -c 'expect\(ratio\)\.toBeLessThan\(' "$SUBJECT" || true)"
+[ -n "$RATIO_ASSERTS" ] || RATIO_ASSERTS=0
+if [ "$RATIO_ASSERTS" -ge 2 ]; then
+  printf 'CLAUSE 1b: PASS -- %s ratio assertions (4N over N), %s Math.max denominator guards\n' \
+    "$RATIO_ASSERTS" "$RATIO_HITS"
+else
+  printf 'CLAUSE 1b: FAIL -- %s ratio assertions found, 2 required\n' "$RATIO_ASSERTS"
+  CLAUSE1=FAIL
+fi
+
+# ---------------------------------------------------------------------------
+# CLAUSE 2 -- the suite runs green.
+# ---------------------------------------------------------------------------
+CLAUSE2=FAIL
+RUN_OUT="$(cd "$REPO_ROOT" && bun test "$SUBJECT" 2>&1)"
+RUN_STATUS=$?
+if [ "$RUN_STATUS" -eq 0 ]; then
+  CLAUSE2=PASS
+  printf '\nCLAUSE 2: PASS -- bun test %s exited 0\n' "$SUBJECT"
+else
+  printf '\nCLAUSE 2: FAIL -- bun test %s exited %s\n' "$SUBJECT" "$RUN_STATUS"
+  printf '%s\n' "$RUN_OUT" | tail -n 15 | sed 's/^/    /'
+fi
+
+printf '\nCLAUSE 1 (growth shape, no wall-clock assertion): %s\n' "$CLAUSE1"
+printf 'CLAUSE 2 (bun test on the subject exits 0):       %s\n' "$CLAUSE2"
+
+if [ "$CLAUSE1" = PASS ] && [ "$CLAUSE2" = PASS ]; then
+  exit 0
+fi
+exit 1

--- a/scripts/ob-backfill.test.ts
+++ b/scripts/ob-backfill.test.ts
@@ -4,14 +4,12 @@ import { containsSecret, SECRET_PATTERNS } from "../src/sharing.ts";
 import { buildDecisionLogParams, sanitize } from "./ob-backfill.ts";
 
 const FAKE_SK = "sk" + "-" + "abcdefghijklmnopqrstuvwxyz0123456789";
-const FAKE_GITHUB_PAT =
-  "github" + "_pat_" + "11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ";
+const FAKE_GITHUB_PAT = "github" + "_pat_" + "11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ";
 const FAKE_GH_PAT = "ghp_" + "11ABCDEFG0aBcDeFgHiJkLmNoPqRsTuVwXyZ";
 const FAKE_AWS_ACCESS_KEY = "AKIA" + "IOSFODNN7EXAMPLE";
 const FAKE_AWS_SECRET = "Aa0/".repeat(10);
 const FAKE_GOOGLE_API_KEY = "AIza" + "A".repeat(35);
-const FAKE_JWT =
-  "eyJhbGciOiJIUzI1NiJ9." + "eyJzdWIiOiJ0ZXN0In0." + "abcdefghijklmnop";
+const FAKE_JWT = "eyJhbGciOiJIUzI1NiJ9." + "eyJzdWIiOiJ0ZXN0In0." + "abcdefghijklmnop";
 const FAKE_PRIVATE_KEY =
   "-----BEGIN RSA PRIVATE KEY-----\nMIIabc\n-----END RSA PRIVATE KEY-----";
 const FAKE_URL = "postgres://admin:hunter2pw@10.0.0.1:5432/app";
@@ -40,30 +38,74 @@ const SECRET_CASES = [
   `access_token=${FAKE_LONG_LABELED_SECRET}`,
 ] as const;
 
+// The sanitize scans are held to their GROWTH SHAPE, not to a wall-clock
+// count: an absolute millisecond assertion fails on a slow shared runner with
+// no regression anywhere (#916, #834). Each scan is measured at N and at 4N of
+// the same input shape and the quotient is asserted, so the machine's speed
+// that minute cancels out. Quadratic work would land near 16, linear near 4;
+// 8 sits between them with room for noise.
+const GROWTH_RATIO_MAX = 8;
+const TOKEN_DENSE_N = 12_000;
+const URL_DENSE_N = 4_000;
+
+const tokenDenseInput = (size: number): string =>
+  Array.from({ length: size }, (_, index) => `Ab${index % 10}cd`).join(" ");
+
+const urlDenseInput = (size: number): string =>
+  Array.from({ length: size }, (_, index) => `https://example.com/${index}`).join(" ");
+
+// The denominator is guarded by Math.max at the call site, so a sub-millisecond
+// small run cannot inflate the quotient.
+const measureSanitize = (input: string): { sanitized: string; elapsedMs: number } => {
+  const startedAt = performance.now();
+  const sanitized = sanitize(input);
+  return { sanitized, elapsedMs: performance.now() - startedAt };
+};
+
+// Hoisted out of the describe body: the suite's assertions live in named
+// functions so the describe callback stays under the length rule and the
+// pattern/case cross-check reads as two plain loops rather than nested
+// callbacks.
+const expectPatternsAndCasesCoverEachOther = (): void => {
+  for (const pattern of SECRET_PATTERNS) {
+    let matched = false;
+    for (const secretCase of SECRET_CASES) {
+      if (pattern.test(secretCase)) matched = true;
+    }
+    expect(matched).toBe(true);
+  }
+  for (const secretCase of SECRET_CASES) {
+    let matched = false;
+    for (const pattern of SECRET_PATTERNS) {
+      if (pattern.test(secretCase)) matched = true;
+    }
+    expect(matched).toBe(true);
+  }
+};
+
+const expectEachSecretCaseRedacted = (): void => {
+  for (const secretCase of SECRET_CASES) {
+    const sanitized = sanitize(
+      [
+        `transcript detail ${secretCase}`,
+        "regular file path src/tools/session-save.ts",
+      ].join("\n"),
+    );
+
+    expect(sanitized).not.toContain(secretCase);
+    expect(sanitized).toContain("[REDACTED]");
+    if (sanitized !== "[REDACTED]") {
+      expect(sanitized).toContain("regular file path src/tools/session-save.ts");
+    }
+    expect(sanitized).not.toContain("\n");
+    expect(containsSecret(sanitized.replace(/\s+/g, ""))).toBe(false);
+  }
+};
+
 describe("ob-backfill sanitize", () => {
   it("redacts each shared secret pattern before OB writes", () => {
-    SECRET_PATTERNS.forEach((pattern) => {
-      expect(SECRET_CASES.some((secretCase) => pattern.test(secretCase))).toBe(true);
-    });
-    SECRET_CASES.forEach((secretCase) => {
-      expect(SECRET_PATTERNS.some((pattern) => pattern.test(secretCase))).toBe(true);
-    });
-
-    for (const secretCase of SECRET_CASES) {
-      const sanitized = sanitize(
-        [`transcript detail ${secretCase}`, "regular file path src/tools/session-save.ts"].join(
-          "\n",
-        ),
-      );
-
-      expect(sanitized).not.toContain(secretCase);
-      expect(sanitized).toContain("[REDACTED]");
-      if (sanitized !== "[REDACTED]") {
-        expect(sanitized).toContain("regular file path src/tools/session-save.ts");
-      }
-      expect(sanitized).not.toContain("\n");
-      expect(containsSecret(sanitized.replace(/\s+/g, ""))).toBe(false);
-    }
+    expectPatternsAndCasesCoverEachOther();
+    expectEachSecretCaseRedacted();
   });
 
   it("redacts repeated same-shape secrets before OB writes", () => {
@@ -131,6 +173,54 @@ describe("ob-backfill sanitize", () => {
     expect(containsSecret(sanitized.replace(/\s+/g, ""))).toBe(false);
   });
 
+  it("redacts wrapped ssh credential URLs", () => {
+    const wrappedSshUrl = [
+      "ssh://admin:hunter2",
+      "\n",
+      "pw@example.test",
+      "/repo",
+    ].join("");
+    const sanitized = sanitize(`wrapped ${wrappedSshUrl} tail`);
+
+    expect(sanitized).toBe("[REDACTED]");
+    expect(containsSecret(sanitized.replace(/\s+/g, ""))).toBe(false);
+  });
+
+  it("does not leave labeled wrapped-secret tails in cleartext", () => {
+    const fragments = FAKE_SK.match(/.{1,2}/g);
+    if (!fragments) throw new Error("Expected fake secret fragments");
+
+    const sanitized = sanitize(`apikey=${fragments.join(" ")}`);
+
+    expect(sanitized).toBe("[REDACTED]");
+    for (const index of Array.from({ length: FAKE_SK.length - 5 }, (_, i) => i)) {
+      expect(sanitized).not.toContain(FAKE_SK.slice(index, index + 6));
+    }
+  });
+
+  it("redacts credential URLs without joining across benign URL prose", () => {
+    const sanitized = sanitize(
+      "see https://good.example/path and postgres://user:pass123@host/db done",
+    );
+
+    expect(sanitized).not.toBe("[REDACTED]");
+    expect(sanitized).toContain("https://good.example/path");
+    expect(sanitized).toContain("[REDACTED]");
+    expect(sanitized).toContain("done");
+    expect(containsSecret(sanitized)).toBe(false);
+  });
+
+  it("preserves benign label prose instead of redacting the whole field", () => {
+    const text = "token: the meeting is at 3pm and everyone should attend the sync";
+    const sanitized = sanitize(text);
+
+    expect(sanitized).not.toBe("[REDACTED]");
+    expect(sanitized).toContain("meeting is at 3pm");
+    expect(containsSecret(sanitized.replace(/\s+/g, ""))).toBe(false);
+  });
+});
+// length rule: these four cases all concern secrets broken across a line wrap.
+describe("ob-backfill sanitize wrapped secrets", () => {
   it("redacts wrapped bearer and mcp-session-id tails", () => {
     const wrappedBearer = [
       "Authorization",
@@ -201,74 +291,31 @@ describe("ob-backfill sanitize", () => {
       }
     }
   });
+});
 
-  it("redacts wrapped ssh credential URLs", () => {
-    const wrappedSshUrl = [
-      "ssh://admin:hunter2",
-      "\n",
-      "pw@example.test",
-      "/repo",
-    ].join("");
-    const sanitized = sanitize(`wrapped ${wrappedSshUrl} tail`);
+// The two growth-shape scans get their own describe so each body stays under
+// the length rule.
+describe("ob-backfill sanitize scan growth", () => {
+  it("scans token-dense transcripts, growing about linearly with input size", () => {
+    const small = measureSanitize(tokenDenseInput(TOKEN_DENSE_N));
+    const large = measureSanitize(tokenDenseInput(TOKEN_DENSE_N * 4));
 
-    expect(sanitized).toBe("[REDACTED]");
-    expect(containsSecret(sanitized.replace(/\s+/g, ""))).toBe(false);
+    expect(small.sanitized).toContain("Ab0cd");
+    expect(large.sanitized).toContain("Ab0cd");
+
+    const ratio = large.elapsedMs / Math.max(small.elapsedMs, 1);
+    expect(ratio).toBeLessThan(GROWTH_RATIO_MAX);
   });
 
-  it("does not leave labeled wrapped-secret tails in cleartext", () => {
-    const fragments = FAKE_SK.match(/.{1,2}/g);
-    if (!fragments) throw new Error("Expected fake secret fragments");
+  it("scans URL-dense transcripts, growing about linearly with input size", () => {
+    const small = measureSanitize(urlDenseInput(URL_DENSE_N));
+    const large = measureSanitize(urlDenseInput(URL_DENSE_N * 4));
 
-    const sanitized = sanitize(`apikey=${fragments.join(" ")}`);
+    expect(small.sanitized).toContain("https://example.com/0");
+    expect(large.sanitized).toContain("https://example.com/0");
 
-    expect(sanitized).toBe("[REDACTED]");
-    for (const index of Array.from({ length: FAKE_SK.length - 5 }, (_, i) => i)) {
-      expect(sanitized).not.toContain(FAKE_SK.slice(index, index + 6));
-    }
-  });
-
-  it("redacts credential URLs without joining across benign URL prose", () => {
-    const sanitized = sanitize(
-      "see https://good.example/path and postgres://user:pass123@host/db done",
-    );
-
-    expect(sanitized).not.toBe("[REDACTED]");
-    expect(sanitized).toContain("https://good.example/path");
-    expect(sanitized).toContain("[REDACTED]");
-    expect(sanitized).toContain("done");
-    expect(containsSecret(sanitized)).toBe(false);
-  });
-
-  it("preserves benign label prose instead of redacting the whole field", () => {
-    const text = "token: the meeting is at 3pm and everyone should attend the sync";
-    const sanitized = sanitize(text);
-
-    expect(sanitized).not.toBe("[REDACTED]");
-    expect(sanitized).toContain("meeting is at 3pm");
-    expect(containsSecret(sanitized.replace(/\s+/g, ""))).toBe(false);
-  });
-
-  it("scans token-dense transcripts without quadratic blowup", () => {
-    const dense = Array.from({ length: 12_000 }, (_, index) => `Ab${index % 10}cd`).join(
-      " ",
-    );
-    const startedAt = performance.now();
-    const sanitized = sanitize(dense);
-
-    expect(sanitized).toContain("Ab0cd");
-    expect(performance.now() - startedAt).toBeLessThan(1_000);
-  });
-
-  it("scans URL-dense transcripts without quadratic prefix-join work", () => {
-    const dense = Array.from(
-      { length: 4_000 },
-      (_, index) => `https://example.com/${index}`,
-    ).join(" ");
-    const startedAt = performance.now();
-    const sanitized = sanitize(dense);
-
-    expect(sanitized).toContain("https://example.com/0");
-    expect(performance.now() - startedAt).toBeLessThan(2_000);
+    const ratio = large.elapsedMs / Math.max(small.elapsedMs, 1);
+    expect(ratio).toBeLessThan(GROWTH_RATIO_MAX);
   });
 });
 
@@ -279,10 +326,7 @@ describe("ob-backfill decision params", () => {
       " because ",
       "pw@example.test:5432/app",
     ].join("");
-    const params = buildDecisionLogParams(
-      splitCredentialUrl,
-      "open-brain",
-    );
+    const params = buildDecisionLogParams(splitCredentialUrl, "open-brain");
 
     expect(params.title).toBe("[REDACTED]");
     expect(params.rationale).toBe("");
@@ -313,3 +357,5 @@ describe("ob-backfill decision params", () => {
     expect(containsSecret(params.tags.join(" "))).toBe(false);
   });
 });
+
+// Split out of "ob-backfill sanitize" so each describe body stays under the


### PR DESCRIPTION
## Summary

- The two sanitize scan tests in `scripts/ob-backfill.test.ts` asserted an absolute wall-clock count on a `performance.now()` difference: `toBeLessThan(1_000)` on the token-dense scan and `toBeLessThan(2_000)` on the URL-dense one. On the shared self-hosted runner that is a distribution tail, not a regression -- 1024ms was observed on run 33053849804 with the file untouched (#916; #834 reports the same assertion).
- Both tests now measure the same input shape at N and at 4N and assert the quotient is under 8. Quadratic work lands near 16 and linear near 4, so the property the tests were written for stays under test while the machine's speed that minute cancels out: both measurements ride the same tail. The denominator is `Math.max(elapsedMs, 1)` so a sub-millisecond small run cannot inflate the quotient. The `toContain` content assertions are unchanged, and both tests are renamed to say the scan grows about linearly with input size.
- Measured on this machine: token-dense **252.7ms at N=12_000** and **972.5ms at 4N=48_000**, a quotient of **3.85** -- well inside 8, and close to the linear 4.
- Adds `scripts/done-means/916-sanitize-scan-growth-shape.sh`, which reads the file for surviving wall-clock assertions and for two ratio assertions, then runs the suite. House style follows `scripts/done-means/878-pg-tests-require-database.sh`: header comment explaining the defect, no arguments, rg-based shape clause, exit 0/1/3.
- The oxlint findings the pre-commit gate reports on this file at `origin/main` (one max-lines-per-function, two max-nested-callbacks) are fixed in the same commit rather than disabled. The pattern/case cross-check and the per-case redaction loop are hoisted into named module-scope functions, which removes both nested-callback findings, and the wrapped-secret and scan-growth cases move into their own sibling `describe` blocks so no describe body exceeds the length rule. No disable comments. `scripts/ob-backfill.ts` is untouched.
- No manifest change: this file is not a Postgres suite and `scripts/assert-db-tests-ran.ts` has no entry for it (verified: `rg -n 'ob-backfill' scripts/assert-db-tests-ran.ts` returns nothing).

Closes #916
Closes #834

## Verification

- Done-means: scripts/done-means/916-sanitize-scan-growth-shape.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED, on the clone at `origin/main` before the test edit, with only the new script present:

```
CLAUSE 1a: FAIL -- wall-clock assertions on a performance.now() difference survive:
    259:    expect(performance.now() - startedAt).toBeLessThan(1_000);
    271:    expect(performance.now() - startedAt).toBeLessThan(2_000);
CLAUSE 1b: FAIL -- 0 ratio assertions found, 2 required
CLAUSE 2: PASS -- bun test scripts/ob-backfill.test.ts exited 0
EXIT=1
```

GREEN, on the committed tree:

```
CLAUSE 1a: PASS -- 0 toBeLessThan assertions on a performance.now() difference
CLAUSE 1b: PASS -- 2 ratio assertions (4N over N), 2 Math.max denominator guards
CLAUSE 2: PASS -- bun test scripts/ob-backfill.test.ts exited 0
EXIT=0
```

Other checks on the committed tree: `./node_modules/.bin/oxlint --deny-warnings scripts/ob-backfill.test.ts` exit 0 with zero findings; `bunx tsc --noEmit` exit 0; `bun run test:isolated scripts/ob-backfill.test.ts` exit 0 with 22 pass, 0 fail, 371 expect() calls. Pre-push ran the Bun suite and passed.

Python package and live Open Brain smoke are not applicable: this PR touches one test file and adds one shell check, with no runtime, contract, schema, or client change.

## Critical Self-Review

- Highest-risk behavior: the growth assertion could be weaker than the wall-clock one it replaces. A truly quadratic sanitize would land near 16 and still be caught by the value 8, but a change that made sanitize uniformly 10x slower at every size would keep a quotient near 4 and pass. That is the deliberate trade the issue asks for -- the tests exist to catch quadratic blowup, and absolute-speed regression is not something a shared runner can assert honestly.
- Assumptions that could be wrong: that the 4x size step is large enough to separate linear from quadratic above the noise floor. Measured 3.85 here against a linear expectation of 4, so the signal is clean on this machine; on a much slower runner both measurements inflate together, which is the point. The `Math.max(elapsedMs, 1)` guard assumes the small run can be sub-millisecond, which it is not here (252.7ms) but could be on faster hardware or a smaller N.
- Missing/weak tests: the done-means script has no negative control of its own. Its clause 1 was observed genuinely RED at `origin/main` on the real unmodified file and GREEN after, which is the differential, but the ratio-assertion count clause was never exercised against a file with exactly one ratio assertion.
- Security/permission risk: none. No auth, namespace, SQL, or network path is touched. The secret-pattern fixtures in the file are unchanged in content; gitleaks passed on the staged diff.
- Migration/deploy risk: none. No migration, no schema, no config.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classifies this out of scope -- no MCP tool, schema, protocol, or client-facing surface changes, so there is no rtech-mcps, mcp2cli, or rtech-hermes handoff.
- Rollback/cleanup concern: reverting the commit restores the wall-clock assertions and removes the new script; nothing else depends on either. The scratch files used to assemble the edit live under the temp workspace and are not in the repo.
- Fixes made before PR: an earlier arrangement of this change moved the `lateSymbolAwsSecret` fixture block to a different line range, and the pre-commit gitleaks scan refused the commit because the relocated-but-unchanged fixture appeared as both a removed and an added line. Restoring that block to its original position cleared the finding without weakening any test. The pre-commit prettier check also refused a first formatting; the file was reformatted with the repo's prettier and oxlint re-run on the result. Neither refusal was bypassed and `--no-verify` was not used.
- Known residual risk: the value 8 is a judgment call between the linear 4 and the quadratic 16. If sanitize acquires a real but sub-quadratic cost -- an n log n step, say -- the quotient would rise toward 5 and stay green.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the lesson here (a wall-clock assertion on a shared runner is a distribution tail, so assert the growth quotient instead) is already the substance of #916 and #834 and is recorded in this PR's harvest comment rather than as a new lane entry; no new reviewer-facing pattern was discovered that the existing entries do not cover.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or tool surface changes; the diff is one test file and one shell check.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched by this diff.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Every downstream box is not-applicable for the same reason: the diff changes one test file and adds one done-means shell script. No MCP tool, schema, transport, Python client, or agent-facing surface is involved, so there is nothing for a downstream consumer to pick up.
