### PR TITLE
test(pg): the graph derivation handler live test requires the test database instead of skipping (#878)

### DIFF
--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -395,6 +395,14 @@ export const REQUIRED_SUITES: ReadonlyArray<{
     name: "ingest_conversation_facts isolation and concurrency (live Postgres)",
     minTests: 3,
   },
+  {
+    name: "graph derivation handler selection and convergence (live Postgres)",
+    minTests: 4,
+  },
+  {
+    name: "graph derivation handler isolation and atomicity (live Postgres)",
+    minTests: 3,
+  },
 ];
 
 // Absolute floor on total executed (non-skipped) live-Postgres testcases,
@@ -444,8 +452,11 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // stopped skipping itself, then 284 -> 285 when #878 re-measured the
 // runSharedPromoter cursor-stall suite at its emitted 1 and registered the
 // clustering and cursor loops suite's 8 as that file stopped skipping
-// itself), so the global floor cannot silently fall behind the per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 285;
+// itself, then 285 -> 292 when #878 registered the two subject-split graph
+// derivation handler selection/convergence and isolation/atomicity suites'
+// 4 + 3 as that file stopped skipping itself), so the global floor cannot
+// silently fall behind the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 292;
 
 export interface SuiteStats {
   tests: number;

--- a/src/graph-derivation-handler-isolation.live.test.ts
+++ b/src/graph-derivation-handler-isolation.live.test.ts
@@ -1,0 +1,431 @@
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import {
+  GraphDerivationTerminalError,
+  SOURCE_ANCHOR_ENTITY_TYPE,
+  makeGraphDerivationHandler,
+  selectSourcesNeedingDerivation,
+} from "./graph-derivation-handler.ts";
+import { requireTestDatabaseUrl } from "../scripts/test-support/require-test-database.ts";
+import {
+  auth,
+  cleanup,
+  expectDefined,
+  hashA,
+  hashB,
+  insertSource,
+  jobFor,
+  ns,
+  otherNs,
+} from "./graph-derivation-handler-test-helpers.ts";
+
+/**
+ * Live-Postgres isolation and atomicity half of the #346 maintenance
+ * integration suite (split out under #878).
+ *
+ * Proves against the REAL schema that derivation never leaks across a
+ * namespace, that a mid-derivation failure leaves no partial graph, and that a
+ * stale job serialized behind a newer one terminal-stops instead of
+ * overwriting the newer committed graph.
+ *
+ * The suite demands OPENBRAIN_TEST_DATABASE_URL through the shared helper
+ * rather than skipping itself when it is absent.
+ */
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+
+function poolFailingAfter(
+  real: Pool,
+  failOn: string,
+): Pick<Pool, "connect"> & { armed: boolean } {
+  const wrapper = {
+    armed: true,
+    connect: async () => {
+      const client = await real.connect();
+      const realQuery = client.query.bind(client);
+      const realRelease = client.release.bind(client);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (client as any).query = ((...args: unknown[]) => {
+        const sql = args[0];
+        if (wrapper.armed && String(sql).includes(failOn)) {
+          wrapper.armed = false;
+          throw new Error("injected mid-derivation failure");
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (realQuery as any)(...args);
+      }) as never;
+      // Un-patch on release so the pooled connection returns to the pool with
+      // its original query/release, never the failure-injecting override.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (client as any).release = ((...args: unknown[]) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (client as any).query = realQuery;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (client as any).release = realRelease;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (realRelease as any)(...args);
+      }) as never;
+      return client;
+    },
+  };
+  return wrapper as Pick<Pool, "connect"> & { armed: boolean };
+}
+
+async function noDerivedEdgeCrossesNamespace(): Promise<void> {
+  const here = await insertSource(pool, ns, { external_id: "iso-here" });
+  const there = await insertSource(pool, otherNs, { external_id: "iso-there" });
+  const handler = makeGraphDerivationHandler({ pool, auth });
+  await handler(
+    jobFor(
+      {
+        source_id: here.id,
+        source_kind: "git",
+        external_id: here.external_id,
+        content_hash: hashA,
+        revision: here.revision,
+        metadata: { topics: ["Shared Topic"], people: [] },
+      },
+      ns,
+    ),
+  );
+  await handler(
+    jobFor(
+      {
+        source_id: there.id,
+        source_kind: "git",
+        external_id: there.external_id,
+        content_hash: hashA,
+        revision: there.revision,
+        metadata: { topics: ["Shared Topic"], people: [] },
+      },
+      otherNs,
+    ),
+  );
+
+  // Every edge sits entirely within one namespace on both endpoints.
+  const crossing = await pool.query(
+    `SELECT COUNT(*)::int AS n
+       FROM ob_links l
+       JOIN ob_entities f ON f.id = l.from_id
+       JOIN ob_entities t ON t.id = l.to_id
+      WHERE l.namespace = ANY($1::text[])
+        AND (f.namespace <> l.namespace OR t.namespace <> l.namespace)`,
+    [[ns, otherNs]],
+  );
+  expect(crossing.rows[0].n).toBe(0);
+}
+
+async function rollbackAtomicityLeavesNoPartialGraph(): Promise<void> {
+  const src = await insertSource(pool, ns, { external_id: "rollback-src" });
+
+  // Inject a failure on the stale-edge prune UPDATE — the LAST derivation
+  // statement, which runs AFTER the anchor upsert has already stamped both the
+  // derivation_hash and the content_hash and after every term node + mentions
+  // edge has been inserted. Pre-fix (statements auto-committed on the pool),
+  // those writes would survive and the stamped hash would falsely short-
+  // circuit the retry. With the fix they all live in one transaction.
+  const failingPool = poolFailingAfter(
+    pool,
+    "UPDATE ob_links\n        SET archived_at = NOW()",
+  );
+  const failingHandler = makeGraphDerivationHandler({
+    pool: failingPool as unknown as Pool,
+    auth,
+  });
+
+  await expect(
+    failingHandler(
+      jobFor(
+        {
+          source_id: src.id,
+          source_kind: "git",
+          external_id: src.external_id,
+          content_hash: hashA,
+          revision: src.revision,
+          metadata: { topics: ["Migrations", "pgvector"], people: ["Rico"] },
+        },
+        ns,
+      ),
+    ),
+  ).rejects.toThrow("injected mid-derivation failure");
+
+  // ROLLBACK proof: nothing landed. No anchor, no term nodes, no edges — and
+  // crucially NO stamped hash for a retry to short-circuit past.
+  const entitiesAfterFail = await pool.query(
+    "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
+    [ns],
+  );
+  expect(entitiesAfterFail.rows[0].n).toBe(0);
+  const linksAfterFail = await pool.query(
+    "SELECT COUNT(*)::int AS n FROM ob_links WHERE namespace = $1",
+    [ns],
+  );
+  expect(linksAfterFail.rows[0].n).toBe(0);
+  const anchorAfterFail = await pool.query(
+    `SELECT COUNT(*)::int AS n FROM ob_entities
+      WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3`,
+    [ns, SOURCE_ANCHOR_ENTITY_TYPE, `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`],
+  );
+  expect(anchorAfterFail.rows[0].n).toBe(0);
+  // The source is still selectable (never derived), proving no partial hash.
+  const stillNeeded = await selectSourcesNeedingDerivation(pool, [ns]);
+  expect(stillNeeded.length).toBe(1);
+  expect(expectDefined(stillNeeded[0], "stillNeeded[0]").id).toBe(src.id);
+
+  // Retry on the healthy pool: the derivation now converges fully.
+  const handler = makeGraphDerivationHandler({ pool, auth });
+  await handler(
+    jobFor(
+      {
+        source_id: src.id,
+        source_kind: "git",
+        external_id: src.external_id,
+        content_hash: hashA,
+        revision: src.revision,
+        metadata: { topics: ["Migrations", "pgvector"], people: ["Rico"] },
+      },
+      ns,
+    ),
+  );
+  const entitiesAfterRetry = await pool.query(
+    "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
+    [ns],
+  );
+  // anchor + 2 topics + 1 person = 4 nodes; 3 mentions edges.
+  expect(entitiesAfterRetry.rows[0].n).toBe(4);
+  const linksAfterRetry = await pool.query(
+    "SELECT COUNT(*)::int AS n FROM ob_links WHERE namespace = $1 AND relation = 'mentions'",
+    [ns],
+  );
+  expect(linksAfterRetry.rows[0].n).toBe(3);
+  const anchorAfterRetry = await pool.query(
+    `SELECT metadata ->> 'content_hash' AS content_hash
+       FROM ob_entities
+      WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
+        AND archived_at IS NULL`,
+    [ns, SOURCE_ANCHOR_ENTITY_TYPE, `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`],
+  );
+  expect(anchorAfterRetry.rows[0].content_hash).toBe(hashA);
+  // Fully converged now: no longer selectable.
+  const afterRetrySelect = await selectSourcesNeedingDerivation(pool, [ns]);
+  expect(afterRetrySelect.length).toBe(0);
+}
+
+async function serializedInterleaveTerminalStopsOnDrift(): Promise<void> {
+  // The source starts at revision R / hash A. The registry then advances it to
+  // revision R+1 / hash B (new bytes AND new terms). A fresh job for (B, R+1)
+  // derives the newer graph. The OLD job for (A, R) — still in the queue — must
+  // never overwrite that newer graph: its FOR UPDATE guard re-reads the live
+  // row under the (A, R) predicate, matches zero rows, and terminal-stops.
+  const src = await insertSource(pool, ns, { external_id: "interleave-src" });
+  const oldRevision = src.revision;
+  const handler = makeGraphDerivationHandler({ pool, auth });
+
+  // Old job runs first and commits the A-graph (one topic: "OldTopic").
+  await handler(
+    jobFor(
+      {
+        source_id: src.id,
+        source_kind: "git",
+        external_id: src.external_id,
+        content_hash: hashA,
+        revision: oldRevision,
+        metadata: { topics: ["OldTopic"], people: [] },
+      },
+      ns,
+    ),
+  );
+
+  // The registry observes new content and advances the source (hash + revision
+  // bump, exactly as source-registry.ts does on a content change).
+  const bumped = await pool.query(
+    `UPDATE ob_sources SET content_hash = $1, revision = revision + 1
+      WHERE id = $2 AND namespace = $3 RETURNING revision`,
+    [hashB, src.id, ns],
+  );
+  const newRevision = bumped.rows[0].revision as number;
+
+  // A fresh job for the newer snapshot derives the B-graph ("NewTopic").
+  await handler(
+    jobFor(
+      {
+        source_id: src.id,
+        source_kind: "git",
+        external_id: src.external_id,
+        content_hash: hashB,
+        revision: newRevision,
+        metadata: { topics: ["NewTopic"], people: [] },
+      },
+      ns,
+    ),
+  );
+
+  // The graph now reflects the NEWER snapshot: anchor stamped hashB, a live
+  // anchor->NewTopic edge, and the stale anchor->OldTopic edge pruned.
+  async function graphState() {
+    const anchor = await pool.query(
+      `SELECT id, metadata ->> 'content_hash' AS content_hash,
+              metadata ->> 'derivation_hash' AS derivation_hash
+         FROM ob_entities
+        WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
+          AND archived_at IS NULL`,
+      [ns, SOURCE_ANCHOR_ENTITY_TYPE, `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`],
+    );
+    const liveTopics = await pool.query(
+      `SELECT e.name
+         FROM ob_links l
+         JOIN ob_entities e ON e.id = l.to_id
+        WHERE l.namespace = $1 AND l.from_id = $2 AND l.relation = 'mentions'
+          AND l.archived_at IS NULL
+        ORDER BY e.name`,
+      [ns, anchor.rows[0].id],
+    );
+    return {
+      contentHash: anchor.rows[0].content_hash as string,
+      derivationHash: anchor.rows[0].derivation_hash as string,
+      liveTopics: liveTopics.rows.map((r) => r.name as string),
+    };
+  }
+  const newer = await graphState();
+  expect(newer.contentHash).toBe(hashB);
+  expect(newer.liveTopics).toEqual(["NewTopic"]);
+
+  // Now replay the OLD job for (A, R). It is obsolete: the live row is (B, R+1).
+  // The FOR UPDATE snapshot guard matches zero rows -> terminal-stop. It must
+  // NOT overwrite the newer graph or re-stamp the old hash.
+  await expect(
+    handler(
+      jobFor(
+        {
+          source_id: src.id,
+          source_kind: "git",
+          external_id: src.external_id,
+          content_hash: hashA,
+          revision: oldRevision,
+          metadata: { topics: ["OldTopic"], people: [] },
+        },
+        ns,
+      ),
+    ),
+  ).rejects.toBeInstanceOf(GraphDerivationTerminalError);
+
+  // The committed graph is UNCHANGED — still the newer B-snapshot. No stale
+  // overwrite: the anchor still stamps hashB and OldTopic did not revive.
+  const afterOldReplay = await graphState();
+  expect(afterOldReplay.contentHash).toBe(hashB);
+  expect(afterOldReplay.derivationHash).toBe(newer.derivationHash);
+  expect(afterOldReplay.liveTopics).toEqual(["NewTopic"]);
+}
+
+async function handlerGuardSerializesCompetingRegistryUpdate(): Promise<void> {
+  // Finally, prove the serialization comes from the HANDLER'S OWN guard, not a
+  // hand-taken lock: while a real handler derivation is mid-transaction (its
+  // FOR UPDATE guard holding the source row), a competing registry UPDATE on
+  // that same row must BLOCK until the handler commits. Pre-fix — no
+  // transaction, no FOR UPDATE — the competing UPDATE would proceed
+  // immediately and advance the snapshot out from under the in-flight job.
+  //
+  // We slow the handler's transaction from the inside by delaying its first
+  // derivation write (the anchor upsert), which runs AFTER the FOR UPDATE
+  // guard has locked the row and BEFORE COMMIT. That widens the window during
+  // which the row lock is held so the race is observable deterministically.
+  const src2 = await insertSource(pool, ns, {
+    external_id: "lock-serialize-src",
+    title: "lock serialization source",
+  });
+  let updateResolved = false;
+  const slowPool = {
+    connect: async () => {
+      const client = await pool.connect();
+      const realQuery = client.query.bind(client);
+      const realRelease = client.release.bind(client);
+      let delayed = false;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (client as any).query = (async (...args: unknown[]) => {
+        // Delay once, on the first anchor upsert — inside the transaction,
+        // after the guard's FOR UPDATE has taken the row lock.
+        if (!delayed && String(args[0]).includes("INSERT INTO ob_entities")) {
+          delayed = true;
+          await new Promise((r) => setTimeout(r, 300));
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (realQuery as any)(...args);
+      }) as never;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (client as any).release = ((...a: unknown[]) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (client as any).query = realQuery;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (client as any).release = realRelease;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (realRelease as any)(...a);
+      }) as never;
+      return client;
+    },
+  };
+  const slowHandler = makeGraphDerivationHandler({
+    pool: slowPool as unknown as Pool,
+    auth,
+  });
+  const derivation = slowHandler(
+    jobFor(
+      {
+        source_id: src2.id,
+        source_kind: "git",
+        external_id: src2.external_id,
+        content_hash: hashA,
+        revision: src2.revision,
+        metadata: { topics: ["LockTopic"], people: [] },
+      },
+      ns,
+    ),
+  );
+  // Let the handler reach its in-transaction delay (guard row lock held).
+  await new Promise((r) => setTimeout(r, 100));
+  // A competing registry update on the locked row must BLOCK, not proceed.
+  const competing = pool
+    .query(
+      `UPDATE ob_sources SET content_hash = $1, revision = revision + 1
+        WHERE id = $2 AND namespace = $3`,
+      [hashB, src2.id, ns],
+    )
+    .then(() => {
+      updateResolved = true;
+    });
+  // Still inside the handler's transaction: the competing UPDATE is blocked.
+  await new Promise((r) => setTimeout(r, 100));
+  expect(updateResolved).toBe(false);
+  // Handler commits and releases the lock; the competing update now completes.
+  await derivation;
+  await competing;
+  expect(updateResolved).toBe(true);
+}
+
+/**
+ * The interleave scenario runs as two sequential halves under one `it`, purely
+ * to keep each function under the code-line standard. Order and assertions are
+ * unchanged from the single body they were hoisted out of.
+ */
+async function serializedInterleave(): Promise<void> {
+  await serializedInterleaveTerminalStopsOnDrift();
+  await handlerGuardSerializesCompetingRegistryUpdate();
+}
+
+describe("graph derivation handler isolation and atomicity (live Postgres)", () => {
+  beforeEach(async () => {
+    await cleanup(pool);
+  });
+  afterAll(async () => {
+    await cleanup(pool);
+    await pool.end();
+  });
+
+  it("no derived edge crosses the namespace boundary", noDerivedEdgeCrossesNamespace);
+  it(
+    "rollback atomicity: a failure after the hash stamp leaves no partial graph, and retry converges",
+    rollbackAtomicityLeavesNoPartialGraph,
+  );
+  it(
+    "serialized interleave: an old job cannot overwrite a newer committed graph and terminal-stops on drift",
+    serializedInterleave,
+  );
+});

