### PR TITLE
test(pg): the source sync test requires the test database instead of skipping (#878)

### DIFF
--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -46,6 +46,14 @@ export const REQUIRED_SUITES: ReadonlyArray<{
     minTests: 8,
   },
   {
+    name: "resumable file-source sync plan, checkpoint, and concurrency (live Postgres)",
+    minTests: 4,
+  },
+  {
+    name: "resumable file-source sync idempotence and isolation (live Postgres)",
+    minTests: 6,
+  },
+  {
     name: "search_brain relational retrieval eval fixture (live Postgres)",
     minTests: 2,
   },
@@ -454,9 +462,11 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // clustering and cursor loops suite's 8 as that file stopped skipping
 // itself, then 285 -> 292 when #878 registered the two subject-split graph
 // derivation handler selection/convergence and isolation/atomicity suites'
-// 4 + 3 as that file stopped skipping itself), so the global floor cannot
-// silently fall behind the per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 292;
+// 4 + 3 as that file stopped skipping itself, then 292 -> 302 when #878
+// registered the two subject-split source-sync plan/checkpoint/concurrency
+// and idempotence/isolation suites' 4 + 6 as that file stopped skipping
+// itself), so the global floor cannot silently fall behind the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 302;
 
 export interface SuiteStats {
   tests: number;

--- a/src/source-sync-idempotence.pg.test.ts
+++ b/src/source-sync-idempotence.pg.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Live-Postgres functional coverage for resumable file-source synchronization
+ * (Issue #338): the idempotence and isolation half. Split from
+ * src/source-sync.pg.test.ts, which keeps the plan/checkpoint/concurrency half.
+ *
+ * The suite requires the test database rather than skipping itself when it is
+ * absent (Issue #878): requireTestDatabaseUrl() throws at module scope so a
+ * database-less run fails loudly instead of reporting a false green.
+ *
+ * What is proven end to end (behavioral input -> output, never SQL shape):
+ *  1. Re-running a completed sync over the same observation is a no-op.
+ *  2. A fresh no-op plan reports its unchanged count through the receipt.
+ *  3. Reverting to an earlier observation (A->B->A) plans a fresh run rather
+ *     than reopening completed history, and restores manifest A exactly.
+ *  4. Namespace isolation: two namespaces that registered the same external
+ *     location keep entirely separate manifests; a sync in one never touches
+ *     the other.
+ *  5. Authorization and lifecycle eligibility both refuse a sync.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../scripts/test-support/require-test-database.ts";
+import { runMigrations } from "./db/migrate.ts";
+import { updateSource } from "./source-registry.ts";
+import { observationHash, syncSource } from "./source-sync.ts";
+import {
+  admin,
+  approvedSource,
+  cleanupNamespaces,
+  expectDefined,
+  H,
+  liveManifest,
+  obs,
+} from "./source-sync-test-helpers.ts";
+import type { AuthInfo } from "./types.ts";
+
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+
+// Unique namespaces per run so cleanup owns exactly these rows.
+const nsA = "lane338-idem-ns-a";
+const nsB = "lane338-idem-ns-b";
+
+async function cleanup(): Promise<void> {
+  await cleanupNamespaces(pool, [nsA, nsB]);
+}
+
+beforeAll(async () => {
+  await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+  await runMigrations(pool);
+});
+
+afterAll(async () => {
+  await cleanup();
+  await pool.end();
+});
+
+beforeEach(cleanup);
+
+async function reRunCompletedSyncIsNoOp(): Promise<void> {
+  const sourceId = await approvedSource(pool, nsA, "git://acme/repo-noop");
+  const observation = obs([
+    ["a.ts", H(1)],
+    ["b.ts", H(2)],
+  ]);
+  const first = await syncSource(pool, admin(), sourceId, observation, {
+    target_namespace: nsA,
+  });
+  // Fresh plan on an empty manifest: two adds, nothing unchanged yet.
+  expect(first.data?.resumed).toBe(false);
+  expect(first.data?.counts.unchanged).toBe(0);
+  expect(first.data?.status).toBe("completed");
+  const firstRunId = first.data?.run_id;
+
+  const m1 = await liveManifest(pool, nsA, sourceId);
+  const idsBefore = new Map([...m1.entries()].map(([p, v]) => [p, v.file_id]));
+
+  const again = await syncSource(pool, admin(), sourceId, observation, {
+    target_namespace: nsA,
+  });
+  expect(again.ok).toBe(true);
+  expect(again.data?.status).toBe("completed");
+  // The first run is COMPLETED history and is not resumable, so this is a FRESH
+  // run (not a reuse of the terminal run). A fresh run cannot regress the
+  // manifest — only running runs are resumable — which is exactly the guard the
+  // A->B->A revert case depends on.
+  expect(again.data?.resumed).toBe(false);
+  expect(again.data?.run_id).not.toBe(firstRunId);
+  // The fresh plan diffs the current manifest, which already matches the
+  // observation exactly: zero mutating ops, both files reported unchanged.
+  expect(again.data?.counts).toMatchObject({
+    added: 0,
+    edited: 0,
+    renamed: 0,
+    deleted: 0,
+    unchanged: 2,
+  });
+
+  // Behaviorally a no-op: the manifest is byte-for-byte unchanged, including
+  // every durable file_id (no delete+re-add churn).
+  const m2 = await liveManifest(pool, nsA, sourceId);
+  expect([...m2.keys()].sort()).toEqual(["a.ts", "b.ts"]);
+  for (const [path, v] of m2) {
+    expect(v.content_hash).toBe(expectDefined(m1.get(path), "m1 entry").content_hash);
+    expect(v.file_id).toBe(expectDefined(idsBefore.get(path), "idsBefore entry"));
+  }
+  // No live path duplicated by the second run.
+  const { rows: dup } = await pool.query(
+    `SELECT path, COUNT(*) AS n FROM ob_source_files
+      WHERE source_id = $1 AND namespace = $2 AND state = 'live'
+      GROUP BY path HAVING COUNT(*) > 1`,
+    [sourceId, nsA],
+  );
+  expect(dup.length).toBe(0);
+}
+
+async function freshNoOpPlanReportsUnchanged(): Promise<void> {
+  const sourceId = await approvedSource(pool, nsA, "git://acme/repo-freshnoop");
+  // Seed the manifest.
+  await syncSource(
+    pool,
+    admin(),
+    sourceId,
+    obs([
+      ["a.ts", H(1)],
+      ["b.ts", H(2)],
+    ]),
+    { target_namespace: nsA },
+  );
+
+  // A DISTINCT observation (different hash → fresh plan) whose file set exactly
+  // matches the live manifest. No ops are emitted, and because it is a fresh
+  // plan the receipt carries the full unchanged count — proving counts.unchanged
+  // is plumbed through, not discarded.
+  const noop = await syncSource(
+    pool,
+    admin(),
+    sourceId,
+    obs([
+      ["a.ts", H(1)],
+      ["b.ts", H(2)],
+      // add a third file so the observation hash differs from the seed run,
+      // forcing a fresh plan rather than a resume of the seed run.
+      ["c.ts", H(3)],
+    ]),
+    { target_namespace: nsA },
+  );
+  expect(noop.data?.resumed).toBe(false);
+  expect(noop.data?.counts).toMatchObject({
+    added: 1, // c.ts is the only op
+    edited: 0,
+    renamed: 0,
+    deleted: 0,
+    unchanged: 2, // a.ts and b.ts matched — plumbed into the receipt
+  });
+}
+
+async function revertPlansFreshRun(): Promise<void> {
+  // A completed run is terminal HISTORY, not a resumable checkpoint. When a
+  // source reverts to a corpus it already synced (A -> B -> A), the recurring
+  // observation A must NOT reopen A's old completed run — that run's checkpoint
+  // is at plan end, so reusing it would re-apply only its tail and leave the
+  // intermediate B edit (b.ts at H(9)) in place while reporting completed. It
+  // must instead plan a FRESH run against the CURRENT (B) manifest, which emits
+  // the edit that restores A, and preserve the prior completed run as history.
+  const sourceId = await approvedSource(pool, nsA, "git://acme/repo-revert");
+
+  const obsA = obs([
+    ["a.ts", H(1)],
+    ["b.ts", H(2)],
+  ]);
+  const obsB = obs([
+    ["a.ts", H(1)],
+    ["b.ts", H(9)],
+  ]);
+
+  // A: two adds, completes.
+  const runA1 = await syncSource(pool, admin(), sourceId, obsA, {
+    target_namespace: nsA,
+  });
+  expect(runA1.data?.status).toBe("completed");
+  expect(runA1.data?.counts.added).toBe(2);
+  const runA1Id = runA1.data?.run_id;
+
+  // B: edit b.ts H(2) -> H(9), completes. Manifest now diverged from A.
+  const runB = await syncSource(pool, admin(), sourceId, obsB, {
+    target_namespace: nsA,
+  });
+  expect(runB.data?.status).toBe("completed");
+  expect(runB.data?.counts).toMatchObject({ edited: 1, added: 0 });
+  expect(
+    expectDefined(
+      (await liveManifest(pool, nsA, sourceId)).get("b.ts"),
+      "manifest b.ts",
+    ).content_hash,
+  ).toBe(H(9));
+
+  // A again: SAME observation hash as runA1, but runA1 is completed history.
+  // This must create a fresh run that edits b.ts back H(9) -> H(2).
+  const runA2 = await syncSource(pool, admin(), sourceId, obsA, {
+    target_namespace: nsA,
+  });
+  expect(runA2.ok).toBe(true);
+  expect(runA2.data?.status).toBe("completed");
+  // Fresh run, not a resume of history.
+  expect(runA2.data?.resumed).toBe(false);
+  // A fresh plan diffed the current (B) manifest: exactly the one edit that
+  // reverts b.ts, one unchanged (a.ts), no re-adds.
+  expect(runA2.data?.counts).toMatchObject({
+    added: 0,
+    edited: 1,
+    renamed: 0,
+    deleted: 0,
+    unchanged: 1,
+  });
+
+  // A DISTINCT run row was created — not the completed one reopened.
+  const runA2Id = runA2.data?.run_id;
+  expect(runA2Id).toBeDefined();
+  expect(runA2Id).not.toBe(runA1Id);
+
+  // The final live manifest matches observation A EXACTLY (paths + hashes).
+  const finalManifest = await liveManifest(pool, nsA, sourceId);
+  expect([...finalManifest.keys()].sort()).toEqual(["a.ts", "b.ts"]);
+  expect(
+    expectDefined(finalManifest.get("a.ts"), "finalManifest a.ts").content_hash,
+  ).toBe(H(1));
+  expect(
+    expectDefined(finalManifest.get("b.ts"), "finalManifest b.ts").content_hash,
+  ).toBe(H(2));
+  // No duplicate live rows.
+  const { rows: dup } = await pool.query(
+    `SELECT path, COUNT(*) AS n FROM ob_source_files
+      WHERE source_id = $1 AND namespace = $2 AND state = 'live'
+      GROUP BY path HAVING COUNT(*) > 1`,
+    [sourceId, nsA],
+  );
+  expect(dup.length).toBe(0);
+
+  // History is preserved: TWO run rows exist for observation A's hash — the
+  // original completed run AND the fresh one — and the original still exists,
+  // completed, untouched.
+  const obsAHash = observationHash(obsA);
+  const { rows: runRows } = await pool.query(
+    `SELECT id, status FROM ob_source_sync_runs
+      WHERE source_id = $1 AND namespace = $2 AND observation_hash = $3
+      ORDER BY created_at ASC`,
+    [sourceId, nsA, obsAHash],
+  );
+  expect(runRows.length).toBe(2);
+  const original = runRows.find((r) => r.id === runA1Id);
+  expect(original).toBeDefined();
+  expect(expectDefined(original, "original run row").status).toBe("completed");
+}
+
+async function isolatesManifestsPerNamespace(): Promise<void> {
+  // The SAME external id registered independently in two namespaces.
+  const ext = "git://acme/shared-repo";
+  const srcA = await approvedSource(pool, nsA, ext);
+  const srcB = await approvedSource(pool, nsB, ext);
+
+  await syncSource(pool, admin(), srcA, obs([["a.ts", H(1)]]), {
+    target_namespace: nsA,
+  });
+  await syncSource(
+    pool,
+    admin(),
+    srcB,
+    obs([
+      ["b.ts", H(2)],
+      ["c.ts", H(3)],
+    ]),
+    { target_namespace: nsB },
+  );
+
+  const mA = await liveManifest(pool, nsA, srcA);
+  const mB = await liveManifest(pool, nsB, srcB);
+  expect([...mA.keys()]).toEqual(["a.ts"]);
+  expect([...mB.keys()].sort()).toEqual(["b.ts", "c.ts"]);
+
+  // A sync targeting srcA's id under nsB must not resolve srcA (namespace-bound
+  // eligibility): the id is not registered in nsB.
+  const cross = await syncSource(pool, admin(), srcA, obs([["x.ts", H(9)]]), {
+    target_namespace: nsB,
+  });
+  expect(cross.ok).toBe(false);
+  expect(cross.code).toBe("source_not_found");
+  // srcA's own manifest is untouched by the cross-namespace attempt.
+  expect((await liveManifest(pool, nsA, srcA)).size).toBe(1);
+}
+
+async function rejectsUnwritableNamespace(): Promise<void> {
+  const sourceId = await approvedSource(pool, nsA, "git://acme/repo-authz");
+  // A header-scoped identity bound to a different namespace cannot write nsA.
+  const headerBound: AuthInfo = {
+    role: "agent",
+    clientId: "someone-else",
+    namespaceSource: "header",
+  };
+  const res = await syncSource(pool, headerBound, sourceId, obs([["a.ts", H(1)]]), {
+    target_namespace: nsA,
+  });
+  expect(res.ok).toBe(false);
+  expect(res.code).toBe("namespace_denied");
+}
+
+async function skipsPausedSource(): Promise<void> {
+  const sourceId = await approvedSource(pool, nsA, "git://acme/repo-paused");
+  // Pause it via the registry update path.
+  const { rows } = await pool.query(`SELECT revision FROM ob_sources WHERE id = $1`, [
+    sourceId,
+  ]);
+  await updateSource(pool, admin(), {
+    id: sourceId,
+    target_namespace: nsA,
+    expected_revision: rows[0].revision as number,
+    lifecycle_state: "paused",
+  });
+  const res = await syncSource(pool, admin(), sourceId, obs([["a.ts", H(1)]]), {
+    target_namespace: nsA,
+  });
+  expect(res.ok).toBe(false);
+  expect(res.code).toBe("source_not_eligible");
+}
+
+describe("resumable file-source sync idempotence and isolation (live Postgres)", () => {
+  it(
+    "re-running a completed sync over the same observation mutates nothing (fresh no-op plan)",
+    reRunCompletedSyncIsNoOp,
+  );
+
+  it(
+    "a fresh no-op plan over an already-synced manifest reports unchanged",
+    freshNoOpPlanReportsUnchanged,
+  );
+
+  it(
+    "reverting to an earlier observation (A->B->A) plans a fresh run and restores manifest A exactly",
+    revertPlansFreshRun,
+  );
+
+  it(
+    "isolates manifests per namespace for the same external location",
+    isolatesManifestsPerNamespace,
+  );
+
+  it(
+    "rejects a sync into a namespace the caller cannot write",
+    rejectsUnwritableNamespace,
+  );
+
+  it("skips syncing a paused (non-active) source", skipsPausedSource);
+});

--- a/src/source-sync-test-helpers.ts
+++ b/src/source-sync-test-helpers.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared fixtures for the two live-Postgres source-sync suites
+ * (src/source-sync.pg.test.ts and src/source-sync-idempotence.pg.test.ts).
+ *
+ * This module holds no test and creates no pool: each suite owns its own
+ * module-scope pool and passes it in, so neither suite's afterAll ends a
+ * connection the other is still using.
+ */
+import type { Pool } from "pg";
+import { registerSource } from "./source-registry.ts";
+import type { SourceObservation } from "./source-sync.ts";
+import type { AuthInfo } from "./types.ts";
+
+/** Narrows an optional value, throwing a labelled error when it is absent. */
+export function expectDefined<T>(value: T | null | undefined, label: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(`expected ${label} to be defined`);
+  }
+  return value;
+}
+
+export const H = (n: number): string => n.toString(16).padStart(64, "0");
+
+export function obs(files: Array<[string, string]>): SourceObservation {
+  return {
+    files: files.map(([path, content_hash]) => ({ path, content_hash })),
+  };
+}
+
+// A token-sourced admin identity: can register+approve and write any namespace.
+export function admin(): AuthInfo {
+  return { role: "admin", clientId: "lane338-admin", namespaceSource: "token" };
+}
+
+/**
+ * Delete the source rows the given namespaces own. Sync-run and manifest rows
+ * FK-cascade from ob_sources, so this clears everything the suite created.
+ */
+export async function cleanupNamespaces(
+  pool: Pool,
+  namespaces: string[],
+): Promise<void> {
+  await pool.query("DELETE FROM ob_sources WHERE namespace = ANY($1::text[])", [
+    namespaces,
+  ]);
+}
+
+/** Register + approve a git source in `namespace`, returning its id. */
+export async function approvedSource(
+  pool: Pool,
+  namespace: string,
+  externalId: string,
+): Promise<string> {
+  const reg = await registerSource(pool, admin(), {
+    source_kind: "git",
+    external_id: externalId,
+    target_namespace: namespace,
+    approved: true,
+  });
+  if (!reg.ok || !reg.data) throw new Error("register failed");
+  return reg.data.id;
+}
+
+/** The live manifest (path -> {file_id, content_hash}) for a source. */
+export async function liveManifest(
+  pool: Pool,
+  namespace: string,
+  sourceId: string,
+): Promise<Map<string, { file_id: string; content_hash: string }>> {
+  const { rows } = await pool.query(
+    `SELECT file_id, path, content_hash FROM ob_source_files
+      WHERE source_id = $1 AND namespace = $2 AND state = 'live'`,
+    [sourceId, namespace],
+  );
+  const out = new Map<string, { file_id: string; content_hash: string }>();
+  for (const r of rows) {
+    out.set(r.path as string, {
+      file_id: r.file_id as string,
+      content_hash: r.content_hash as string,
+    });
+  }
+  return out;
+}

--- a/src/source-sync.pg.test.ts
+++ b/src/source-sync.pg.test.ts
@@ -1,10 +1,12 @@
 /**
  * Live-Postgres functional coverage for resumable file-source synchronization
  * (Issue #338), exercised against the real migration-030 schema and the real
- * transaction/checkpoint path in syncSource.
+ * transaction/checkpoint path in syncSource. The idempotence and isolation half
+ * lives in src/source-sync-idempotence.pg.test.ts.
  *
- * Gated on OPENBRAIN_TEST_DATABASE_URL (repo convention): skips when unset so a
- * DB-less run passes, while the CI db-integration job runs it against Postgres.
+ * The suite requires the test database rather than skipping itself when it is
+ * absent (Issue #878): requireTestDatabaseUrl() throws at module scope so a
+ * database-less run fails loudly instead of reporting a false green.
  *
  * What is proven end to end (behavioral input -> output, never SQL shape):
  *  1. A full uninterrupted sync applies the reconciliation plan and leaves the
@@ -14,456 +16,209 @@
  *     stays `running` mid-way, then resumes and completes — and the resumed final
  *     manifest is IDENTICAL to an uninterrupted run over the same observation,
  *     with no duplicated files (idempotent at-least-once).
- *  4. Re-running a completed sync over the same observation is a no-op.
- *  5. Namespace isolation: two namespaces that registered the same external
- *     location keep entirely separate manifests; a sync in one never touches the
- *     other.
+ *  4. Concurrent syncs of one source serialize on the eligible-source row lock,
+ *     producing a single-writer manifest rather than a hybrid corpus.
  */
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-} from "bun:test";
-import type { Pool } from "pg";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../scripts/test-support/require-test-database.ts";
 import { runMigrations } from "./db/migrate.ts";
-import { registerSource, updateSource } from "./source-registry.ts";
+import { syncSource } from "./source-sync.ts";
 import {
-  observationHash,
-  syncSource,
-  type SourceObservation,
-} from "./source-sync.ts";
-import type { AuthInfo } from "./types.ts";
+  admin,
+  approvedSource,
+  cleanupNamespaces,
+  expectDefined,
+  H,
+  liveManifest,
+  obs,
+} from "./source-sync-test-helpers.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
-const H = (n: number): string => n.toString(16).padStart(64, "0");
+// Unique namespaces per run so cleanup owns exactly these rows.
+const nsA = "lane338-ns-a";
+const nsB = "lane338-ns-b";
 
-function obs(files: Array<[string, string]>): SourceObservation {
-  return {
-    files: files.map(([path, content_hash]) => ({ path, content_hash })),
-  };
+async function cleanup(): Promise<void> {
+  await cleanupNamespaces(pool, [nsA, nsB]);
 }
 
-// A token-sourced admin identity: can register+approve and write any namespace.
-function admin(): AuthInfo {
-  return { role: "admin", clientId: "lane338-admin", namespaceSource: "token" };
+beforeAll(async () => {
+  await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+  await runMigrations(pool);
+});
+
+afterAll(async () => {
+  await cleanup();
+  await pool.end();
+});
+
+beforeEach(cleanup);
+
+async function appliesFullPlan(): Promise<void> {
+  const sourceId = await approvedSource(pool, nsA, "git://acme/repo-full");
+
+  // First sync: three adds.
+  const first = await syncSource(
+    pool,
+    admin(),
+    sourceId,
+    obs([
+      ["keep.ts", H(1)],
+      ["edit.ts", H(2)],
+      ["old.ts", H(3)],
+    ]),
+    { target_namespace: nsA },
+  );
+  expect(first.ok).toBe(true);
+  expect(first.data?.status).toBe("completed");
+  expect(first.data?.counts.added).toBe(3);
+
+  const m1 = await liveManifest(pool, nsA, sourceId);
+  const renamedId = expectDefined(m1.get("old.ts"), "m1 old.ts").file_id;
+
+  // Second sync: keep unchanged, edit content, rename old.ts->new.ts, drop nothing
+  // new but add fresh.ts. edit.ts content changes; old.ts moves to new.ts.
+  const second = await syncSource(
+    pool,
+    admin(),
+    sourceId,
+    obs([
+      ["keep.ts", H(1)],
+      ["edit.ts", H(20)],
+      ["new.ts", H(3)],
+      ["fresh.ts", H(5)],
+    ]),
+    { target_namespace: nsA },
+  );
+  expect(second.ok).toBe(true);
+  expect(second.data?.status).toBe("completed");
+  // Mixed receipt: keep.ts is an unchanged no-op (no op emitted, counted as
+  // unchanged), plus one edit, one rename, one add. This is a FRESH plan, so
+  // counts.unchanged carries the no-op count.
+  expect(second.data?.resumed).toBe(false);
+  expect(second.data?.counts).toMatchObject({
+    added: 1,
+    edited: 1,
+    renamed: 1,
+    deleted: 0,
+    unchanged: 1,
+  });
+
+  const m2 = await liveManifest(pool, nsA, sourceId);
+  expect([...m2.keys()].sort()).toEqual(["edit.ts", "fresh.ts", "keep.ts", "new.ts"]);
+  // Rename preserved the durable file_id; old path is gone.
+  expect(expectDefined(m2.get("new.ts"), "m2 new.ts").file_id).toBe(renamedId);
+  expect(m2.has("old.ts")).toBe(false);
+  // Edit kept identity, changed hash.
+  expect(expectDefined(m2.get("edit.ts"), "m2 edit.ts").content_hash).toBe(H(20));
+  expect(expectDefined(m2.get("edit.ts"), "m2 edit.ts").file_id).toBe(
+    expectDefined(m1.get("edit.ts"), "m1 edit.ts").file_id,
+  );
 }
 
-dbDescribe("resumable file-source sync (live Postgres)", () => {
-  let pool: Pool;
-  // Unique namespaces per run so cleanup owns exactly these rows.
-  const nsA = "lane338-ns-a";
-  const nsB = "lane338-ns-b";
+async function checkpointsSplitRunAndResumes(): Promise<void> {
+  const interrupted = await approvedSource(pool, nsA, "git://acme/repo-resume");
+  const straight = await approvedSource(pool, nsA, "git://acme/repo-straight");
 
-  beforeAll(async () => {
-    const { Pool } = await import("pg");
-    pool = new Pool({ connectionString: DB_URL });
-    await pool.query("CREATE EXTENSION IF NOT EXISTS vector");
-    await runMigrations(pool);
+  const observation = obs([
+    ["a.ts", H(1)],
+    ["b.ts", H(2)],
+    ["c.ts", H(3)],
+    ["d.ts", H(4)],
+    ["e.ts", H(5)],
+  ]);
+
+  // Uninterrupted baseline.
+  const baseline = await syncSource(pool, admin(), straight, observation, {
+    target_namespace: nsA,
   });
+  expect(baseline.data?.status).toBe("completed");
+  expect(baseline.data?.counts.added).toBe(5);
 
-  afterAll(async () => {
-    await cleanup();
-    await pool.end();
+  // Interrupted: apply only 2 of the 5 ops, then stop mid-run.
+  const partial = await syncSource(pool, admin(), interrupted, observation, {
+    target_namespace: nsA,
+    apply_budget: 2,
   });
+  expect(partial.ok).toBe(true);
+  expect(partial.data?.status).toBe("running");
+  expect(partial.data?.applied_ops).toBe(2);
+  expect(partial.data?.resumed).toBe(false);
+  // Only a partial manifest is live so far.
+  expect((await liveManifest(pool, nsA, interrupted)).size).toBe(2);
 
-  async function cleanup(): Promise<void> {
-    // Sync-run and manifest rows FK-cascade from ob_sources; deleting the source
-    // rows this suite created clears everything it owns in both namespaces.
-    await pool.query(
-      "DELETE FROM ob_sources WHERE namespace = ANY($1::text[])",
-      [[nsA, nsB]],
-    );
+  // Persisted checkpoint advanced.
+  const { rows: ckpt } = await pool.query(
+    `SELECT checkpoint_index, status FROM ob_source_sync_runs
+      WHERE source_id = $1 AND namespace = $2`,
+    [interrupted, nsA],
+  );
+  expect(ckpt[0].status).toBe("running");
+  expect(ckpt[0].checkpoint_index).toBe(2);
+
+  // Resume with the SAME observation. It re-plans to the persisted run and
+  // finishes the tail; the boundary op is re-applied idempotently.
+  const resumed = await syncSource(pool, admin(), interrupted, observation, {
+    target_namespace: nsA,
+  });
+  expect(resumed.ok).toBe(true);
+  expect(resumed.data?.status).toBe("completed");
+  expect(resumed.data?.resumed).toBe(true);
+
+  // Final manifests match exactly (by path + content_hash); no duplicates.
+  const mResumed = await liveManifest(pool, nsA, interrupted);
+  const mBaseline = await liveManifest(pool, nsA, straight);
+  expect(mResumed.size).toBe(5);
+  expect(mBaseline.size).toBe(5);
+  for (const [path, v] of mBaseline) {
+    expect(mResumed.get(path)?.content_hash).toBe(v.content_hash);
   }
+  // No file row is duplicated: total live rows equals distinct paths.
+  const { rows: dupCheck } = await pool.query(
+    `SELECT path, COUNT(*) AS n FROM ob_source_files
+      WHERE source_id = $1 AND namespace = $2 AND state = 'live'
+      GROUP BY path HAVING COUNT(*) > 1`,
+    [interrupted, nsA],
+  );
+  expect(dupCheck.length).toBe(0);
+}
 
-  beforeEach(cleanup);
+async function serializesConcurrentSyncs(): Promise<void> {
+  // Two concurrent syncs of the SAME source must not interleave their manifest
+  // read/plan/commit. Without a lock, both planners read the same manifest and
+  // commit disjoint edits, producing a hybrid corpus neither caller observed,
+  // and a late resumer can regress a checkpoint. syncSource takes a FOR UPDATE
+  // lock on the eligible source row BEFORE reading the manifest and holds it
+  // through COMMIT, so the second sync blocks until the first commits and then
+  // plans against the manifest the first already produced.
+  //
+  // Determinism without a production hook: this test itself holds the exact
+  // source-row lock syncSource would take (same namespace + id predicate) in an
+  // outer transaction, launches syncSource concurrently, and proves it cannot
+  // make progress until the test releases the lock. The gate is real Postgres
+  // row locking, not a sleep race.
+  const sourceId = await approvedSource(pool, nsA, "git://acme/repo-serialize");
 
-  /** Register + approve a git source in `namespace`, returning its id. */
-  async function approvedSource(
-    namespace: string,
-    externalId: string,
-  ): Promise<string> {
-    const reg = await registerSource(pool, admin(), {
-      source_kind: "git",
-      external_id: externalId,
-      target_namespace: namespace,
-      approved: true,
-    });
-    if (!reg.ok || !reg.data) throw new Error("register failed");
-    return reg.data.id;
-  }
-
-  /** The live manifest (path -> {file_id, content_hash}) for a source. */
-  async function liveManifest(
-    namespace: string,
-    sourceId: string,
-  ): Promise<Map<string, { file_id: string; content_hash: string }>> {
-    const { rows } = await pool.query(
-      `SELECT file_id, path, content_hash FROM ob_source_files
-        WHERE source_id = $1 AND namespace = $2 AND state = 'live'`,
-      [sourceId, namespace],
-    );
-    const out = new Map<string, { file_id: string; content_hash: string }>();
-    for (const r of rows) {
-      out.set(r.path as string, {
-        file_id: r.file_id as string,
-        content_hash: r.content_hash as string,
-      });
-    }
-    return out;
-  }
-
-  it("applies a full add/edit/rename/delete plan and leaves the expected manifest", async () => {
-    const sourceId = await approvedSource(nsA, "git://acme/repo-full");
-
-    // First sync: three adds.
-    const first = await syncSource(
-      pool,
-      admin(),
-      sourceId,
-      obs([
-        ["keep.ts", H(1)],
-        ["edit.ts", H(2)],
-        ["old.ts", H(3)],
-      ]),
-      { target_namespace: nsA },
-    );
-    expect(first.ok).toBe(true);
-    expect(first.data?.status).toBe("completed");
-    expect(first.data?.counts.added).toBe(3);
-
-    const m1 = await liveManifest(nsA, sourceId);
-    const renamedId = m1.get("old.ts")!.file_id;
-
-    // Second sync: keep unchanged, edit content, rename old.ts->new.ts, drop nothing
-    // new but add fresh.ts. edit.ts content changes; old.ts moves to new.ts.
-    const second = await syncSource(
-      pool,
-      admin(),
-      sourceId,
-      obs([
-        ["keep.ts", H(1)],
-        ["edit.ts", H(20)],
-        ["new.ts", H(3)],
-        ["fresh.ts", H(5)],
-      ]),
-      { target_namespace: nsA },
-    );
-    expect(second.ok).toBe(true);
-    expect(second.data?.status).toBe("completed");
-    // Mixed receipt: keep.ts is an unchanged no-op (no op emitted, counted as
-    // unchanged), plus one edit, one rename, one add. This is a FRESH plan, so
-    // counts.unchanged carries the no-op count.
-    expect(second.data?.resumed).toBe(false);
-    expect(second.data?.counts).toMatchObject({
-      added: 1,
-      edited: 1,
-      renamed: 1,
-      deleted: 0,
-      unchanged: 1,
-    });
-
-    const m2 = await liveManifest(nsA, sourceId);
-    expect([...m2.keys()].sort()).toEqual([
-      "edit.ts",
-      "fresh.ts",
-      "keep.ts",
-      "new.ts",
-    ]);
-    // Rename preserved the durable file_id; old path is gone.
-    expect(m2.get("new.ts")!.file_id).toBe(renamedId);
-    expect(m2.has("old.ts")).toBe(false);
-    // Edit kept identity, changed hash.
-    expect(m2.get("edit.ts")!.content_hash).toBe(H(20));
-    expect(m2.get("edit.ts")!.file_id).toBe(m1.get("edit.ts")!.file_id);
-  });
-
-  it("checkpoints a split run and resumes to the SAME manifest as an uninterrupted run", async () => {
-    const interrupted = await approvedSource(nsA, "git://acme/repo-resume");
-    const straight = await approvedSource(nsA, "git://acme/repo-straight");
-
-    const observation = obs([
-      ["a.ts", H(1)],
-      ["b.ts", H(2)],
-      ["c.ts", H(3)],
-      ["d.ts", H(4)],
-      ["e.ts", H(5)],
-    ]);
-
-    // Uninterrupted baseline.
-    const baseline = await syncSource(pool, admin(), straight, observation, {
-      target_namespace: nsA,
-    });
-    expect(baseline.data?.status).toBe("completed");
-    expect(baseline.data?.counts.added).toBe(5);
-
-    // Interrupted: apply only 2 of the 5 ops, then stop mid-run.
-    const partial = await syncSource(pool, admin(), interrupted, observation, {
-      target_namespace: nsA,
-      apply_budget: 2,
-    });
-    expect(partial.ok).toBe(true);
-    expect(partial.data?.status).toBe("running");
-    expect(partial.data?.applied_ops).toBe(2);
-    expect(partial.data?.resumed).toBe(false);
-    // Only a partial manifest is live so far.
-    expect((await liveManifest(nsA, interrupted)).size).toBe(2);
-
-    // Persisted checkpoint advanced.
-    const { rows: ckpt } = await pool.query(
-      `SELECT checkpoint_index, status FROM ob_source_sync_runs
-        WHERE source_id = $1 AND namespace = $2`,
-      [interrupted, nsA],
-    );
-    expect(ckpt[0].status).toBe("running");
-    expect(ckpt[0].checkpoint_index).toBe(2);
-
-    // Resume with the SAME observation. It re-plans to the persisted run and
-    // finishes the tail; the boundary op is re-applied idempotently.
-    const resumed = await syncSource(pool, admin(), interrupted, observation, {
-      target_namespace: nsA,
-    });
-    expect(resumed.ok).toBe(true);
-    expect(resumed.data?.status).toBe("completed");
-    expect(resumed.data?.resumed).toBe(true);
-
-    // Final manifests match exactly (by path + content_hash); no duplicates.
-    const mResumed = await liveManifest(nsA, interrupted);
-    const mBaseline = await liveManifest(nsA, straight);
-    expect(mResumed.size).toBe(5);
-    expect(mBaseline.size).toBe(5);
-    for (const [path, v] of mBaseline) {
-      expect(mResumed.get(path)?.content_hash).toBe(v.content_hash);
-    }
-    // No file row is duplicated: total live rows equals distinct paths.
-    const { rows: dupCheck } = await pool.query(
-      `SELECT path, COUNT(*) AS n FROM ob_source_files
-        WHERE source_id = $1 AND namespace = $2 AND state = 'live'
-        GROUP BY path HAVING COUNT(*) > 1`,
-      [interrupted, nsA],
-    );
-    expect(dupCheck.length).toBe(0);
-  });
-
-  it("serializes concurrent syncs of one source on the eligible-source row lock (no hybrid corpus, no checkpoint regress)", async () => {
-    // Two concurrent syncs of the SAME source must not interleave their manifest
-    // read/plan/commit. Without a lock, both planners read the same manifest and
-    // commit disjoint edits, producing a hybrid corpus neither caller observed,
-    // and a late resumer can regress a checkpoint. syncSource takes a FOR UPDATE
-    // lock on the eligible source row BEFORE reading the manifest and holds it
-    // through COMMIT, so the second sync blocks until the first commits and then
-    // plans against the manifest the first already produced.
-    //
-    // Determinism without a production hook: this test itself holds the exact
-    // source-row lock syncSource would take (same namespace + id predicate) in an
-    // outer transaction, launches syncSource concurrently, and proves it cannot
-    // make progress until the test releases the lock. The gate is real Postgres
-    // row locking, not a sleep race.
-    const sourceId = await approvedSource(nsA, "git://acme/repo-serialize");
-
-    // Client 1 (the test): grab the source row lock and hold it open.
-    const holder = await pool.connect();
-    let syncSettled = false;
-    let syncResult: Awaited<ReturnType<typeof syncSource>> | undefined;
-    try {
-      await holder.query("BEGIN");
-      const locked = await holder.query(
-        `SELECT id FROM ${"ob_sources"}
-          WHERE id = $1 AND namespace = $2
-            AND source_kind IN ('git', 'directory')
-          FOR UPDATE`,
-        [sourceId, nsA],
-      );
-      expect(locked.rows.length).toBe(1);
-
-      // Client 2: a real sync of the same source. It must block at its own
-      // FOR UPDATE on this row and cannot commit while the test holds the lock.
-      const syncPromise = syncSource(
-        pool,
-        admin(),
-        sourceId,
-        obs([
-          ["a.ts", H(1)],
-          ["b.ts", H(2)],
-        ]),
-        { target_namespace: nsA },
-      ).then((r) => {
-        syncSettled = true;
-        syncResult = r;
-        return r;
-      });
-
-      // Give the blocked sync ample time to (fail to) proceed. It must still be
-      // pending: the lock is held, so it cannot have read the manifest, planned,
-      // or committed anything.
-      await new Promise((resolve) => setTimeout(resolve, 300));
-      expect(syncSettled).toBe(false);
-      // And nothing has been written to the manifest yet.
-      expect((await liveManifest(nsA, sourceId)).size).toBe(0);
-
-      // Release the lock — the blocked sync can now acquire it and finish.
-      await holder.query("COMMIT");
-      const finished = await syncPromise;
-      expect(finished.ok).toBe(true);
-      expect(finished.data?.status).toBe("completed");
-    } finally {
-      // Ensure the holder transaction is not left open even if an assertion threw.
-      await holder.query("ROLLBACK").catch(() => undefined);
-      holder.release();
-    }
-
-    expect(syncSettled).toBe(true);
-    expect(syncResult?.data?.counts.added).toBe(2);
-    // The manifest is exactly what the (single, serialized) sync observed — not a
-    // hybrid of concurrent writers.
-    const m = await liveManifest(nsA, sourceId);
-    expect([...m.keys()].sort()).toEqual(["a.ts", "b.ts"]);
-    expect(m.get("a.ts")!.content_hash).toBe(H(1));
-    expect(m.get("b.ts")!.content_hash).toBe(H(2));
-
-    // Checkpoint did not regress: it equals the plan length for the completed run.
-    const { rows: ckpt } = await pool.query(
-      `SELECT plan, checkpoint_index, status FROM ob_source_sync_runs
-        WHERE source_id = $1 AND namespace = $2`,
+  // Client 1 (the test): grab the source row lock and hold it open.
+  const holder = await pool.connect();
+  let syncSettled = false;
+  let syncResult: Awaited<ReturnType<typeof syncSource>> | undefined;
+  try {
+    await holder.query("BEGIN");
+    const locked = await holder.query(
+      `SELECT id FROM ${"ob_sources"}
+        WHERE id = $1 AND namespace = $2
+          AND source_kind IN ('git', 'directory')
+        FOR UPDATE`,
       [sourceId, nsA],
     );
-    expect(ckpt.length).toBe(1);
-    expect(ckpt[0].status).toBe("completed");
-    expect(ckpt[0].checkpoint_index).toBe((ckpt[0].plan as unknown[]).length);
-  });
+    expect(locked.rows.length).toBe(1);
 
-  it("two concurrent differing observations serialize to one non-hybrid manifest", async () => {
-    // A stronger end-to-end race: two syncs of the SAME source with DIFFERENT
-    // observations launched together. The lock forces a total order. Whichever
-    // commits first seeds the manifest; the second re-diffs against THAT manifest
-    // (not the empty one it might have seen unlocked). The final live manifest is
-    // therefore exactly one observation's corpus reconciled onto the other — never
-    // a hybrid union of two independently-planned add sets, and never a duplicated
-    // path. We don't fix which order wins (that's Postgres' lock queue); we prove
-    // the outcome is a consistent single-writer result either way.
-    const sourceId = await approvedSource(nsA, "git://acme/repo-race");
-
-    const obs1 = obs([
-      ["shared.ts", H(1)],
-      ["only1.ts", H(2)],
-    ]);
-    const obs2 = obs([
-      ["shared.ts", H(1)],
-      ["only2.ts", H(3)],
-    ]);
-
-    const [r1, r2] = await Promise.all([
-      syncSource(pool, admin(), sourceId, obs1, { target_namespace: nsA }),
-      syncSource(pool, admin(), sourceId, obs2, { target_namespace: nsA }),
-    ]);
-    expect(r1.ok).toBe(true);
-    expect(r2.ok).toBe(true);
-    expect(r1.data?.status).toBe("completed");
-    expect(r2.data?.status).toBe("completed");
-
-    // The final manifest is the LAST-committed observation's corpus exactly. The
-    // two observations differ only in only1.ts vs only2.ts (shared.ts is common),
-    // so the live set is {shared.ts, only1.ts} OR {shared.ts, only2.ts} — one or
-    // the other, never {shared.ts, only1.ts, only2.ts} (which would be the hybrid
-    // corpus a lost lock produces).
-    const m = await liveManifest(nsA, sourceId);
-    const keys = [...m.keys()].sort();
-    const isCorpus1 =
-      keys.length === 2 && keys[0] === "only1.ts" && keys[1] === "shared.ts";
-    const isCorpus2 =
-      keys.length === 2 && keys[0] === "only2.ts" && keys[1] === "shared.ts";
-    expect(isCorpus1 || isCorpus2).toBe(true);
-    expect(m.get("shared.ts")!.content_hash).toBe(H(1));
-
-    // No live path is duplicated.
-    const { rows: dup } = await pool.query(
-      `SELECT path, COUNT(*) AS n FROM ob_source_files
-        WHERE source_id = $1 AND namespace = $2 AND state = 'live'
-        GROUP BY path HAVING COUNT(*) > 1`,
-      [sourceId, nsA],
-    );
-    expect(dup.length).toBe(0);
-
-    // Every run row for this source is a completed run whose checkpoint reached
-    // its plan end — no run was left mid-flight or checkpoint-regressed.
-    const { rows: runs } = await pool.query(
-      `SELECT plan, checkpoint_index, status FROM ob_source_sync_runs
-        WHERE source_id = $1 AND namespace = $2`,
-      [sourceId, nsA],
-    );
-    for (const run of runs) {
-      expect(run.status).toBe("completed");
-      expect(run.checkpoint_index).toBe((run.plan as unknown[]).length);
-    }
-  });
-
-  it("re-running a completed sync over the same observation mutates nothing (fresh no-op plan)", async () => {
-    const sourceId = await approvedSource(nsA, "git://acme/repo-noop");
-    const observation = obs([
-      ["a.ts", H(1)],
-      ["b.ts", H(2)],
-    ]);
-    const first = await syncSource(pool, admin(), sourceId, observation, {
-      target_namespace: nsA,
-    });
-    // Fresh plan on an empty manifest: two adds, nothing unchanged yet.
-    expect(first.data?.resumed).toBe(false);
-    expect(first.data?.counts.unchanged).toBe(0);
-    expect(first.data?.status).toBe("completed");
-    const firstRunId = first.data?.run_id;
-
-    const m1 = await liveManifest(nsA, sourceId);
-    const idsBefore = new Map(
-      [...m1.entries()].map(([p, v]) => [p, v.file_id]),
-    );
-
-    const again = await syncSource(pool, admin(), sourceId, observation, {
-      target_namespace: nsA,
-    });
-    expect(again.ok).toBe(true);
-    expect(again.data?.status).toBe("completed");
-    // The first run is COMPLETED history and is not resumable, so this is a FRESH
-    // run (not a reuse of the terminal run). A fresh run cannot regress the
-    // manifest — only running runs are resumable — which is exactly the guard the
-    // A->B->A revert case depends on.
-    expect(again.data?.resumed).toBe(false);
-    expect(again.data?.run_id).not.toBe(firstRunId);
-    // The fresh plan diffs the current manifest, which already matches the
-    // observation exactly: zero mutating ops, both files reported unchanged.
-    expect(again.data?.counts).toMatchObject({
-      added: 0,
-      edited: 0,
-      renamed: 0,
-      deleted: 0,
-      unchanged: 2,
-    });
-
-    // Behaviorally a no-op: the manifest is byte-for-byte unchanged, including
-    // every durable file_id (no delete+re-add churn).
-    const m2 = await liveManifest(nsA, sourceId);
-    expect([...m2.keys()].sort()).toEqual(["a.ts", "b.ts"]);
-    for (const [path, v] of m2) {
-      expect(v.content_hash).toBe(m1.get(path)!.content_hash);
-      expect(v.file_id).toBe(idsBefore.get(path)!);
-    }
-    // No live path duplicated by the second run.
-    const { rows: dup } = await pool.query(
-      `SELECT path, COUNT(*) AS n FROM ob_source_files
-        WHERE source_id = $1 AND namespace = $2 AND state = 'live'
-        GROUP BY path HAVING COUNT(*) > 1`,
-      [sourceId, nsA],
-    );
-    expect(dup.length).toBe(0);
-  });
-
-  it("a fresh no-op plan over an already-synced manifest reports unchanged", async () => {
-    const sourceId = await approvedSource(nsA, "git://acme/repo-freshnoop");
-    // Seed the manifest.
-    await syncSource(
+    // Client 2: a real sync of the same source. It must block at its own
+    // FOR UPDATE on this row and cannot commit while the test holds the lock.
+    const syncPromise = syncSource(
       pool,
       admin(),
       sourceId,
@@ -472,204 +227,134 @@ dbDescribe("resumable file-source sync (live Postgres)", () => {
         ["b.ts", H(2)],
       ]),
       { target_namespace: nsA },
-    );
-
-    // A DISTINCT observation (different hash → fresh plan) whose file set exactly
-    // matches the live manifest. No ops are emitted, and because it is a fresh
-    // plan the receipt carries the full unchanged count — proving counts.unchanged
-    // is plumbed through, not discarded.
-    const noop = await syncSource(
-      pool,
-      admin(),
-      sourceId,
-      obs([
-        ["a.ts", H(1)],
-        ["b.ts", H(2)],
-        // add a third file so the observation hash differs from the seed run,
-        // forcing a fresh plan rather than a resume of the seed run.
-        ["c.ts", H(3)],
-      ]),
-      { target_namespace: nsA },
-    );
-    expect(noop.data?.resumed).toBe(false);
-    expect(noop.data?.counts).toMatchObject({
-      added: 1, // c.ts is the only op
-      edited: 0,
-      renamed: 0,
-      deleted: 0,
-      unchanged: 2, // a.ts and b.ts matched — plumbed into the receipt
-    });
-  });
-
-  it("reverting to an earlier observation (A->B->A) plans a fresh run and restores manifest A exactly", async () => {
-    // A completed run is terminal HISTORY, not a resumable checkpoint. When a
-    // source reverts to a corpus it already synced (A -> B -> A), the recurring
-    // observation A must NOT reopen A's old completed run — that run's checkpoint
-    // is at plan end, so reusing it would re-apply only its tail and leave the
-    // intermediate B edit (b.ts at H(9)) in place while reporting completed. It
-    // must instead plan a FRESH run against the CURRENT (B) manifest, which emits
-    // the edit that restores A, and preserve the prior completed run as history.
-    const sourceId = await approvedSource(nsA, "git://acme/repo-revert");
-
-    const obsA = obs([
-      ["a.ts", H(1)],
-      ["b.ts", H(2)],
-    ]);
-    const obsB = obs([
-      ["a.ts", H(1)],
-      ["b.ts", H(9)],
-    ]);
-
-    // A: two adds, completes.
-    const runA1 = await syncSource(pool, admin(), sourceId, obsA, {
-      target_namespace: nsA,
-    });
-    expect(runA1.data?.status).toBe("completed");
-    expect(runA1.data?.counts.added).toBe(2);
-    const runA1Id = runA1.data?.run_id;
-
-    // B: edit b.ts H(2) -> H(9), completes. Manifest now diverged from A.
-    const runB = await syncSource(pool, admin(), sourceId, obsB, {
-      target_namespace: nsA,
-    });
-    expect(runB.data?.status).toBe("completed");
-    expect(runB.data?.counts).toMatchObject({ edited: 1, added: 0 });
-    expect((await liveManifest(nsA, sourceId)).get("b.ts")!.content_hash).toBe(
-      H(9),
-    );
-
-    // A again: SAME observation hash as runA1, but runA1 is completed history.
-    // This must create a fresh run that edits b.ts back H(9) -> H(2).
-    const runA2 = await syncSource(pool, admin(), sourceId, obsA, {
-      target_namespace: nsA,
-    });
-    expect(runA2.ok).toBe(true);
-    expect(runA2.data?.status).toBe("completed");
-    // Fresh run, not a resume of history.
-    expect(runA2.data?.resumed).toBe(false);
-    // A fresh plan diffed the current (B) manifest: exactly the one edit that
-    // reverts b.ts, one unchanged (a.ts), no re-adds.
-    expect(runA2.data?.counts).toMatchObject({
-      added: 0,
-      edited: 1,
-      renamed: 0,
-      deleted: 0,
-      unchanged: 1,
+    ).then((r) => {
+      syncSettled = true;
+      syncResult = r;
+      return r;
     });
 
-    // A DISTINCT run row was created — not the completed one reopened.
-    const runA2Id = runA2.data?.run_id;
-    expect(runA2Id).toBeDefined();
-    expect(runA2Id).not.toBe(runA1Id);
+    // Give the blocked sync ample time to (fail to) proceed. It must still be
+    // pending: the lock is held, so it cannot have read the manifest, planned,
+    // or committed anything.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(syncSettled).toBe(false);
+    // And nothing has been written to the manifest yet.
+    expect((await liveManifest(pool, nsA, sourceId)).size).toBe(0);
 
-    // The final live manifest matches observation A EXACTLY (paths + hashes).
-    const finalManifest = await liveManifest(nsA, sourceId);
-    expect([...finalManifest.keys()].sort()).toEqual(["a.ts", "b.ts"]);
-    expect(finalManifest.get("a.ts")!.content_hash).toBe(H(1));
-    expect(finalManifest.get("b.ts")!.content_hash).toBe(H(2));
-    // No duplicate live rows.
-    const { rows: dup } = await pool.query(
-      `SELECT path, COUNT(*) AS n FROM ob_source_files
-        WHERE source_id = $1 AND namespace = $2 AND state = 'live'
-        GROUP BY path HAVING COUNT(*) > 1`,
-      [sourceId, nsA],
-    );
-    expect(dup.length).toBe(0);
+    // Release the lock — the blocked sync can now acquire it and finish.
+    await holder.query("COMMIT");
+    const finished = await syncPromise;
+    expect(finished.ok).toBe(true);
+    expect(finished.data?.status).toBe("completed");
+  } finally {
+    // Ensure the holder transaction is not left open even if an assertion threw.
+    await holder.query("ROLLBACK").catch(() => undefined);
+    holder.release();
+  }
 
-    // History is preserved: TWO run rows exist for observation A's hash — the
-    // original completed run AND the fresh one — and the original still exists,
-    // completed, untouched.
-    const obsAHash = observationHash(obsA);
-    const { rows: runRows } = await pool.query(
-      `SELECT id, status FROM ob_source_sync_runs
-        WHERE source_id = $1 AND namespace = $2 AND observation_hash = $3
-        ORDER BY created_at ASC`,
-      [sourceId, nsA, obsAHash],
-    );
-    expect(runRows.length).toBe(2);
-    const original = runRows.find((r) => r.id === runA1Id);
-    expect(original).toBeDefined();
-    expect(original!.status).toBe("completed");
-  });
+  expect(syncSettled).toBe(true);
+  expect(syncResult?.data?.counts.added).toBe(2);
+  // The manifest is exactly what the (single, serialized) sync observed — not a
+  // hybrid of concurrent writers.
+  const m = await liveManifest(pool, nsA, sourceId);
+  expect([...m.keys()].sort()).toEqual(["a.ts", "b.ts"]);
+  expect(expectDefined(m.get("a.ts"), "m a.ts").content_hash).toBe(H(1));
+  expect(expectDefined(m.get("b.ts"), "m b.ts").content_hash).toBe(H(2));
 
-  it("isolates manifests per namespace for the same external location", async () => {
-    // The SAME external id registered independently in two namespaces.
-    const ext = "git://acme/shared-repo";
-    const srcA = await approvedSource(nsA, ext);
-    const srcB = await approvedSource(nsB, ext);
+  // Checkpoint did not regress: it equals the plan length for the completed run.
+  const { rows: ckpt } = await pool.query(
+    `SELECT plan, checkpoint_index, status FROM ob_source_sync_runs
+      WHERE source_id = $1 AND namespace = $2`,
+    [sourceId, nsA],
+  );
+  expect(ckpt.length).toBe(1);
+  expect(ckpt[0].status).toBe("completed");
+  expect(ckpt[0].checkpoint_index).toBe((ckpt[0].plan as unknown[]).length);
+}
 
-    await syncSource(pool, admin(), srcA, obs([["a.ts", H(1)]]), {
-      target_namespace: nsA,
-    });
-    await syncSource(
-      pool,
-      admin(),
-      srcB,
-      obs([
-        ["b.ts", H(2)],
-        ["c.ts", H(3)],
-      ]),
-      { target_namespace: nsB },
-    );
+async function concurrentDifferingObservations(): Promise<void> {
+  // A stronger end-to-end race: two syncs of the SAME source with DIFFERENT
+  // observations launched together. The lock forces a total order. Whichever
+  // commits first seeds the manifest; the second re-diffs against THAT manifest
+  // (not the empty one it might have seen unlocked). The final live manifest is
+  // therefore exactly one observation's corpus reconciled onto the other — never
+  // a hybrid union of two independently-planned add sets, and never a duplicated
+  // path. We don't fix which order wins (that's Postgres' lock queue); we prove
+  // the outcome is a consistent single-writer result either way.
+  const sourceId = await approvedSource(pool, nsA, "git://acme/repo-race");
 
-    const mA = await liveManifest(nsA, srcA);
-    const mB = await liveManifest(nsB, srcB);
-    expect([...mA.keys()]).toEqual(["a.ts"]);
-    expect([...mB.keys()].sort()).toEqual(["b.ts", "c.ts"]);
+  const obs1 = obs([
+    ["shared.ts", H(1)],
+    ["only1.ts", H(2)],
+  ]);
+  const obs2 = obs([
+    ["shared.ts", H(1)],
+    ["only2.ts", H(3)],
+  ]);
 
-    // A sync targeting srcA's id under nsB must not resolve srcA (namespace-bound
-    // eligibility): the id is not registered in nsB.
-    const cross = await syncSource(pool, admin(), srcA, obs([["x.ts", H(9)]]), {
-      target_namespace: nsB,
-    });
-    expect(cross.ok).toBe(false);
-    expect(cross.code).toBe("source_not_found");
-    // srcA's own manifest is untouched by the cross-namespace attempt.
-    expect((await liveManifest(nsA, srcA)).size).toBe(1);
-  });
+  const [r1, r2] = await Promise.all([
+    syncSource(pool, admin(), sourceId, obs1, { target_namespace: nsA }),
+    syncSource(pool, admin(), sourceId, obs2, { target_namespace: nsA }),
+  ]);
+  expect(r1.ok).toBe(true);
+  expect(r2.ok).toBe(true);
+  expect(r1.data?.status).toBe("completed");
+  expect(r2.data?.status).toBe("completed");
 
-  it("rejects a sync into a namespace the caller cannot write", async () => {
-    const sourceId = await approvedSource(nsA, "git://acme/repo-authz");
-    // A header-scoped identity bound to a different namespace cannot write nsA.
-    const headerBound: AuthInfo = {
-      role: "agent",
-      clientId: "someone-else",
-      namespaceSource: "header",
-    };
-    const res = await syncSource(
-      pool,
-      headerBound,
-      sourceId,
-      obs([["a.ts", H(1)]]),
-      { target_namespace: nsA },
-    );
-    expect(res.ok).toBe(false);
-    expect(res.code).toBe("namespace_denied");
-  });
+  // The final manifest is the LAST-committed observation's corpus exactly. The
+  // two observations differ only in only1.ts vs only2.ts (shared.ts is common),
+  // so the live set is {shared.ts, only1.ts} OR {shared.ts, only2.ts} — one or
+  // the other, never {shared.ts, only1.ts, only2.ts} (which would be the hybrid
+  // corpus a lost lock produces).
+  const m = await liveManifest(pool, nsA, sourceId);
+  const keys = [...m.keys()].sort();
+  const isCorpus1 =
+    keys.length === 2 && keys[0] === "only1.ts" && keys[1] === "shared.ts";
+  const isCorpus2 =
+    keys.length === 2 && keys[0] === "only2.ts" && keys[1] === "shared.ts";
+  expect(isCorpus1 || isCorpus2).toBe(true);
+  expect(expectDefined(m.get("shared.ts"), "m shared.ts").content_hash).toBe(H(1));
 
-  it("skips syncing a paused (non-active) source", async () => {
-    const sourceId = await approvedSource(nsA, "git://acme/repo-paused");
-    // Pause it via the registry update path.
-    const { rows } = await pool.query(
-      `SELECT revision FROM ob_sources WHERE id = $1`,
-      [sourceId],
-    );
-    await updateSource(pool, admin(), {
-      id: sourceId,
-      target_namespace: nsA,
-      expected_revision: rows[0].revision as number,
-      lifecycle_state: "paused",
-    });
-    const res = await syncSource(
-      pool,
-      admin(),
-      sourceId,
-      obs([["a.ts", H(1)]]),
-      {
-        target_namespace: nsA,
-      },
-    );
-    expect(res.ok).toBe(false);
-    expect(res.code).toBe("source_not_eligible");
-  });
+  // No live path is duplicated.
+  const { rows: dup } = await pool.query(
+    `SELECT path, COUNT(*) AS n FROM ob_source_files
+      WHERE source_id = $1 AND namespace = $2 AND state = 'live'
+      GROUP BY path HAVING COUNT(*) > 1`,
+    [sourceId, nsA],
+  );
+  expect(dup.length).toBe(0);
+
+  // Every run row for this source is a completed run whose checkpoint reached
+  // its plan end — no run was left mid-flight or checkpoint-regressed.
+  const { rows: runs } = await pool.query(
+    `SELECT plan, checkpoint_index, status FROM ob_source_sync_runs
+      WHERE source_id = $1 AND namespace = $2`,
+    [sourceId, nsA],
+  );
+  for (const run of runs) {
+    expect(run.status).toBe("completed");
+    expect(run.checkpoint_index).toBe((run.plan as unknown[]).length);
+  }
+}
+
+describe("resumable file-source sync plan, checkpoint, and concurrency (live Postgres)", () => {
+  it(
+    "applies a full add/edit/rename/delete plan and leaves the expected manifest",
+    appliesFullPlan,
+  );
+
+  it(
+    "checkpoints a split run and resumes to the SAME manifest as an uninterrupted run",
+    checkpointsSplitRunAndResumes,
+  );
+
+  it(
+    "serializes concurrent syncs of one source on the eligible-source row lock (no hybrid corpus, no checkpoint regress)",
+    serializesConcurrentSyncs,
+  );
+
+  it(
+    "two concurrent differing observations serialize to one non-hybrid manifest",
+    concurrentDifferingObservations,
+  );
 });


### PR DESCRIPTION
## Summary

- `src/source-sync.pg.test.ts` read `OPENBRAIN_TEST_DATABASE_URL` itself and swapped in `describe.skip` when it was unset. A database-less run reported `0 pass, 12 skip, 0 fail` and exited 0 — at the exit code, indistinguishable from a suite that ran and passed, so the Postgres behavior nobody exercised could drift under a green CI.
- The suites now call `requireTestDatabaseUrl()` at module scope, so an absent variable throws `test_database_required` and the run fails loudly.
- Split by subject, because one `describe` callback carried all ten cases and exceeded the function-length rule: `src/source-sync.pg.test.ts` keeps plan, checkpoint, and concurrency (4 cases); the new `src/source-sync-idempotence.pg.test.ts` holds idempotence and isolation (6 cases).
- New `src/source-sync-test-helpers.ts` holds `H`, `obs`, `admin`, `cleanupNamespaces`, `approvedSource`, and `liveManifest`. Each database helper takes the pool as its first parameter and the module creates none, so neither suite's `afterAll` ends a connection the other still uses.
- Every `it` body is hoisted to a module-scope `async function` called as `it("<same name>", fn)`; test names, order, and assertions are unchanged. The 14 non-null assertions become `expectDefined(value, label)` guards, matching the existing helper in `scripts/test-support/promote-lane-shared-helpers.ts`.
- `scripts/assert-db-tests-ran.ts` registers both `describe` names at their JUnit-measured counts (4 and 6) and raises `MIN_TOTAL_LIVE_TESTCASES` 285 -> 295.
- No production source changed: `src/source-sync.ts` is untouched.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- `CHANGED_FILES="src/source-sync.pg.test.ts src/source-sync-idempotence.pg.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` -> exit 0, all four clauses PASS. The same invocation over `src/source-sync.pg.test.ts` at `origin/main`, before any edit, exited 1 with clauses 1, 2, and 3 FAIL.
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bun run test:isolated src/source-sync.pg.test.ts src/source-sync-idempotence.pg.test.ts` -> exit 0, 10 pass, 0 fail, 99 expect() calls. `bunx tsc --noEmit` -> exit 0. `oxlint --deny-warnings` over all four touched files -> exit 0, taken on the committed tree after prettier ran inside the pre-commit gate. Per-suite counts read from JUnit, not tallied by eye: 4 and 6.

Python package and live smoke are not applicable — this branch touches only TypeScript test files and one test manifest.

## Critical Self-Review

- Highest-risk behavior: the split. Ten cases moved across two files, so a body could silently land in the wrong suite or lose an assertion. Mitigated by moving every body with shell line-range copies rather than retyping, and by the JUnit count check (4 + 6 = the 10 that ran before).
- Assumptions that could be wrong: that the two halves are genuinely independent. They share only the namespace-scoped cleanup, and each file now uses its own namespace pair (`lane338-ns-*` and `lane338-idem-ns-*`), so a concurrent run of both cannot delete the other's rows. If some case depended on ordering within the old single suite, the split would break it — the green run over both files is the evidence it does not.
- Missing/weak tests: no new behavioral coverage is added; this is a conversion. The suites prove the same properties they proved before.
- Security/permission risk: none. No auth, namespace predicate, or SQL shape changed. The namespace-isolation cases move verbatim and still assert `source_not_found` across namespaces and `namespace_denied` for a header-bound identity.
- Migration/deploy risk: none. No migration, no runtime source, no config.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface is touched, so `docs/downstream-rollout.md` does not apply.
- Rollback/cleanup concern: reverting the commit restores the single skipping file. The new manifest entries would then name suites that no longer exist and CI's anti-skip guard would fail, so a revert must take all four files together.
- Fixes made before PR: the first hoist pass used `it`-close line numbers that were one line too high and swallowed a closing brace, which prettier caught as a syntax error; boundaries were re-derived from the source and the file rebuilt. `MIN_TOTAL_LIVE_TESTCASES` was raised by the measured delta rather than carried from a prior branch.
- Known residual risk: `minTests` is a floor measured on this tree. If another branch registers suites and merges first, the global floor here is stale-low rather than wrong — it under-counts, it does not falsely pass a vanished suite, since the per-suite entries are exact names.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no MEDIUM+ finding surfaced; the conversion patterns used here (hoisted bodies, pool-as-parameter helpers, `expectDefined`) are already recorded in the lane contract's round-39 Tightenings.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: test-only change with no runtime or contract surface.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing schema is touched — the diff is two test files, a test helper module, and the test manifest.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable throughout: no MCP tool, schema, protocol, or client-facing behavior changed. The conversion is confined to test files and the test manifest.
