### PR TITLE
fix(done-means): clause 2 of the #878 check judges the helper demand across a wrapped import and a sibling relay (#945)

### DIFF
--- a/scripts/done-means/878-pg-tests-require-database.sh
+++ b/scripts/done-means/878-pg-tests-require-database.sh
@@ -63,16 +63,35 @@
 #   The exemption is line-shaped (`//`, `/*`, `*`), which is what prettier
 #   leaves behind; a literal buried mid-expression on a code line still fails.
 #
-# CLAUSE 2 -- THE HELPER IS ACTUALLY IMPORTED.
+# CLAUSE 2 -- THE HELPER DEMAND ACTUALLY REACHES THE FILE.
 #   Clause 1 alone is satisfiable by deleting the environment read and leaving
 #   the suite connecting to nothing, which is worse than the defect. So clause 2
-#   demands one of `requireTestDatabaseUrl`, `requireLocalCloneTestDatabaseUrl`,
-#   or `requireScratchAdminUrl` on an import line whose
-#   module path ends in the basename `require-test-database`. Matching the
-#   IDENTIFIER and the BASENAME rather than a fixed relative path is what lets
-#   files at different depths under server/ and src/ satisfy the same clause --
-#   `../../scripts/test-support/...` and `../scripts/test-support/...` are the
-#   same import.
+#   demands that one of `requireTestDatabaseUrl`,
+#   `requireLocalCloneTestDatabaseUrl`, or `requireScratchAdminUrl` is CALLED,
+#   and that the identifier arrives from a module whose specifier basename is
+#   `require-test-database`. Matching the IDENTIFIER and the BASENAME rather
+#   than a fixed relative path is what lets files at different depths under
+#   server/ and src/ satisfy the same clause -- `../../scripts/test-support/...`
+#   and `../scripts/test-support/...` are the same import.
+#
+#   Issue #945: the clause used to judge the LINE SHAPE of the import, and two
+#   honest conversions failed it while clauses 1, 3, and 4 passed. Prettier
+#   wraps a two-specifier import across physical lines, putting the identifier
+#   and the module specifier on different lines so no single line carries both;
+#   and one half of a split suite can reach the helper only through the shared
+#   sibling module the split created. So the clause is now STATEMENT-AWARE and
+#   allows ONE RELAY HOP:
+#     - an import statement is joined from its `import` keyword to the
+#       terminating `;` before matching, so wrapping is invisible to it;
+#     - failing a direct import, each RELATIVE sibling module the file imports
+#       (resolved from the subject's own directory, `.ts` appended when the
+#       specifier carries none) is read once, and the clause passes when that
+#       sibling imports the identifier from a `require-test-database` module.
+#       The relay owns the call in that shape, so the call is looked for there.
+#   The hop is deliberately ONE deep: a chain longer than that is no longer a
+#   split's shared helper, and following it would turn a source check into a
+#   module resolver. A file that CALLS a helper it never imports at all still
+#   fails -- that is the case clause 2 exists to catch.
 #
 # CLAUSE 3 -- THE HARD FAIL IS OBSERVED, not merely arranged, per file.
 #   Clauses 1 and 2 read source. Clause 3 runs the thing: with the variable THAT