--- a/src/graph-derivation-handler-test-helpers.ts
+++ b/src/graph-derivation-handler-test-helpers.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared fixtures for the two live graph-derivation suites.
+ *
+ * The #878 split put selection/convergence and isolation/atomicity in separate
+ * files. Both need the same namespaces, the same source-row writer, and the
+ * same maintenance-job shape, so those live here.
+ *
+ * This module holds no test and creates no pool: each database function takes
+ * the caller's `pool` first, so each suite owns exactly one connection pool and
+ * ends it in its own afterAll. A helper that made its own pool would give one
+ * half of the split an afterAll that closes a connection the other half is
+ * still using.
+ */
+import { Pool } from "pg";
+import {
+  GRAPH_DERIVATION_JOB_KIND,
+  type GraphDerivationPayload,
+} from "./graph-derivation-handler.ts";
+import { type MaintenanceJob } from "./maintenance-queue.ts";
+import type { AuthInfo } from "./types.ts";
+
+export const ns = "test-graph-derivation-maint";
+export const otherNs = "test-graph-derivation-maint-other";
+
+export const auth: AuthInfo = {
+  role: "admin",
+  clientId: "test-graph-derivation-maint",
+  namespaceSource: "token",
+};
+
+export const hashA = "a".repeat(64);
+export const hashB = "b".repeat(64);
+
+/**
+ * Narrows a possibly-absent value, throwing with a caller-supplied label.
+ *
+ * Replaces the `x!` non-null assertions the oxlint standard forbids: the
+ * assertion's runtime meaning (throw when absent) is kept, and the label says
+ * which expectation went missing instead of a bare TypeError.
+ *
+ * @throws {Error} when `value` is null or undefined.
+ */
+export function expectDefined<T>(value: T | null | undefined, label: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(`expected ${label} to be defined`);
+  }
+  return value;
+}
+
+export async function cleanup(pool: Pool): Promise<void> {
+  for (const namespace of [ns, otherNs]) {
+    await pool.query("DELETE FROM ob_links WHERE namespace = $1", [namespace]);
+    await pool.query("DELETE FROM ob_entities WHERE namespace = $1", [namespace]);
+    await pool.query("DELETE FROM ob_sources WHERE namespace = $1", [namespace]);
+  }
+}
+
+export async function insertSource(
+  pool: Pool,
+  namespace: string,
+  over: Partial<{
+    approval_state: string;
+    lifecycle_state: string;
+    content_hash: string | null;
+    title: string | null;
+    external_id: string;
+  }> = {},
+): Promise<{ id: string; revision: number; external_id: string }> {
+  const externalId = over.external_id ?? `ext-${namespace}`;
+  const { rows } = await pool.query(
+    `INSERT INTO ob_sources
+       (namespace, source_kind, external_id, title,
+        approval_state, lifecycle_state, content_hash, created_by)
+     VALUES ($1, 'git', $2, $3, $4, $5, $6, 'tester')
+     RETURNING id, revision, external_id`,
+    [
+      namespace,
+      externalId,
+      over.title ?? "release plan",
+      over.approval_state ?? "approved",
+      over.lifecycle_state ?? "active",
+      over.content_hash === undefined ? hashA : over.content_hash,
+    ],
+  );
+  return {
+    id: rows[0].id as string,
+    revision: rows[0].revision as number,
+    external_id: rows[0].external_id as string,
+  };
+}
+
+export function jobFor(
+  payload: GraphDerivationPayload,
+  namespace: string,
+): MaintenanceJob {
+  return {
+    id: "job-live",
+    kind: GRAPH_DERIVATION_JOB_KIND,
+    version: 1,
+    payload: payload as unknown as Record<string, unknown>,
+    idempotencyKey: "k",
+    state: "running",
+    runAfter: new Date("2026-07-22T12:00:00.000Z"),
+    leaseToken: "00000000-0000-4000-8000-000000000009",
+    leaseUntil: new Date("2026-07-22T12:00:30.000Z"),
+    attempts: 1,
+    maxAttempts: 3,
+    backoffBaseMs: 1_000,
+    backoffMaxMs: 4_000,
+    lastErrorCategory: null,
+    terminalAt: null,
+    deadLetteredAt: null,
+    namespace,
+    provenance: null,
+    createdAt: new Date("2026-07-22T12:00:00.000Z"),
+    updatedAt: new Date("2026-07-22T12:00:00.000Z"),
+  };
+}

