### PR TITLE
test(server): pin the tier_lane_denied warn line on a namespace denial (#827)

### DIFF
--- a/scripts/done-means/827-tier-lane-denied-warn-pinned.sh
+++ b/scripts/done-means/827-tier-lane-denied-warn-pinned.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #827 — the acceptance gate, not the fix.
+#
+#   bash scripts/done-means/827-tier-lane-denied-warn-pinned.sh
+#
+# THE DEFECT. `authorizeTierLane` (server/tools/tier-lane.ts) emits
+# `dependencies.logger.warn({ tool, role, namespace }, "tier_lane_denied")` when
+# `canTargetNamespace` refuses a caller-named namespace. That warn line is the
+# ONLY record a namespace denial on this tool ever leaves, and nothing asserted
+# it. The shared `authorize` in server/tools/memory-helpers.ts emits no such
+# event, so a behavior-preserving-looking swap to that helper — exactly the kind
+# of reuse a sweep reaches for, and one the file's own comment warns against —
+# deletes the denial log while every existing test stays green. A refusal that
+# stops logging is indistinguishable in test output from a refusal that still
+# logs, which is why the event name AND its fields need pinning, not just the
+# `isError` result.
+#
+# WHY CLAUSE 3 MUTATES THE SOURCE. Clauses 1 and 2 prove the test exists and
+# passes; neither proves it would NOTICE the defect. A test that asserted only
+# `result.isError` would satisfy both and pin nothing. So the check deletes the
+# warn statement from `authorizeTierLane` and requires the same test to go red:
+# that is the smallest observation distinguishing "the event is pinned" from
+# "the refusal is pinned". The mutation is applied to the working tree and
+# restored from a copy by an EXIT trap, and the clause refuses to start unless
+# the file is clean so a failed restore can never be mistaken for the author's
+# own edit.
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.." || {
+  echo "DONE-MEANS 827: FAIL — clause 0: cannot enter repo root" >&2
+  exit 1
+}
+
+TEST_FILE="server/tools/tier-lane-denied.test.ts"
+SOURCE_FILE="server/tools/tier-lane.ts"
+EVENT="tier_lane_denied"
+BACKUP="/Volumes/ThunderBolt/_tmp/open-brain/_scratch/session10/tier-lane.ts.pre-mutation"
+
+# --- clause 1: the test file exists and names the event on a code line -------
+if [[ ! -f "$TEST_FILE" ]]; then
+  echo "DONE-MEANS 827: FAIL — clause 1: $TEST_FILE not found" >&2
+  exit 1
+fi
+if ! grep -q "\"$EVENT\"" "$TEST_FILE"; then
+  echo "DONE-MEANS 827: FAIL — clause 1: $TEST_FILE never names \"$EVENT\"" >&2
+  exit 1
+fi
+echo "DONE-MEANS 827: clause 1 OK — $TEST_FILE pins \"$EVENT\""
+
+# --- clause 2: the test passes on the tree as it stands ---------------------
+if ! bun run test:isolated "$TEST_FILE"; then
+  echo "DONE-MEANS 827: FAIL — clause 2: $TEST_FILE exited non-zero" >&2
+  exit 1
+fi
+echo "DONE-MEANS 827: clause 2 OK — $TEST_FILE passes"
+
+# --- clause 3: the deliberate miss — delete the warn, require red -----------
+if [[ -n "$(git status --porcelain "$SOURCE_FILE")" ]]; then
+  echo "DONE-MEANS 827: FAIL — clause 3: $SOURCE_FILE is already modified; the" \
+    "mutation needs a clean file so the restore is verifiable" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$BACKUP")" || {
+  echo "DONE-MEANS 827: FAIL — clause 3: cannot create the backup directory" >&2
+  exit 1
+}
+cp "$SOURCE_FILE" "$BACKUP" || {
+  echo "DONE-MEANS 827: FAIL — clause 3: cannot copy $SOURCE_FILE aside" >&2
+  exit 1
+}
+
+restore_source() {
+  cp "$BACKUP" "$SOURCE_FILE"
+}
+trap restore_source EXIT
+
+perl -0pi -e 's/\n\s*dependencies\.logger\.warn\(.*?\);\n/\n/s' "$SOURCE_FILE"
+
+# Scoped to the STATEMENT, not the file: the helper's doc comment names the
+# event too, and a file-wide grep would call a correct deletion a failure.
+if grep -q "^\s*dependencies\.logger\.warn(" "$SOURCE_FILE"; then
+  echo "DONE-MEANS 827: FAIL — clause 3: the mutation did not remove the warn" \
+    "statement from $SOURCE_FILE; the regex no longer matches the source" >&2
+  exit 1
+fi
+
+bun run test:isolated "$TEST_FILE"
+MUTATED_STATUS=$?
+
+restore_source
+trap - EXIT
+
+if [[ -n "$(git status --porcelain "$SOURCE_FILE")" ]]; then
+  echo "DONE-MEANS 827: FAIL — clause 3: the restore left $SOURCE_FILE dirty" >&2
+  exit 1
+fi
+
+if [[ "$MUTATED_STATUS" -eq 0 ]]; then
+  echo "DONE-MEANS 827: FAIL — clause 3: $TEST_FILE still passed with the" \
+    "\"$EVENT\" warn deleted; the test pins the refusal, not the event" >&2
+  exit 1
+fi
+echo "DONE-MEANS 827: clause 3 OK — deleting the warn turns $TEST_FILE red" \
+  "(exit $MUTATED_STATUS), and $SOURCE_FILE is restored clean"
+
+echo "DONE-MEANS 827: PASS"