@@ -131,6 +150,66 @@ demanded_variable_of() {
   elif rg -qF 'requireTestDatabaseUrl' "$1" 2>/dev/null; then
     printf 'OPENBRAIN_TEST_DATABASE_URL\n'
   fi
+}
+
+# Prints one line per import STATEMENT in the file, each statement joined from
+# its `import` keyword to the terminating `;`. Prettier wraps a multi-specifier
+# import across physical lines, so a per-line match sees the identifiers and
+# the module specifier on different lines and finds neither together.
+import_statements_of() {
+  awk '
+    /^[[:space:]]*import[[:space:]]/ && !collecting { collecting = 1; buf = "" }
+    collecting {
+      line = $0
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+      buf = (buf == "" ? line : buf " " line)
+      if (index($0, ";") > 0) { print buf; collecting = 0 }
+    }
+  ' "$1" 2>/dev/null
+}
+
+# The import statements of a file that both name a helper identifier and load a
+# module whose specifier basename is `require-test-database`.
+direct_helper_imports_of() {
+  import_statements_of "$1" | rg "$HELPER_IDENT" | rg -F "$HELPER_BASENAME" || true
+}
+
+# Collapses `.` and `..` segments in a repo-relative path textually. `realpath
+# --relative-to` is GNU-only and this check runs on macOS as well.
+normalize_repo_path() {
+  printf '%s\n' "$1" | awk -F/ '
+    {
+      n = 0
+      for (i = 1; i <= NF; i++) {
+        if ($i == "" || $i == ".") continue
+        if ($i == ".." && n > 0 && out[n] != "..") { n--; continue }
+        out[++n] = $i
+      }
+      s = ""
+      for (i = 1; i <= n; i++) s = (s == "" ? out[i] : s "/" out[i])
+      print s
+    }
+  '
+}
+
+# The relative sibling modules a file imports. Each printed as a repo-relative
+# path resolved from the importing file's own directory, with `.ts` appended
+# when the specifier carries no extension.
+relative_imports_of() {
+  local file="$1"
+  local dir
+  dir="$(dirname "$file")"
+  import_statements_of "$REPO_ROOT/$file" \
+    | rg -o 'from[[:space:]]+"\.[^"]*"' \
+    | sed 's/^from[[:space:]]*"//; s/"$//' \
+    | while IFS= read -r spec; do
+        [ -n "$spec" ] || continue
+        case "$spec" in
+          *.ts | *.tsx | *.js) : ;;
+          *) spec="$spec.ts" ;;
+        esac
+        normalize_repo_path "$dir/$spec"
+      done
 }
 
 # ---------------------------------------------------------------------------
@@ -213,12 +292,34 @@ while IFS= read -r FILE; do
   # -------------------------------------------------------------------------
   # CLAUSE 2 -- the helper arrives, matched on identifier plus module basename.
   # -------------------------------------------------------------------------
