### PR TITLE
test(pg): the agent_context_pack durable lane test requires the test database instead of skipping (#878)

### DIFF
--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -411,6 +411,12 @@ export const REQUIRED_SUITES: ReadonlyArray<{
     name: "graph derivation handler isolation and atomicity (live Postgres)",
     minTests: 3,
   },
+  // #878 split the agent_context_pack durable lane file by subject; the live
+  // half is the only one that reaches Postgres, and it stopped skipping itself.
+  {
+    name: "agent_context_pack durable lane reads (live Postgres)",
+    minTests: 2,
+  },
 ];
 
 // Absolute floor on total executed (non-skipped) live-Postgres testcases,
@@ -465,8 +471,10 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // 4 + 3 as that file stopped skipping itself, then 292 -> 302 when #878
 // registered the two subject-split source-sync plan/checkpoint/concurrency
 // and idempotence/isolation suites' 4 + 6 as that file stopped skipping
-// itself), so the global floor cannot silently fall behind the per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 302;
+// itself, then 302 -> 304 when #878 registered the agent_context_pack durable
+// lane live-reads suite's 2 as that file stopped skipping itself), so the
+// global floor cannot silently fall behind the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 304;
 
 export interface SuiteStats {
   tests: number;

--- a/src/tools/__tests__/agent-context-pack-durable-lane-fail-closed.test.ts
+++ b/src/tools/__tests__/agent-context-pack-durable-lane-fail-closed.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "bun:test";
+import type { AuthInfo } from "../../types.ts";
+import {
+  AGENT_CONTEXT_PACK_SCOPE as SCOPE,
+  setupAgentContextPackToolClient as setupToolClient,
+} from "./agent-context-pack-test-helpers.ts";
+import {
+  expectDefined,
+  parsePackPayload,
+  type RecordedQuery,
+} from "./agent-context-pack-durable-lane-test-helpers.ts";
+
+async function failsClosedWithoutEventReadsWhenTheExactDura() {
+  const queries: string[] = [];
+  const auth: AuthInfo = { role: "admin", clientId: "rico" };
+  const { client, cleanup } = await setupToolClient(auth, {
+    query: async (sql: string) => {
+      queries.push(sql);
+      return { rows: [] };
+    },
+  });
+
+  try {
+    const pack = await client.callTool({
+      name: "agent_context_pack",
+      arguments: {
+        ...SCOPE,
+        channel_id: "wrong-channel",
+        requested_sections: ["durable_lane_context"],
+      },
+    });
+
+    expect(pack.isError).toBeFalsy();
+    const payload = parsePackPayload(pack.content);
+    expect(payload.sections.durable_lane_context).toBeUndefined();
+    expect(payload.warnings.scope_denials).toContainEqual({
+      source: "durable_lane_context",
+      reasons: ["exact_scope"],
+    });
+    expect(queries).toHaveLength(1);
+    expect(queries[0]).not.toContain("ob_session_events");
+  } finally {
+    await cleanup();
+  }
+}
+
+async function failsClosedForEveryMismatchedDurableExactsco() {
+  const cases = [
+    ["namespace", { namespace: "other" }],
+    ["agent", { agent: "other-agent" }],
+    ["platform", { platform: "other-platform" }],
+    ["server_id", { server_id: "other-server" }],
+    ["channel_id", { channel_id: "other-channel" }],
+    ["thread_id", { thread_id: "other-thread" }],
+    ["session_key", { session_key: "other-session" }],
+  ] as const;
+  const expectedParams = [
+    SCOPE.namespace,
+    SCOPE.session_key,
+    SCOPE.agent,
+    SCOPE.platform,
+    SCOPE.server_id,
+    SCOPE.channel_id,
+    null,
+  ];
+
+  for (const [, override] of cases) {
+    const queries: RecordedQuery[] = [];
+    const auth: AuthInfo = { role: "admin", clientId: "rico" };
+    const { client, cleanup } = await setupToolClient(auth, {
+      query: async (sql: string, params?: unknown[]) => {
+        queries.push({ sql, params });
+        const exact = expectedParams.every((value, index) => params?.[index] === value);
+        return {
+          rows: exact
+            ? [
+                {
+                  id: "lane-durable-exact",
+                  session_key: SCOPE.session_key,
+                  status: "active",
+                  agent: SCOPE.agent,
+                  source: SCOPE.platform,
+                  channel_id: SCOPE.channel_id,
+                  thread_id: null,
+                  project: "open-brain",
+                  topic: "exact scope",
+                  current_context_md: "exact context",
+                  updated_at: "2026-07-17T00:00:00.000Z",
+                },
+              ]
+            : [],
+        };
+      },
+    });
+
+    try {
+      const pack = await client.callTool({
+        name: "agent_context_pack",
+        arguments: {
+          ...SCOPE,
+          ...override,
+          requested_sections: ["durable_lane_context"],
+        },
+      });
+
+      expect(pack.isError).toBeFalsy();
+      const payload = parsePackPayload(pack.content);
+      expect(payload.sections.durable_lane_context).toBeUndefined();
+      expect(payload.warnings.scope_denials).toContainEqual({
+        source: "durable_lane_context",
+        reasons: ["exact_scope"],
+      });
+      expect(queries).toHaveLength(1);
+      expect(expectDefined(queries[0], "query 0").sql).not.toContain(
+        "ob_session_events",
+      );
+    } finally {
+      await cleanup();
+    }
+  }
+}
+
+async function degradesDurableLaneLookupFailuresWithoutLeak() {
+  const auth: AuthInfo = { role: "admin", clientId: "rico" };
+  const { client, cleanup } = await setupToolClient(auth, {
+    query: async () => {
+      throw new Error("postgres://secret-host/internal-detail");
+    },
+  });
+
+  try {
+    const pack = await client.callTool({
+      name: "agent_context_pack",
+      arguments: {
+        ...SCOPE,
+        requested_sections: ["durable_lane_context"],
+      },
+    });
+
+    expect(pack.isError).toBeFalsy();
+    const payload = parsePackPayload(pack.content);
+    expect(payload.sections.durable_lane_context).toBeUndefined();
+    expect(payload.warnings.degraded_sources).toEqual([
+      {
+        source: "durable_lane_context",
+        reason: "database_unavailable",
+      },
+    ]);
+    expect(JSON.stringify(payload)).not.toContain("secret-host");
+    expect(JSON.stringify(payload)).not.toContain("internal-detail");
+  } finally {
+    await cleanup();
+  }
+}
+
+async function discardsThePoolClientAfterATimedoutDurableRe() {
+  let statementTimeoutMs = 0;
+  let activeQueries = 0;
+  let releaseCount = 0;
+  let releaseArgument: unknown;
+  let rolledBack = false;
+  const lane = {
+    id: "lane-timeout",
+    session_key: SCOPE.session_key,
+    status: "active",
+    agent: SCOPE.agent,
+    source: SCOPE.platform,
+    channel_id: SCOPE.channel_id,
+    thread_id: null,
+    project: "open-brain",
+    topic: "timeout",
+    current_context_md: "context",
+    updated_at: "2026-07-17T18:00:00Z",
+  };
+  const dbClient = {
+    query: async (config: {
+      text: string;
+      values?: unknown[];
+      query_timeout?: number;
+    }) => {
+      const { text, values, query_timeout: queryTimeoutMs } = config;
+      expect(queryTimeoutMs).toBeGreaterThan(0);
+      if (text === "BEGIN READ ONLY" || text === "COMMIT") {
+        return { rows: [] };
+      }
+      if (text === "ROLLBACK") {
+        rolledBack = true;
+        return { rows: [] };
+      }
+      if (text.includes("set_config('statement_timeout'")) {
+        statementTimeoutMs = Number.parseInt(String(values?.[0]), 10);
+        return { rows: [] };
+      }
+      if (text.includes("FROM ob_session_lanes") && !text.includes("JOIN")) {
+        return { rows: [lane] };
+      }
+      if (text.includes("FROM ob_session_events")) {
+        activeQueries += 1;
+        await new Promise((resolve) => setTimeout(resolve, statementTimeoutMs + 2));
+        activeQueries -= 1;
+        throw new Error("canceling statement due to statement timeout secret-detail");
+      }
+      return { rows: [] };
+    },
+    release: (error?: unknown) => {
+      releaseCount += 1;
+      releaseArgument = error;
+    },
+  };
+  const auth: AuthInfo = { role: "admin", clientId: "rico" };
+  const { client, cleanup } = await setupToolClient(auth, {
+    query: async () => {
+      throw new Error("budgeted reads must use a checked-out client");
+    },
+    connect: async () => dbClient,
+  });
+
+  try {
+    const startedAt = performance.now();
+    const pack = await client.callTool({
+      name: "agent_context_pack",
+      arguments: {
+        ...SCOPE,
+        requested_sections: ["durable_lane_context"],
+        budget: { max_latency_ms: 25 },
+      },
+    });
+    const elapsedMs = performance.now() - startedAt;
+
+    expect(pack.isError).toBeFalsy();
+    const payload = parsePackPayload(pack.content);
+    expect(payload.sections.durable_lane_context).toBeUndefined();
+    expect(payload.warnings.degraded_sources).toEqual([
+      {
+        source: "durable_lane_context",
+        reason: "database_unavailable",
+      },
+    ]);
+    expect(JSON.stringify(payload)).not.toContain("secret-detail");
+    expect(elapsedMs).toBeLessThan(250);
+    expect(activeQueries).toBe(0);
+    expect(rolledBack).toBe(false);
+    expect(releaseCount).toBe(1);
+    expect(releaseArgument).toBeInstanceOf(Error);
+  } finally {
+    await cleanup();
+  }
+}
+
+describe("agent_context_pack durable lane fail-closed context", () => {
+  it(
+    "fails closed without event reads when the exact durable lane does not match",
+    failsClosedWithoutEventReadsWhenTheExactDura,
+  );
+
+  it(
+    "fails closed for every mismatched durable exact-scope coordinate",
+    failsClosedForEveryMismatchedDurableExactsco,
+  );
+
+  it(
+    "degrades durable lane lookup failures without leaking database errors",
+    degradesDurableLaneLookupFailuresWithoutLeak,
+  );
+
+  it(
+    "discards the pool client after a timed-out durable read",
+    discardsThePoolClientAfterATimedoutDurableRe,
+  );
+});

--- a/src/tools/__tests__/agent-context-pack-durable-lane-test-helpers.ts
+++ b/src/tools/__tests__/agent-context-pack-durable-lane-test-helpers.ts
@@ -1,0 +1,68 @@
+import type { setupAgentContextPackToolClient } from "./agent-context-pack-test-helpers.ts";
+
+/**
+ * The structural pool shape the agent_context_pack tool client accepts. Named
+ * here so a test can widen a real `Pool` or a mock into it without `any`.
+ */
+export type ToolClientPool = Parameters<typeof setupAgentContextPackToolClient>[1];
+
+/** A recorded SQL call, as the mock query functions in these suites push it. */
+export type RecordedQuery = { sql: string; params?: unknown[] };
+
+/** An event object as it arrives inside a parsed durable_lane_context. */
+export interface PackEvent {
+  id: string;
+  content: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Returns `value` when it is neither null nor undefined, and throws otherwise.
+ * Replaces the non-null assertions the oxlint standard forbids while keeping
+ * the assertion that follows it reading against a defined value.
+ */
+export function expectDefined<T>(value: T | null | undefined, label: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(`expected ${label} to be defined`);
+  }
+  return value;
+}
+
+/**
+ * The parts of an agent_context_pack result these suites assert against. Only
+ * the read properties are declared, so a typo in a test is a typecheck error
+ * rather than a silent `undefined`.
+ */
+export interface PackPayload {
+  sections: { durable_lane_context?: DurableLaneSection };
+  warnings: {
+    degraded_sources?: unknown;
+    scope_denials?: unknown;
+    truncation?: unknown;
+  };
+  budget: {
+    durable_lane_context: {
+      max_events: number;
+      max_event_chars: number;
+      content_chars_used: number;
+      content_char_limit: number;
+    };
+  };
+  citations: unknown[];
+}
+
+/** The durable lane section of a pack, as the suites read it. */
+export interface DurableLaneSection {
+  events: PackEvent[];
+  event_count: number;
+  truncated: boolean;
+  label: string;
+  exact_scope_required: boolean;
+  lane: { current_context_md: string; [key: string]: unknown };
+}
+
+/** The text payload of the first content block of a tool result, parsed. */
+export function parsePackPayload(content: unknown): PackPayload {
+  const blocks = content as Array<{ text: string }>;
+  return JSON.parse(expectDefined(blocks[0], "first content block").text);
+}

--- a/src/tools/__tests__/agent-context-pack-durable-lane.pg.test.ts
+++ b/src/tools/__tests__/agent-context-pack-durable-lane.pg.test.ts
@@ -1,0 +1,175 @@
+// Live Postgres reads for the agent_context_pack durable lane section.
+//
+// This suite demands a real database: `requireTestDatabaseUrl()` throws
+// `test_database_required` at module scope when the test database is absent,
+// so a run without one fails loudly instead of reporting a skipped suite as a
+// pass (#878).
+import { afterAll, describe, expect, it } from "bun:test";
+import { Pool } from "pg";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
+import { setupAgentContextPackToolClient as setupToolClient } from "./agent-context-pack-test-helpers.ts";
+import {
+  expectDefined,
+  parsePackPayload,
+  type PackEvent,
+  type ToolClientPool,
+} from "./agent-context-pack-durable-lane-test-helpers.ts";
+
+const pool = new Pool({
+  connectionString: requireTestDatabaseUrl(),
+  max: 2,
+  connectionTimeoutMillis: 500,
+});
+const namespace = `test-context-pack-${process.pid}`;
+const liveScope = {
+  namespace,
+  agent: "nagatha",
+  platform: "discord",
+  server_id: "live-server",
+  channel_id: "live-channel",
+  session_key: `live-context-pack-${process.pid}`,
+};
+const laneId = "10000000-0000-0000-0000-000000000001";
+
+async function cleanupDatabaseRows() {
+  await pool.query(
+    `DELETE FROM ob_session_events
+      WHERE lane_id IN (SELECT id FROM ob_session_lanes WHERE namespace = $1)`,
+    [namespace],
+  );
+  await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [namespace]);
+}
+
+async function insertLane() {
+  await pool.query(
+    `INSERT INTO ob_session_lanes
+       (id, session_key, namespace, agent, source, channel_id, thread_id,
+        project, topic, current_context_md, metadata, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6, NULL, 'open-brain', 'live context',
+             'live checkpoint', jsonb_build_object('server_id', $7::text), 'test')`,
+    [
+      laneId,
+      liveScope.session_key,
+      namespace,
+      liveScope.agent,
+      liveScope.platform,
+      liveScope.channel_id,
+      liveScope.server_id,
+    ],
+  );
+}
+
+async function callLivePack(maxLatencyMs?: number) {
+  const { client, cleanup } = await setupToolClient(
+    { role: "admin", clientId: namespace },
+    pool as unknown as ToolClientPool,
+  );
+  try {
+    return await client.callTool({
+      name: "agent_context_pack",
+      arguments: {
+        ...liveScope,
+        requested_sections: ["durable_lane_context"],
+        ...(maxLatencyMs === undefined
+          ? {}
+          : { budget: { max_latency_ms: maxLatencyMs } }),
+      },
+    });
+  } finally {
+    await cleanup();
+  }
+}
+
+afterAll(async () => {
+  await cleanupDatabaseRows();
+  await pool.end();
+});
+
+async function readsWholeLaneChronologically() {
+  await cleanupDatabaseRows();
+  try {
+    await insertLane();
+    const createdAt = "2026-07-17T17:00:00.000Z";
+    for (let index = 1; index <= 9; index += 1) {
+      const id = `00000000-0000-0000-0000-${String(index).padStart(12, "0")}`;
+      await pool.query(
+        `INSERT INTO ob_session_events
+           (id, lane_id, event_type, content, source, importance, created_by, created_at)
+         VALUES ($1, $2, 'fact', $3, 'test', 'warm', 'test', $4)`,
+        [id, laneId, `short event ${index}`, createdAt],
+      );
+    }
+
+    const pack = await callLivePack();
+    const payload = parsePackPayload(pack.content);
+    expect(pack.isError).toBeFalsy();
+    expect(payload.sections.durable_lane_context).toBeDefined();
+    // No budget was requested, so the whole lane comes back whole. All nine
+    // events share one timestamp, so the `created_at DESC, id DESC` tie-break
+    // is what makes the order deterministic; after the chronological reverse
+    // that surfaces as UUID ascending. This used to expect only the eight
+    // "recent" events and `truncated: true`, dropping ...0001 to the 8-event
+    // ceiling. That ceiling and its truncation marker are gone as of
+    // 2026-07-30 (see agent-context-pack-durable-lane.ts) -- the oldest event
+    // is no longer the price of a full read.
+    expect(
+      expectDefined(
+        payload.sections.durable_lane_context,
+        "the durable lane section",
+      ).events.map((event: PackEvent) => event.id),
+    ).toEqual(
+      Array.from(
+        { length: 9 },
+        (_, index) => `00000000-0000-0000-0000-${String(index + 1).padStart(12, "0")}`,
+      ),
+    );
+    expect(payload.sections.durable_lane_context).toMatchObject({
+      event_count: 9,
+      truncated: false,
+    });
+  } finally {
+    await cleanupDatabaseRows();
+  }
+}
+
+async function cancelsLockDelayedRead() {
+  await cleanupDatabaseRows();
+  const blocker = await pool.connect();
+  try {
+    await insertLane();
+    await blocker.query("BEGIN");
+    await blocker.query("LOCK TABLE ob_session_events IN ACCESS EXCLUSIVE MODE");
+
+    const startedAt = performance.now();
+    const pack = await callLivePack(50);
+    const elapsedMs = performance.now() - startedAt;
+    const payload = parsePackPayload(pack.content);
+
+    expect(pack.isError).toBeFalsy();
+    expect(payload.sections.durable_lane_context).toBeUndefined();
+    expect(payload.warnings.degraded_sources).toEqual([
+      {
+        source: "durable_lane_context",
+        reason: "database_unavailable",
+      },
+    ]);
+    expect(elapsedMs).toBeLessThan(500);
+    await pool.query("SELECT 1");
+  } finally {
+    await blocker.query("ROLLBACK").catch(() => undefined);
+    blocker.release();
+    await cleanupDatabaseRows();
+  }
+}
+
+describe("agent_context_pack durable lane reads (live Postgres)", () => {
+  it(
+    "orders equal-timestamp events by UUID and returns the whole lane chronologically",
+    readsWholeLaneChronologically,
+  );
+
+  it(
+    "cancels a lock-delayed event read before returning and releases its pool client",
+    cancelsLockDelayedRead,
+  );
+});