--- a/src/graph-derivation-handler.live.test.ts
+++ b/src/graph-derivation-handler.live.test.ts
@@ -1,18 +1,27 @@
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import { Pool } from "pg";
 import {
-  GRAPH_DERIVATION_JOB_KIND,
-  GraphDerivationTerminalError,
   SOURCE_ANCHOR_ENTITY_TYPE,
   makeGraphDerivationHandler,
   selectSourcesNeedingDerivation,
-  type GraphDerivationPayload,
 } from "./graph-derivation-handler.ts";
-import { type MaintenanceJob } from "./maintenance-queue.ts";
-import type { AuthInfo } from "./types.ts";
+import { requireTestDatabaseUrl } from "../scripts/test-support/require-test-database.ts";
+import {
+  auth,
+  cleanup,
+  expectDefined,
+  hashA,
+  hashB,
+  insertSource,
+  jobFor,
+  ns,
+  otherNs,
+} from "./graph-derivation-handler-test-helpers.ts";
 
 /**
- * Live-Postgres regression for the #346 maintenance integration.
+ * Live-Postgres regression for the #346 maintenance integration: the selection
+ * and convergence half (the isolation and atomicity half lives in
+ * graph-derivation-handler-isolation.live.test.ts, split under #878).
  *
  * The in-memory FakeSourcePool in graph-derivation-handler.test.ts models the
  * selection join and snapshot guard by hand. This suite proves the NOVEL SQL
@@ -25,746 +34,273 @@ import type { AuthInfo } from "./types.ts";
  *   - the anchor content_hash stamp that makes selection converge (unchanged →
  *     empty sweep) and reruns idempotent.
  *
- * Env-gated exactly like the other live suites: skipped unless
- * OPENBRAIN_TEST_DATABASE_URL points at a migrated database.
+ * The suite demands OPENBRAIN_TEST_DATABASE_URL through the shared helper
+ * rather than skipping itself when it is absent.
  */
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
-dbDescribe("graph derivation maintenance integration (live Postgres)", () => {
-  const pool = new Pool({ connectionString: DB_URL });
-  const ns = "test-graph-derivation-maint";
-  const otherNs = "test-graph-derivation-maint-other";
-  const auth: AuthInfo = {
-    role: "admin",
-    clientId: "test-graph-derivation-maint",
-    namespaceSource: "token",
-  };
+async function selectsNewApprovedSourceThenNoOps(): Promise<void> {
+  const newSource = await insertSource(pool, ns, { external_id: "new-src" });
+  await insertSource(pool, ns, {
+    external_id: "pending-src",
+    approval_state: "pending",
+  });
+  await insertSource(pool, ns, {
+    external_id: "retired-src",
+    lifecycle_state: "retired",
+  });
+  await insertSource(pool, ns, { external_id: "nohash-src", content_hash: null });
+  await insertSource(pool, otherNs, { external_id: "foreign-src" });
 
-  const hashA = "a".repeat(64);
-  const hashB = "b".repeat(64);
+  // Namespace-scoped selection: only the one new, approved, active, hashed
+  // source in `ns` is returned.
+  const selected = await selectSourcesNeedingDerivation(pool, [ns]);
+  expect(selected.length).toBe(1);
+  expect(expectDefined(selected[0], "selected[0]").id).toBe(newSource.id);
+  expect(expectDefined(selected[0], "selected[0]").derived_content_hash).toBeNull();
 
-  async function cleanup(): Promise<void> {
-    for (const namespace of [ns, otherNs]) {
-      await pool.query("DELETE FROM ob_links WHERE namespace = $1", [
-        namespace,
-      ]);
-      await pool.query("DELETE FROM ob_entities WHERE namespace = $1", [
-        namespace,
-      ]);
-      await pool.query("DELETE FROM ob_sources WHERE namespace = $1", [
-        namespace,
-      ]);
-    }
-  }
+  // Derive it via the handler.
+  const handler = makeGraphDerivationHandler({ pool, auth });
+  await handler(
+    jobFor(
+      {
+        source_id: newSource.id,
+        source_kind: "git",
+        external_id: newSource.external_id,
+        content_hash: hashA,
+        revision: newSource.revision,
+        metadata: { topics: ["Migrations", "pgvector"], people: ["Rico"] },
+      },
+      ns,
+    ),
+  );
 
-  async function insertSource(
-    namespace: string,
-    over: Partial<{
-      approval_state: string;
-      lifecycle_state: string;
-      content_hash: string | null;
-      title: string | null;
-      external_id: string;
-    }> = {},
-  ): Promise<{ id: string; revision: number; external_id: string }> {
-    const externalId = over.external_id ?? `ext-${namespace}`;
-    const { rows } = await pool.query(
-      `INSERT INTO ob_sources
-         (namespace, source_kind, external_id, title,
-          approval_state, lifecycle_state, content_hash, created_by)
-       VALUES ($1, 'git', $2, $3, $4, $5, $6, 'tester')
-       RETURNING id, revision, external_id`,
-      [
-        namespace,
-        externalId,
-        over.title ?? "release plan",
-        over.approval_state ?? "approved",
-        over.lifecycle_state ?? "active",
-        over.content_hash === undefined ? hashA : over.content_hash,
-      ],
-    );
-    return {
-      id: rows[0].id as string,
-      revision: rows[0].revision as number,
-      external_id: rows[0].external_id as string,
-    };
-  }
+  // The anchor entity exists, stamped with the content hash.
+  const anchor = await pool.query(
+    `SELECT metadata ->> 'content_hash' AS content_hash
+       FROM ob_entities
+      WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
+        AND archived_at IS NULL`,
+    [ns, SOURCE_ANCHOR_ENTITY_TYPE, `${SOURCE_ANCHOR_ENTITY_TYPE}:${newSource.id}`],
+  );
+  expect(anchor.rows.length).toBe(1);
+  expect(anchor.rows[0].content_hash).toBe(hashA);
 
-  function jobFor(
-    payload: GraphDerivationPayload,
-    namespace: string,
-  ): MaintenanceJob {
-    return {
-      id: "job-live",
-      kind: GRAPH_DERIVATION_JOB_KIND,
-      version: 1,
-      payload: payload as unknown as Record<string, unknown>,
-      idempotencyKey: "k",
-      state: "running",
-      runAfter: new Date("2026-07-22T12:00:00.000Z"),
-      leaseToken: "00000000-0000-4000-8000-000000000009",
-      leaseUntil: new Date("2026-07-22T12:00:30.000Z"),
-      attempts: 1,
-      maxAttempts: 3,
-      backoffBaseMs: 1_000,
-      backoffMaxMs: 4_000,
-      lastErrorCategory: null,
-      terminalAt: null,
-      deadLetteredAt: null,
-      namespace,
-      provenance: null,
-      createdAt: new Date("2026-07-22T12:00:00.000Z"),
-      updatedAt: new Date("2026-07-22T12:00:00.000Z"),
-    };
-  }
+  // 3 term entities (2 topics + 1 person) + anchor, and 3 mentions edges.
+  const terms = await pool.query(
+    "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
+    [ns],
+  );
+  expect(terms.rows[0].n).toBe(4);
+  const edges = await pool.query(
+    "SELECT COUNT(*)::int AS n FROM ob_links WHERE namespace = $1 AND relation = 'mentions'",
+    [ns],
+  );
+  expect(edges.rows[0].n).toBe(3);
 
-  beforeEach(cleanup);
+  // Unchanged now: selection returns nothing for this source.
+  const afterSelect = await selectSourcesNeedingDerivation(pool, [ns]);
+  expect(afterSelect.length).toBe(0);
+
+  // Rerun the exact job: converges, no duplicate nodes/edges.
+  await handler(
+    jobFor(
+      {
+        source_id: newSource.id,
+        source_kind: "git",
+        external_id: newSource.external_id,
+        content_hash: hashA,
+        revision: newSource.revision,
+        metadata: { topics: ["Migrations", "pgvector"], people: ["Rico"] },
+      },
+      ns,
+    ),
+  );
+  const termsAfter = await pool.query(
+    "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
+    [ns],
+  );
+  expect(termsAfter.rows[0].n).toBe(4);
+  const edgesAfter = await pool.query(
+    "SELECT COUNT(*)::int AS n FROM ob_links WHERE namespace = $1",
+    [ns],
+  );
+  expect(edgesAfter.rows[0].n).toBe(3);
+}
+
+async function changedHashReselectedWithoutDuplicatingAnchor(): Promise<void> {
+  const src = await insertSource(pool, ns, { external_id: "changing-src" });
+  const handler = makeGraphDerivationHandler({ pool, auth });
+
+  await handler(
+    jobFor(
+      {
+        source_id: src.id,
+        source_kind: "git",
+        external_id: src.external_id,
+        content_hash: hashA,
+        revision: src.revision,
+        metadata: { topics: ["Migrations"], people: [] },
+      },
+      ns,
+    ),
+  );
+
+  // Observe new content: bump the source's content_hash (and revision, as the
+  // registry would). It becomes selectable again as `changed`.
+  const bumped = await pool.query(
+    `UPDATE ob_sources SET content_hash = $1, revision = revision + 1
+      WHERE id = $2 AND namespace = $3
+      RETURNING revision`,
+    [hashB, src.id, ns],
+  );
+  const newRevision = bumped.rows[0].revision as number;
+
+  const selected = await selectSourcesNeedingDerivation(pool, [ns]);
+  expect(selected.length).toBe(1);
+  expect(expectDefined(selected[0], "selected[0]").derived_content_hash).toBe(hashA);
+
+  await handler(
+    jobFor(
+      {
+        source_id: src.id,
+        source_kind: "git",
+        external_id: src.external_id,
+        content_hash: hashB,
+        revision: newRevision,
+        metadata: { topics: ["Migrations", "pgvector"], people: [] },
+      },
+      ns,
+    ),
+  );
+
+  // Exactly one anchor row (renamed/updated in place), stamped with hashB.
+  const anchor = await pool.query(
+    `SELECT COUNT(*)::int AS n, MAX(metadata ->> 'content_hash') AS content_hash
+       FROM ob_entities
+      WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
+        AND archived_at IS NULL`,
+    [ns, SOURCE_ANCHOR_ENTITY_TYPE, `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`],
+  );
+  expect(anchor.rows[0].n).toBe(1);
+  expect(anchor.rows[0].content_hash).toBe(hashB);
+}
+
+async function changedBytesIdenticalTermsStillConverges(): Promise<void> {
+  // The corner case the in-memory sentinel guards, proven live: a source's
+  // bytes change (new content_hash + revision) while its extracted terms stay
+  // identical, so the derivation node set — and thus derivation_hash — is
+  // unchanged. The run takes the primitive's `unchanged` node path but MUST
+  // refresh the anchor's stamped content_hash, or the source is re-selected on
+  // every sweep forever.
+  const src = await insertSource(pool, ns, { external_id: "same-terms-src" });
+  const handler = makeGraphDerivationHandler({ pool, auth });
+  await handler(
+    jobFor(
+      {
+        source_id: src.id,
+        source_kind: "git",
+        external_id: src.external_id,
+        content_hash: hashA,
+        revision: src.revision,
+        metadata: { topics: ["Migrations"], people: [] },
+      },
+      ns,
+    ),
+  );
+
+  // Bump ONLY the content hash + revision; keep the same extracted terms.
+  const bumped = await pool.query(
+    `UPDATE ob_sources SET content_hash = $1, revision = revision + 1
+      WHERE id = $2 AND namespace = $3 RETURNING revision`,
+    [hashB, src.id, ns],
+  );
+  const newRevision = bumped.rows[0].revision as number;
+
+  // Selectable as changed (source hash B <> stamped hash A).
+  const selectedBefore = await selectSourcesNeedingDerivation(pool, [ns]);
+  expect(selectedBefore.length).toBe(1);
+  expect(
+    expectDefined(selectedBefore[0], "selectedBefore[0]").derived_content_hash,
+  ).toBe(hashA);
+
+  await handler(
+    jobFor(
+      {
+        source_id: src.id,
+        source_kind: "git",
+        external_id: src.external_id,
+        content_hash: hashB,
+        revision: newRevision,
+        metadata: { topics: ["Migrations"], people: [] },
+      },
+      ns,
+    ),
+  );
+
+  // The anchor's stamped content_hash advanced to B even though the node set
+  // (and derivation_hash) never changed. The sweep now skips this source.
+  const anchor = await pool.query(
+    `SELECT metadata ->> 'content_hash' AS content_hash
+       FROM ob_entities
+      WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
+        AND archived_at IS NULL`,
+    [ns, SOURCE_ANCHOR_ENTITY_TYPE, `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`],
+  );
+  expect(anchor.rows[0].content_hash).toBe(hashB);
+  const selectedAfter = await selectSourcesNeedingDerivation(pool, [ns]);
+  expect(selectedAfter.length).toBe(0);
+}
+
+async function snapshotGuardStaleRevisionDerivesNothing(): Promise<void> {
+  const src = await insertSource(pool, ns, { external_id: "stale-src" });
+  const handler = makeGraphDerivationHandler({ pool, auth });
+  await expect(
+    handler(
+      jobFor(
+        {
+          source_id: src.id,
+          source_kind: "git",
+          external_id: src.external_id,
+          content_hash: hashA,
+          revision: src.revision + 99,
+        },
+        ns,
+      ),
+    ),
+  ).rejects.toThrow();
+
+  // Nothing derived: no anchor entity was written.
+  const anchor = await pool.query(
+    "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
+    [ns],
+  );
+  expect(anchor.rows[0].n).toBe(0);
+}
+
+describe("graph derivation handler selection and convergence (live Postgres)", () => {
+  beforeEach(async () => {
+    await cleanup(pool);
+  });
   afterAll(async () => {
-    await cleanup();
+    await cleanup(pool);
     await pool.end();
   });
 
-  it("selects a new approved source, skips pending/retired/foreign, derives, then no-ops", async () => {
-    const newSource = await insertSource(ns, { external_id: "new-src" });
-    await insertSource(ns, {
-      external_id: "pending-src",
-      approval_state: "pending",
-    });
-    await insertSource(ns, {
-      external_id: "retired-src",
-      lifecycle_state: "retired",
-    });
-    await insertSource(ns, { external_id: "nohash-src", content_hash: null });
-    await insertSource(otherNs, { external_id: "foreign-src" });
-
-    // Namespace-scoped selection: only the one new, approved, active, hashed
-    // source in `ns` is returned.
-    const selected = await selectSourcesNeedingDerivation(pool, [ns]);
-    expect(selected.length).toBe(1);
-    expect(selected[0]!.id).toBe(newSource.id);
-    expect(selected[0]!.derived_content_hash).toBeNull();
-
-    // Derive it via the handler.
-    const handler = makeGraphDerivationHandler({ pool, auth });
-    await handler(
-      jobFor(
-        {
-          source_id: newSource.id,
-          source_kind: "git",
-          external_id: newSource.external_id,
-          content_hash: hashA,
-          revision: newSource.revision,
-          metadata: { topics: ["Migrations", "pgvector"], people: ["Rico"] },
-        },
-        ns,
-      ),
-    );
-
-    // The anchor entity exists, stamped with the content hash.
-    const anchor = await pool.query(
-      `SELECT metadata ->> 'content_hash' AS content_hash
-         FROM ob_entities
-        WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
-          AND archived_at IS NULL`,
-      [
-        ns,
-        SOURCE_ANCHOR_ENTITY_TYPE,
-        `${SOURCE_ANCHOR_ENTITY_TYPE}:${newSource.id}`,
-      ],
-    );
-    expect(anchor.rows.length).toBe(1);
-    expect(anchor.rows[0].content_hash).toBe(hashA);
-
-    // 3 term entities (2 topics + 1 person) + anchor, and 3 mentions edges.
-    const terms = await pool.query(
-      "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
-      [ns],
-    );
-    expect(terms.rows[0].n).toBe(4);
-    const edges = await pool.query(
-      "SELECT COUNT(*)::int AS n FROM ob_links WHERE namespace = $1 AND relation = 'mentions'",
-      [ns],
-    );
-    expect(edges.rows[0].n).toBe(3);
-
-    // Unchanged now: selection returns nothing for this source.
-    const afterSelect = await selectSourcesNeedingDerivation(pool, [ns]);
-    expect(afterSelect.length).toBe(0);
-
-    // Rerun the exact job: converges, no duplicate nodes/edges.
-    await handler(
-      jobFor(
-        {
-          source_id: newSource.id,
-          source_kind: "git",
-          external_id: newSource.external_id,
-          content_hash: hashA,
-          revision: newSource.revision,
-          metadata: { topics: ["Migrations", "pgvector"], people: ["Rico"] },
-        },
-        ns,
-      ),
-    );
-    const termsAfter = await pool.query(
-      "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
-      [ns],
-    );
-    expect(termsAfter.rows[0].n).toBe(4);
-    const edgesAfter = await pool.query(
-      "SELECT COUNT(*)::int AS n FROM ob_links WHERE namespace = $1",
-      [ns],
-    );
-    expect(edgesAfter.rows[0].n).toBe(3);
-  });
-
-  it("changed content hash is re-selected and derived without duplicating the anchor", async () => {
-    const src = await insertSource(ns, { external_id: "changing-src" });
-    const handler = makeGraphDerivationHandler({ pool, auth });
-
-    await handler(
-      jobFor(
-        {
-          source_id: src.id,
-          source_kind: "git",
-          external_id: src.external_id,
-          content_hash: hashA,
-          revision: src.revision,
-          metadata: { topics: ["Migrations"], people: [] },
-        },
-        ns,
-      ),
-    );
-
-    // Observe new content: bump the source's content_hash (and revision, as the
-    // registry would). It becomes selectable again as `changed`.
-    const bumped = await pool.query(
-      `UPDATE ob_sources SET content_hash = $1, revision = revision + 1
-        WHERE id = $2 AND namespace = $3
-        RETURNING revision`,
-      [hashB, src.id, ns],
-    );
-    const newRevision = bumped.rows[0].revision as number;
-
-    const selected = await selectSourcesNeedingDerivation(pool, [ns]);
-    expect(selected.length).toBe(1);
-    expect(selected[0]!.derived_content_hash).toBe(hashA);
-
-    await handler(
-      jobFor(
-        {
-          source_id: src.id,
-          source_kind: "git",
-          external_id: src.external_id,
-          content_hash: hashB,
-          revision: newRevision,
-          metadata: { topics: ["Migrations", "pgvector"], people: [] },
-        },
-        ns,
-      ),
-    );
-
-    // Exactly one anchor row (renamed/updated in place), stamped with hashB.
-    const anchor = await pool.query(
-      `SELECT COUNT(*)::int AS n, MAX(metadata ->> 'content_hash') AS content_hash
-         FROM ob_entities
-        WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
-          AND archived_at IS NULL`,
-      [ns, SOURCE_ANCHOR_ENTITY_TYPE, `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`],
-    );
-    expect(anchor.rows[0].n).toBe(1);
-    expect(anchor.rows[0].content_hash).toBe(hashB);
-  });
-
-  it("changed bytes but identical terms still converges (content_hash stamp refreshes)", async () => {
-    // The corner case the in-memory sentinel guards, proven live: a source's
-    // bytes change (new content_hash + revision) while its extracted terms stay
-    // identical, so the derivation node set — and thus derivation_hash — is
-    // unchanged. The run takes the primitive's `unchanged` node path but MUST
-    // refresh the anchor's stamped content_hash, or the source is re-selected on
-    // every sweep forever.
-    const src = await insertSource(ns, { external_id: "same-terms-src" });
-    const handler = makeGraphDerivationHandler({ pool, auth });
-    await handler(
-      jobFor(
-        {
-          source_id: src.id,
-          source_kind: "git",
-          external_id: src.external_id,
-          content_hash: hashA,
-          revision: src.revision,
-          metadata: { topics: ["Migrations"], people: [] },
-        },
-        ns,
-      ),
-    );
-
-    // Bump ONLY the content hash + revision; keep the same extracted terms.
-    const bumped = await pool.query(
-      `UPDATE ob_sources SET content_hash = $1, revision = revision + 1
-        WHERE id = $2 AND namespace = $3 RETURNING revision`,
-      [hashB, src.id, ns],
-    );
-    const newRevision = bumped.rows[0].revision as number;
-
-    // Selectable as changed (source hash B <> stamped hash A).
-    const selectedBefore = await selectSourcesNeedingDerivation(pool, [ns]);
-    expect(selectedBefore.length).toBe(1);
-    expect(selectedBefore[0]!.derived_content_hash).toBe(hashA);
-
-    await handler(
-      jobFor(
-        {
-          source_id: src.id,
-          source_kind: "git",
-          external_id: src.external_id,
-          content_hash: hashB,
-          revision: newRevision,
-          metadata: { topics: ["Migrations"], people: [] },
-        },
-        ns,
-      ),
-    );
-
-    // The anchor's stamped content_hash advanced to B even though the node set
-    // (and derivation_hash) never changed. The sweep now skips this source.
-    const anchor = await pool.query(
-      `SELECT metadata ->> 'content_hash' AS content_hash
-         FROM ob_entities
-        WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
-          AND archived_at IS NULL`,
-      [ns, SOURCE_ANCHOR_ENTITY_TYPE, `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`],
-    );
-    expect(anchor.rows[0].content_hash).toBe(hashB);
-    const selectedAfter = await selectSourcesNeedingDerivation(pool, [ns]);
-    expect(selectedAfter.length).toBe(0);
-  });
-
-  it("snapshot guard: a stale-revision job derives nothing against the live row", async () => {
-    const src = await insertSource(ns, { external_id: "stale-src" });
-    const handler = makeGraphDerivationHandler({ pool, auth });
-    await expect(
-      handler(
-        jobFor(
-          {
-            source_id: src.id,
-            source_kind: "git",
-            external_id: src.external_id,
-            content_hash: hashA,
-            revision: src.revision + 99,
-          },
-          ns,
-        ),
-      ),
-    ).rejects.toThrow();
-
-    // Nothing derived: no anchor entity was written.
-    const anchor = await pool.query(
-      "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
-      [ns],
-    );
-    expect(anchor.rows[0].n).toBe(0);
-  });
-
-  it("no derived edge crosses the namespace boundary", async () => {
-    const here = await insertSource(ns, { external_id: "iso-here" });
-    const there = await insertSource(otherNs, { external_id: "iso-there" });
-    const handler = makeGraphDerivationHandler({ pool, auth });
-    await handler(
-      jobFor(
-        {
-          source_id: here.id,
-          source_kind: "git",
-          external_id: here.external_id,
-          content_hash: hashA,
-          revision: here.revision,
-          metadata: { topics: ["Shared Topic"], people: [] },
-        },
-        ns,
-      ),
-    );
-    await handler(
-      jobFor(
-        {
-          source_id: there.id,
-          source_kind: "git",
-          external_id: there.external_id,
-          content_hash: hashA,
-          revision: there.revision,
-          metadata: { topics: ["Shared Topic"], people: [] },
-        },
-        otherNs,
-      ),
-    );
-
-    // Every edge sits entirely within one namespace on both endpoints.
-    const crossing = await pool.query(
-      `SELECT COUNT(*)::int AS n
-         FROM ob_links l
-         JOIN ob_entities f ON f.id = l.from_id
-         JOIN ob_entities t ON t.id = l.to_id
-        WHERE l.namespace = ANY($1::text[])
-          AND (f.namespace <> l.namespace OR t.namespace <> l.namespace)`,
-      [[ns, otherNs]],
-    );
-    expect(crossing.rows[0].n).toBe(0);
-  });
-
-  // -------------------------------------------------------------------------
-  // Mutation-sensitive regressions for the coupled P1 atomicity findings.
-  //
-  // These are the tests the pre-fix code fails: they mutate real graph state
-  // through a real failure/race, not a hand-modeled fake. Finding A: a failure
-  // AFTER the anchor/hash mutation but BEFORE completion must roll the whole
-  // derivation back — no partial hash/nodes/links — so a retry converges rather
-  // than being falsely short-circuited by a completed hash. Finding B: an old
-  // job must never overwrite a newer committed graph; the FOR UPDATE snapshot
-  // guard serializes it so it either runs before the source advances or observes
-  // drift and terminal-stops.
-  // -------------------------------------------------------------------------
-
-  /**
-   * Wrap a pool so the client it hands out throws exactly once, on the first
-   * statement whose SQL contains `failOn`. Everything else — including
-   * BEGIN/COMMIT/ROLLBACK and every other statement — passes straight through to
-   * a real checked-out client, so the transaction the handler opens is genuine
-   * and the injected failure lands mid-derivation on real Postgres state. This
-   * injects the failure without touching production code: the handler still runs
-   * its own BEGIN/guard/derive/COMMIT; we only make one inner statement fail.
-   *
-   * Two harness-safety rules the override MUST honor, or it corrupts the shared
-   * `pool` for every later query in the suite:
-   *  - Forward ALL arguments verbatim (`...args`), so the callback form
-   *    `client.query(text, values, cb)` that `pool.query()` uses internally
-   *    still resolves. An override that only accepts `(sql, params)` and returns
-   *    a Promise silently drops the callback, and every later `pool.query()` on
-   *    the reused connection hangs forever.
-   *  - Restore the pristine `query` when the client is released back to the
-   *    pool. The client we mutate is a POOLED connection; leaving the override
-   *    on it poisons whatever code checks it out next.
-   */
-  function poolFailingAfter(
-    real: Pool,
-    failOn: string,
-  ): Pick<Pool, "connect"> & { armed: boolean } {
-    const wrapper = {
-      armed: true,
-      connect: async () => {
-        const client = await real.connect();
-        const realQuery = client.query.bind(client);
-        const realRelease = client.release.bind(client);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (client as any).query = ((...args: unknown[]) => {
-          const sql = args[0];
-          if (wrapper.armed && String(sql).includes(failOn)) {
-            wrapper.armed = false;
-            throw new Error("injected mid-derivation failure");
-          }
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          return (realQuery as any)(...args);
-        }) as never;
-        // Un-patch on release so the pooled connection returns to the pool with
-        // its original query/release, never the failure-injecting override.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (client as any).release = ((...args: unknown[]) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (client as any).query = realQuery;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (client as any).release = realRelease;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          return (realRelease as any)(...args);
-        }) as never;
-        return client;
-      },
-    };
-    return wrapper as Pick<Pool, "connect"> & { armed: boolean };
-  }
-
-  it("rollback atomicity: a failure after the hash stamp leaves no partial graph, and retry converges", async () => {
-    const src = await insertSource(ns, { external_id: "rollback-src" });
-
-    // Inject a failure on the stale-edge prune UPDATE — the LAST derivation
-    // statement, which runs AFTER the anchor upsert has already stamped both the
-    // derivation_hash and the content_hash and after every term node + mentions
-    // edge has been inserted. Pre-fix (statements auto-committed on the pool),
-    // those writes would survive and the stamped hash would falsely short-
-    // circuit the retry. With the fix they all live in one transaction.
-    const failingPool = poolFailingAfter(
-      pool,
-      "UPDATE ob_links\n        SET archived_at = NOW()",
-    );
-    const failingHandler = makeGraphDerivationHandler({
-      pool: failingPool as unknown as Pool,
-      auth,
-    });
-
-    await expect(
-      failingHandler(
-        jobFor(
-          {
-            source_id: src.id,
-            source_kind: "git",
-            external_id: src.external_id,
-            content_hash: hashA,
-            revision: src.revision,
-            metadata: { topics: ["Migrations", "pgvector"], people: ["Rico"] },
-          },
-          ns,
-        ),
-      ),
-    ).rejects.toThrow("injected mid-derivation failure");
-
-    // ROLLBACK proof: nothing landed. No anchor, no term nodes, no edges — and
-    // crucially NO stamped hash for a retry to short-circuit past.
-    const entitiesAfterFail = await pool.query(
-      "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
-      [ns],
-    );
-    expect(entitiesAfterFail.rows[0].n).toBe(0);
-    const linksAfterFail = await pool.query(
-      "SELECT COUNT(*)::int AS n FROM ob_links WHERE namespace = $1",
-      [ns],
-    );
-    expect(linksAfterFail.rows[0].n).toBe(0);
-    const anchorAfterFail = await pool.query(
-      `SELECT COUNT(*)::int AS n FROM ob_entities
-        WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3`,
-      [ns, SOURCE_ANCHOR_ENTITY_TYPE, `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`],
-    );
-    expect(anchorAfterFail.rows[0].n).toBe(0);
-    // The source is still selectable (never derived), proving no partial hash.
-    const stillNeeded = await selectSourcesNeedingDerivation(pool, [ns]);
-    expect(stillNeeded.length).toBe(1);
-    expect(stillNeeded[0]!.id).toBe(src.id);
-
-    // Retry on the healthy pool: the derivation now converges fully.
-    const handler = makeGraphDerivationHandler({ pool, auth });
-    await handler(
-      jobFor(
-        {
-          source_id: src.id,
-          source_kind: "git",
-          external_id: src.external_id,
-          content_hash: hashA,
-          revision: src.revision,
-          metadata: { topics: ["Migrations", "pgvector"], people: ["Rico"] },
-        },
-        ns,
-      ),
-    );
-    const entitiesAfterRetry = await pool.query(
-      "SELECT COUNT(*)::int AS n FROM ob_entities WHERE namespace = $1",
-      [ns],
-    );
-    // anchor + 2 topics + 1 person = 4 nodes; 3 mentions edges.
-    expect(entitiesAfterRetry.rows[0].n).toBe(4);
-    const linksAfterRetry = await pool.query(
-      "SELECT COUNT(*)::int AS n FROM ob_links WHERE namespace = $1 AND relation = 'mentions'",
-      [ns],
-    );
-    expect(linksAfterRetry.rows[0].n).toBe(3);
-    const anchorAfterRetry = await pool.query(
-      `SELECT metadata ->> 'content_hash' AS content_hash
-         FROM ob_entities
-        WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
-          AND archived_at IS NULL`,
-      [ns, SOURCE_ANCHOR_ENTITY_TYPE, `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`],
-    );
-    expect(anchorAfterRetry.rows[0].content_hash).toBe(hashA);
-    // Fully converged now: no longer selectable.
-    const afterRetrySelect = await selectSourcesNeedingDerivation(pool, [ns]);
-    expect(afterRetrySelect.length).toBe(0);
-  });
-
-  it("serialized interleave: an old job cannot overwrite a newer committed graph and terminal-stops on drift", async () => {
-    // The source starts at revision R / hash A. The registry then advances it to
-    // revision R+1 / hash B (new bytes AND new terms). A fresh job for (B, R+1)
-    // derives the newer graph. The OLD job for (A, R) — still in the queue — must
-    // never overwrite that newer graph: its FOR UPDATE guard re-reads the live
-    // row under the (A, R) predicate, matches zero rows, and terminal-stops.
-    const src = await insertSource(ns, { external_id: "interleave-src" });
-    const oldRevision = src.revision;
-    const handler = makeGraphDerivationHandler({ pool, auth });
-
-    // Old job runs first and commits the A-graph (one topic: "OldTopic").
-    await handler(
-      jobFor(
-        {
-          source_id: src.id,
-          source_kind: "git",
-          external_id: src.external_id,
-          content_hash: hashA,
-          revision: oldRevision,
-          metadata: { topics: ["OldTopic"], people: [] },
-        },
-        ns,
-      ),
-    );
-
-    // The registry observes new content and advances the source (hash + revision
-    // bump, exactly as source-registry.ts does on a content change).
-    const bumped = await pool.query(
-      `UPDATE ob_sources SET content_hash = $1, revision = revision + 1
-        WHERE id = $2 AND namespace = $3 RETURNING revision`,
-      [hashB, src.id, ns],
-    );
-    const newRevision = bumped.rows[0].revision as number;
-
-    // A fresh job for the newer snapshot derives the B-graph ("NewTopic").
-    await handler(
-      jobFor(
-        {
-          source_id: src.id,
-          source_kind: "git",
-          external_id: src.external_id,
-          content_hash: hashB,
-          revision: newRevision,
-          metadata: { topics: ["NewTopic"], people: [] },
-        },
-        ns,
-      ),
-    );
-
-    // The graph now reflects the NEWER snapshot: anchor stamped hashB, a live
-    // anchor->NewTopic edge, and the stale anchor->OldTopic edge pruned.
-    async function graphState() {
-      const anchor = await pool.query(
-        `SELECT id, metadata ->> 'content_hash' AS content_hash,
-                metadata ->> 'derivation_hash' AS derivation_hash
-           FROM ob_entities
-          WHERE namespace = $1 AND entity_type = $2 AND canonical_id = $3
-            AND archived_at IS NULL`,
-        [
-          ns,
-          SOURCE_ANCHOR_ENTITY_TYPE,
-          `${SOURCE_ANCHOR_ENTITY_TYPE}:${src.id}`,
-        ],
-      );
-      const liveTopics = await pool.query(
-        `SELECT e.name
-           FROM ob_links l
-           JOIN ob_entities e ON e.id = l.to_id
-          WHERE l.namespace = $1 AND l.from_id = $2 AND l.relation = 'mentions'
-            AND l.archived_at IS NULL
-          ORDER BY e.name`,
-        [ns, anchor.rows[0].id],
-      );
-      return {
-        contentHash: anchor.rows[0].content_hash as string,
-        derivationHash: anchor.rows[0].derivation_hash as string,
-        liveTopics: liveTopics.rows.map((r) => r.name as string),
-      };
-    }
-    const newer = await graphState();
-    expect(newer.contentHash).toBe(hashB);
-    expect(newer.liveTopics).toEqual(["NewTopic"]);
-
-    // Now replay the OLD job for (A, R). It is obsolete: the live row is (B, R+1).
-    // The FOR UPDATE snapshot guard matches zero rows -> terminal-stop. It must
-    // NOT overwrite the newer graph or re-stamp the old hash.
-    await expect(
-      handler(
-        jobFor(
-          {
-            source_id: src.id,
-            source_kind: "git",
-            external_id: src.external_id,
-            content_hash: hashA,
-            revision: oldRevision,
-            metadata: { topics: ["OldTopic"], people: [] },
-          },
-          ns,
-        ),
-      ),
-    ).rejects.toBeInstanceOf(GraphDerivationTerminalError);
-
-    // The committed graph is UNCHANGED — still the newer B-snapshot. No stale
-    // overwrite: the anchor still stamps hashB and OldTopic did not revive.
-    const afterOldReplay = await graphState();
-    expect(afterOldReplay.contentHash).toBe(hashB);
-    expect(afterOldReplay.derivationHash).toBe(newer.derivationHash);
-    expect(afterOldReplay.liveTopics).toEqual(["NewTopic"]);
-
-    // Finally, prove the serialization comes from the HANDLER'S OWN guard, not a
-    // hand-taken lock: while a real handler derivation is mid-transaction (its
-    // FOR UPDATE guard holding the source row), a competing registry UPDATE on
-    // that same row must BLOCK until the handler commits. Pre-fix — no
-    // transaction, no FOR UPDATE — the competing UPDATE would proceed
-    // immediately and advance the snapshot out from under the in-flight job.
-    //
-    // We slow the handler's transaction from the inside by delaying its first
-    // derivation write (the anchor upsert), which runs AFTER the FOR UPDATE
-    // guard has locked the row and BEFORE COMMIT. That widens the window during
-    // which the row lock is held so the race is observable deterministically.
-    const src2 = await insertSource(ns, {
-      external_id: "lock-serialize-src",
-      title: "lock serialization source",
-    });
-    let updateResolved = false;
-    const slowPool = {
-      connect: async () => {
-        const client = await pool.connect();
-        const realQuery = client.query.bind(client);
-        const realRelease = client.release.bind(client);
-        let delayed = false;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (client as any).query = (async (...args: unknown[]) => {
-          // Delay once, on the first anchor upsert — inside the transaction,
-          // after the guard's FOR UPDATE has taken the row lock.
-          if (!delayed && String(args[0]).includes("INSERT INTO ob_entities")) {
-            delayed = true;
-            await new Promise((r) => setTimeout(r, 300));
-          }
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          return (realQuery as any)(...args);
-        }) as never;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (client as any).release = ((...a: unknown[]) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (client as any).query = realQuery;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (client as any).release = realRelease;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          return (realRelease as any)(...a);
-        }) as never;
-        return client;
-      },
-    };
-    const slowHandler = makeGraphDerivationHandler({
-      pool: slowPool as unknown as Pool,
-      auth,
-    });
-    const derivation = slowHandler(
-      jobFor(
-        {
-          source_id: src2.id,
-          source_kind: "git",
-          external_id: src2.external_id,
-          content_hash: hashA,
-          revision: src2.revision,
-          metadata: { topics: ["LockTopic"], people: [] },
-        },
-        ns,
-      ),
-    );
-    // Let the handler reach its in-transaction delay (guard row lock held).
-    await new Promise((r) => setTimeout(r, 100));
-    // A competing registry update on the locked row must BLOCK, not proceed.
-    const competing = pool
-      .query(
-        `UPDATE ob_sources SET content_hash = $1, revision = revision + 1
-          WHERE id = $2 AND namespace = $3`,
-        [hashB, src2.id, ns],
-      )
-      .then(() => {
-        updateResolved = true;
-      });
-    // Still inside the handler's transaction: the competing UPDATE is blocked.
-    await new Promise((r) => setTimeout(r, 100));
-    expect(updateResolved).toBe(false);
-    // Handler commits and releases the lock; the competing update now completes.
-    await derivation;
-    await competing;
-    expect(updateResolved).toBe(true);
-  });
+  it(
+    "selects a new approved source, skips pending/retired/foreign, derives, then no-ops",
+    selectsNewApprovedSourceThenNoOps,
+  );
+  it(
+    "changed content hash is re-selected and derived without duplicating the anchor",
+    changedHashReselectedWithoutDuplicatingAnchor,
+  );
+  it(
+    "changed bytes but identical terms still converges (content_hash stamp refreshes)",
+    changedBytesIdenticalTermsStillConverges,
+  );
+  it(
+    "snapshot guard: a stale-revision job derives nothing against the live row",
+    snapshotGuardStaleRevisionDerivesNothing,
+  );
 });