--- a/server/tools/tier-lane-denied.test.ts
+++ b/server/tools/tier-lane-denied.test.ts
@@ -1,0 +1,144 @@
+/**
+ * The `tier_lane_denied` warn line is part of this tool's contract.
+ *
+ * `authorizeTierLane` (./tier-lane.ts) is a LOCAL helper rather than the shared
+ * `authorize` in ./memory-helpers.ts for exactly one reason, which its own
+ * comment states: the shared helper emits no denial event, so calling it would
+ * drop this line. That reason is only enforceable if something reads the line.
+ * Nothing did — the existing suites assert the refusal's `isError` and its
+ * message, both of which survive the swap untouched.
+ *
+ * So these tests assert the EVENT, not the refusal: the message string
+ * `tier_lane_denied` and each field the log record carries. A denial that stops
+ * logging and a denial that still logs produce identical tool results, and the
+ * captured record is the only thing that tells them apart.
+ *
+ * No database: the namespace check runs before any pool call, and the stub pool
+ * here is asserted to have recorded ZERO statements — which is itself the
+ * second half of the isolation claim (a refused caller never reaches the pool).
+ */
+import { describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Logger } from "pino";
+import type { Pool, PoolClient } from "pg";
+import type { Role } from "../config.ts";
+import { registerTierLaneTool } from "./tier-lane.ts";
+import { DEFAULT_SHARED_NAMESPACE_NAMES } from "./shared-namespace-fixture.ts";
+
+/** One captured `logger.warn(fields, message)` call. */
+interface CapturedWarn {
+  readonly fields: Record<string, unknown>;
+  readonly message: string;
+}
+
+/**
+ * A `tier_lane` client whose logger and pool both record instead of acting.
+ *
+ * Only `registerTierLaneTool` is registered, so any captured statement or warn
+ * belongs to this tool and nothing else.
+ */
+async function tierLaneClient(
+  role: Role,
+  clientId: string,
+): Promise<{
+  client: Client;
+  warns: CapturedWarn[];
+  statements: string[];
+  close: () => Promise<void>;
+}> {
+  const warns: CapturedWarn[] = [];
+  const statements: string[] = [];
+  const run = async (sql: string) => {
+    statements.push(sql);
+    return { rows: [], rowCount: 0 };
+  };
+  const pool = {
+    query: run,
+    connect: async () =>
+      ({ query: run, release: () => undefined }) as unknown as PoolClient,
+  } as unknown as Pool;
+  const logger = {
+    warn: (fields: Record<string, unknown>, message: string) => {
+      warns.push({ fields, message });
+    },
+    info: () => undefined,
+    debug: () => undefined,
+    error: () => undefined,
+  } as unknown as Logger;
+
+  const server = new McpServer({ name: "tier-lane-denied", version: "1.0.0" });
+  registerTierLaneTool(server, {
+    pool,
+    embedFn: async () => null,
+    logger,
+    sharedNamespaceNames: DEFAULT_SHARED_NAMESPACE_NAMES,
+  });
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const send = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message, options) =>
+    send(message, {
+      ...options,
+      authInfo: { role, clientId, namespaceSource: "token" },
+    } as unknown as Parameters<typeof send>[1]);
+  const client = new Client({
+    name: "tier-lane-denied-client",
+    version: "1.0.0",
+  });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    warns,
+    statements,
+    close: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+describe("tier_lane denial log", () => {
+  test("a refused namespace emits tier_lane_denied with tool, role and namespace", async () => {
+    const { client, warns, statements, close } = await tierLaneClient("agent", "rico");
+    try {
+      const result = await client.callTool({
+        name: "tier_lane",
+        arguments: { session_key: "lane-6", namespace: "someone-else" },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(warns).toHaveLength(1);
+      expect(warns[0]?.message).toBe("tier_lane_denied");
+      expect(warns[0]?.fields).toEqual({
+        tool: "tier_lane",
+        role: "agent",
+        namespace: "someone-else",
+      });
+      // The refusal happens before any pool call, so a denied caller leaves no
+      // statement behind at all.
+      expect(statements).toEqual([]);
+    } finally {
+      await close();
+    }
+  });
+
+  test("the caller's own namespace emits no tier_lane_denied warn", async () => {
+    // Without this, a logger that warned on EVERY call would satisfy the test
+    // above and the event would still be unpinned.
+    const { client, warns, close } = await tierLaneClient("agent", "rico");
+    try {
+      await client.callTool({
+        name: "tier_lane",
+        arguments: { session_key: "lane-6", namespace: "rico" },
+      });
+
+      expect(warns.filter((warn) => warn.message === "tier_lane_denied")).toEqual([]);
+    } finally {
+      await close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- `authorizeTierLane` in `server/tools/tier-lane.ts` stays a local helper instead of the shared `authorize` in `server/tools/memory-helpers.ts` for one reason its own comment states: the shared helper emits no denial event, so calling it would drop this tool's `tier_lane_denied` warn. Nothing read that line, so the reason was documentation rather than a check.
- The existing suites assert the refusal's `isError` and its message, and both survive that swap untouched. A denial that stops logging and a denial that still logs produce identical tool results, so the warn record is the only thing that distinguishes them.
- New `server/tools/tier-lane-denied.test.ts` asserts the EVENT rather than the refusal: the message string plus every field of the record (`tool`, `role`, `namespace`). A second test drives the caller's own namespace and requires no denial warn, so a logger that warned on every call cannot satisfy the first test. The stub pool is asserted to have recorded zero statements, pinning the other half of the claim — a refused caller never reaches the pool, because the namespace check runs first.
- Unit only: no database, no manifest entry. Harness copied from `server/tools/ported-tools-scope.test.ts`, registering `registerTierLaneTool` alone so any captured statement or warn belongs to this tool.
- Sibling denial events are reported, not widened. `promote_shared_denied`, `adjacent_context_denied`, `citation_recall_denied` and `promote_entry_denied` all exist and are all unpinned today. `src/tools/tier-lane.ts:75` is the legacy twin and was left alone.
- No production code changed.

## Verification

- Done-means: scripts/done-means/827-tier-lane-denied-warn-pinned.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts on the committed tree (f9036e4):

- `bash scripts/done-means/827-tier-lane-denied-warn-pinned.sh` -> exit 0, all three clauses OK.
- `bun run test:isolated server/tools/tier-lane-denied.test.ts` -> exit 0, 2 pass / 0 fail, 6 expect() calls.
- `./node_modules/.bin/oxlint --deny-warnings` on both new files -> exit 0, no findings (the shell script is skipped by oxlint, which reports nothing for it).
- `bunx tsc --noEmit` -> exit 0.

RED receipts, both taken before the green ones:

- Before the test file existed, the done-means exited 1 at clause 1 naming the missing file.
- With `authorizeTierLane` temporarily rewritten to call the shared `authorize` (matching its union return), `bun run test:isolated server/tools/tier-lane-denied.test.ts` -> exit 1, failing at `expect(warns).toHaveLength(1)`, 1 pass / 1 fail. `git restore` returned the file clean before anything was staged.

Clause 3 of the done-means repeats that proof mechanically: it deletes the warn statement from the working tree with `perl -0pi`, requires the same test to go non-zero, and restores from a copy via an EXIT trap. It refuses to start unless `git status --porcelain` on the source file is empty, and re-checks that the restore left it empty, so a failed restore can never be read as the author's own edit.

## Critical Self-Review

- Highest-risk behavior: none in production code — this PR adds a test and a check script and changes no shipped path. The risk it carries is a test that looks like it pins the event but does not, which is precisely what clause 3's mutation exists to rule out.
- Assumptions that could be wrong: that `tier_lane`'s namespace check runs before any pool call. Asserted directly rather than assumed — the test requires the recorded statement list to be empty on the denial path, so if that ordering ever changes this test says so.
- Missing/weak tests: the four sibling denial events named above stay unpinned; widening to them was out of scope for this lane and is worth its own item. Role-permission denial (a role that cannot write thoughts at all) returns before the namespace branch and emits no event, so it is not covered here and there is nothing to pin.
- Security/permission risk: none added. This raises the cost of silently deleting a namespace-denial audit line, which is the observability half of a security boundary.
- Migration/deploy risk: none. No schema, no migration, no config.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface changed, so `docs/downstream-rollout.md` does not apply.
- Rollback/cleanup concern: reverting the commit removes only the test and the script. Clause 3 mutates the working tree while it runs; the trap restores from a copy and the clause verifies the file is clean afterwards, so an interrupted run does not leave the source modified.
- Fixes made before PR: the first done-means run exited 1 at clause 3 with two real defects in the check itself — its post-mutation guard grepped the whole file for the event name, which the helper's own doc comment also contains, so a correct deletion read as a failed regex. Scoped the guard to the warn statement and verified the `perl` mutation on a copy first, confirming it removes that statement and leaves the adjacent `logger.error` intact. The gate catching its own bad regex rather than banking a false kill is the behavior clause 3 was written for.
- Known residual risk: clause 3's regex is anchored on the literal `dependencies.logger.warn(` shape. If that call is reformatted, the clause fails loudly with a message saying the regex no longer matches the source rather than passing silently, which is the correct direction to fail.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: no new MEDIUM+ review finding surfaced in this lane; the one lesson (a mutation clause's post-mutation guard must be scoped to the statement it deletes, because prose in the same file legitimately repeats the event name) is offered as a Tightening for the harvest rather than as a new SME entry.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no live surface is touched; this is a unit test and a check script.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape changed — the PR adds a test over an existing server-side log line.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable throughout: no MCP tool, schema, protocol, or client-facing shape changed. The diff is two new files, one a test and one a check script.