-  IMPORT_HITS="$(cd "$REPO_ROOT" && rg -n "$HELPER_IDENT" "$FILE" 2>/dev/null \
-    | rg -F "$HELPER_BASENAME" || true)"
+  # The demand is a CALL of a helper identifier in this file. Where the
+  # identifier comes from is the second half, answered directly or one hop away.
+  CALL_HITS="$(cd "$REPO_ROOT" && rg -n "($HELPER_IDENT)\(" "$FILE" 2>/dev/null || true)"
+  IMPORT_HITS="$(direct_helper_imports_of "$REPO_ROOT/$FILE")"
+  CLAUSE2_VIA=""
+  [ -n "$IMPORT_HITS" ] && CLAUSE2_VIA="its own import"
+  if [ -z "$CLAUSE2_VIA" ]; then
+    while IFS= read -r SIBLING; do
+      [ -n "$SIBLING" ] || continue
+      [ -f "$REPO_ROOT/$SIBLING" ] || continue
+      if [ -n "$(direct_helper_imports_of "$REPO_ROOT/$SIBLING")" ]; then
+        CLAUSE2_VIA="the relay module $SIBLING"
+        # The relay owns the call; the subject reaches the demand through it.
+        CALL_HITS="$(cd "$REPO_ROOT" && rg -n "($HELPER_IDENT)\(" "$SIBLING" 2>/dev/null || true)"
+        break
+      fi
+    done <<EOSIB
+$(relative_imports_of "$FILE")
+EOSIB
+  fi
   DEMANDED="$(cd "$REPO_ROOT" && demanded_variable_of "$FILE")"
-  if [ -n "$IMPORT_HITS" ]; then
-    printf 'CLAUSE 2 [%s]: PASS -- imports %s from a %s module\n' \
-      "$FILE" "$HELPER_IDENT" "$HELPER_BASENAME"
+  if [ -n "$CALL_HITS" ] && [ -n "$CLAUSE2_VIA" ]; then
+    printf 'CLAUSE 2 [%s]: PASS -- calls %s, reaching it through %s\n' \
+      "$FILE" "$HELPER_IDENT" "$CLAUSE2_VIA"
+  elif [ -n "$CLAUSE2_VIA" ]; then
+    printf 'CLAUSE 2 [%s]: FAIL -- %s arrives through %s but is never called\n' \
+      "$FILE" "$HELPER_IDENT" "$CLAUSE2_VIA"
+    CLAUSE2=FAIL
   else
     printf 'CLAUSE 2 [%s]: FAIL -- no import of %s from a %s module\n' \
       "$FILE" "$HELPER_IDENT" "$HELPER_BASENAME"
@@ -272,7 +373,7 @@ else
 fi
 
 printf '\nCLAUSE 1 (no self-skipping machinery on code lines): %s\n' "$CLAUSE1"
-printf 'CLAUSE 2 (imports requireTestDatabaseUrl):           %s\n' "$CLAUSE2"
+printf 'CLAUSE 2 (the helper demand reaches the file):      %s\n' "$CLAUSE2"
 printf 'CLAUSE 3 (hard fail observed without the variable):  %s\n' "$CLAUSE3"
 printf 'CLAUSE 4 (test:isolated over the subject exits 0):   %s\n' "$CLAUSE4"
 


### PR DESCRIPTION
## Summary

- Clause 2 of `scripts/done-means/878-pg-tests-require-database.sh` matched the require-test-database identifier and the module basename on a single physical LINE. Two honest conversions failed it while clauses 1, 3, and 4 passed: prettier wraps a two-specifier import so the identifier and the module specifier land on different lines, and one half of a split suite reaches the helper only through the shared sibling module the split created (round-40 harvest, #945).
- The clause now judges the DEMAND. Import statements are joined from `import` to the terminating `;` before matching, so wrapping is invisible to the check. Failing a direct import, each relative sibling module the subject imports is resolved from the subject's own directory (`.ts` appended when the specifier carries none) and read once; the clause passes when that sibling imports the identifier from a require-test-database module, and the call is looked for there because the relay owns it.
- One relay hop only. A file that calls a helper it never imports at all still fails, which is the case clause 2 exists to catch. Clauses 1, 3, and 4 are unchanged, and the header prose was rewritten so the documented rule matches the code.
- Closes #945.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
  `CHANGED_FILES="scripts/__tests__/backup-restore-live.test.ts scripts/__tests__/backup-restore-live-refusals.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` exits 0 on the committed tree, all four clauses PASS.
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED, at origin/main (751c7268), with an untracked fixture carrying a prettier-wrapped two-specifier import and a module-scope `requireTestDatabaseUrl()` call: clause 2 FAIL, clauses 1, 3, 4 PASS, exit 1.

GREEN, after the change: the same fixture exits 0; a second fixture reaching the helper only through an untracked sibling relay module exits 0 and names the relay in its PASS line; a third fixture that calls the helper with no import at all still exits 1 on clause 2. The two real backup-restore files above still exit 0. The four fixtures and the relay helper were moved out of the tree with `mv` before staging and `git status` showed none of them.

## Critical Self-Review

- Highest-risk behavior: a check that gates every #878 conversion lane now accepts a wider set of shapes. A too-permissive clause 2 would let a suite that never demands the database through, reinstating the false green this whole script exists to catch.
- Assumptions that could be wrong: that the awk statement joiner handles every import spelling in this repo. It keys on a line starting with `import` and closes at the first `;`, so an import with a `;` inside a string specifier, or a semicolon-free style, would join wrong. Neither shape exists in this repo's test files, and clause 2 fails closed when the join is wrong rather than passing.
- Missing/weak tests: the change has no committed unit test; the proof is the four fixture runs recorded above, which are untracked by design. A tracked fixture pair for the wrapped and relay shapes would make this a standing regression rather than a one-time receipt.
- Security/permission risk: none. The script reads source files inside the repo and runs no new command; there is no namespace, token, or database mutation in the change.
- Migration/deploy risk: none. This is a developer-run check script with no runtime, migration, or service surface.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md`. No MCP tool, schema, transport, or Python client path is touched, so rtech-mcps, mcp2cli, and Hermes are unaffected.
- Rollback/cleanup concern: reverting the commit restores the line-shaped clause exactly; nothing else depends on the new helper functions. The lane created four untracked fixtures and moved them to the session scratch area before staging.
- Fixes made before PR: the first relay resolver used `realpath --relative-to`, which is GNU-only and absent on macOS where this check runs; it was replaced with a textual `.`/`..` collapser. The relay branch initially left the call search on the subject file, which would have failed the relay fixture because the subject calls the relay wrapper rather than the helper; the call is now looked for in the relay module.
- Known residual risk: the one-hop rule is deliberate, so a two-hop relay chain fails clause 2 with a message that reads as a missing import. That is the intended trade against turning a source check into a module resolver, but it will surprise a lane that builds a deeper helper chain.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the pattern this fixes is already recorded as a round-40 Tightening in `docs/lane-contract.md` and is the issue this PR closes; the lane found no new MEDIUM+ review finding to promote.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: the change is a shell check script with no service surface.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, schema, or client-facing shape is touched.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- The done-means invocation above was re-run on the committed tree after the pre-commit gate, not on the staged one. `bunx tsc --noEmit` exits 0 and `bash -n` on the script exits 0; oxlint has no shell rule set, so it reports nothing to lint for this path.