### PR DESCRIPTION
## Summary

- `src/graph-derivation-handler.live.test.ts` read `OPENBRAIN_TEST_DATABASE_URL` itself and swapped in `describe.skip` when it was unset. Absent the variable it reported `0 pass, 8 skip, 0 fail` and exited 0, which at the exit code is indistinguishable from a suite that ran and passed. It now calls `requireTestDatabaseUrl()` at module scope and fails loudly with `test_database_required`.
- Split by subject in the same change, because the pre-commit gate lints staged files whole and the 770-line original carried eight findings on `origin/main` (5 `no-non-null-assertion`, 2 `max-lines-per-function`, 1 `max-lines`). `src/graph-derivation-handler.live.test.ts` keeps selection and convergence; the new `src/graph-derivation-handler-isolation.live.test.ts` takes isolation and atomicity, and `poolFailingAfter` moves with it.
- New `src/graph-derivation-handler-test-helpers.ts` holds the namespaces, auth, `cleanup`, `insertSource` and `jobFor`. It creates no pool: each database function takes the caller's `pool` first, so each half creates one module-scope pool and ends exactly its own connection in its own `afterAll`.
- Test names, order and assertions are unchanged. Every `it` body is a hoisted module-scope `async function` so no describe callback exceeds the code-line standard, and the five non-null assertions became an `expectDefined(value, label)` guard exported from the helper module. No disable comments.
- `scripts/assert-db-tests-ran.ts` registers both new describe names at their JUnit-measured counts (4 and 3) and moves `MIN_TOTAL_LIVE_TESTCASES` 285 -> 292, with the comment chain extended by one clause.
- `src/graph-derivation-handler.ts` and `src/maintenance-queue.ts` are untouched.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- Run as `CHANGED_FILES="src/graph-derivation-handler.live.test.ts src/graph-derivation-handler-isolation.live.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh`. RED on `origin/main` before any edit: exit 1, clauses 1/2/3 FAIL. GREEN on the committed tree: exit 0, all four clauses PASS.
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts on the committed tree:

