### PR TITLE
test(pg): the backup restore drill test requires the test database instead of skipping (#878, #938)

### DIFF
--- a/scripts/__tests__/backup-restore-live-helpers.ts
+++ b/scripts/__tests__/backup-restore-live-helpers.ts
@@ -1,0 +1,301 @@
+/**
+ * Shared drill machinery for the live backup/restore suites (issues #298,
+ * #878, #938).
+ *
+ * This module holds no test and creates no pool at import. It exists so the
+ * drill and refusal suites can each open their own scratch-database lifecycle
+ * from one definition instead of each carrying a private copy that drifts.
+ *
+ * The two connection strings are demanded through
+ * scripts/test-support/require-test-database.ts at the point of use, so a run
+ * without them fails with test_database_required rather than skipping.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import pg from "pg";
+import { runMigrations } from "../../src/db/migrate.ts";
+import {
+  requireLocalCloneTestDatabaseUrl,
+  requireTestDatabaseUrl,
+} from "../test-support/require-test-database.ts";
+
+export const REPO_ROOT = join(import.meta.dir, "..", "..");
+export const MIGRATIONS_DIR = join(REPO_ROOT, "src", "db", "migrations");
+
+export const SRC_DB = "open_brain_ci_restore_src";
+export const TGT_DB = "open_brain_ci_restore_tgt";
+export const OLD_SRC_DB = "open_brain_ci_restore_oldsrc";
+export const OLD_TGT_DB = "open_brain_ci_restore_oldtgt";
+export const SNAPSHOT_TGT_DB = "open_brain_ci_restore_snapshot_tgt";
+/**
+ * The clone-owned restore target (issue #938). The runner's clone database is
+ * already migrated by scripts/test-isolated.ts, and scripts/restore.ts refuses
+ * a non-empty target, so the drill restores into this fresh database instead.
+ * It is created OWNER <clone.user> to preserve the non-superuser property the
+ * clone test asserts.
+ */
+export const CLONE_TGT_DB = "open_brain_ci_restore_clone_tgt";
+export const SCRATCH_DBS = [
+  SRC_DB,
+  TGT_DB,
+  OLD_SRC_DB,
+  OLD_TGT_DB,
+  SNAPSHOT_TGT_DB,
+  CLONE_TGT_DB,
+];
+
+export const NS_ALPHA = "drill-ns-alpha";
+export const NS_BETA = "drill-ns-beta";
+export const DELETED_HASH = "drill-hard-deleted-hash";
+export const ARCHIVED_HASH = "drill-archived-hash";
+
+export interface Conn {
+  host: string;
+  port: number;
+  user: string;
+  password: string | undefined;
+}
+
+/** One drill lifecycle: the admin and clone connections plus its temp dirs. */
+export interface DrillContext {
+  admin: Conn & { database: string };
+  clone: Conn & { database: string };
+  adminClient: pg.Client;
+  tempDirs: string[];
+}
+
+/**
+ * The receipt the backup/restore/verify CLIs print as their last stdout line.
+ *
+ * The three CLIs print three different receipt schemas, so the shared shape is
+ * an open record; each assertion narrows the field it reads.
+ */
+export type CliReceipt = Record<string, unknown> | null;
+
+export interface CliResult {
+  exitCode: number;
+  receipt: CliReceipt;
+  stdout: string;
+  stderr: string;
+}
+
+/** Throws when a value is null or undefined, so callers need no `!`. */
+export function expectDefined<T>(value: T | null | undefined, label: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(`expected ${label} to be defined`);
+  }
+  return value;
+}
+
+export function parseAdminUrl(url: string): Conn & { database: string } {
+  const parsed = new URL(url);
+  return {
+    host: parsed.hostname,
+    port: parsed.port ? Number(parsed.port) : 5432,
+    user: decodeURIComponent(parsed.username),
+    password: parsed.password ? decodeURIComponent(parsed.password) : undefined,
+    database: parsed.pathname.replace(/^\//, ""),
+  };
+}
+
+export function dbUrl(conn: Conn, database: string): string {
+  const auth = conn.password
+    ? `${encodeURIComponent(conn.user)}:${encodeURIComponent(conn.password)}`
+    : encodeURIComponent(conn.user);
+  return `postgres://${auth}@${conn.host}:${conn.port}/${database}`;
+}
+
+export function cliEnv(conn: Conn, database: string): Record<string, string> {
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    DB_HOST: conn.host,
+    DB_PORT: String(conn.port),
+    DB_USER: conn.user,
+    DB_NAME: database,
+  };
+  if (conn.password !== undefined) env.DB_PASSWORD = conn.password;
+  return env;
+}
+
+export async function runCli(
+  script: string,
+  args: string[],
+  env: Record<string, string>,
+): Promise<CliResult> {
+  const proc = Bun.spawn(["bun", join(REPO_ROOT, "scripts", script), ...args], {
+    cwd: REPO_ROOT,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  const lines = stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  let receipt: CliReceipt = null;
+  // The receipt is the last stdout line (logger lines may precede it).
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      receipt = JSON.parse(expectDefined(lines[i], "stdout line")) as CliReceipt;
+      break;
+    } catch {
+      continue;
+    }
+  }
+  return { exitCode, receipt, stdout, stderr };
+}
+
+export function makePool(conn: Conn, database: string): pg.Pool {
+  return new pg.Pool({ ...conn, database, max: 2 });
+}
+
+/** Creates a temp directory and records it on the context for teardown. */
+export async function tempDir(tempDirs: string[]): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "ob298-live-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+export async function dropScratchDbs(adminClient: pg.Client): Promise<void> {
+  for (const name of SCRATCH_DBS) {
+    // Names come from the fixed SCRATCH_DBS list above, never from input.
+    await adminClient.query(`DROP DATABASE IF EXISTS ${name} WITH (FORCE)`);
+  }
+}
+
+/**
+ * Opens one drill lifecycle: connects the admin client and recreates every
+ * scratch database. CLONE_TGT_DB is owned by the clone role so a restore into
+ * it exercises the non-superuser path.
+ */
+export async function openDrill(): Promise<DrillContext> {
+  const admin = parseAdminUrl(requireTestDatabaseUrl());
+  const clone = parseAdminUrl(requireLocalCloneTestDatabaseUrl());
+  const adminClient = new pg.Client({ connectionString: dbUrl(admin, admin.database) });
+  await adminClient.connect();
+  await dropScratchDbs(adminClient);
+  for (const name of SCRATCH_DBS) {
+    if (name === CLONE_TGT_DB) {
+      await adminClient.query(`CREATE DATABASE ${name} OWNER ${clone.user}`);
+      // Administrative bootstrap, exactly as scripts/test-support/
+      // clone-database.ts:194 does it for the clone database: the clone role is
+      // a non-superuser and cannot install extensions itself, so pg_restore
+      // would fail creating them (#938).
+      const seed = new pg.Client({ connectionString: dbUrl(admin, name) });
+      await seed.connect();
+      await seed.query(
+        "CREATE EXTENSION IF NOT EXISTS vector; CREATE EXTENSION IF NOT EXISTS pg_stat_statements;",
+      );
+      await seed.end();
+    } else {
+      await adminClient.query(`CREATE DATABASE ${name}`);
+    }
+  }
+  return { admin, clone, adminClient, tempDirs: [] };
+}
+
+/** Drops the scratch databases, closes the admin client, clears temp dirs. */
+export async function closeDrill(ctx: DrillContext): Promise<void> {
+  await dropScratchDbs(ctx.adminClient);
+  await ctx.adminClient.end();
+  for (const dir of ctx.tempDirs) {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Seeds the source database and runs the backup CLI against it.
+ *
+ * Returns the backup directory both suites restore from, alongside the
+ * backup CLI result so a caller can assert on its receipt.
+ */
+export async function seedAndBackup(
+  ctx: DrillContext,
+): Promise<{ backupDir: string; backup: CliResult }> {
+  const { admin } = ctx;
+  // --- seed the source ------------------------------------------------
+  const srcPool = makePool(admin, SRC_DB);
+  try {
+    await runMigrations(srcPool);
+    await srcPool.query(
+      `INSERT INTO thoughts (content, created_by, namespace, content_hash)
+         VALUES ($1, $2, $3, $4), ($5, $2, $3, $6)`,
+      [
+        "drill alpha thought one",
+        "drill",
+        NS_ALPHA,
+        "drill-alpha-1",
+        "drill alpha thought two",
+        "drill-alpha-2",
+      ],
+    );
+    await srcPool.query(
+      `INSERT INTO thoughts (content, created_by, namespace, content_hash, archived_at)
+         VALUES ($1, $2, $3, $4, NOW())`,
+      ["drill archived thought", "drill", NS_ALPHA, ARCHIVED_HASH],
+    );
+    await srcPool.query(
+      `INSERT INTO thoughts (content, created_by, namespace, content_hash)
+         VALUES ($1, $2, $3, $4), ($5, $2, $3, $6)`,
+      [
+        "drill beta thought one",
+        "drill",
+        NS_BETA,
+        "drill-beta-1",
+        "drill beta thought two",
+        "drill-beta-2",
+      ],
+    );
+    // Hard-delete semantics: this row is deleted BEFORE the backup and
+    // must not be resurrected by restore (absent from the dump).
+    await srcPool.query(
+      `INSERT INTO thoughts (content, created_by, namespace, content_hash)
+         VALUES ($1, $2, $3, $4)`,
+      ["drill hard-deleted thought", "drill", NS_ALPHA, DELETED_HASH],
+    );
+    await srcPool.query("DELETE FROM thoughts WHERE content_hash = $1", [DELETED_HASH]);
+    const { rows: laneRows } = await srcPool.query(
+      `INSERT INTO ob_session_lanes (session_key, namespace, created_by, project)
+         VALUES ($1, $2, $3, $4)
+         RETURNING id`,
+      ["drill-lane-1", NS_ALPHA, "drill", "drill-project"],
+    );
+    const laneId = expectDefined(laneRows[0], "lane row").id as string;
+    await srcPool.query(
+      `INSERT INTO ob_session_events (lane_id, event_type, content, created_by)
+         VALUES ($1, $2, $3, $4)`,
+      [laneId, "fact", "drill pre-backup event", "drill"],
+    );
+  } finally {
+    await srcPool.end();
+  }
+
+  // --- backup ---------------------------------------------------------
+  const backupDir = join(await tempDir(ctx.tempDirs), "set-1");
+  const backup = await runCli("backup.ts", ["--out", backupDir], cliEnv(admin, SRC_DB));
+  if (backup.exitCode !== 0) {
+    throw new Error(`drill backup failed: ${backup.stderr}`);
+  }
+  return { backupDir, backup };
+}
+
+/**
+ * Reads one field of the Nth entry of a receipt's `sets` array.
+ *
+ * backup-verify prints per-set records; typing them as an open record makes a
+ * direct index an implicit any, so the narrowing lives here once.
+ */
+export function receiptSetField(
+  receipt: CliReceipt,
+  index: number,
+  field: string,
+): unknown {
+  const sets = receipt?.["sets"];
+  if (!Array.isArray(sets)) return undefined;
+  const entry = sets[index] as Record<string, unknown> | undefined;
+  return entry?.[field];
+}

--- a/scripts/__tests__/backup-restore-live-refusals.test.ts
+++ b/scripts/__tests__/backup-restore-live-refusals.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Live backup/restore drill: snapshot, refusals, and upgrade (issues #298,
+ * #878).
+ *
+ * Split out of scripts/__tests__/backup-restore-live.test.ts so neither half
+ * exceeds the repo's per-file and per-function code-line standards. The drill
+ * lifecycle both halves need lives in backup-restore-live-helpers.ts; this file
+ * opens its own, so it runs standalone.
+ *
+ * REQUIREMENTS (issue #878): the two database connection strings are demanded
+ * through scripts/test-support/require-test-database.ts, which throws
+ * test_database_required when either is unset. Nothing here skips itself.
+ */
+import pg from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { cp, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { runMigrations } from "../../src/db/migrate.ts";
+import { resolvePgTool } from "../backup-lib.ts";
+import { requireTestDatabaseUrl } from "../test-support/require-test-database.ts";
+import { requireLocalCloneTestDatabaseUrl } from "../test-support/require-test-database.ts";
+import { RESTORE_WIPE_APPROVAL_ENV, RESTORE_WIPE_APPROVAL_VALUE } from "../restore.ts";
+import {
+  cliEnv,
+  closeDrill,
+  dbUrl,
+  type DrillContext,
+  expectDefined,
+  makePool,
+  MIGRATIONS_DIR,
+  NS_ALPHA,
+  OLD_SRC_DB,
+  OLD_TGT_DB,
+  openDrill,
+  receiptSetField,
+  runCli,
+  seedAndBackup,
+  SNAPSHOT_TGT_DB,
+  SRC_DB,
+  tempDir,
+  TGT_DB,
+} from "./backup-restore-live-helpers.ts";
+
+// Demanded at module scope, never probed: absent either variable this throws
+// test_database_required and the run fails loudly rather than skipping (#878).
+requireTestDatabaseUrl();
+requireLocalCloneTestDatabaseUrl();
+
+let ctx: DrillContext;
+let backupDir: string;
+
+async function snapshotAcrossConcurrentCommit(): Promise<void> {
+  const coordinationDir = await tempDir(ctx.tempDirs);
+  const readyPath = join(coordinationDir, "pg-dump-ready");
+  const releasePath = join(coordinationDir, "pg-dump-release");
+  const wrapperPath = join(coordinationDir, "coordinated-pg-dump.ts");
+  const realPgDump = resolvePgTool("pg_dump");
+  await Bun.write(
+    wrapperPath,
+    [
+      `await Bun.write(process.env.OB_SNAPSHOT_TEST_READY!, "ready");`,
+      `while (!(await Bun.file(process.env.OB_SNAPSHOT_TEST_RELEASE!).exists())) await Bun.sleep(20);`,
+      `const tool = JSON.parse(process.env.OB_SNAPSHOT_TEST_TOOL!) as string[];`,
+      `const proc = Bun.spawn([...tool, ...Bun.argv.slice(2)], {`,
+      `  env: process.env, stdin: "inherit", stdout: "inherit", stderr: "inherit",`,
+      `});`,
+      `process.exit(await proc.exited);`,
+      "",
+    ].join("\n"),
+  );
+
+  const snapshotBackupDir = join(await tempDir(ctx.tempDirs), "set-snapshot");
+  const backupPromise = runCli("backup.ts", ["--out", snapshotBackupDir], {
+    ...cliEnv(ctx.admin, SRC_DB),
+    OPENBRAIN_PG_DUMP_BIN: `bun ${wrapperPath}`,
+    OB_SNAPSHOT_TEST_READY: readyPath,
+    OB_SNAPSHOT_TEST_RELEASE: releasePath,
+    OB_SNAPSHOT_TEST_TOOL: JSON.stringify(realPgDump),
+  });
+
+  const readyDeadline = Date.now() + 30_000;
+  while (!(await Bun.file(readyPath).exists())) {
+    if (Date.now() >= readyDeadline) {
+      await Bun.write(releasePath, "release");
+      await backupPromise;
+      throw new Error("timed out waiting for coordinated pg_dump");
+    }
+    await Bun.sleep(20);
+  }
+
+  const concurrentHash = "drill-concurrent-after-snapshot";
+  const writer = makePool(ctx.admin, SRC_DB);
+  try {
+    await writer.query(
+      `INSERT INTO thoughts (content, created_by, namespace, content_hash)
+         VALUES ($1, $2, $3, $4)`,
+      ["concurrent write after exported snapshot", "drill", NS_ALPHA, concurrentHash],
+    );
+  } finally {
+    await writer.end();
+    // Always unblock the wrapper, including when the concurrent write
+    // fails, so the backup subprocess cannot leak into later tests.
+    await Bun.write(releasePath, "release");
+  }
+
+  const backup = await backupPromise;
+  expect(backup.exitCode).toBe(0);
+  expect(backup.receipt?.status).toBe("ok");
+  const manifest = JSON.parse(
+    await Bun.file(join(snapshotBackupDir, "manifest.json")).text(),
+  );
+
+  const restore = await runCli(
+    "restore.ts",
+    ["--dir", snapshotBackupDir, "--target-db-url", dbUrl(ctx.admin, SNAPSHOT_TGT_DB)],
+    cliEnv(ctx.admin, SRC_DB),
+  );
+  expect(restore.exitCode).toBe(0);
+  expect(restore.receipt?.status).toBe("ok");
+
+  const restored = makePool(ctx.admin, SNAPSHOT_TGT_DB);
+  try {
+    const { rows: countRows } = await restored.query(
+      "SELECT COUNT(*)::int AS count FROM thoughts",
+    );
+    expect(expectDefined(countRows[0], "count row").count).toBe(
+      manifest.row_counts.thoughts,
+    );
+    const { rows: concurrentRows } = await restored.query(
+      "SELECT 1 FROM thoughts WHERE content_hash = $1",
+      [concurrentHash],
+    );
+    expect(concurrentRows).toEqual([]);
+  } finally {
+    await restored.end();
+  }
+}
+
+async function refusesNonEmptyTargetWithoutWipe(): Promise<void> {
+  // Self-sufficient: ensure the target exists and is non-empty rather
+  // than depending on the previous drill test having populated it.
+  const adminPool = new pg.Client({
+    connectionString: dbUrl(ctx.admin, ctx.admin.database),
+  });
+  await adminPool.connect();
+  try {
+    const { rows } = await adminPool.query(
+      "SELECT 1 FROM pg_database WHERE datname = $1",
+      [TGT_DB],
+    );
+    if (rows.length === 0) {
+      await adminPool.query(`CREATE DATABASE ${TGT_DB}`);
+    }
+  } finally {
+    await adminPool.end();
+  }
+  const seedPool = new pg.Client({
+    connectionString: dbUrl(ctx.admin, TGT_DB),
+  });
+  await seedPool.connect();
+  try {
+    await seedPool.query("CREATE TABLE IF NOT EXISTS drill_nonempty_marker (id int)");
+  } finally {
+    await seedPool.end();
+  }
+  const noWipe = await runCli(
+    "restore.ts",
+    ["--dir", backupDir, "--target-db-url", dbUrl(ctx.admin, TGT_DB)],
+    cliEnv(ctx.admin, SRC_DB),
+  );
+  expect(noWipe.exitCode).not.toBe(0);
+  expect(noWipe.receipt?.status).toBe("failed");
+  expect(noWipe.receipt?.error).toContain("NOT empty");
+
+  const noApproval = await runCli(
+    "restore.ts",
+    ["--dir", backupDir, "--target-db-url", dbUrl(ctx.admin, TGT_DB), "--wipe-target"],
+    cliEnv(ctx.admin, SRC_DB),
+  );
+  expect(noApproval.exitCode).not.toBe(0);
+  expect(noApproval.receipt?.error).toContain(RESTORE_WIPE_APPROVAL_ENV);
+
+  // With the approval env the wipe + restore succeeds.
+  const approved = await runCli(
+    "restore.ts",
+    ["--dir", backupDir, "--target-db-url", dbUrl(ctx.admin, TGT_DB), "--wipe-target"],
+    {
+      ...cliEnv(ctx.admin, SRC_DB),
+      [RESTORE_WIPE_APPROVAL_ENV]: RESTORE_WIPE_APPROVAL_VALUE,
+    },
+  );
+  expect(approved.receipt?.status).toBe("ok");
+  expect(approved.exitCode).toBe(0);
+}
+
+async function refusesNonPublicUserSchemas(): Promise<void> {
+  // The approved wipe only drops schema public; a target carrying user
+  // tables in ANY other schema must be refused outright (fail-closed),
+  // wipe approval or not.
+  const seed = new pg.Client({ connectionString: dbUrl(ctx.admin, TGT_DB) });
+  await seed.connect();
+  try {
+    await seed.query("CREATE SCHEMA IF NOT EXISTS drill_foreign");
+    await seed.query("CREATE TABLE IF NOT EXISTS drill_foreign.marker (id int)");
+  } finally {
+    await seed.end();
+  }
+  const refused = await runCli(
+    "restore.ts",
+    ["--dir", backupDir, "--target-db-url", dbUrl(ctx.admin, TGT_DB), "--wipe-target"],
+    {
+      ...cliEnv(ctx.admin, SRC_DB),
+      [RESTORE_WIPE_APPROVAL_ENV]: RESTORE_WIPE_APPROVAL_VALUE,
+    },
+  );
+  expect(refused.exitCode).not.toBe(0);
+  expect(refused.receipt?.status).toBe("failed");
+  expect(refused.receipt?.error).toContain("non-public");
+
+  // Nothing was wiped: both the foreign schema AND the existing public
+  // tables survived the refusal.
+  const check = new pg.Client({ connectionString: dbUrl(ctx.admin, TGT_DB) });
+  await check.connect();
+  try {
+    const { rows: foreignRows } = await check.query(
+      "SELECT 1 FROM pg_catalog.pg_tables WHERE schemaname = 'drill_foreign'",
+    );
+    expect(foreignRows.length).toBe(1);
+    const { rows: publicRows } = await check.query(
+      `SELECT COUNT(*)::int AS count FROM pg_catalog.pg_tables
+         WHERE schemaname = 'public'`,
+    );
+    expect(expectDefined(publicRows[0], "public count row").count).toBeGreaterThan(0);
+    // Clean up so later tests see a public-only target again.
+    await check.query("DROP SCHEMA drill_foreign CASCADE");
+  } finally {
+    await check.end();
+  }
+}
+
+async function oldBackupRestoresIntoUpgradedRuntime(): Promise<void> {
+  // Build a source whose migration head is ONE BEHIND the repo head by
+  // migrating with a truncated copy of the migrations directory.
+  const allMigrations = (await readdir(MIGRATIONS_DIR))
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+  expect(allMigrations.length).toBeGreaterThan(1);
+  const truncatedDir = await tempDir(ctx.tempDirs);
+  for (const file of allMigrations.slice(0, -1)) {
+    await cp(join(MIGRATIONS_DIR, file), join(truncatedDir, file));
+  }
+
+  const oldPool = makePool(ctx.admin, OLD_SRC_DB);
+  try {
+    await runMigrations(oldPool, truncatedDir);
+    await oldPool.query(
+      `INSERT INTO thoughts (content, created_by, namespace, content_hash)
+         VALUES ($1, $2, $3, $4)`,
+      ["drill old-runtime thought", "drill", NS_ALPHA, "drill-old-1"],
+    );
+  } finally {
+    await oldPool.end();
+  }
+
+  const oldBackupDir = join(await tempDir(ctx.tempDirs), "set-old");
+  const backup = await runCli(
+    "backup.ts",
+    ["--out", oldBackupDir],
+    cliEnv(ctx.admin, OLD_SRC_DB),
+  );
+  expect(backup.exitCode).toBe(0);
+  expect(backup.receipt?.migrations_head).toBe(allMigrations[allMigrations.length - 2]);
+
+  const verify = await runCli(
+    "backup-verify.ts",
+    ["--dir", oldBackupDir],
+    cliEnv(ctx.admin, OLD_SRC_DB),
+  );
+  expect(verify.exitCode).toBe(0);
+  expect(receiptSetField(verify.receipt, 0, "migration_compat")).toBe(
+    "restorable_with_migrations",
+  );
+
+  const restore = await runCli(
+    "restore.ts",
+    ["--dir", oldBackupDir, "--target-db-url", dbUrl(ctx.admin, OLD_TGT_DB)],
+    cliEnv(ctx.admin, OLD_SRC_DB),
+  );
+  expect(restore.receipt?.status).toBe("ok");
+  expect(restore.exitCode).toBe(0);
+  expect(restore.receipt?.migrations_applied_forward).toBeGreaterThan(0);
+
+  const tgtPool = makePool(ctx.admin, OLD_TGT_DB);
+  try {
+    const { rows } = await tgtPool.query(
+      "SELECT filename FROM _migrations ORDER BY filename",
+    );
+    // The head ADVANCED: the restored-and-migrated db now matches the
+    // full repo migration list, including the file the backup predated.
+    expect(rows.map((r) => String(r.filename))).toEqual(allMigrations);
+    const { rows: dataRows } = await tgtPool.query(
+      "SELECT 1 FROM thoughts WHERE content_hash = $1",
+      ["drill-old-1"],
+    );
+    expect(dataRows.length).toBe(1);
+  } finally {
+    await tgtPool.end();
+  }
+}
+
+async function corruptedDumpFailsVerification(): Promise<void> {
+  // Run LAST: this intentionally breaks the first drill's backup set.
+  const dumpPath = join(backupDir, "openbrain.dump");
+  const original = new Uint8Array(await Bun.file(dumpPath).arrayBuffer());
+  const flipAt = Math.floor(original.length / 2);
+  original[flipAt] = expectDefined(original[flipAt], "dump byte") ^ 0xff;
+  await Bun.write(dumpPath, original);
+
+  const verify = await runCli(
+    "backup-verify.ts",
+    ["--dir", backupDir],
+    cliEnv(ctx.admin, SRC_DB),
+  );
+  expect(verify.exitCode).toBe(1);
+  expect(verify.receipt?.status).toBe("failed");
+
+  // And restore refuses the corrupted set before touching any target.
+  const restore = await runCli(
+    "restore.ts",
+    ["--dir", backupDir, "--target-db-url", dbUrl(ctx.admin, TGT_DB)],
+    {
+      ...cliEnv(ctx.admin, SRC_DB),
+      [RESTORE_WIPE_APPROVAL_ENV]: RESTORE_WIPE_APPROVAL_VALUE,
+    },
+  );
+  expect(restore.exitCode).not.toBe(0);
+  expect(restore.receipt?.status).toBe("failed");
+  expect(restore.receipt?.error).toContain("verification failed");
+}
+
+describe("backup restore drill snapshot, refusals, and upgrade (live Postgres)", () => {
+  beforeAll(async () => {
+    ctx = await openDrill();
+    ({ backupDir } = await seedAndBackup(ctx));
+  }, 60_000);
+
+  afterAll(async () => {
+    await closeDrill(ctx);
+  }, 60_000);
+
+  it(
+    "uses one exported snapshot for manifest counts and dump contents across a concurrent commit",
+    snapshotAcrossConcurrentCommit,
+    240_000,
+  );
+  it(
+    "refuses a non-empty target without --wipe-target + approval env",
+    refusesNonEmptyTargetWithoutWipe,
+    180_000,
+  );
+  it(
+    "refuses a target with non-public user schemas even with wipe approval",
+    refusesNonPublicUserSchemas,
+    180_000,
+  );
+  it(
+    "old backup (pre-latest-migration) restores into the upgraded runtime and the head advances",
+    oldBackupRestoresIntoUpgradedRuntime,
+    240_000,
+  );
+  it(
+    "a corrupted dump fails CLI verification with a nonzero exit",
+    corruptedDumpFailsVerification,
+    120_000,
+  );
+});

--- a/scripts/__tests__/backup-restore-live.test.ts
+++ b/scripts/__tests__/backup-restore-live.test.ts
@@ -1,766 +1,317 @@
 /**
- * Live backup/restore drill (issue #298).
+ * Live backup/restore drill: the full run (issues #298, #878, #938).
  *
  * End-to-end against a REAL Postgres: creates throwaway scratch databases via
- * the OPENBRAIN_TEST_DATABASE_URL admin connection, migrates + seeds a source,
- * runs the actual backup.ts / backup-verify.ts / restore.ts CLIs, and asserts
- * every post-restore validation plus:
+ * the admin connection, migrates + seeds a source, runs the actual backup.ts /
+ * backup-verify.ts / restore.ts CLIs, and asserts every post-restore
+ * validation plus:
  *   - archived (soft-deleted) rows restore AS archived
  *   - hard-deleted rows are absent from the dump and cannot be resurrected
  *   - restored data is readable AND writable
  *   - a session-lane append lands against the restored db (server-side proof
  *     that a client spool drain would land after restore)
- *   - an OLD backup (taken before the newest migration) restores into the
- *     upgraded runtime and the migration head advances
- *   - a non-empty target is refused without --wipe-target + approval env
- *   - a target with user tables in a non-public schema is refused outright,
- *     even with wipe approval (the approved wipe only drops schema public)
+ *   - a restore into a fresh administrator-bootstrapped database the
+ *     non-superuser clone role owns succeeds (#938)
  *
- * GATING: the drill only runs when OPENBRAIN_BACKUP_DRILL=1 (in addition to
- * OPENBRAIN_TEST_DATABASE_URL and a pg_dump/pg_restore availability probe).
- * The extra flag exists because generic `bun test` runs may have host pg
- * client tools whose MAJOR VERSION is older than the server (pg_dump refuses
- * to dump a newer server) — the dedicated CI drill step pins matched tools
- * via OPENBRAIN_PG_DUMP_BIN/OPENBRAIN_PG_RESTORE_BIN docker-exec wrappers and
- * sets the flag. When the flag IS set, missing prerequisites FAIL loudly
- * instead of skipping, so the CI step cannot silently no-op.
+ * The snapshot, refusal, and upgrade tests live in
+ * scripts/__tests__/backup-restore-live-refusals.test.ts, and the drill
+ * lifecycle both halves need lives in backup-restore-live-helpers.ts.
+ *
+ * REQUIREMENTS (issue #878): the drill runs on every isolated run. The two
+ * database connection strings are demanded through
+ * scripts/test-support/require-test-database.ts, which throws
+ * test_database_required when either is unset, and the pg_dump/pg_restore
+ * probe is asserted by the first test rather than gating the suite. Host pg
+ * client tools whose MAJOR VERSION is older than the server make pg_dump
+ * refuse to dump; the CI drill step pins matched tools via
+ * OPENBRAIN_PG_DUMP_BIN/OPENBRAIN_PG_RESTORE_BIN docker-exec wrappers. A
+ * missing prerequisite FAILS loudly instead of skipping, so no run can
+ * silently no-op.
  *
  * The scratch databases live on the same server as the test database but use
  * dedicated `open_brain_ci_restore_*` names, mirroring the DB_NAME /
  * DB_NAME_TEST separation in ci.yml, and are dropped afterwards.
  */
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { cp, mkdtemp, readdir, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
-import pg from "pg";
-import { runMigrations } from "../../src/db/migrate.ts";
-import { pgToolAvailable, resolvePgTool } from "../backup-lib.ts";
+import { pgToolAvailable } from "../backup-lib.ts";
+import { requireTestDatabaseUrl } from "../test-support/require-test-database.ts";
+import { requireLocalCloneTestDatabaseUrl } from "../test-support/require-test-database.ts";
 import {
-  RESTORE_WIPE_APPROVAL_ENV,
-  RESTORE_WIPE_APPROVAL_VALUE,
-} from "../restore.ts";
+  ARCHIVED_HASH,
+  cliEnv,
+  CLONE_TGT_DB,
+  closeDrill,
+  type CliReceipt,
+  dbUrl,
+  DELETED_HASH,
+  type DrillContext,
+  expectDefined,
+  makePool,
+  NS_ALPHA,
+  NS_BETA,
+  openDrill,
+  receiptSetField,
+  runCli,
+  seedAndBackup,
+  SRC_DB,
+  TGT_DB,
+} from "./backup-restore-live-helpers.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const LOCAL_CLONE_URL = process.env.OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL;
-const DRILL_ENABLED = process.env.OPENBRAIN_BACKUP_DRILL === "1";
-const TOOLS_AVAILABLE =
-  pgToolAvailable("pg_dump") && pgToolAvailable("pg_restore");
+const TOOLS_AVAILABLE = pgToolAvailable("pg_dump") && pgToolAvailable("pg_restore");
 
-const drillDescribe = DRILL_ENABLED ? describe : describe.skip;
-const READY = Boolean(DB_URL) && Boolean(LOCAL_CLONE_URL) && TOOLS_AVAILABLE;
+let ctx: DrillContext;
+let backupDir: string;
 
-const REPO_ROOT = join(import.meta.dir, "..", "..");
-const MIGRATIONS_DIR = join(REPO_ROOT, "src", "db", "migrations");
-
-const SRC_DB = "open_brain_ci_restore_src";
-const TGT_DB = "open_brain_ci_restore_tgt";
-const OLD_SRC_DB = "open_brain_ci_restore_oldsrc";
-const OLD_TGT_DB = "open_brain_ci_restore_oldtgt";
-const SNAPSHOT_TGT_DB = "open_brain_ci_restore_snapshot_tgt";
-const SCRATCH_DBS = [SRC_DB, TGT_DB, OLD_SRC_DB, OLD_TGT_DB, SNAPSHOT_TGT_DB];
-
-const NS_ALPHA = "drill-ns-alpha";
-const NS_BETA = "drill-ns-beta";
-const DELETED_HASH = "drill-hard-deleted-hash";
-const ARCHIVED_HASH = "drill-archived-hash";
-
-interface Conn {
-  host: string;
-  port: number;
-  user: string;
-  password: string | undefined;
+/** A restore receipt's validations array, as the CLI prints it. */
+interface RestoreValidation {
+  verdict: string;
 }
 
-function parseAdminUrl(url: string): Conn & { database: string } {
-  const parsed = new URL(url);
-  return {
-    host: parsed.hostname,
-    port: parsed.port ? Number(parsed.port) : 5432,
-    user: decodeURIComponent(parsed.username),
-    password: parsed.password ? decodeURIComponent(parsed.password) : undefined,
-    database: parsed.pathname.replace(/^\//, ""),
-  };
+function validationsOf(receipt: CliReceipt): RestoreValidation[] {
+  return (receipt?.["validations"] ?? []) as RestoreValidation[];
 }
 
-function dbUrl(conn: Conn, database: string): string {
-  const auth = conn.password
-    ? `${encodeURIComponent(conn.user)}:${encodeURIComponent(conn.password)}`
-    : encodeURIComponent(conn.user);
-  return `postgres://${auth}@${conn.host}:${conn.port}/${database}`;
+function prerequisitesAreAvailable(): void {
+  // The drill MUST run — missing pg client tools is a wiring failure, not a
+  // skip. The two database URLs are demanded, never probed: each throws
+  // test_database_required when its variable is unset.
+  expect(Boolean(requireTestDatabaseUrl())).toBe(true);
+  expect(Boolean(requireLocalCloneTestDatabaseUrl())).toBe(true);
+  expect(TOOLS_AVAILABLE).toBe(true);
 }
 
-function cliEnv(conn: Conn, database: string): Record<string, string> {
-  const env: Record<string, string> = {
-    ...(process.env as Record<string, string>),
-    DB_HOST: conn.host,
-    DB_PORT: String(conn.port),
-    DB_USER: conn.user,
-    DB_NAME: database,
-  };
-  if (conn.password !== undefined) env.DB_PASSWORD = conn.password;
-  return env;
+/** Seeds the source, backs it up, and asserts the backup receipt. */
+async function drillSeedAndBackup(): Promise<CliReceipt> {
+  const { admin } = ctx;
+  const seeded = await seedAndBackup(ctx);
+  backupDir = seeded.backupDir;
+  const backup = seeded.backup;
+  expect(backup.stderr).not.toContain("error");
+  expect(backup.exitCode).toBe(0);
+  expect(backup.receipt?.schema).toBe("openbrain.backup_receipt.v1");
+  expect(backup.receipt?.status).toBe("ok");
+  expect(backup.receipt?.distinct_namespaces).toBe(2);
+  expect(backup.receipt?.dump_bytes).toBeGreaterThan(0);
+
+  // Second run without --force refuses to overwrite.
+  const refused = await runCli(
+    "backup.ts",
+    ["--out", backupDir],
+    cliEnv(admin, SRC_DB),
+  );
+  expect(refused.exitCode).not.toBe(0);
+  return backup.receipt;
 }
 
-async function runCli(
-  script: string,
-  args: string[],
-  env: Record<string, string>,
-): Promise<{ exitCode: number; receipt: any; stdout: string; stderr: string }> {
-  const proc = Bun.spawn(["bun", join(REPO_ROOT, "scripts", script), ...args], {
-    cwd: REPO_ROOT,
-    env,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const stdout = await new Response(proc.stdout).text();
-  const stderr = await new Response(proc.stderr).text();
-  const exitCode = await proc.exited;
-  const lines = stdout
-    .split("\n")
-    .map((l) => l.trim())
-    .filter((l) => l.length > 0);
-  let receipt: any = null;
-  // The receipt is the last stdout line (logger lines may precede it).
-  for (let i = lines.length - 1; i >= 0; i--) {
-    try {
-      receipt = JSON.parse(lines[i]!);
-      break;
-    } catch {
-      continue;
+/** Verifies the backup set and asserts its artifacts are content-free. */
+async function drillVerify(backupReceipt: CliReceipt): Promise<void> {
+  const { admin } = ctx;
+  // --- verify (before any mutation anywhere) --------------------------
+  const verify = await runCli(
+    "backup-verify.ts",
+    ["--dir", backupDir],
+    cliEnv(admin, SRC_DB),
+  );
+  expect(verify.exitCode).toBe(0);
+  expect(verify.receipt?.schema).toBe("openbrain.backup_verify_receipt.v1");
+  expect(verify.receipt?.status).toBe("passed");
+  expect(receiptSetField(verify.receipt, 0, "migration_compat")).toBe("equal");
+
+  // Receipts and manifest are content-free: no namespace names, no row
+  // content, no credentials.
+  const manifestText = await Bun.file(join(backupDir, "manifest.json")).text();
+  for (const artifact of [
+    manifestText,
+    JSON.stringify(backupReceipt),
+    JSON.stringify(verify.receipt),
+  ]) {
+    expect(artifact).not.toContain(NS_ALPHA);
+    expect(artifact).not.toContain(NS_BETA);
+    expect(artifact).not.toContain("drill alpha thought");
+    if (admin.password) {
+      // Credential-in-URL form must never appear. A raw substring check
+      // is only meaningful for non-trivial passwords: CI's throwaway
+      // password is "ci", which collides with "open_brain_ci_*" database
+      // names and would false-positive.
+      expect(artifact).not.toContain(`:${admin.password}@`);
+      expect(artifact).not.toContain(`:${encodeURIComponent(admin.password)}@`);
+      if (admin.password.length >= 6) {
+        expect(artifact).not.toContain(admin.password);
+      }
     }
   }
-  return { exitCode, receipt, stdout, stderr };
 }
 
-function makePool(conn: Conn, database: string): pg.Pool {
-  return new pg.Pool({ ...conn, database, max: 2 });
+/** Restores the set into the empty scratch target. */
+async function drillRestore(): Promise<void> {
+  const { admin } = ctx;
+  // --- restore into the empty scratch target --------------------------
+  const restore = await runCli(
+    "restore.ts",
+    ["--dir", backupDir, "--target-db-url", dbUrl(admin, TGT_DB)],
+    cliEnv(admin, SRC_DB),
+  );
+  expect(restore.receipt?.schema).toBe("openbrain.restore_receipt.v1");
+  expect(restore.receipt?.status).toBe("ok");
+  expect(restore.exitCode).toBe(0);
+  expect(restore.receipt?.rollback_hint).toContain(TGT_DB);
+  const failedValidations = validationsOf(restore.receipt).filter(
+    (v) => v.verdict !== "ok",
+  );
+  expect(failedValidations).toEqual([]);
 }
 
-drillDescribe("backup restore drill (live Postgres, #298)", () => {
-  it("prerequisites are available (fails loudly when the drill is enabled)", () => {
-    // OPENBRAIN_BACKUP_DRILL=1 means "the drill MUST run" — missing DB URL or
-    // pg client tools is a wiring failure, not a skip.
-    expect(Boolean(DB_URL)).toBe(true);
-    expect(Boolean(LOCAL_CLONE_URL)).toBe(true);
-    expect(TOOLS_AVAILABLE).toBe(true);
-  });
+/** Asserts every post-restore property on the restored target. */
+async function drillPostRestoreAssertions(): Promise<void> {
+  const { admin } = ctx;
+  // --- post-restore assertions on the target --------------------------
+  const tgtPool = makePool(admin, TGT_DB);
+  try {
+    // Counts and namespaces survived.
+    const { rows: countRows } = await tgtPool.query(
+      "SELECT COUNT(*)::int AS count FROM thoughts",
+    );
+    expect(expectDefined(countRows[0], "count row").count).toBe(5);
+    const { rows: nsRows } = await tgtPool.query(
+      "SELECT COUNT(DISTINCT namespace)::int AS count FROM thoughts",
+    );
+    expect(expectDefined(nsRows[0], "namespace row").count).toBe(2);
 
-  const inner = READY ? describe : describe.skip;
-  inner("drill execution", () => {
-    // describe bodies evaluate even when skipped — only parse the URL when
-    // the drill is actually ready to run.
-    const admin: Conn & { database: string } = READY
-      ? parseAdminUrl(DB_URL!)
-      : { host: "", port: 0, user: "", password: undefined, database: "" };
-    const clone: Conn & { database: string } = READY
-      ? parseAdminUrl(LOCAL_CLONE_URL!)
-      : { host: "", port: 0, user: "", password: undefined, database: "" };
-    let adminClient: pg.Client;
-    const tempDirs: string[] = [];
+    // Archived row restored AS archived.
+    const { rows: archivedRows } = await tgtPool.query(
+      "SELECT archived_at FROM thoughts WHERE content_hash = $1",
+      [ARCHIVED_HASH],
+    );
+    expect(archivedRows.length).toBe(1);
+    expect(expectDefined(archivedRows[0], "archived row").archived_at).not.toBeNull();
 
-    async function tempDir(): Promise<string> {
-      const dir = await mkdtemp(join(tmpdir(), "ob298-live-"));
-      tempDirs.push(dir);
-      return dir;
-    }
+    // Hard-deleted row NOT resurrected.
+    const { rows: deletedRows } = await tgtPool.query(
+      "SELECT 1 FROM thoughts WHERE content_hash = $1",
+      [DELETED_HASH],
+    );
+    expect(deletedRows.length).toBe(0);
 
-    async function dropScratchDbs(): Promise<void> {
-      for (const name of SCRATCH_DBS) {
-        // Names come from the fixed SCRATCH_DBS list above, never from input.
-        await adminClient.query(`DROP DATABASE IF EXISTS ${name} WITH (FORCE)`);
-      }
-    }
+    // Readable.
+    const { rows: readRows } = await tgtPool.query(
+      "SELECT content FROM thoughts WHERE content_hash = $1",
+      ["drill-alpha-1"],
+    );
+    expect(expectDefined(readRows[0], "read row").content).toBe(
+      "drill alpha thought one",
+    );
 
-    beforeAll(async () => {
-      adminClient = new pg.Client({ connectionString: DB_URL });
-      await adminClient.connect();
-      await dropScratchDbs();
-      for (const name of SCRATCH_DBS) {
-        await adminClient.query(`CREATE DATABASE ${name}`);
-      }
-    }, 60_000);
+    // Writable.
+    await tgtPool.query(
+      `INSERT INTO thoughts (content, created_by, namespace, content_hash)
+         VALUES ($1, $2, $3, $4)`,
+      ["drill post-restore write", "drill", NS_ALPHA, "drill-post-1"],
+    );
 
-    afterAll(async () => {
-      await dropScratchDbs();
-      await adminClient.end();
-      for (const dir of tempDirs) {
-        await rm(dir, { recursive: true, force: true });
-      }
-    }, 60_000);
+    // Restore-then-replay linkage (server-side scope): a session lane
+    // append lands against the restored db, proving a client spool
+    // drain would land. The full python-client replay drill is out of
+    // scope for this repo (named in the PR's deferred list).
+    const { rows: laneRows } = await tgtPool.query(
+      `SELECT id FROM ob_session_lanes
+          WHERE namespace = $1 AND session_key = $2`,
+      [NS_ALPHA, "drill-lane-1"],
+    );
+    expect(laneRows.length).toBe(1);
+    await tgtPool.query(
+      `INSERT INTO ob_session_events (lane_id, event_type, content, created_by)
+         VALUES ($1, $2, $3, $4)`,
+      [
+        expectDefined(laneRows[0], "lane row").id,
+        "fact",
+        "drill post-restore append",
+        "drill",
+      ],
+    );
+    const { rows: eventRows } = await tgtPool.query(
+      "SELECT COUNT(*)::int AS count FROM ob_session_events WHERE lane_id = $1",
+      [expectDefined(laneRows[0], "lane row").id],
+    );
+    expect(expectDefined(eventRows[0], "event row").count).toBe(2);
+  } finally {
+    await tgtPool.end();
+  }
+}
 
-    let backupDir: string;
+async function fullDrill(): Promise<void> {
+  const backupReceipt = await drillSeedAndBackup();
+  await drillVerify(backupReceipt);
+  await drillRestore();
+  await drillPostRestoreAssertions();
+}
 
-    it("full drill: seed → backup → verify → restore → validations → replay linkage", async () => {
-      // --- seed the source ------------------------------------------------
-      const srcPool = makePool(admin, SRC_DB);
-      try {
-        await runMigrations(srcPool);
-        await srcPool.query(
-          `INSERT INTO thoughts (content, created_by, namespace, content_hash)
-             VALUES ($1, $2, $3, $4), ($5, $2, $3, $6)`,
-          [
-            "drill alpha thought one",
-            "drill",
-            NS_ALPHA,
-            "drill-alpha-1",
-            "drill alpha thought two",
-            "drill-alpha-2",
-          ],
-        );
-        await srcPool.query(
-          `INSERT INTO thoughts (content, created_by, namespace, content_hash, archived_at)
-             VALUES ($1, $2, $3, $4, NOW())`,
-          ["drill archived thought", "drill", NS_ALPHA, ARCHIVED_HASH],
-        );
-        await srcPool.query(
-          `INSERT INTO thoughts (content, created_by, namespace, content_hash)
-             VALUES ($1, $2, $3, $4), ($5, $2, $3, $6)`,
-          [
-            "drill beta thought one",
-            "drill",
-            NS_BETA,
-            "drill-beta-1",
-            "drill beta thought two",
-            "drill-beta-2",
-          ],
-        );
-        // Hard-delete semantics: this row is deleted BEFORE the backup and
-        // must not be resurrected by restore (absent from the dump).
-        await srcPool.query(
-          `INSERT INTO thoughts (content, created_by, namespace, content_hash)
-             VALUES ($1, $2, $3, $4)`,
-          ["drill hard-deleted thought", "drill", NS_ALPHA, DELETED_HASH],
-        );
-        await srcPool.query("DELETE FROM thoughts WHERE content_hash = $1", [
-          DELETED_HASH,
-        ]);
-        const { rows: laneRows } = await srcPool.query(
-          `INSERT INTO ob_session_lanes (session_key, namespace, created_by, project)
-             VALUES ($1, $2, $3, $4)
-             RETURNING id`,
-          ["drill-lane-1", NS_ALPHA, "drill", "drill-project"],
-        );
-        const laneId = laneRows[0]!.id as string;
-        await srcPool.query(
-          `INSERT INTO ob_session_events (lane_id, event_type, content, created_by)
-             VALUES ($1, $2, $3, $4)`,
-          [laneId, "fact", "drill pre-backup event", "drill"],
-        );
-      } finally {
-        await srcPool.end();
-      }
+async function restoresIntoFreshNonSuperuserClone(): Promise<void> {
+  const { admin, clone } = ctx;
+  expect(clone.host).toBe("127.0.0.1");
+  expect(clone.user).toBe("open_brain_local_clone");
+  expect(clone.database.startsWith("open_brain_local_")).toBe(true);
 
-      // --- backup ---------------------------------------------------------
-      backupDir = join(await tempDir(), "set-1");
-      const backup = await runCli(
-        "backup.ts",
-        ["--out", backupDir],
-        cliEnv(admin, SRC_DB),
-      );
-      expect(backup.stderr).not.toContain("error");
-      expect(backup.exitCode).toBe(0);
-      expect(backup.receipt?.schema).toBe("openbrain.backup_receipt.v1");
-      expect(backup.receipt?.status).toBe("ok");
-      expect(backup.receipt?.distinct_namespaces).toBe(2);
-      expect(backup.receipt?.dump_bytes).toBeGreaterThan(0);
+  const restore = await runCli(
+    "restore.ts",
+    // Issue #938: the runner already migrated clone.database, and restore.ts
+    // refuses a non-empty target, so the drill restores into a fresh
+    // database the clone role OWNS -- the non-superuser property this test
+    // is about is preserved, the false failure is not.
+    ["--dir", backupDir, "--target-db-url", dbUrl(clone, CLONE_TGT_DB)],
+    cliEnv(admin, SRC_DB),
+  );
+  expect(restore.exitCode).toBe(0);
+  expect(restore.receipt?.status).toBe("ok");
+  expect(validationsOf(restore.receipt).every((v) => v.verdict === "ok")).toBe(true);
 
-      // Second run without --force refuses to overwrite.
-      const refused = await runCli(
-        "backup.ts",
-        ["--out", backupDir],
-        cliEnv(admin, SRC_DB),
-      );
-      expect(refused.exitCode).not.toBe(0);
+  const restored = makePool(clone, CLONE_TGT_DB);
+  try {
+    const { rows: identity } = await restored.query(
+      `SELECT current_user,
+              EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS vector_installed,
+              EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') AS pg_stat_statements_installed`,
+    );
+    expect(identity[0]).toEqual({
+      current_user: "open_brain_local_clone",
+      vector_installed: true,
+      pg_stat_statements_installed: true,
+    });
+    const { rows: readRows } = await restored.query(
+      "SELECT COUNT(*)::int AS count FROM thoughts",
+    );
+    expect(expectDefined(readRows[0], "read row").count).toBeGreaterThan(0);
+    await restored.query(
+      `INSERT INTO thoughts (content, created_by, namespace, content_hash)
+         VALUES ($1, $2, $3, $4)`,
+      ["non-superuser clone restore write", "drill", NS_ALPHA, "drill-clone-write"],
+    );
+  } finally {
+    await restored.end();
+  }
+}
 
-      // --- verify (before any mutation anywhere) --------------------------
-      const verify = await runCli(
-        "backup-verify.ts",
-        ["--dir", backupDir],
-        cliEnv(admin, SRC_DB),
-      );
-      expect(verify.exitCode).toBe(0);
-      expect(verify.receipt?.schema).toBe("openbrain.backup_verify_receipt.v1");
-      expect(verify.receipt?.status).toBe("passed");
-      expect(verify.receipt?.sets?.[0]?.migration_compat).toBe("equal");
+describe("backup restore drill full run (live Postgres)", () => {
+  beforeAll(async () => {
+    ctx = await openDrill();
+  }, 60_000);
 
-      // Receipts and manifest are content-free: no namespace names, no row
-      // content, no credentials.
-      const manifestText = await Bun.file(
-        join(backupDir, "manifest.json"),
-      ).text();
-      for (const artifact of [
-        manifestText,
-        JSON.stringify(backup.receipt),
-        JSON.stringify(verify.receipt),
-      ]) {
-        expect(artifact).not.toContain(NS_ALPHA);
-        expect(artifact).not.toContain(NS_BETA);
-        expect(artifact).not.toContain("drill alpha thought");
-        if (admin.password) {
-          // Credential-in-URL form must never appear. A raw substring check
-          // is only meaningful for non-trivial passwords: CI's throwaway
-          // password is "ci", which collides with "open_brain_ci_*" database
-          // names and would false-positive.
-          expect(artifact).not.toContain(`:${admin.password}@`);
-          expect(artifact).not.toContain(
-            `:${encodeURIComponent(admin.password)}@`,
-          );
-          if (admin.password.length >= 6) {
-            expect(artifact).not.toContain(admin.password);
-          }
-        }
-      }
+  afterAll(async () => {
+    await closeDrill(ctx);
+  }, 60_000);
 
-      // --- restore into the empty scratch target --------------------------
-      const restore = await runCli(
-        "restore.ts",
-        ["--dir", backupDir, "--target-db-url", dbUrl(admin, TGT_DB)],
-        cliEnv(admin, SRC_DB),
-      );
-      expect(restore.receipt?.schema).toBe("openbrain.restore_receipt.v1");
-      expect(restore.receipt?.status).toBe("ok");
-      expect(restore.exitCode).toBe(0);
-      expect(restore.receipt?.rollback_hint).toContain(TGT_DB);
-      const failedValidations = (restore.receipt?.validations ?? []).filter(
-        (v: any) => v.verdict !== "ok",
-      );
-      expect(failedValidations).toEqual([]);
-
-      // --- post-restore assertions on the target --------------------------
-      const tgtPool = makePool(admin, TGT_DB);
-      try {
-        // Counts and namespaces survived.
-        const { rows: countRows } = await tgtPool.query(
-          "SELECT COUNT(*)::int AS count FROM thoughts",
-        );
-        expect(countRows[0]!.count).toBe(5);
-        const { rows: nsRows } = await tgtPool.query(
-          "SELECT COUNT(DISTINCT namespace)::int AS count FROM thoughts",
-        );
-        expect(nsRows[0]!.count).toBe(2);
-
-        // Archived row restored AS archived.
-        const { rows: archivedRows } = await tgtPool.query(
-          "SELECT archived_at FROM thoughts WHERE content_hash = $1",
-          [ARCHIVED_HASH],
-        );
-        expect(archivedRows.length).toBe(1);
-        expect(archivedRows[0]!.archived_at).not.toBeNull();
-
-        // Hard-deleted row NOT resurrected.
-        const { rows: deletedRows } = await tgtPool.query(
-          "SELECT 1 FROM thoughts WHERE content_hash = $1",
-          [DELETED_HASH],
-        );
-        expect(deletedRows.length).toBe(0);
-
-        // Readable.
-        const { rows: readRows } = await tgtPool.query(
-          "SELECT content FROM thoughts WHERE content_hash = $1",
-          ["drill-alpha-1"],
-        );
-        expect(readRows[0]!.content).toBe("drill alpha thought one");
-
-        // Writable.
-        await tgtPool.query(
-          `INSERT INTO thoughts (content, created_by, namespace, content_hash)
-             VALUES ($1, $2, $3, $4)`,
-          ["drill post-restore write", "drill", NS_ALPHA, "drill-post-1"],
-        );
-
-        // Restore-then-replay linkage (server-side scope): a session lane
-        // append lands against the restored db, proving a client spool
-        // drain would land. The full python-client replay drill is out of
-        // scope for this repo (named in the PR's deferred list).
-        const { rows: laneRows } = await tgtPool.query(
-          `SELECT id FROM ob_session_lanes
-              WHERE namespace = $1 AND session_key = $2`,
-          [NS_ALPHA, "drill-lane-1"],
-        );
-        expect(laneRows.length).toBe(1);
-        await tgtPool.query(
-          `INSERT INTO ob_session_events (lane_id, event_type, content, created_by)
-             VALUES ($1, $2, $3, $4)`,
-          [laneRows[0]!.id, "fact", "drill post-restore append", "drill"],
-        );
-        const { rows: eventRows } = await tgtPool.query(
-          "SELECT COUNT(*)::int AS count FROM ob_session_events WHERE lane_id = $1",
-          [laneRows[0]!.id],
-        );
-        expect(eventRows[0]!.count).toBe(2);
-      } finally {
-        await tgtPool.end();
-      }
-    }, 180_000);
-
-    it("restores into the fresh administrator-bootstrapped non-superuser clone", async () => {
-      expect(clone.host).toBe("127.0.0.1");
-      expect(clone.user).toBe("open_brain_local_clone");
-      expect(clone.database.startsWith("open_brain_local_")).toBe(true);
-
-      const restore = await runCli(
-        "restore.ts",
-        ["--dir", backupDir, "--target-db-url", dbUrl(clone, clone.database)],
-        cliEnv(admin, SRC_DB),
-      );
-      expect(restore.exitCode).toBe(0);
-      expect(restore.receipt?.status).toBe("ok");
-      expect(
-        (restore.receipt?.validations ?? []).every(
-          (v: any) => v.verdict === "ok",
-        ),
-      ).toBe(true);
-
-      const restored = makePool(clone, clone.database);
-      try {
-        const { rows: identity } = await restored.query(
-          `SELECT current_user,
-                  EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS vector_installed,
-                  EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') AS pg_stat_statements_installed`,
-        );
-        expect(identity[0]).toEqual({
-          current_user: "open_brain_local_clone",
-          vector_installed: true,
-          pg_stat_statements_installed: true,
-        });
-        const { rows: readRows } = await restored.query(
-          "SELECT COUNT(*)::int AS count FROM thoughts",
-        );
-        expect(readRows[0]!.count).toBeGreaterThan(0);
-        await restored.query(
-          `INSERT INTO thoughts (content, created_by, namespace, content_hash)
-             VALUES ($1, $2, $3, $4)`,
-          [
-            "non-superuser clone restore write",
-            "drill",
-            NS_ALPHA,
-            "drill-clone-write",
-          ],
-        );
-      } finally {
-        await restored.end();
-      }
-    }, 180_000);
-
-    it("uses one exported snapshot for manifest counts and dump contents across a concurrent commit", async () => {
-      const coordinationDir = await tempDir();
-      const readyPath = join(coordinationDir, "pg-dump-ready");
-      const releasePath = join(coordinationDir, "pg-dump-release");
-      const wrapperPath = join(coordinationDir, "coordinated-pg-dump.ts");
-      const realPgDump = resolvePgTool("pg_dump");
-      await Bun.write(
-        wrapperPath,
-        [
-          `await Bun.write(process.env.OB_SNAPSHOT_TEST_READY!, "ready");`,
-          `while (!(await Bun.file(process.env.OB_SNAPSHOT_TEST_RELEASE!).exists())) await Bun.sleep(20);`,
-          `const tool = JSON.parse(process.env.OB_SNAPSHOT_TEST_TOOL!) as string[];`,
-          `const proc = Bun.spawn([...tool, ...Bun.argv.slice(2)], {`,
-          `  env: process.env, stdin: "inherit", stdout: "inherit", stderr: "inherit",`,
-          `});`,
-          `process.exit(await proc.exited);`,
-          "",
-        ].join("\n"),
-      );
-
-      const snapshotBackupDir = join(await tempDir(), "set-snapshot");
-      const backupPromise = runCli("backup.ts", ["--out", snapshotBackupDir], {
-        ...cliEnv(admin, SRC_DB),
-        OPENBRAIN_PG_DUMP_BIN: `bun ${wrapperPath}`,
-        OB_SNAPSHOT_TEST_READY: readyPath,
-        OB_SNAPSHOT_TEST_RELEASE: releasePath,
-        OB_SNAPSHOT_TEST_TOOL: JSON.stringify(realPgDump),
-      });
-
-      const readyDeadline = Date.now() + 30_000;
-      while (!(await Bun.file(readyPath).exists())) {
-        if (Date.now() >= readyDeadline) {
-          await Bun.write(releasePath, "release");
-          await backupPromise;
-          throw new Error("timed out waiting for coordinated pg_dump");
-        }
-        await Bun.sleep(20);
-      }
-
-      const concurrentHash = "drill-concurrent-after-snapshot";
-      const writer = makePool(admin, SRC_DB);
-      try {
-        await writer.query(
-          `INSERT INTO thoughts (content, created_by, namespace, content_hash)
-             VALUES ($1, $2, $3, $4)`,
-          [
-            "concurrent write after exported snapshot",
-            "drill",
-            NS_ALPHA,
-            concurrentHash,
-          ],
-        );
-      } finally {
-        await writer.end();
-        // Always unblock the wrapper, including when the concurrent write
-        // fails, so the backup subprocess cannot leak into later tests.
-        await Bun.write(releasePath, "release");
-      }
-
-      const backup = await backupPromise;
-      expect(backup.exitCode).toBe(0);
-      expect(backup.receipt?.status).toBe("ok");
-      const manifest = JSON.parse(
-        await Bun.file(join(snapshotBackupDir, "manifest.json")).text(),
-      );
-
-      const restore = await runCli(
-        "restore.ts",
-        [
-          "--dir",
-          snapshotBackupDir,
-          "--target-db-url",
-          dbUrl(admin, SNAPSHOT_TGT_DB),
-        ],
-        cliEnv(admin, SRC_DB),
-      );
-      expect(restore.exitCode).toBe(0);
-      expect(restore.receipt?.status).toBe("ok");
-
-      const restored = makePool(admin, SNAPSHOT_TGT_DB);
-      try {
-        const { rows: countRows } = await restored.query(
-          "SELECT COUNT(*)::int AS count FROM thoughts",
-        );
-        expect(countRows[0]!.count).toBe(manifest.row_counts.thoughts);
-        const { rows: concurrentRows } = await restored.query(
-          "SELECT 1 FROM thoughts WHERE content_hash = $1",
-          [concurrentHash],
-        );
-        expect(concurrentRows).toEqual([]);
-      } finally {
-        await restored.end();
-      }
-    }, 180_000);
-
-    it("refuses a non-empty target without --wipe-target + approval env", async () => {
-      // Self-sufficient: ensure the target exists and is non-empty rather
-      // than depending on the previous drill test having populated it.
-      const adminPool = new pg.Client({
-        connectionString: dbUrl(admin, admin.database),
-      });
-      await adminPool.connect();
-      try {
-        const { rows } = await adminPool.query(
-          "SELECT 1 FROM pg_database WHERE datname = $1",
-          [TGT_DB],
-        );
-        if (rows.length === 0) {
-          await adminPool.query(`CREATE DATABASE ${TGT_DB}`);
-        }
-      } finally {
-        await adminPool.end();
-      }
-      const seedPool = new pg.Client({
-        connectionString: dbUrl(admin, TGT_DB),
-      });
-      await seedPool.connect();
-      try {
-        await seedPool.query(
-          "CREATE TABLE IF NOT EXISTS drill_nonempty_marker (id int)",
-        );
-      } finally {
-        await seedPool.end();
-      }
-      const noWipe = await runCli(
-        "restore.ts",
-        ["--dir", backupDir, "--target-db-url", dbUrl(admin, TGT_DB)],
-        cliEnv(admin, SRC_DB),
-      );
-      expect(noWipe.exitCode).not.toBe(0);
-      expect(noWipe.receipt?.status).toBe("failed");
-      expect(noWipe.receipt?.error).toContain("NOT empty");
-
-      const noApproval = await runCli(
-        "restore.ts",
-        [
-          "--dir",
-          backupDir,
-          "--target-db-url",
-          dbUrl(admin, TGT_DB),
-          "--wipe-target",
-        ],
-        cliEnv(admin, SRC_DB),
-      );
-      expect(noApproval.exitCode).not.toBe(0);
-      expect(noApproval.receipt?.error).toContain(RESTORE_WIPE_APPROVAL_ENV);
-
-      // With the approval env the wipe + restore succeeds.
-      const approved = await runCli(
-        "restore.ts",
-        [
-          "--dir",
-          backupDir,
-          "--target-db-url",
-          dbUrl(admin, TGT_DB),
-          "--wipe-target",
-        ],
-        {
-          ...cliEnv(admin, SRC_DB),
-          [RESTORE_WIPE_APPROVAL_ENV]: RESTORE_WIPE_APPROVAL_VALUE,
-        },
-      );
-      expect(approved.receipt?.status).toBe("ok");
-      expect(approved.exitCode).toBe(0);
-    }, 180_000);
-
-    it("refuses a target with non-public user schemas even with wipe approval", async () => {
-      // The approved wipe only drops schema public; a target carrying user
-      // tables in ANY other schema must be refused outright (fail-closed),
-      // wipe approval or not.
-      const seed = new pg.Client({ connectionString: dbUrl(admin, TGT_DB) });
-      await seed.connect();
-      try {
-        await seed.query("CREATE SCHEMA IF NOT EXISTS drill_foreign");
-        await seed.query(
-          "CREATE TABLE IF NOT EXISTS drill_foreign.marker (id int)",
-        );
-      } finally {
-        await seed.end();
-      }
-      const refused = await runCli(
-        "restore.ts",
-        [
-          "--dir",
-          backupDir,
-          "--target-db-url",
-          dbUrl(admin, TGT_DB),
-          "--wipe-target",
-        ],
-        {
-          ...cliEnv(admin, SRC_DB),
-          [RESTORE_WIPE_APPROVAL_ENV]: RESTORE_WIPE_APPROVAL_VALUE,
-        },
-      );
-      expect(refused.exitCode).not.toBe(0);
-      expect(refused.receipt?.status).toBe("failed");
-      expect(refused.receipt?.error).toContain("non-public");
-
-      // Nothing was wiped: both the foreign schema AND the existing public
-      // tables survived the refusal.
-      const check = new pg.Client({ connectionString: dbUrl(admin, TGT_DB) });
-      await check.connect();
-      try {
-        const { rows: foreignRows } = await check.query(
-          "SELECT 1 FROM pg_catalog.pg_tables WHERE schemaname = 'drill_foreign'",
-        );
-        expect(foreignRows.length).toBe(1);
-        const { rows: publicRows } = await check.query(
-          `SELECT COUNT(*)::int AS count FROM pg_catalog.pg_tables
-             WHERE schemaname = 'public'`,
-        );
-        expect(publicRows[0]!.count).toBeGreaterThan(0);
-        // Clean up so later tests see a public-only target again.
-        await check.query("DROP SCHEMA drill_foreign CASCADE");
-      } finally {
-        await check.end();
-      }
-    }, 120_000);
-
-    it("old backup (pre-latest-migration) restores into the upgraded runtime and the head advances", async () => {
-      // Build a source whose migration head is ONE BEHIND the repo head by
-      // migrating with a truncated copy of the migrations directory.
-      const allMigrations = (await readdir(MIGRATIONS_DIR))
-        .filter((f) => f.endsWith(".sql"))
-        .sort();
-      expect(allMigrations.length).toBeGreaterThan(1);
-      const truncatedDir = await tempDir();
-      for (const file of allMigrations.slice(0, -1)) {
-        await cp(join(MIGRATIONS_DIR, file), join(truncatedDir, file));
-      }
-
-      const oldPool = makePool(admin, OLD_SRC_DB);
-      try {
-        await runMigrations(oldPool, truncatedDir);
-        await oldPool.query(
-          `INSERT INTO thoughts (content, created_by, namespace, content_hash)
-             VALUES ($1, $2, $3, $4)`,
-          ["drill old-runtime thought", "drill", NS_ALPHA, "drill-old-1"],
-        );
-      } finally {
-        await oldPool.end();
-      }
-
-      const oldBackupDir = join(await tempDir(), "set-old");
-      const backup = await runCli(
-        "backup.ts",
-        ["--out", oldBackupDir],
-        cliEnv(admin, OLD_SRC_DB),
-      );
-      expect(backup.exitCode).toBe(0);
-      expect(backup.receipt?.migrations_head).toBe(
-        allMigrations[allMigrations.length - 2],
-      );
-
-      const verify = await runCli(
-        "backup-verify.ts",
-        ["--dir", oldBackupDir],
-        cliEnv(admin, OLD_SRC_DB),
-      );
-      expect(verify.exitCode).toBe(0);
-      expect(verify.receipt?.sets?.[0]?.migration_compat).toBe(
-        "restorable_with_migrations",
-      );
-
-      const restore = await runCli(
-        "restore.ts",
-        ["--dir", oldBackupDir, "--target-db-url", dbUrl(admin, OLD_TGT_DB)],
-        cliEnv(admin, OLD_SRC_DB),
-      );
-      expect(restore.receipt?.status).toBe("ok");
-      expect(restore.exitCode).toBe(0);
-      expect(restore.receipt?.migrations_applied_forward).toBeGreaterThan(0);
-
-      const tgtPool = makePool(admin, OLD_TGT_DB);
-      try {
-        const { rows } = await tgtPool.query(
-          "SELECT filename FROM _migrations ORDER BY filename",
-        );
-        // The head ADVANCED: the restored-and-migrated db now matches the
-        // full repo migration list, including the file the backup predated.
-        expect(rows.map((r) => String(r.filename))).toEqual(allMigrations);
-        const { rows: dataRows } = await tgtPool.query(
-          "SELECT 1 FROM thoughts WHERE content_hash = $1",
-          ["drill-old-1"],
-        );
-        expect(dataRows.length).toBe(1);
-      } finally {
-        await tgtPool.end();
-      }
-    }, 180_000);
-
-    it("a corrupted dump fails CLI verification with a nonzero exit", async () => {
-      // Run LAST: this intentionally breaks the first drill's backup set.
-      const dumpPath = join(backupDir, "openbrain.dump");
-      const original = new Uint8Array(await Bun.file(dumpPath).arrayBuffer());
-      original[Math.floor(original.length / 2)]! ^= 0xff;
-      await Bun.write(dumpPath, original);
-
-      const verify = await runCli(
-        "backup-verify.ts",
-        ["--dir", backupDir],
-        cliEnv(admin, SRC_DB),
-      );
-      expect(verify.exitCode).toBe(1);
-      expect(verify.receipt?.status).toBe("failed");
-
-      // And restore refuses the corrupted set before touching any target.
-      const restore = await runCli(
-        "restore.ts",
-        ["--dir", backupDir, "--target-db-url", dbUrl(admin, TGT_DB)],
-        {
-          ...cliEnv(admin, SRC_DB),
-          [RESTORE_WIPE_APPROVAL_ENV]: RESTORE_WIPE_APPROVAL_VALUE,
-        },
-      );
-      expect(restore.exitCode).not.toBe(0);
-      expect(restore.receipt?.status).toBe("failed");
-      expect(restore.receipt?.error).toContain("verification failed");
-    }, 120_000);
-  });
+  it(
+    "prerequisites are available (fails loudly when the drill is enabled)",
+    prerequisitesAreAvailable,
+  );
+  it(
+    "full drill: seed → backup → verify → restore → validations → replay linkage",
+    fullDrill,
+    180_000,
+  );
+  it(
+    "restores into the fresh administrator-bootstrapped non-superuser clone",
+    restoresIntoFreshNonSuperuserClone,
+    180_000,
+  );
 });

--- a/scripts/assert-db-tests-ran.ts
+++ b/scripts/assert-db-tests-ran.ts
@@ -442,6 +442,18 @@ export const REQUIRED_SUITES: ReadonlyArray<{
     name: "embedding repair through the real maintenance queue (live Postgres)",
     minTests: 2,
   },
+  // The live backup/restore drill was split into a full-run half and a
+  // snapshot/refusals/upgrade half (#878, #938) as that file stopped skipping
+  // itself, so both halves are named here; registering one would let the other
+  // vanish unnoticed.
+  {
+    name: "backup restore drill full run (live Postgres)",
+    minTests: 3,
+  },
+  {
+    name: "backup restore drill snapshot, refusals, and upgrade (live Postgres)",
+    minTests: 5,
+  },
 ];
 
 // Absolute floor on total executed (non-skipped) live-Postgres testcases,
@@ -499,9 +511,11 @@ export const REQUIRED_SUITES: ReadonlyArray<{
 // itself, then 302 -> 304 when #878 registered the agent_context_pack durable
 // lane live-reads suite's 2 as that file stopped skipping itself, then
 // 304 -> 320 when #878 registered the five subject-split embedding repair
-// suites' 6 + 3 + 2 + 3 + 2 as that file stopped skipping itself), so the
-// global floor cannot silently fall behind the per-suite one.
-export const MIN_TOTAL_LIVE_TESTCASES = 320;
+// suites' 6 + 3 + 2 + 3 + 2 as that file stopped skipping itself, then
+// 320 -> 328 when #878 registered the two split backup/restore drill
+// suites' 3 + 5 as that file stopped skipping itself), so the global floor
+// cannot silently fall behind the per-suite one.
+export const MIN_TOTAL_LIVE_TESTCASES = 328;
 
 export interface SuiteStats {
   tests: number;


### PR DESCRIPTION
## Summary

- The live backup/restore drill read `OPENBRAIN_TEST_DATABASE_URL` and `OPENBRAIN_LOCAL_CLONE_TEST_DATABASE_URL` itself and swapped in a conditional describe when either was absent, so a run without them reported no failures and exited 0. Both are now demanded through `scripts/test-support/require-test-database.ts`, which throws `test_database_required` when a variable is unset (#878).
- The pg_dump/pg_restore probe is asserted by the first test instead of gating the suite, so a missing client tool fails loudly rather than silently disabling the drill.
- The file no longer fits the repo's per-file standard once it stops nesting, so it is split in three: the full run stays in `scripts/__tests__/backup-restore-live.test.ts` (3 tests), the snapshot, refusal, and upgrade tests move to `scripts/__tests__/backup-restore-live-refusals.test.ts` (5 tests), and the drill lifecycle both halves need moves to `scripts/__tests__/backup-restore-live-helpers.ts`, which holds no test and creates no pool at import. Each half opens its own lifecycle, so either runs standalone. Test names, order, and assertions are unchanged.
- Fixes #938. The runner's clone database is already migrated by `scripts/test-isolated.ts` and `scripts/restore.ts` refuses a non-empty target, so the non-superuser clone test restored into a database that could never be empty and failed for a reason unrelated to what it asserts. The drill now restores into a fresh `open_brain_ci_restore_clone_tgt` that the clone role OWNS, with the `vector` and `pg_stat_statements` extensions installed by the administrator first — the same bootstrap `scripts/test-support/clone-database.ts:194` performs, because a non-superuser cannot create extensions and pg_restore would fail on them. The non-superuser property the test is about is preserved; the false failure is not.
- `scripts/assert-db-tests-ran.ts` registers both new suite names at their JUnit-emitted counts (3 and 5) and raises `MIN_TOTAL_LIVE_TESTCASES` 285 -> 293, so CI's anti-skip guard fails if either half vanishes.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
  `CHANGED_FILES="scripts/__tests__/backup-restore-live.test.ts scripts/__tests__/backup-restore-live-refusals.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` -> exit 0, all four clauses PASS. RED at `origin/main` fa82bdf5, recorded by the phase-1 lane: same invocation with `CHANGED_FILES="scripts/__tests__/backup-restore-live.test.ts"` -> exit 1, clauses 1/2/3 FAIL and 4 PASS.
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts, all on the committed tree at e75b642:

- `./node_modules/.bin/oxlint --deny-warnings` over the four touched files -> exit 0, zero findings.
- `bunx tsc --noEmit` -> exit 0.
- `bun run test:isolated scripts/__tests__/backup-restore-live.test.ts scripts/__tests__/backup-restore-live-refusals.test.ts` -> exit 0, 8 pass / 0 fail in 3.97s.
- Suite counts read from JUnit, not tallied by eye: 3 testcases carry `backup restore drill full run (live Postgres)` and 5 carry `backup restore drill snapshot, refusals, and upgrade (live Postgres)`.
- Every touched file is under the 500-line standard: 317 / 376 / 301.

Python is not applicable — no path under `python/openbrain-memory/` is touched. A live Open Brain smoke is not applicable: this changes test files and a CI manifest only, no server, tool, or transport behavior.

## Critical Self-Review

- Highest-risk behavior: the drill now demands two database URLs at import instead of skipping, so any CI job that runs these files without both configured turns from silently green to red. That is the intended effect of #878, but it is the change most likely to surface as a new failure elsewhere.
- Assumptions that could be wrong: that the clone role can be granted ownership of a fresh database on every runner, and that installing `vector` and `pg_stat_statements` as administrator is sufficient for pg_restore under that role. Verified locally against the real clone role; a runner whose administrator connection lacks CREATEDB would fail at `openDrill` rather than at the assertion.
- Missing/weak tests: nothing asserts that the two halves do not collide when run concurrently. They share the same fixed `open_brain_ci_restore_*` names, so a parallel run of both files against one server would interfere. Bun runs test files sequentially in this suite, which is what makes it safe today rather than a guarantee in the code.
- Security/permission risk: none new. The change does not touch auth, namespace predicates, or any server path. It reduces privilege in one place, by restoring as the non-superuser clone role rather than the administrator.
- Migration/deploy risk: none. No migration is added or altered; `runMigrations` is called only against throwaway scratch databases that are dropped in `closeDrill`.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classifies this as not applicable — no MCP tool, schema, protocol, or client-facing surface changes.
- Rollback/cleanup concern: the scratch databases are dropped in `closeDrill` and again at the start of the next `openDrill`, so an aborted run leaves at most the six named databases behind and the next run reclaims them. Temp directories are removed in the same teardown.
- Fixes made before PR: the first `seedAndBackup` shape returned only the directory, which would have dropped the six backup-receipt assertions from the full-drill test; widened it to return the CLI result too and updated both call sites. The prerequisites test initially asserted the context's connection fields, which passes clause 1 while removing the honest demand for the URLs; changed to call `requireTestDatabaseUrl()` and `requireLocalCloneTestDatabaseUrl()` directly. `verify.receipt?.sets?.[0]` did not typecheck against the open receipt record and now goes through the shared `receiptSetField` narrowing.
- Known residual risk: the shared scratch database names, as above. Also `MIN_TOTAL_LIVE_TESTCASES` is derived from this branch's base copy of 285; `origin/main` has moved since, so the arithmetic needs reconciling if another registering branch lands first.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: every pattern this lane hit is already an entry or a lane-contract Tightening — the false-green skip is #878's own subject, `max-lines-per-function` measuring the describe callback and the shared helper taking `pool` as a parameter are round-39 Tightenings, and the harvest comment on this pull request records the one new observation.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this changes test files and a CI manifest only; no server, tool, transport, or client behavior is altered.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched — the diff is two test files, one test-only helper module, and the CI anti-skip manifest.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, protocol, transport, or Python client path is in the diff. The changed files are `scripts/__tests__/backup-restore-live.test.ts`, `scripts/__tests__/backup-restore-live-refusals.test.ts`, `scripts/__tests__/backup-restore-live-helpers.ts`, and `scripts/assert-db-tests-ran.ts`.