--- a/src/tools/__tests__/agent-context-pack-durable-lane.test.ts
+++ b/src/tools/__tests__/agent-context-pack-durable-lane.test.ts
@@ -1,725 +1,357 @@
-import { afterAll, describe, expect, it } from "bun:test";
-import { Pool } from "pg";
+import { describe, expect, it } from "bun:test";
 import type { AuthInfo } from "../../types.ts";
 import {
   AGENT_CONTEXT_PACK_SCOPE as SCOPE,
   setupAgentContextPackToolClient as setupToolClient,
 } from "./agent-context-pack-test-helpers.ts";
+import {
+  expectDefined,
+  parsePackPayload,
+  type PackEvent,
+  type RecordedQuery,
+} from "./agent-context-pack-durable-lane-test-helpers.ts";
 
-describe("agent_context_pack durable lane context", () => {
-  it("does not query or return durable lane context unless explicitly requested", async () => {
-    let queryCount = 0;
-    const auth: AuthInfo = { role: "admin", clientId: "rico" };
-    const { client, cleanup } = await setupToolClient(auth, {
-      query: async () => {
-        queryCount += 1;
-        return { rows: [] };
+async function doesNotQueryOrReturnDurableLaneContextUnless() {
+  let queryCount = 0;
+  const auth: AuthInfo = { role: "admin", clientId: "rico" };
+  const { client, cleanup } = await setupToolClient(auth, {
+    query: async () => {
+      queryCount += 1;
+      return { rows: [] };
+    },
+  });
+
+  try {
+    const pack = await client.callTool({
+      name: "agent_context_pack",
+      arguments: {
+        ...SCOPE,
+        requested_sections: ["working_set"],
       },
     });
 
-    try {
-      const pack = await client.callTool({
-        name: "agent_context_pack",
-        arguments: {
-          ...SCOPE,
-          requested_sections: ["working_set"],
-        },
-      });
+    const payload = parsePackPayload(pack.content);
+    expect(pack.isError).toBeFalsy();
+    expect(payload.sections.durable_lane_context).toBeUndefined();
+    expect(queryCount).toBe(0);
+  } finally {
+    await cleanup();
+  }
+}
 
-      const payload = JSON.parse((pack.content as any)[0].text);
-      expect(pack.isError).toBeFalsy();
-      expect(payload.sections.durable_lane_context).toBeUndefined();
-      expect(queryCount).toBe(0);
-    } finally {
-      await cleanup();
-    }
+// Fixture for the bounded-distillation case: one oversized checkpoint and
+// ten oversized events, so the whole-pack fitter has something to spend its
+// allocation on.
+const lane = {
+  id: "lane-durable-1",
+  session_key: SCOPE.session_key,
+  status: "active",
+  agent: SCOPE.agent,
+  source: SCOPE.platform,
+  channel_id: SCOPE.channel_id,
+  thread_id: null,
+  project: "open-brain",
+  topic: "First-class local memory",
+  current_context_md: "C".repeat(9000),
+  updated_at: "2026-07-17T18:00:00Z",
+  metadata: { private_raw: "must not escape" },
+};
+const events = Array.from({ length: 10 }, (_, index) => ({
+  id: `event-${index}`,
+  event_type: index % 2 === 0 ? "decision" : "fact",
+  content: `event-${index}:` + "E".repeat(2000),
+  source: "shared",
+  importance: "warm",
+  artifact_path: null,
+  transcript_ref: `collab/open-brain/conversations/${index}`,
+  transcript: "RAW TRANSCRIPT MUST NOT ESCAPE",
+  metadata: { tool_output: "RAW TOOL OUTPUT MUST NOT ESCAPE" },
+  occurred_at: null,
+  created_at: `2026-07-17T17:00:0${index}Z`,
+}));
+
+async function returnsBoundedDistilledDurableContextForTheE() {
+  const queries: RecordedQuery[] = [];
+  const auth: AuthInfo = { role: "admin", clientId: "rico" };
+  const { client, cleanup } = await setupToolClient(auth, {
+    query: async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      if (sql.includes("FROM ob_session_lanes") && !sql.includes("JOIN")) {
+        return { rows: [lane] };
+      }
+      if (sql.includes("FROM ob_session_events")) {
+        // Real SQL selects newest-first (created_at DESC); mirror it so the
+        // loader's chronological reverse() lands the newest event at the tail.
+        return { rows: [...events].reverse().slice(0, 8) };
+      }
+      return { rows: [] };
+    },
   });
 
-  it("returns bounded distilled durable context for the exact authorized lane", async () => {
-    const queries: Array<{ sql: string; params?: any[] }> = [];
-    const lane = {
-      id: "lane-durable-1",
-      session_key: SCOPE.session_key,
-      status: "active",
-      agent: SCOPE.agent,
-      source: SCOPE.platform,
-      channel_id: SCOPE.channel_id,
-      thread_id: null,
-      project: "open-brain",
-      topic: "First-class local memory",
-      current_context_md: "C".repeat(9000),
-      updated_at: "2026-07-17T18:00:00Z",
-      metadata: { private_raw: "must not escape" },
-    };
-    const events = Array.from({ length: 10 }, (_, index) => ({
-      id: `event-${index}`,
-      event_type: index % 2 === 0 ? "decision" : "fact",
-      content: `event-${index}:` + "E".repeat(2000),
-      source: "shared",
-      importance: "warm",
-      artifact_path: null,
-      transcript_ref: `collab/open-brain/conversations/${index}`,
-      transcript: "RAW TRANSCRIPT MUST NOT ESCAPE",
-      metadata: { tool_output: "RAW TOOL OUTPUT MUST NOT ESCAPE" },
-      occurred_at: null,
-      created_at: `2026-07-17T17:00:0${index}Z`,
-    }));
-    const auth: AuthInfo = { role: "admin", clientId: "rico" };
-    const { client, cleanup } = await setupToolClient(auth, {
-      query: async (sql: string, params?: any[]) => {
-        queries.push({ sql, params });
-        if (sql.includes("FROM ob_session_lanes") && !sql.includes("JOIN")) {
-          return { rows: [lane] };
-        }
-        if (sql.includes("FROM ob_session_events")) {
-          // Real SQL selects newest-first (created_at DESC); mirror it so the
-          // loader's chronological reverse() lands the newest event at the tail.
-          return { rows: [...events].reverse().slice(0, 8) };
-        }
-        return { rows: [] };
+  try {
+    const pack = await client.callTool({
+      name: "agent_context_pack",
+      arguments: {
+        ...SCOPE,
+        requested_sections: ["durable_lane_context"],
+        budget: { max_tokens: 3000 },
       },
     });
 
-    try {
-      const pack = await client.callTool({
-        name: "agent_context_pack",
-        arguments: {
-          ...SCOPE,
-          requested_sections: ["durable_lane_context"],
-          budget: { max_tokens: 3000 },
-        },
-      });
-
-      expect(pack.isError).toBeFalsy();
-      const payload = JSON.parse((pack.content as any)[0].text);
-      const durable = payload.sections.durable_lane_context;
-      // THIS caller asked for a bound (budget.max_tokens: 3000), so it gets one
-      // -- that path is unchanged. What changed on 2026-07-30 is what the bound
-      // spends its room on. Previously a fixed 6,000-char checkpoint ceiling and
-      // a 1,000-char-per-event ceiling meant three events arrived, each severed
-      // mid-content. Now the checkpoint takes at most half the allocation and
-      // the events that fit arrive WHOLE: fewer events, none of them mutilated.
-      // An event the caller can read beats three it cannot.
-      expect(durable).toMatchObject({
-        label: "durable_lane_context",
-        exact_scope_required: true,
-        event_count: 2,
-        truncated: true,
-      });
-      expect(durable.events.map((e: any) => e.id)).toEqual([
-        "event-8",
-        "event-9",
-      ]);
-      // Checkpoint bounded to half the allocation, not to a hardcoded 6000.
-      // Slightly under half after the whole-pack fitter charges serialization
-      // framing; the assertion is the share, not an exact byte count.
-      const halfAllocation = Math.floor((3000 * 4 - 1200) / 2);
-      expect(durable.lane.current_context_md.length).toBeLessThanOrEqual(
-        halfAllocation,
-      );
-      expect(durable.lane.current_context_md.length).toBeGreaterThan(
-        halfAllocation - 100,
-      );
-      // No per-event ceiling is applied any more. The old 1,000-char cut is
-      // gone, so retained bodies run past it -- the last one is bounded only by
-      // whatever allocation remains, not by a fixed number.
-      expect(
-        durable.events.every((event: any) => event.content.length > 1000),
-      ).toBe(true);
-      // The whole serialized section stays within the whole-pack budget.
-      expect(JSON.stringify(durable).length).toBeLessThanOrEqual(
-        3000 * 4 - 1200,
-      );
-      expect(JSON.stringify(durable)).not.toContain("RAW TRANSCRIPT");
-      expect(JSON.stringify(durable)).not.toContain("RAW TOOL OUTPUT");
-      expect(JSON.stringify(durable)).not.toContain("must not escape");
-      expect(payload.warnings.truncation).not.toEqual([]);
-      // Reconciled to what was actually retained -- the halved checkpoint plus
-      // the whole events that fit -- and reported as unbounded, because no
-      // per-section ceiling exists any more.
-      const laneBudget = payload.budget.durable_lane_context;
-      expect(laneBudget.max_events).toBe(Number.MAX_SAFE_INTEGER);
-      expect(laneBudget.max_event_chars).toBe(Number.MAX_SAFE_INTEGER);
-      expect(laneBudget.content_chars_used).toBeGreaterThan(
-        halfAllocation + 3000,
-      );
-      expect(laneBudget.content_chars_used).toBeLessThanOrEqual(
-        laneBudget.content_char_limit,
-      );
-      // One lane citation plus one per retained event.
-      expect(payload.citations).toHaveLength(3);
-
-      expect(queries[0]!.sql).toContain("WHERE namespace = $1");
-      expect(queries[0]!.sql).toContain("AND session_key = $2");
-      expect(queries[0]!.sql).toContain("AND agent = $3");
-      expect(queries[0]!.sql).toContain("AND source = $4");
-      expect(queries[0]!.sql).toContain("metadata->>'server_id' = $5");
-      expect(queries[0]!.sql).toContain("AND channel_id = $6");
-      expect(queries[0]!.sql).toContain(
-        "thread_id IS NOT DISTINCT FROM $7::text",
-      );
-      expect(queries[0]!.params).toEqual([
-        "rico",
-        SCOPE.session_key,
-        SCOPE.agent,
-        SCOPE.platform,
-        SCOPE.server_id,
-        SCOPE.channel_id,
-        null,
-      ]);
-      expect(queries[1]!.sql).toContain("e.lane_id = $1");
-      expect(queries[1]!.sql).toContain("l.namespace = $2");
-      expect(queries[1]!.params?.slice(0, 3)).toEqual([
-        "lane-durable-1",
-        "rico",
-        SCOPE.session_key,
-      ]);
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("declares omitted short events and returns the selected recent subset chronologically", async () => {
-    const lane = {
-      id: "lane-nine-events",
-      session_key: SCOPE.session_key,
-      status: "active",
-      agent: SCOPE.agent,
-      source: SCOPE.platform,
-      channel_id: SCOPE.channel_id,
-      thread_id: null,
-      project: "open-brain",
-      topic: "bounded recent events",
-      current_context_md: "short checkpoint",
-      updated_at: "2026-07-17T18:00:00Z",
-    };
-    const events = Array.from({ length: 9 }, (_, index) => ({
-      id: `event-${index}`,
-      event_type: "fact",
-      content: `short event ${index}`,
-      source: "shared",
-      importance: "warm",
-      artifact_path: null,
-      transcript_ref: null,
-      occurred_at: null,
-      created_at: `2026-07-17T17:00:0${index}Z`,
-    })).reverse();
-    const auth: AuthInfo = { role: "admin", clientId: "rico" };
-    const { client, cleanup } = await setupToolClient(auth, {
-      query: async (sql: string) => {
-        if (sql.includes("FROM ob_session_lanes") && !sql.includes("JOIN")) {
-          return { rows: [lane] };
-        }
-        if (sql.includes("FROM ob_session_events")) {
-          return { rows: events };
-        }
-        return { rows: [] };
-      },
+    expect(pack.isError).toBeFalsy();
+    const payload = parsePackPayload(pack.content);
+    const durable = expectDefined(
+      payload.sections.durable_lane_context,
+      "the durable lane section",
+    );
+    // THIS caller asked for a bound (budget.max_tokens: 3000), so it gets one
+    // -- that path is unchanged. What changed on 2026-07-30 is what the bound
+    // spends its room on. Previously a fixed 6,000-char checkpoint ceiling and
+    // a 1,000-char-per-event ceiling meant three events arrived, each severed
+    // mid-content. Now the checkpoint takes at most half the allocation and
+    // the events that fit arrive WHOLE: fewer events, none of them mutilated.
+    // An event the caller can read beats three it cannot.
+    expect(durable).toMatchObject({
+      label: "durable_lane_context",
+      exact_scope_required: true,
+      event_count: 2,
+      truncated: true,
     });
+    expect(durable.events.map((e: PackEvent) => e.id)).toEqual(["event-8", "event-9"]);
+    // Checkpoint bounded to half the allocation, not to a hardcoded 6000.
+    // Slightly under half after the whole-pack fitter charges serialization
+    // framing; the assertion is the share, not an exact byte count.
+    const halfAllocation = Math.floor((3000 * 4 - 1200) / 2);
+    expect(durable.lane.current_context_md.length).toBeLessThanOrEqual(halfAllocation);
+    expect(durable.lane.current_context_md.length).toBeGreaterThan(
+      halfAllocation - 100,
+    );
+    // No per-event ceiling is applied any more. The old 1,000-char cut is
+    // gone, so retained bodies run past it -- the last one is bounded only by
+    // whatever allocation remains, not by a fixed number.
+    expect(
+      durable.events.every((event: PackEvent) => event.content.length > 1000),
+    ).toBe(true);
+    // The whole serialized section stays within the whole-pack budget.
+    expect(JSON.stringify(durable).length).toBeLessThanOrEqual(3000 * 4 - 1200);
+    expect(JSON.stringify(durable)).not.toContain("RAW TRANSCRIPT");
+    expect(JSON.stringify(durable)).not.toContain("RAW TOOL OUTPUT");
+    expect(JSON.stringify(durable)).not.toContain("must not escape");
+    expect(payload.warnings.truncation).not.toEqual([]);
+    // Reconciled to what was actually retained -- the halved checkpoint plus
+    // the whole events that fit -- and reported as unbounded, because no
+    // per-section ceiling exists any more.
+    const laneBudget = payload.budget.durable_lane_context;
+    expect(laneBudget.max_events).toBe(Number.MAX_SAFE_INTEGER);
+    expect(laneBudget.max_event_chars).toBe(Number.MAX_SAFE_INTEGER);
+    expect(laneBudget.content_chars_used).toBeGreaterThan(halfAllocation + 3000);
+    expect(laneBudget.content_chars_used).toBeLessThanOrEqual(
+      laneBudget.content_char_limit,
+    );
+    // One lane citation plus one per retained event.
+    expect(payload.citations).toHaveLength(3);
 
-    try {
-      const pack = await client.callTool({
-        name: "agent_context_pack",
-        arguments: {
-          ...SCOPE,
-          requested_sections: ["durable_lane_context"],
-        },
-      });
+    const laneQuery = expectDefined(queries[0], "the lane query");
 
-      expect(pack.isError).toBeFalsy();
-      const payload = JSON.parse((pack.content as any)[0].text);
-      const durable = payload.sections.durable_lane_context;
-      // No budget was requested, so every event in the lane comes back whole.
-      // This used to expect events 1..8 and `truncated: true` -- event-0 was
-      // dropped by the 8-event ceiling and the caller was told the lane had
-      // been shortened. Both the ceiling and the marker are gone as of
-      // 2026-07-30; the oldest event is no longer the price of a full read.
-      expect(durable.events.map((event: any) => event.id)).toEqual([
-        "event-0",
-        "event-1",
-        "event-2",
-        "event-3",
-        "event-4",
-        "event-5",
-        "event-6",
-        "event-7",
-        "event-8",
-      ]);
-      expect(durable).toMatchObject({ event_count: 9, truncated: false });
-      expect(payload.warnings.truncation).toEqual([]);
-    } finally {
-      await cleanup();
-    }
-  });
+    const eventQuery = expectDefined(queries[1], "the event query");
 
-  it("preserves sub-millisecond database ordering in chronological output", async () => {
-    const lane = {
-      id: "lane-sub-millisecond-events",
-      session_key: SCOPE.session_key,
-      status: "active",
-      agent: SCOPE.agent,
-      source: SCOPE.platform,
-      channel_id: SCOPE.channel_id,
-      thread_id: null,
-      project: "open-brain",
-      topic: "precision-preserving event order",
-      current_context_md: "checkpoint",
-      updated_at: "2026-07-17T18:00:00Z",
-    };
-    const newerId = "00000000-0000-4000-8000-000000000001";
-    const olderId = "ffffffff-ffff-4fff-bfff-ffffffffffff";
-    const events = [
-      {
-        id: newerId,
-        event_type: "fact",
-        content: "newer event",
-        source: "shared",
-        importance: "warm",
-        artifact_path: null,
-        transcript_ref: null,
-        occurred_at: null,
-        created_at: "2026-07-17T17:00:00.123900Z",
-      },
-      {
-        id: olderId,
-        event_type: "fact",
-        content: "older event",
-        source: "shared",
-        importance: "warm",
-        artifact_path: null,
-        transcript_ref: null,
-        occurred_at: null,
-        created_at: "2026-07-17T17:00:00.123100Z",
-      },
-    ];
-    const auth: AuthInfo = { role: "admin", clientId: "rico" };
-    const { client, cleanup } = await setupToolClient(auth, {
-      query: async (sql: string) => {
-        if (sql.includes("FROM ob_session_lanes") && !sql.includes("JOIN")) {
-          return { rows: [lane] };
-        }
-        if (sql.includes("FROM ob_session_events")) {
-          return { rows: events };
-        }
-        return { rows: [] };
-      },
-    });
-
-    try {
-      const pack = await client.callTool({
-        name: "agent_context_pack",
-        arguments: {
-          ...SCOPE,
-          requested_sections: ["durable_lane_context"],
-        },
-      });
-
-      expect(pack.isError).toBeFalsy();
-      const payload = JSON.parse((pack.content as any)[0].text);
-      expect(
-        payload.sections.durable_lane_context.events.map(
-          (event: any) => event.id,
-        ),
-      ).toEqual([olderId, newerId]);
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("fails closed without event reads when the exact durable lane does not match", async () => {
-    const queries: string[] = [];
-    const auth: AuthInfo = { role: "admin", clientId: "rico" };
-    const { client, cleanup } = await setupToolClient(auth, {
-      query: async (sql: string) => {
-        queries.push(sql);
-        return { rows: [] };
-      },
-    });
-
-    try {
-      const pack = await client.callTool({
-        name: "agent_context_pack",
-        arguments: {
-          ...SCOPE,
-          channel_id: "wrong-channel",
-          requested_sections: ["durable_lane_context"],
-        },
-      });
-
-      expect(pack.isError).toBeFalsy();
-      const payload = JSON.parse((pack.content as any)[0].text);
-      expect(payload.sections.durable_lane_context).toBeUndefined();
-      expect(payload.warnings.scope_denials).toContainEqual({
-        source: "durable_lane_context",
-        reasons: ["exact_scope"],
-      });
-      expect(queries).toHaveLength(1);
-      expect(queries[0]).not.toContain("ob_session_events");
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("fails closed for every mismatched durable exact-scope coordinate", async () => {
-    const cases = [
-      ["namespace", { namespace: "other" }],
-      ["agent", { agent: "other-agent" }],
-      ["platform", { platform: "other-platform" }],
-      ["server_id", { server_id: "other-server" }],
-      ["channel_id", { channel_id: "other-channel" }],
-      ["thread_id", { thread_id: "other-thread" }],
-      ["session_key", { session_key: "other-session" }],
-    ] as const;
-    const expectedParams = [
-      SCOPE.namespace,
+    expect(laneQuery.sql).toContain("WHERE namespace = $1");
+    expect(laneQuery.sql).toContain("AND session_key = $2");
+    expect(laneQuery.sql).toContain("AND agent = $3");
+    expect(laneQuery.sql).toContain("AND source = $4");
+    expect(laneQuery.sql).toContain("metadata->>'server_id' = $5");
+    expect(laneQuery.sql).toContain("AND channel_id = $6");
+    expect(laneQuery.sql).toContain("thread_id IS NOT DISTINCT FROM $7::text");
+    expect(laneQuery.params).toEqual([
+      "rico",
       SCOPE.session_key,
       SCOPE.agent,
       SCOPE.platform,
       SCOPE.server_id,
       SCOPE.channel_id,
       null,
-    ];
-
-    for (const [, override] of cases) {
-      const queries: Array<{ sql: string; params?: any[] }> = [];
-      const auth: AuthInfo = { role: "admin", clientId: "rico" };
-      const { client, cleanup } = await setupToolClient(auth, {
-        query: async (sql: string, params?: any[]) => {
-          queries.push({ sql, params });
-          const exact = expectedParams.every(
-            (value, index) => params?.[index] === value,
-          );
-          return {
-            rows: exact
-              ? [
-                  {
-                    id: "lane-durable-exact",
-                    session_key: SCOPE.session_key,
-                    status: "active",
-                    agent: SCOPE.agent,
-                    source: SCOPE.platform,
-                    channel_id: SCOPE.channel_id,
-                    thread_id: null,
-                    project: "open-brain",
-                    topic: "exact scope",
-                    current_context_md: "exact context",
-                    updated_at: "2026-07-17T00:00:00.000Z",
-                  },
-                ]
-              : [],
-          };
-        },
-      });
-
-      try {
-        const pack = await client.callTool({
-          name: "agent_context_pack",
-          arguments: {
-            ...SCOPE,
-            ...override,
-            requested_sections: ["durable_lane_context"],
-          },
-        });
-
-        expect(pack.isError).toBeFalsy();
-        const payload = JSON.parse((pack.content as any)[0].text);
-        expect(payload.sections.durable_lane_context).toBeUndefined();
-        expect(payload.warnings.scope_denials).toContainEqual({
-          source: "durable_lane_context",
-          reasons: ["exact_scope"],
-        });
-        expect(queries).toHaveLength(1);
-        expect(queries[0]!.sql).not.toContain("ob_session_events");
-      } finally {
-        await cleanup();
-      }
-    }
-  });
-
-  it("degrades durable lane lookup failures without leaking database errors", async () => {
-    const auth: AuthInfo = { role: "admin", clientId: "rico" };
-    const { client, cleanup } = await setupToolClient(auth, {
-      query: async () => {
-        throw new Error("postgres://secret-host/internal-detail");
-      },
-    });
-
-    try {
-      const pack = await client.callTool({
-        name: "agent_context_pack",
-        arguments: {
-          ...SCOPE,
-          requested_sections: ["durable_lane_context"],
-        },
-      });
-
-      expect(pack.isError).toBeFalsy();
-      const payload = JSON.parse((pack.content as any)[0].text);
-      expect(payload.sections.durable_lane_context).toBeUndefined();
-      expect(payload.warnings.degraded_sources).toEqual([
-        {
-          source: "durable_lane_context",
-          reason: "database_unavailable",
-        },
-      ]);
-      expect(JSON.stringify(payload)).not.toContain("secret-host");
-      expect(JSON.stringify(payload)).not.toContain("internal-detail");
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("discards the pool client after a timed-out durable read", async () => {
-    let statementTimeoutMs = 0;
-    let activeQueries = 0;
-    let releaseCount = 0;
-    let releaseArgument: unknown;
-    let rolledBack = false;
-    const lane = {
-      id: "lane-timeout",
-      session_key: SCOPE.session_key,
-      status: "active",
-      agent: SCOPE.agent,
-      source: SCOPE.platform,
-      channel_id: SCOPE.channel_id,
-      thread_id: null,
-      project: "open-brain",
-      topic: "timeout",
-      current_context_md: "context",
-      updated_at: "2026-07-17T18:00:00Z",
-    };
-    const dbClient = {
-      query: async (config: {
-        text: string;
-        values?: unknown[];
-        query_timeout?: number;
-      }) => {
-        const { text, values, query_timeout: queryTimeoutMs } = config;
-        expect(queryTimeoutMs).toBeGreaterThan(0);
-        if (text === "BEGIN READ ONLY" || text === "COMMIT") {
-          return { rows: [] };
-        }
-        if (text === "ROLLBACK") {
-          rolledBack = true;
-          return { rows: [] };
-        }
-        if (text.includes("set_config('statement_timeout'")) {
-          statementTimeoutMs = Number.parseInt(String(values?.[0]), 10);
-          return { rows: [] };
-        }
-        if (text.includes("FROM ob_session_lanes") && !text.includes("JOIN")) {
-          return { rows: [lane] };
-        }
-        if (text.includes("FROM ob_session_events")) {
-          activeQueries += 1;
-          await new Promise((resolve) =>
-            setTimeout(resolve, statementTimeoutMs + 2),
-          );
-          activeQueries -= 1;
-          throw new Error(
-            "canceling statement due to statement timeout secret-detail",
-          );
-        }
-        return { rows: [] };
-      },
-      release: (error?: unknown) => {
-        releaseCount += 1;
-        releaseArgument = error;
-      },
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "rico" };
-    const { client, cleanup } = await setupToolClient(auth, {
-      query: async () => {
-        throw new Error("budgeted reads must use a checked-out client");
-      },
-      connect: async () => dbClient,
-    });
-
-    try {
-      const startedAt = performance.now();
-      const pack = await client.callTool({
-        name: "agent_context_pack",
-        arguments: {
-          ...SCOPE,
-          requested_sections: ["durable_lane_context"],
-          budget: { max_latency_ms: 25 },
-        },
-      });
-      const elapsedMs = performance.now() - startedAt;
-
-      expect(pack.isError).toBeFalsy();
-      const payload = JSON.parse((pack.content as any)[0].text);
-      expect(payload.sections.durable_lane_context).toBeUndefined();
-      expect(payload.warnings.degraded_sources).toEqual([
-        {
-          source: "durable_lane_context",
-          reason: "database_unavailable",
-        },
-      ]);
-      expect(JSON.stringify(payload)).not.toContain("secret-detail");
-      expect(elapsedMs).toBeLessThan(250);
-      expect(activeQueries).toBe(0);
-      expect(rolledBack).toBe(false);
-      expect(releaseCount).toBe(1);
-      expect(releaseArgument).toBeInstanceOf(Error);
-    } finally {
-      await cleanup();
-    }
-  });
-});
-
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-
-dbDescribe("agent_context_pack durable lane reads (live Postgres)", () => {
-  const pool = new Pool({
-    connectionString: DB_URL,
-    max: 2,
-    connectionTimeoutMillis: 500,
-  });
-  const namespace = `test-context-pack-${process.pid}`;
-  const liveScope = {
-    namespace,
-    agent: "nagatha",
-    platform: "discord",
-    server_id: "live-server",
-    channel_id: "live-channel",
-    session_key: `live-context-pack-${process.pid}`,
-  };
-  const laneId = "10000000-0000-0000-0000-000000000001";
-
-  async function cleanupDatabaseRows() {
-    await pool.query(
-      `DELETE FROM ob_session_events
-        WHERE lane_id IN (SELECT id FROM ob_session_lanes WHERE namespace = $1)`,
-      [namespace],
-    );
-    await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [
-      namespace,
     ]);
+    expect(eventQuery.sql).toContain("e.lane_id = $1");
+    expect(eventQuery.sql).toContain("l.namespace = $2");
+    expect(eventQuery.params?.slice(0, 3)).toEqual([
+      "lane-durable-1",
+      "rico",
+      SCOPE.session_key,
+    ]);
+  } finally {
+    await cleanup();
   }
+}
 
-  async function insertLane() {
-    await pool.query(
-      `INSERT INTO ob_session_lanes
-         (id, session_key, namespace, agent, source, channel_id, thread_id,
-          project, topic, current_context_md, metadata, created_by)
-       VALUES ($1, $2, $3, $4, $5, $6, NULL, 'open-brain', 'live context',
-               'live checkpoint', jsonb_build_object('server_id', $7::text), 'test')`,
-      [
-        laneId,
-        liveScope.session_key,
-        namespace,
-        liveScope.agent,
-        liveScope.platform,
-        liveScope.channel_id,
-        liveScope.server_id,
-      ],
-    );
-  }
-
-  async function callLivePack(maxLatencyMs?: number) {
-    const { client, cleanup } = await setupToolClient(
-      { role: "admin", clientId: namespace },
-      pool as any,
-    );
-    try {
-      return await client.callTool({
-        name: "agent_context_pack",
-        arguments: {
-          ...liveScope,
-          requested_sections: ["durable_lane_context"],
-          ...(maxLatencyMs === undefined
-            ? {}
-            : { budget: { max_latency_ms: maxLatencyMs } }),
-        },
-      });
-    } finally {
-      await cleanup();
-    }
-  }
-
-  afterAll(async () => {
-    await cleanupDatabaseRows();
-    await pool.end();
-  });
-
-  it("orders equal-timestamp events by UUID and returns the whole lane chronologically", async () => {
-    await cleanupDatabaseRows();
-    try {
-      await insertLane();
-      const createdAt = "2026-07-17T17:00:00.000Z";
-      for (let index = 1; index <= 9; index += 1) {
-        const id = `00000000-0000-0000-0000-${String(index).padStart(12, "0")}`;
-        await pool.query(
-          `INSERT INTO ob_session_events
-             (id, lane_id, event_type, content, source, importance, created_by, created_at)
-           VALUES ($1, $2, 'fact', $3, 'test', 'warm', 'test', $4)`,
-          [id, laneId, `short event ${index}`, createdAt],
-        );
+async function declaresOmittedShortEventsAndReturnsTheSelec() {
+  const lane = {
+    id: "lane-nine-events",
+    session_key: SCOPE.session_key,
+    status: "active",
+    agent: SCOPE.agent,
+    source: SCOPE.platform,
+    channel_id: SCOPE.channel_id,
+    thread_id: null,
+    project: "open-brain",
+    topic: "bounded recent events",
+    current_context_md: "short checkpoint",
+    updated_at: "2026-07-17T18:00:00Z",
+  };
+  const events = Array.from({ length: 9 }, (_, index) => ({
+    id: `event-${index}`,
+    event_type: "fact",
+    content: `short event ${index}`,
+    source: "shared",
+    importance: "warm",
+    artifact_path: null,
+    transcript_ref: null,
+    occurred_at: null,
+    created_at: `2026-07-17T17:00:0${index}Z`,
+  })).reverse();
+  const auth: AuthInfo = { role: "admin", clientId: "rico" };
+  const { client, cleanup } = await setupToolClient(auth, {
+    query: async (sql: string) => {
+      if (sql.includes("FROM ob_session_lanes") && !sql.includes("JOIN")) {
+        return { rows: [lane] };
       }
-
-      const pack = await callLivePack();
-      const payload = JSON.parse((pack.content as any)[0].text);
-      expect(pack.isError).toBeFalsy();
-      expect(payload.sections.durable_lane_context).toBeDefined();
-      // No budget was requested, so the whole lane comes back whole. All nine
-      // events share one timestamp, so the `created_at DESC, id DESC` tie-break
-      // is what makes the order deterministic; after the chronological reverse
-      // that surfaces as UUID ascending. This used to expect only the eight
-      // "recent" events and `truncated: true`, dropping ...0001 to the 8-event
-      // ceiling. That ceiling and its truncation marker are gone as of
-      // 2026-07-30 (see agent-context-pack-durable-lane.ts) -- the oldest event
-      // is no longer the price of a full read.
-      expect(
-        payload.sections.durable_lane_context.events.map(
-          (event: Record<string, unknown>) => event.id,
-        ),
-      ).toEqual(
-        Array.from(
-          { length: 9 },
-          (_, index) =>
-            `00000000-0000-0000-0000-${String(index + 1).padStart(12, "0")}`,
-        ),
-      );
-      expect(payload.sections.durable_lane_context).toMatchObject({
-        event_count: 9,
-        truncated: false,
-      });
-    } finally {
-      await cleanupDatabaseRows();
-    }
+      if (sql.includes("FROM ob_session_events")) {
+        return { rows: events };
+      }
+      return { rows: [] };
+    },
   });
 
-  it("cancels a lock-delayed event read before returning and releases its pool client", async () => {
-    await cleanupDatabaseRows();
-    const blocker = await pool.connect();
-    try {
-      await insertLane();
-      await blocker.query("BEGIN");
-      await blocker.query(
-        "LOCK TABLE ob_session_events IN ACCESS EXCLUSIVE MODE",
-      );
+  try {
+    const pack = await client.callTool({
+      name: "agent_context_pack",
+      arguments: {
+        ...SCOPE,
+        requested_sections: ["durable_lane_context"],
+      },
+    });
 
-      const startedAt = performance.now();
-      const pack = await callLivePack(50);
-      const elapsedMs = performance.now() - startedAt;
-      const payload = JSON.parse((pack.content as any)[0].text);
+    expect(pack.isError).toBeFalsy();
+    const payload = parsePackPayload(pack.content);
+    const durable = expectDefined(
+      payload.sections.durable_lane_context,
+      "the durable lane section",
+    );
+    // No budget was requested, so every event in the lane comes back whole.
+    // This used to expect events 1..8 and `truncated: true` -- event-0 was
+    // dropped by the 8-event ceiling and the caller was told the lane had
+    // been shortened. Both the ceiling and the marker are gone as of
+    // 2026-07-30; the oldest event is no longer the price of a full read.
+    expect(durable.events.map((event: PackEvent) => event.id)).toEqual([
+      "event-0",
+      "event-1",
+      "event-2",
+      "event-3",
+      "event-4",
+      "event-5",
+      "event-6",
+      "event-7",
+      "event-8",
+    ]);
+    expect(durable).toMatchObject({ event_count: 9, truncated: false });
+    expect(payload.warnings.truncation).toEqual([]);
+  } finally {
+    await cleanup();
+  }
+}
 
-      expect(pack.isError).toBeFalsy();
-      expect(payload.sections.durable_lane_context).toBeUndefined();
-      expect(payload.warnings.degraded_sources).toEqual([
-        {
-          source: "durable_lane_context",
-          reason: "database_unavailable",
-        },
-      ]);
-      expect(elapsedMs).toBeLessThan(500);
-      await pool.query("SELECT 1");
-    } finally {
-      await blocker.query("ROLLBACK").catch(() => undefined);
-      blocker.release();
-      await cleanupDatabaseRows();
-    }
+async function preservesSubmillisecondDatabaseOrderingInChr() {
+  const lane = {
+    id: "lane-sub-millisecond-events",
+    session_key: SCOPE.session_key,
+    status: "active",
+    agent: SCOPE.agent,
+    source: SCOPE.platform,
+    channel_id: SCOPE.channel_id,
+    thread_id: null,
+    project: "open-brain",
+    topic: "precision-preserving event order",
+    current_context_md: "checkpoint",
+    updated_at: "2026-07-17T18:00:00Z",
+  };
+  const newerId = "00000000-0000-4000-8000-000000000001";
+  const olderId = "ffffffff-ffff-4fff-bfff-ffffffffffff";
+  const events = [
+    {
+      id: newerId,
+      event_type: "fact",
+      content: "newer event",
+      source: "shared",
+      importance: "warm",
+      artifact_path: null,
+      transcript_ref: null,
+      occurred_at: null,
+      created_at: "2026-07-17T17:00:00.123900Z",
+    },
+    {
+      id: olderId,
+      event_type: "fact",
+      content: "older event",
+      source: "shared",
+      importance: "warm",
+      artifact_path: null,
+      transcript_ref: null,
+      occurred_at: null,
+      created_at: "2026-07-17T17:00:00.123100Z",
+    },
+  ];
+  const auth: AuthInfo = { role: "admin", clientId: "rico" };
+  const { client, cleanup } = await setupToolClient(auth, {
+    query: async (sql: string) => {
+      if (sql.includes("FROM ob_session_lanes") && !sql.includes("JOIN")) {
+        return { rows: [lane] };
+      }
+      if (sql.includes("FROM ob_session_events")) {
+        return { rows: events };
+      }
+      return { rows: [] };
+    },
   });
+
+  try {
+    const pack = await client.callTool({
+      name: "agent_context_pack",
+      arguments: {
+        ...SCOPE,
+        requested_sections: ["durable_lane_context"],
+      },
+    });
+
+    expect(pack.isError).toBeFalsy();
+    const payload = parsePackPayload(pack.content);
+    expect(
+      expectDefined(
+        payload.sections.durable_lane_context,
+        "the durable lane section",
+      ).events.map((event: PackEvent) => event.id),
+    ).toEqual([olderId, newerId]);
+  } finally {
+    await cleanup();
+  }
+}
+
+describe("agent_context_pack durable lane context", () => {
+  it(
+    "does not query or return durable lane context unless explicitly requested",
+    doesNotQueryOrReturnDurableLaneContextUnless,
+  );
+
+  it(
+    "returns bounded distilled durable context for the exact authorized lane",
+    returnsBoundedDistilledDurableContextForTheE,
+  );
+
+  it(
+    "declares omitted short events and returns the selected recent subset chronologically",
+    declaresOmittedShortEventsAndReturnsTheSelec,
+  );
+
+  it(
+    "preserves sub-millisecond database ordering in chronological output",
+    preservesSubmillisecondDatabaseOrderingInChr,
+  );
 });


### PR DESCRIPTION
## Summary

- `src/tools/__tests__/agent-context-pack-durable-lane.test.ts` read `OPENBRAIN_TEST_DATABASE_URL` itself and swapped in `describe.skip` when it was unset. Without a database the file reported `8 pass, 3 skip, 0 fail` and exited 0, which at the exit code is indistinguishable from a suite that ran and passed (#878).
- Split the file by subject: the original keeps its four mocked-dependency `durable lane context` tests, a new `agent-context-pack-durable-lane-fail-closed.test.ts` holds the four mocked fail-closed and degradation tests, and a new `agent-context-pack-durable-lane.pg.test.ts` holds the two live reads. Neither unit file builds a pool.
- The live file builds its module-scope pool from `requireTestDatabaseUrl()`, so a run without the variable throws `test_database_required` and fails loudly instead of skipping.
- New `agent-context-pack-durable-lane-test-helpers.ts` carries the shared `expectDefined` guard, the parsed-payload shapes the suites assert against, and the tool-client pool type. It holds no test and creates no pool.
- Test names, bodies, and assertions moved verbatim. Only the `describe` wrappers, imports, pool creation, and helper plumbing changed.
- The touched files also go to the oxlint standard the pre-commit gate applies to staged files whole: 19 `no-explicit-any` became the declared type or `unknown`, 12 `no-non-null-assertion` became `expectDefined` guards, and the long `it` bodies were hoisted to module-scope `async function` declarations so no `describe` callback runs past 100 code lines. No disable comments.
- `scripts/assert-db-tests-ran.ts` registers the new live suite at its JUnit-measured 2 testcases and moves `MIN_TOTAL_LIVE_TESTCASES` 285 -> 287, so CI's anti-skip guard fails if the suite ever stops running.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- Full invocation, on the committed tree: `CHANGED_FILES="src/tools/__tests__/agent-context-pack-durable-lane.pg.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` -> exit 0, all four clauses PASS. The RED receipt was taken on `origin/main` before any edit with `CHANGED_FILES="src/tools/__tests__/agent-context-pack-durable-lane.test.ts"` -> exit 1, clauses 1, 2 and 3 FAIL (clause 1 named lines 546-549, the `DB_URL` read and the `dbDescribe` swap).
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bun run test:isolated` over the three files on the committed tree: 10 pass, 0 fail, 0 skip. On `origin/main` the same subject was 8 pass, 3 skip. `bunx tsc --noEmit` clean. `./node_modules/.bin/oxlint --deny-warnings` clean on all four touched or created files; 37 findings on the `origin/main` copy, 0 now.

## Critical Self-Review

- Highest-risk behavior: the two live reads now run in CI where before they silently skipped. If either is flaky against a fresh database, this PR turns a permanent green into an intermittent red. Both passed on an isolated database created and dropped by `test:isolated`; the lock-delayed read asserts an elapsed bound under 500 ms, which is the one assertion that could be timing-sensitive on a loaded runner.
- Assumptions that could be wrong: that the two live tests are the only ones in the file needing a database. Verified by reading the file, not inferred: the other eight construct their own mock `query`/`connect` and never reach `pg`, and they pass in files that import no pool at all.
- Missing/weak tests: no test was added. The change is a conversion; the done-means check's clause 3 is what proves the new fail-closed behavior, by running the file with the variable removed and requiring both a non-zero exit and `test_database_required` in the output.
- Security/permission risk: none. No auth, namespace, or predicate logic is touched, and no non-test file changed.
- Migration/deploy risk: none. No migration, no schema, no runtime path.
- Downstream client/runtime risk: none. Per `docs/downstream-rollout.md` this is test-only; no MCP tool, schema, transport, or Python client surface changed.
- Rollback/cleanup concern: reverting restores the skipping file. The manifest entry and the 287 floor would need to go with it, or CI's anti-skip guard fails on a suite name it cannot find.
- Fixes made before PR: the first commit attempt was blocked by the pre-commit prettier check; ran `prettier --write`, re-ran oxlint on the reformatted files to confirm the reflow did not push a function back over 100 lines, and re-staged. The lint, test, and done-means receipts above are all from the committed tree, not the staged one.
- Known residual risk: `PackPayload` declares only the properties these suites read. A future assertion against an undeclared property is a typecheck error rather than a silent `undefined` — intended, but it means adding an assertion may mean widening the interface first.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane surfaced no new MEDIUM+ review finding; the patterns it hit (inheriting a touched file's pre-existing lint findings, hoisting `it` bodies for `max-lines-per-function`, re-measuring the manifest per split half) are already recorded in round 39 of the lane contract's Tightenings from PRs #929-#935.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: test-only change, no service surface touched.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape changed; only test files and the anti-skip manifest.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Test-only. The five changed paths are three test files, one test helper module, and `scripts/assert-db-tests-ran.ts`. No tool, transport, schema, or client surface is in the diff, so every downstream item is not applicable.
- JUnit measurement for the manifest entry: 2 `testcase` elements carry `agent_context_pack durable lane reads (live Postgres)`, counted from the reporter output rather than tallied by eye.