- `./node_modules/.bin/oxlint --deny-warnings` over all four touched files -> exit 0, no findings.
- `bunx tsc --noEmit` -> exit 0.
- `bun run test:isolated src/graph-derivation-handler.live.test.ts src/graph-derivation-handler-isolation.live.test.ts --reporter=junit` -> exit 0, 7 pass / 0 fail / 39 expect() calls, 4 and 3 `testcase` elements per describe.

## Critical Self-Review

- Highest-risk behavior: the split could silently drop a test or an assertion. Guarded by moving every body with shell line-range copies rather than retyping, and by the JUnit counts summing to the original 7 with 39 expect() calls.
- Assumptions that could be wrong: that the two halves share no state through the database. They use the same two namespaces and each half runs its own `beforeEach(cleanup)`, so a concurrent run of both files could interleave deletes. Bun runs test files in one process sequentially, so this is not exercised today, but it is the assumption most likely to bite if the runner ever parallelizes.
- Missing/weak tests: none added -- this is a conversion, and the assertion set is byte-identical to `origin/main`. The `expectDefined` guard itself has no direct unit test; its failure path is only reached when an assertion was already going to fail.
- Security/permission risk: none. No auth, namespace predicate, or SQL changed; the namespace-isolation test moved intact and still asserts no derived edge crosses the boundary.
- Migration/deploy risk: none. No migration, no runtime source file, and the helper module is test-only.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classifies this as not applicable -- no MCP tool, schema, protocol, or client-facing surface is touched.
- Rollback/cleanup concern: reverting the commit restores the single file. The two new files and the helper would need deleting with it, and the manifest floor would need to return to 285; a partial revert that left the floor at 292 would fail CI's anti-skip guard.
- Fixes made before PR: added the missing `otherNs` import that `tsc` caught after the split; replaced the five `x!` assertions with `expectDefined`; ran prettier and re-took every lint, typecheck, test, and done-means receipt on the committed tree rather than the staged one.
- Known residual risk: the interleave test runs as two sequential halves under one `it` to keep each function under the code-line standard. The halves are independent (the second shares no variable with the first), but a future edit that introduces a dependency across the seam would be easy to miss.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane found no new MEDIUM+ pattern -- the split, hoist, and helper-takes-pool shapes are already captured in round 39 of the lane contract's Tightenings from the session-9 lanes.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: test-only change with no runtime or contract surface.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape changed -- the diff is test files and the anti-skip manifest.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable throughout: no MCP tool, transport, schema, or Python client path is in the diff.
