### PR TITLE
test(pg): the lane_upsert live suite requires the test database instead of skipping, split by subject (#878)

### DIFF
--- a/src/tools/__tests__/lane-upsert-embedding-and-defaults.test.ts
+++ b/src/tools/__tests__/lane-upsert-embedding-and-defaults.test.ts
@@ -1,0 +1,389 @@
+/**
+ * Unit coverage for lane_upsert embedding behavior and field defaulting.
+ *
+ * Split out of lane-upsert.test.ts by subject. Mock pool only, no database.
+ */
+import { describe, it, expect } from "bun:test";
+import { createMockEmbed } from "./test-helpers.ts";
+import {
+  createThrowingEmbed,
+  firstText,
+  setupToolClient,
+  type ObAuthInfo,
+} from "./lane-upsert-test-helpers.ts";
+
+async function case1() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-noembed",
+          is_new: true,
+          status: "active",
+          updated_at: "2026-06-07T15:30:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "bare-lane" },
+    });
+
+    const parsed = JSON.parse(firstText(result));
+    expect(parsed.embedded).toBe(false);
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case2() {
+  let embedCalled = false;
+  const embedFn = async (text: string) => {
+    embedCalled = true;
+    expect(text).toContain("my topic");
+    return Array(768).fill(0.1);
+  };
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-topic",
+          is_new: true,
+          status: "active",
+          updated_at: "2026-06-07T15:30:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth, embedFn);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "topic-lane", topic: "my topic" },
+    });
+
+    expect(embedCalled).toBe(true);
+    const parsed = JSON.parse(firstText(result));
+    expect(parsed.embedded).toBe(true);
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case3() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-nullembed",
+          is_new: true,
+          status: "active",
+          updated_at: "2026-06-07T15:30:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(
+    mockPool,
+    auth,
+    createMockEmbed(null),
+  );
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: {
+        session_key: "null-embed-lane",
+        current_context_md: "some context",
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(firstText(result));
+    expect(parsed.embedded).toBe(false);
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case4() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-embedfail",
+          is_new: true,
+          status: "active",
+          updated_at: "2026-06-07T15:30:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(
+    mockPool,
+    auth,
+    createThrowingEmbed(new Error("embedding provider timeout")),
+  );
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: {
+        session_key: "embed-crash-lane",
+        current_context_md: "context that triggers embed failure",
+      },
+    });
+
+    // Should succeed with embedded=false, NOT crash
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(firstText(result));
+    expect(parsed.embedded).toBe(false);
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case5() {
+  const mockPool = {
+    query: async () => {
+      throw new Error("connection refused");
+    },
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "db-fail-lane" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(firstText(result)).toContain("connection refused");
+    expect(firstText(result)).toContain("Database error");
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case6() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-nometa",
+          is_new: true,
+          status: "active",
+          updated_at: "2026-06-07T15:30:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "no-meta-lane" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(firstText(result));
+    expect(parsed.id).toBe("uuid-nometa");
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case7() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-clear",
+          is_new: false,
+          status: "active",
+          updated_at: "2026-06-07T15:30:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "clear-test", agent: "" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(firstText(result));
+    expect(parsed.id).toBe("uuid-clear");
+    expect(parsed.status).toBe("active");
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case8() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-preserve",
+          is_new: false,
+          status: "wrapped",
+          updated_at: "2026-06-07T15:30:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "status-preserve", topic: "updated topic" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(firstText(result));
+    // DB returned "wrapped" proving status was preserved (not overwritten to "active")
+    expect(parsed.status).toBe("wrapped");
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case9() {
+  // Regression for lane_upsert_db_error: omitting status previously bound an
+  // explicit NULL into the NOT NULL status column, so creating a NEW lane
+  // failed the constraint. The INSERT value must default to 'active' while
+  // the ON CONFLICT path keeps a nullable status to preserve existing rows.
+  let capturedSql = "";
+  let capturedParams: unknown[] = [];
+  const mockPool = {
+    query: async (sql: string, params: unknown[]) => {
+      capturedSql = sql;
+      capturedParams = params;
+      return {
+        rows: [
+          {
+            id: "uuid-new",
+            is_new: true,
+            status: "active",
+            updated_at: "2026-06-07T15:30:00Z",
+          },
+        ],
+      };
+    },
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "bilby" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "new-lane-no-status" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    // $3 (ON CONFLICT / status-preserve source) stays NULL on omission.
+    expect(capturedParams[2]).toBeNull();
+    // $24 (INSERT VALUES status) defaults to 'active' so the NOT NULL
+    // column is satisfied for brand-new lanes.
+    expect(capturedParams[23]).toBe("active");
+    // ended_at must key off $3 (nullable), NOT EXCLUDED.status, otherwise a
+    // status-omitted update would reactivate a wrapped/archived lane. The
+    // ended_at clause is the segment after the embedding_model update line.
+    const endedAtClause = capturedSql.slice(capturedSql.indexOf("ended_at ="));
+    // $3 is cast to ::text so Postgres can infer the param type (it is no
+    // longer bound into a typed column position).
+    expect(endedAtClause).toContain("$3::text = 'active'");
+    expect(endedAtClause).not.toContain("EXCLUDED.status");
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case10() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-min",
+          is_new: true,
+          status: "active",
+          updated_at: "2026-06-07T15:30:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "minimal" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(firstText(result));
+    expect(parsed.session_key).toBe("minimal");
+    expect(parsed.namespace).toBe("skippy");
+    expect(parsed.is_new).toBe(true);
+    expect(parsed.embedded).toBe(false);
+  } finally {
+    await cleanup();
+  }
+}
+
+describe("lane_upsert embedding and defaults", () => {
+  // ── EMBEDDING PATHS ──
+
+  it("skips embedding when no context or topic provided", case1);
+
+  it("embeds from topic when current_context_md is absent", case2);
+
+  it("returns null embedding when embedFn returns null (graceful degradation)", case3);
+
+  it("continues without embedding when embedFn throws (error resilience)", case4);
+
+  // ── DATABASE ERROR PATH ──
+
+  it("returns isError=true with message when DB query throws", case5);
+
+  // ── METADATA HANDLING ──
+
+  it("succeeds with default metadata when not provided", case6);
+
+  // ── EXPLICIT FIELD CLEARING ──
+
+  it("succeeds when agent is empty string (explicit clear)", case7);
+
+  // ── STATUS PRESERVATION ──
+
+  it("preserves existing status when status param is omitted", case8);
+
+  it(
+    "inserts status 'active' for a new lane when status is omitted (NOT NULL regression)",
+    case9,
+  );
+
+  // ── MINIMAL CALL ──
+
+  it("succeeds with only the required session_key", case10);
+});

--- a/src/tools/__tests__/lane-upsert-test-helpers.ts
+++ b/src/tools/__tests__/lane-upsert-test-helpers.ts
@@ -1,0 +1,81 @@
+/**
+ * Helpers shared by the split lane_upsert test files.
+ *
+ * Holds no test and creates no pool: a database-touching helper takes its
+ * `pool` as a parameter so each split half owns its own connection lifecycle.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { Pool } from "pg";
+import { registerLaneUpsert } from "../lane-upsert.ts";
+import { createMockEmbed, type MockPool } from "./test-helpers.ts";
+import type { ToolDeps } from "../index.ts";
+import type { AuthInfo as ObAuthInfo } from "../../types.ts";
+
+export type { ObAuthInfo };
+
+type TransportSend = InMemoryTransport["send"];
+type SendMessage = Parameters<TransportSend>[0];
+type SendOptions = Parameters<TransportSend>[1];
+
+export type ToolResult = Awaited<ReturnType<Client["callTool"]>>;
+
+/** Narrowing guard replacing the non-null assertions in the moved bodies. */
+export function expectDefined<T>(value: T | null | undefined, label: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(`expected ${label} to be defined`);
+  }
+  return value;
+}
+
+/** Typed read of the first text block of a tool result. */
+export function firstText(result: ToolResult): string {
+  const content = expectDefined(
+    result.content as Array<{ text?: string }> | undefined,
+    "result.content",
+  );
+  const block = expectDefined(content[0], "result.content[0]");
+  return expectDefined(block.text, "result.content[0].text");
+}
+
+export function createThrowingEmbed(error: Error) {
+  return async (_text: string): Promise<number[] | null> => {
+    throw error;
+  };
+}
+
+export async function setupToolClient(
+  mockPool: MockPool,
+  auth: ObAuthInfo,
+  embedFn?: (text: string) => Promise<number[] | null>,
+): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = {
+    pool: mockPool as unknown as Pool,
+    embedFn: embedFn ?? createMockEmbed(),
+  };
+  registerLaneUpsert(server, deps);
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  const originalSend = clientTransport.send.bind(clientTransport);
+  clientTransport.send = (message: SendMessage, options?: SendOptions) => {
+    return originalSend(message, {
+      ...options,
+      authInfo: auth as unknown as NonNullable<SendOptions>["authInfo"],
+    });
+  };
+
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return {
+    client,
+    cleanup: async () => {
+      await client.close();
+      await server.close();
+    },
+  };
+}

--- a/src/tools/__tests__/lane-upsert.pg.test.ts
+++ b/src/tools/__tests__/lane-upsert.pg.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Live Postgres coverage for lane_upsert.
+ *
+ * The mock harness in the sibling unit files cannot catch Postgres parameter
+ * type inference or the real NOT NULL / ended_at behavior. These tests run the
+ * ACTUAL query through a real pool, and demand the test database rather than
+ * skipping themselves when it is absent.
+ */
+import { describe, it, expect, afterAll } from "bun:test";
+import { Pool } from "pg";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { requireTestDatabaseUrl } from "../../../scripts/test-support/require-test-database.ts";
+import { registerLaneUpsert } from "../lane-upsert.ts";
+import { createMockEmbed } from "./test-helpers.ts";
+import { firstText } from "./lane-upsert-test-helpers.ts";
+import type { ToolDeps } from "../index.ts";
+
+type TransportSend = InMemoryTransport["send"];
+type SendMessage = Parameters<TransportSend>[0];
+type SendOptions = Parameters<TransportSend>[1];
+
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
+const ns = "test-lane-upsert-live";
+
+async function callLaneUpsert(args: Record<string, unknown>) {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  const deps: ToolDeps = { pool, embedFn: createMockEmbed(null) };
+  registerLaneUpsert(server, deps);
+  const [ct, st] = InMemoryTransport.createLinkedPair();
+  const original = ct.send.bind(ct);
+  ct.send = (m: SendMessage, o?: SendOptions) =>
+    original(m, {
+      ...o,
+      authInfo: {
+        role: "admin",
+        clientId: ns,
+      } as unknown as NonNullable<SendOptions>["authInfo"],
+    });
+  const client = new Client({ name: "tc", version: "1.0.0" });
+  await server.connect(st);
+  await client.connect(ct);
+  const res = await client.callTool({ name: "lane_upsert", arguments: args });
+  await client.close();
+  await server.close();
+  return res;
+}
+
+async function cleanupNs() {
+  await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [ns]);
+}
+
+afterAll(async () => {
+  await pool.end();
+});
+
+describe("lane_upsert (live Postgres)", () => {
+  it("creates a new lane with status omitted (no $3 type-inference error, NOT NULL satisfied)", async () => {
+    await cleanupNs();
+    try {
+      const res = await callLaneUpsert({ session_key: "live-new", namespace: ns });
+      expect(res.isError).toBeFalsy();
+      const parsed = JSON.parse(firstText(res));
+      expect(parsed.is_new).toBe(true);
+      expect(parsed.status).toBe("active");
+    } finally {
+      await cleanupNs();
+    }
+  });
+
+  it("preserves status and ended_at on a status-omitted update of a wrapped lane", async () => {
+    await cleanupNs();
+    try {
+      await callLaneUpsert({ session_key: "live-wrap", namespace: ns });
+      await callLaneUpsert({
+        session_key: "live-wrap",
+        namespace: ns,
+        status: "wrapped",
+      });
+      const { rows: afterWrap } = await pool.query(
+        "SELECT status, ended_at FROM ob_session_lanes WHERE namespace=$1 AND session_key=$2",
+        [ns, "live-wrap"],
+      );
+      expect(afterWrap[0].status).toBe("wrapped");
+      expect(afterWrap[0].ended_at).not.toBeNull();
+
+      // status omitted: must NOT reactivate the lane
+      const res = await callLaneUpsert({
+        session_key: "live-wrap",
+        namespace: ns,
+        topic: "touch",
+      });
+      expect(res.isError).toBeFalsy();
+      const { rows: afterTouch } = await pool.query(
+        "SELECT status, ended_at FROM ob_session_lanes WHERE namespace=$1 AND session_key=$2",
+        [ns, "live-wrap"],
+      );
+      expect(afterTouch[0].status).toBe("wrapped");
+      expect(afterTouch[0].ended_at).not.toBeNull();
+    } finally {
+      await cleanupNs();
+    }
+  });
+});

--- a/src/tools/__tests__/lane-upsert.test.ts
+++ b/src/tools/__tests__/lane-upsert.test.ts
@@ -1,838 +1,393 @@
-import { describe, it, expect, afterAll } from "bun:test";
+/**
+ * Unit coverage for lane_upsert auth paths and core create/update behavior.
+ *
+ * Embedding and defaulting cases live in
+ * lane-upsert-embedding-and-defaults.test.ts; live Postgres coverage lives in
+ * lane-upsert.pg.test.ts.
+ */
+import { describe, it, expect } from "bun:test";
 import { Pool } from "pg";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { registerLaneUpsert } from "../lane-upsert.ts";
+import { createMockEmbed } from "./test-helpers.ts";
+import {
+  firstText,
+  setupToolClient,
+  type ObAuthInfo,
+} from "./lane-upsert-test-helpers.ts";
 import type { ToolDeps } from "../index.ts";
-import type { AuthInfo } from "../../types.ts";
 
-function createMockEmbed(result: number[] | null = Array(768).fill(0.1)) {
-  return async (_text: string) => result;
-}
-
-function createThrowingEmbed(error: Error) {
-  return async (_text: string): Promise<number[] | null> => {
-    throw error;
-  };
-}
-
-async function setupToolClient(
-  mockPool: { query: (...args: any[]) => Promise<{ rows: any[] }> },
-  auth: AuthInfo,
-  embedFn?: (text: string) => Promise<number[] | null>,
-): Promise<{ client: Client; cleanup: () => Promise<void> }> {
+async function case1() {
+  const mockPool = { query: async () => ({ rows: [] }) };
   const server = new McpServer({ name: "test", version: "1.0.0" });
   const deps: ToolDeps = {
-    pool: mockPool as any,
-    embedFn: embedFn ?? createMockEmbed(),
+    pool: mockPool as unknown as Pool,
+    embedFn: createMockEmbed(),
   };
   registerLaneUpsert(server, deps);
 
-  const [clientTransport, serverTransport] =
-    InMemoryTransport.createLinkedPair();
-
-  const originalSend = clientTransport.send.bind(clientTransport);
-  clientTransport.send = (message: any, options?: any) => {
-    return originalSend(message, { ...options, authInfo: auth });
-  };
-
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  // No authInfo injection at all
   const client = new Client({ name: "test-client", version: "1.0.0" });
   await server.connect(serverTransport);
   await client.connect(clientTransport);
 
-  return {
-    client,
-    cleanup: async () => {
-      await client.close();
-      await server.close();
-    },
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "test" },
+    });
+    expect(result.isError).toBe(true);
+    expect(firstText(result)).toContain("Permission denied");
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+async function case2() {
+  const mockPool = { query: async () => ({ rows: [] }) };
+  const auth: ObAuthInfo = { role: "discord", clientId: "random-user" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "test-lane" },
+    });
+    expect(result.isError).toBe(true);
+    expect(firstText(result)).toContain("Permission denied");
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case3() {
+  const mockPool = { query: async () => ({ rows: [] }) };
+  const auth: ObAuthInfo = { role: "readonly", clientId: "viewer" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "test-lane" },
+    });
+    expect(result.isError).toBe(true);
+    expect(firstText(result)).toContain("Permission denied");
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case4() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-1",
+          is_new: true,
+          status: "active",
+          updated_at: "2026-06-07T15:30:00Z",
+        },
+      ],
+    }),
   };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "test" },
+    });
+    expect(result.isError).toBeFalsy();
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case5() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-2",
+          is_new: true,
+          status: "active",
+          updated_at: "2026-06-07T15:30:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "agent", clientId: "bilby" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "test" },
+    });
+    expect(result.isError).toBeFalsy();
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case6() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-3",
+          is_new: true,
+          status: "active",
+          updated_at: "2026-06-07T15:30:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "ob-admin", clientId: "ob-admin-worker" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "test" },
+    });
+    expect(result.isError).toBeFalsy();
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case7() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-new",
+          is_new: true,
+          status: "active",
+          updated_at: "2026-06-07T15:30:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: {
+        session_key: "ob-v2-session-lanes",
+        namespace: "team-kb",
+        project: "open-brain",
+        agent: "skippy",
+        source: "discord",
+        channel_id: "123456",
+        thread_id: "789",
+        topic: "Building session lane schema",
+        current_context_md: "## Session Lanes\nMigration 010 written.",
+        metadata: { pr: 42, branch: "feat/session-lanes" },
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(firstText(result));
+    expect(parsed.id).toBe("uuid-new");
+    expect(parsed.session_key).toBe("ob-v2-session-lanes");
+    expect(parsed.namespace).toBe("team-kb");
+    expect(parsed.is_new).toBe(true);
+    expect(parsed.status).toBe("active");
+    expect(parsed.embedded).toBe(true);
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case8() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-existing",
+          is_new: false,
+          status: "active",
+          updated_at: "2026-06-07T16:00:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: {
+        session_key: "ob-v2-session-lanes",
+        current_context_md: "## Updated context\nTests passing.",
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(firstText(result));
+    expect(parsed.is_new).toBe(false);
+    expect(parsed.embedded).toBe(true);
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case9() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-ns",
+          is_new: true,
+          status: "active",
+          updated_at: "2026-06-07T15:30:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "bilby-agent" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "my-lane" },
+    });
+
+    const parsed = JSON.parse(firstText(result));
+    expect(parsed.namespace).toBe("bilby-agent");
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case10() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-ns2",
+          is_new: true,
+          status: "active",
+          updated_at: "2026-06-07T15:30:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "shared-lane", namespace: "team-kb" },
+    });
+
+    const parsed = JSON.parse(firstText(result));
+    expect(parsed.namespace).toBe("team-kb");
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case11() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-wrap",
+          is_new: false,
+          status: "wrapped",
+          updated_at: "2026-06-07T17:00:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "done-lane", status: "wrapped" },
+    });
+
+    const parsed = JSON.parse(firstText(result));
+    expect(parsed.status).toBe("wrapped");
+  } finally {
+    await cleanup();
+  }
+}
+
+async function case12() {
+  const mockPool = {
+    query: async () => ({
+      rows: [
+        {
+          id: "uuid-arch",
+          is_new: false,
+          status: "archived",
+          updated_at: "2026-06-07T18:00:00Z",
+        },
+      ],
+    }),
+  };
+  const auth: ObAuthInfo = { role: "admin", clientId: "skippy" };
+  const { client, cleanup } = await setupToolClient(mockPool, auth);
+
+  try {
+    const result = await client.callTool({
+      name: "lane_upsert",
+      arguments: { session_key: "old-lane", status: "archived" },
+    });
+
+    const parsed = JSON.parse(firstText(result));
+    expect(parsed.status).toBe("archived");
+  } finally {
+    await cleanup();
+  }
 }
 
 describe("lane_upsert", () => {
   // ── AUTH PATHS ──
 
-  it("denies write when auth is missing entirely", async () => {
-    const mockPool = { query: async () => ({ rows: [] }) };
-    const server = new McpServer({ name: "test", version: "1.0.0" });
-    const deps: ToolDeps = {
-      pool: mockPool as any,
-      embedFn: createMockEmbed(),
-    };
-    registerLaneUpsert(server, deps);
+  it("denies write when auth is missing entirely", case1);
 
-    const [clientTransport, serverTransport] =
-      InMemoryTransport.createLinkedPair();
-    // No authInfo injection at all
-    const client = new Client({ name: "test-client", version: "1.0.0" });
-    await server.connect(serverTransport);
-    await client.connect(clientTransport);
+  it("denies write for discord role (write-thoughts-only)", case2);
 
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "test" },
-      });
-      expect(result.isError).toBe(true);
-      expect((result.content as any)[0].text).toContain("Permission denied");
-    } finally {
-      await client.close();
-      await server.close();
-    }
-  });
+  it("denies write for readonly role", case3);
 
-  it("denies write for discord role (write-thoughts-only)", async () => {
-    const mockPool = { query: async () => ({ rows: [] }) };
-    const auth: AuthInfo = { role: "discord", clientId: "random-user" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
+  it("allows admin role", case4);
 
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "test-lane" },
-      });
-      expect(result.isError).toBe(true);
-      expect((result.content as any)[0].text).toContain("Permission denied");
-    } finally {
-      await cleanup();
-    }
-  });
+  it("allows agent role", case5);
 
-  it("denies write for readonly role", async () => {
-    const mockPool = { query: async () => ({ rows: [] }) };
-    const auth: AuthInfo = { role: "readonly", clientId: "viewer" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "test-lane" },
-      });
-      expect(result.isError).toBe(true);
-      expect((result.content as any)[0].text).toContain("Permission denied");
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("allows admin role", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-1",
-            is_new: true,
-            status: "active",
-            updated_at: "2026-06-07T15:30:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "test" },
-      });
-      expect(result.isError).toBeFalsy();
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("allows agent role", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-2",
-            is_new: true,
-            status: "active",
-            updated_at: "2026-06-07T15:30:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "agent", clientId: "bilby" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "test" },
-      });
-      expect(result.isError).toBeFalsy();
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("allows ob-admin role", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-3",
-            is_new: true,
-            status: "active",
-            updated_at: "2026-06-07T15:30:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "ob-admin", clientId: "ob-admin-worker" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "test" },
-      });
-      expect(result.isError).toBeFalsy();
-    } finally {
-      await cleanup();
-    }
-  });
+  it("allows ob-admin role", case6);
 
   // ── CREATE vs UPDATE ──
 
-  it("creates a new lane — is_new=true, full field propagation", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-new",
-            is_new: true,
-            status: "active",
-            updated_at: "2026-06-07T15:30:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
+  it("creates a new lane — is_new=true, full field propagation", case7);
 
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: {
-          session_key: "ob-v2-session-lanes",
-          namespace: "team-kb",
-          project: "open-brain",
-          agent: "skippy",
-          source: "discord",
-          channel_id: "123456",
-          thread_id: "789",
-          topic: "Building session lane schema",
-          current_context_md: "## Session Lanes\nMigration 010 written.",
-          metadata: { pr: 42, branch: "feat/session-lanes" },
-        },
-      });
-
-      expect(result.isError).toBeFalsy();
-      const parsed = JSON.parse((result.content as any)[0].text);
-      expect(parsed.id).toBe("uuid-new");
-      expect(parsed.session_key).toBe("ob-v2-session-lanes");
-      expect(parsed.namespace).toBe("team-kb");
-      expect(parsed.is_new).toBe(true);
-      expect(parsed.status).toBe("active");
-      expect(parsed.embedded).toBe(true);
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("updates an existing lane — is_new=false on conflict", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-existing",
-            is_new: false,
-            status: "active",
-            updated_at: "2026-06-07T16:00:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: {
-          session_key: "ob-v2-session-lanes",
-          current_context_md: "## Updated context\nTests passing.",
-        },
-      });
-
-      expect(result.isError).toBeFalsy();
-      const parsed = JSON.parse((result.content as any)[0].text);
-      expect(parsed.is_new).toBe(false);
-      expect(parsed.embedded).toBe(true);
-    } finally {
-      await cleanup();
-    }
-  });
+  it("updates an existing lane — is_new=false on conflict", case8);
 
   // ── NAMESPACE DEFAULTING ──
 
-  it("defaults namespace to auth.clientId when not provided", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-ns",
-            is_new: true,
-            status: "active",
-            updated_at: "2026-06-07T15:30:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "bilby-agent" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
+  it("defaults namespace to auth.clientId when not provided", case9);
 
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "my-lane" },
-      });
-
-      const parsed = JSON.parse((result.content as any)[0].text);
-      expect(parsed.namespace).toBe("bilby-agent");
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("uses explicit namespace when provided", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-ns2",
-            is_new: true,
-            status: "active",
-            updated_at: "2026-06-07T15:30:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "shared-lane", namespace: "team-kb" },
-      });
-
-      const parsed = JSON.parse((result.content as any)[0].text);
-      expect(parsed.namespace).toBe("team-kb");
-    } finally {
-      await cleanup();
-    }
-  });
+  it("uses explicit namespace when provided", case10);
 
   // ── STATUS TRANSITIONS ──
 
-  it("wraps a lane — status=wrapped", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-wrap",
-            is_new: false,
-            status: "wrapped",
-            updated_at: "2026-06-07T17:00:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
+  it("wraps a lane — status=wrapped", case11);
 
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "done-lane", status: "wrapped" },
-      });
-
-      const parsed = JSON.parse((result.content as any)[0].text);
-      expect(parsed.status).toBe("wrapped");
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("archives a lane — status=archived", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-arch",
-            is_new: false,
-            status: "archived",
-            updated_at: "2026-06-07T18:00:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "old-lane", status: "archived" },
-      });
-
-      const parsed = JSON.parse((result.content as any)[0].text);
-      expect(parsed.status).toBe("archived");
-    } finally {
-      await cleanup();
-    }
-  });
-
-  // ── EMBEDDING PATHS ──
-
-  it("skips embedding when no context or topic provided", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-noembed",
-            is_new: true,
-            status: "active",
-            updated_at: "2026-06-07T15:30:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "bare-lane" },
-      });
-
-      const parsed = JSON.parse((result.content as any)[0].text);
-      expect(parsed.embedded).toBe(false);
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("embeds from topic when current_context_md is absent", async () => {
-    let embedCalled = false;
-    const embedFn = async (text: string) => {
-      embedCalled = true;
-      expect(text).toContain("my topic");
-      return Array(768).fill(0.1);
-    };
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-topic",
-            is_new: true,
-            status: "active",
-            updated_at: "2026-06-07T15:30:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth, embedFn);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "topic-lane", topic: "my topic" },
-      });
-
-      expect(embedCalled).toBe(true);
-      const parsed = JSON.parse((result.content as any)[0].text);
-      expect(parsed.embedded).toBe(true);
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("returns null embedding when embedFn returns null (graceful degradation)", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-nullembed",
-            is_new: true,
-            status: "active",
-            updated_at: "2026-06-07T15:30:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(
-      mockPool,
-      auth,
-      createMockEmbed(null),
-    );
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: {
-          session_key: "null-embed-lane",
-          current_context_md: "some context",
-        },
-      });
-
-      expect(result.isError).toBeFalsy();
-      const parsed = JSON.parse((result.content as any)[0].text);
-      expect(parsed.embedded).toBe(false);
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("continues without embedding when embedFn throws (error resilience)", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-embedfail",
-            is_new: true,
-            status: "active",
-            updated_at: "2026-06-07T15:30:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(
-      mockPool,
-      auth,
-      createThrowingEmbed(new Error("embedding provider timeout")),
-    );
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: {
-          session_key: "embed-crash-lane",
-          current_context_md: "context that triggers embed failure",
-        },
-      });
-
-      // Should succeed with embedded=false, NOT crash
-      expect(result.isError).toBeFalsy();
-      const parsed = JSON.parse((result.content as any)[0].text);
-      expect(parsed.embedded).toBe(false);
-    } finally {
-      await cleanup();
-    }
-  });
-
-  // ── DATABASE ERROR PATH ──
-
-  it("returns isError=true with message when DB query throws", async () => {
-    const mockPool = {
-      query: async () => {
-        throw new Error("connection refused");
-      },
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "db-fail-lane" },
-      });
-
-      expect(result.isError).toBe(true);
-      expect((result.content as any)[0].text).toContain("connection refused");
-      expect((result.content as any)[0].text).toContain("Database error");
-    } finally {
-      await cleanup();
-    }
-  });
-
-  // ── METADATA HANDLING ──
-
-  it("succeeds with default metadata when not provided", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-nometa",
-            is_new: true,
-            status: "active",
-            updated_at: "2026-06-07T15:30:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "no-meta-lane" },
-      });
-
-      expect(result.isError).toBeFalsy();
-      const parsed = JSON.parse((result.content as any)[0].text);
-      expect(parsed.id).toBe("uuid-nometa");
-    } finally {
-      await cleanup();
-    }
-  });
-
-  // ── EXPLICIT FIELD CLEARING ──
-
-  it("succeeds when agent is empty string (explicit clear)", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-clear",
-            is_new: false,
-            status: "active",
-            updated_at: "2026-06-07T15:30:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "clear-test", agent: "" },
-      });
-
-      expect(result.isError).toBeFalsy();
-      const parsed = JSON.parse((result.content as any)[0].text);
-      expect(parsed.id).toBe("uuid-clear");
-      expect(parsed.status).toBe("active");
-    } finally {
-      await cleanup();
-    }
-  });
-
-  // ── STATUS PRESERVATION ──
-
-  it("preserves existing status when status param is omitted", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-preserve",
-            is_new: false,
-            status: "wrapped",
-            updated_at: "2026-06-07T15:30:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "status-preserve", topic: "updated topic" },
-      });
-
-      expect(result.isError).toBeFalsy();
-      const parsed = JSON.parse((result.content as any)[0].text);
-      // DB returned "wrapped" proving status was preserved (not overwritten to "active")
-      expect(parsed.status).toBe("wrapped");
-    } finally {
-      await cleanup();
-    }
-  });
-
-  it("inserts status 'active' for a new lane when status is omitted (NOT NULL regression)", async () => {
-    // Regression for lane_upsert_db_error: omitting status previously bound an
-    // explicit NULL into the NOT NULL status column, so creating a NEW lane
-    // failed the constraint. The INSERT value must default to 'active' while
-    // the ON CONFLICT path keeps a nullable status to preserve existing rows.
-    let capturedSql = "";
-    let capturedParams: any[] = [];
-    const mockPool = {
-      query: async (sql: string, params: any[]) => {
-        capturedSql = sql;
-        capturedParams = params;
-        return {
-          rows: [
-            {
-              id: "uuid-new",
-              is_new: true,
-              status: "active",
-              updated_at: "2026-06-07T15:30:00Z",
-            },
-          ],
-        };
-      },
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "bilby" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "new-lane-no-status" },
-      });
-
-      expect(result.isError).toBeFalsy();
-      // $3 (ON CONFLICT / status-preserve source) stays NULL on omission.
-      expect(capturedParams[2]).toBeNull();
-      // $24 (INSERT VALUES status) defaults to 'active' so the NOT NULL
-      // column is satisfied for brand-new lanes.
-      expect(capturedParams[23]).toBe("active");
-      // ended_at must key off $3 (nullable), NOT EXCLUDED.status, otherwise a
-      // status-omitted update would reactivate a wrapped/archived lane. The
-      // ended_at clause is the segment after the embedding_model update line.
-      const endedAtClause = capturedSql.slice(capturedSql.indexOf("ended_at ="));
-      // $3 is cast to ::text so Postgres can infer the param type (it is no
-      // longer bound into a typed column position).
-      expect(endedAtClause).toContain("$3::text = 'active'");
-      expect(endedAtClause).not.toContain("EXCLUDED.status");
-    } finally {
-      await cleanup();
-    }
-  });
-
-  // ── MINIMAL CALL ──
-
-  it("succeeds with only the required session_key", async () => {
-    const mockPool = {
-      query: async () => ({
-        rows: [
-          {
-            id: "uuid-min",
-            is_new: true,
-            status: "active",
-            updated_at: "2026-06-07T15:30:00Z",
-          },
-        ],
-      }),
-    };
-    const auth: AuthInfo = { role: "admin", clientId: "skippy" };
-    const { client, cleanup } = await setupToolClient(mockPool, auth);
-
-    try {
-      const result = await client.callTool({
-        name: "lane_upsert",
-        arguments: { session_key: "minimal" },
-      });
-
-      expect(result.isError).toBeFalsy();
-      const parsed = JSON.parse((result.content as any)[0].text);
-      expect(parsed.session_key).toBe("minimal");
-      expect(parsed.namespace).toBe("skippy");
-      expect(parsed.is_new).toBe(true);
-      expect(parsed.embedded).toBe(false);
-    } finally {
-      await cleanup();
-    }
-  });
-});
-
-// ── DB-BACKED INTEGRATION ──
-// The mock harness above cannot catch Postgres parameter-type inference or the
-// real NOT NULL / ended_at behavior. These tests run the ACTUAL query through a
-// real pool and are gated on OPENBRAIN_TEST_DATABASE_URL so the default suite
-// stays infra-free. Run with:
-//   OPENBRAIN_TEST_DATABASE_URL=postgres://... bun test src/tools/__tests__/lane-upsert.test.ts
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-
-dbDescribe("lane_upsert (live Postgres)", () => {
-  const pool = new Pool({ connectionString: DB_URL });
-  const ns = "test-lane-upsert-live";
-
-  async function callLaneUpsert(args: Record<string, unknown>) {
-    const server = new McpServer({ name: "test", version: "1.0.0" });
-    const deps: ToolDeps = { pool: pool as any, embedFn: createMockEmbed(null) };
-    registerLaneUpsert(server, deps);
-    const [ct, st] = InMemoryTransport.createLinkedPair();
-    const original = ct.send.bind(ct);
-    ct.send = (m: any, o?: any) =>
-      original(m, { ...o, authInfo: { role: "admin", clientId: ns } });
-    const client = new Client({ name: "tc", version: "1.0.0" });
-    await server.connect(st);
-    await client.connect(ct);
-    const res = await client.callTool({ name: "lane_upsert", arguments: args });
-    await client.close();
-    await server.close();
-    return res;
-  }
-
-  async function cleanupNs() {
-    await pool.query("DELETE FROM ob_session_lanes WHERE namespace = $1", [ns]);
-  }
-
-  afterAll(async () => {
-    await pool.end();
-  });
-
-  it("creates a new lane with status omitted (no $3 type-inference error, NOT NULL satisfied)", async () => {
-    await cleanupNs();
-    try {
-      const res = await callLaneUpsert({ session_key: "live-new", namespace: ns });
-      expect(res.isError).toBeFalsy();
-      const parsed = JSON.parse((res.content as any)[0].text);
-      expect(parsed.is_new).toBe(true);
-      expect(parsed.status).toBe("active");
-    } finally {
-      await cleanupNs();
-    }
-  });
-
-  it("preserves status and ended_at on a status-omitted update of a wrapped lane", async () => {
-    await cleanupNs();
-    try {
-      await callLaneUpsert({ session_key: "live-wrap", namespace: ns });
-      await callLaneUpsert({
-        session_key: "live-wrap",
-        namespace: ns,
-        status: "wrapped",
-      });
-      const { rows: afterWrap } = await pool.query(
-        "SELECT status, ended_at FROM ob_session_lanes WHERE namespace=$1 AND session_key=$2",
-        [ns, "live-wrap"],
-      );
-      expect(afterWrap[0].status).toBe("wrapped");
-      expect(afterWrap[0].ended_at).not.toBeNull();
-
-      // status omitted: must NOT reactivate the lane
-      const res = await callLaneUpsert({
-        session_key: "live-wrap",
-        namespace: ns,
-        topic: "touch",
-      });
-      expect(res.isError).toBeFalsy();
-      const { rows: afterTouch } = await pool.query(
-        "SELECT status, ended_at FROM ob_session_lanes WHERE namespace=$1 AND session_key=$2",
-        [ns, "live-wrap"],
-      );
-      expect(afterTouch[0].status).toBe("wrapped");
-      expect(afterTouch[0].ended_at).not.toBeNull();
-    } finally {
-      await cleanupNs();
-    }
-  });
+  it("archives a lane — status=archived", case12);
 });


### PR DESCRIPTION
## Summary

- The `lane_upsert` live Postgres suite read `OPENBRAIN_TEST_DATABASE_URL` itself and swapped in `describe.skip` when it was unset, so an absent database reported `0 pass, 2 skip, 0 fail` and exited 0 — at the exit code that is indistinguishable from a suite that ran and passed. It now lives in `src/tools/__tests__/lane-upsert.pg.test.ts`, builds its module-scope pool from `requireTestDatabaseUrl()`, and fails loudly with `test_database_required` when the variable is absent.
- The 838-line `src/tools/__tests__/lane-upsert.test.ts` is split by subject in the same commit, because the pre-commit gate lints a staged file whole and the original carried 31 `no-explicit-any` findings plus `max-lines` and `max-lines-per-function`: helpers to `lane-upsert-test-helpers.ts` (no test, no pool), the 12 auth and create/update `it`s stay in `lane-upsert.test.ts`, the 10 embedding and defaulting `it`s move to `lane-upsert-embedding-and-defaults.test.ts`, the 2 live `it`s move to `lane-upsert.pg.test.ts`.
- The local `createMockEmbed` copy is deleted in favour of the byte-identical one already exported from `test-helpers.ts`. Every `as any` becomes a declared type (`mockPool as unknown as Pool`, a typed `firstText(result)` reader, the SDK's own send-signature types). Every `it` body is hoisted to a module-scope `async function` called as `it("<same name>", fn)`; names, order, and assertions are unchanged.
- `scripts/assert-db-tests-ran.ts` is unchanged and correct: JUnit reports exactly 2 testcases under `lane_upsert (live Postgres)`, which is what its existing `minTests: 2` entry already records, and the total is unmoved.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- Invocation: `CHANGED_FILES="src/tools/__tests__/lane-upsert.pg.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` -> exit 0, all four clauses PASS. RED before the change: `CHANGED_FILES="src/tools/__tests__/lane-upsert.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` at `origin/main` -> exit 1, clauses 1, 2, and 3 FAIL.
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts, all re-taken on the COMMITTED tree after the pre-commit prettier rewrite:

- `./node_modules/.bin/oxlint --deny-warnings` over all four files -> exit 0
- `bunx tsc --noEmit` -> exit 0
- `bun run test:isolated` over the three test files -> exit 0, 24 pass, 0 fail
- JUnit classnames: `lane_upsert` 12, `lane_upsert embedding and defaults` 10, `lane_upsert (live Postgres)` 2

## Critical Self-Review

- Highest-risk behavior: a mechanically hoisted `it` body that silently no longer runs. Guarded by the JUnit classname counts above — 12 + 10 + 2 is exactly the 24 the original file declared, so no test was dropped in the split.
- Assumptions that could be wrong: that `createMockEmbed` in `test-helpers.ts` is byte-identical to the deleted local copy. Compared directly before deleting; both take `result: number[] | null = Array(768).fill(0.1)` and return `async (_text: string) => result`.
- Missing/weak tests: none added — this is a conversion, and assertion meaning is preserved verbatim. The two live `it`s were previously skipped in any run without the variable, so this PR is the first time CI can actually fail on them.
- Security/permission risk: none. No auth, namespace, or SQL predicate changed; the only auth-shaped edit is a cast at the transport `authInfo` seam, which the original expressed as `any`.
- Migration/deploy risk: none. No migration, tool, or non-test source file is touched.
- Downstream client/runtime risk: none. `src/tools/lane-upsert.ts` is unchanged, so no MCP tool, schema, or client contract moves.
- Rollback/cleanup concern: revert is a single commit; the four files are self-contained under `src/tools/__tests__/`.
- Fixes made before PR: the repo `AuthInfo` collided with the SDK's identically-named type once the `any` casts were removed — imported as `ObAuthInfo` and cast at the one transport seam rather than widening the repo type. `SendOptions` is optional in the SDK signature, so the `authInfo` read needed `NonNullable<SendOptions>["authInfo"]`.
- Known residual risk: the live suite now demands a database wherever it runs. A developer running `bun test` on that file without `OPENBRAIN_TEST_DATABASE_URL` gets a hard failure instead of a skip — that is the intended behavior of #878, not a regression, and `bun run test:isolated` supplies the variable.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane surfaced no new MEDIUM+ review finding — the patterns it hit (`max-lines-per-function` measured at the describe callback, prettier rewriting staged files so receipts are re-taken on the committed tree, a shared helper taking `pool` as a parameter) are already recorded as round 39 and round 40 Tightenings in the lane contract.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or tool behavior changed; the diff is test files only.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing schema is touched — the change is confined to `src/tools/__tests__/`.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Every downstream item is not applicable: `docs/downstream-rollout.md` scopes the gate to MCP tool, schema, protocol, and client-facing changes, and this diff touches four files, all under `src/tools/__tests__/`. `src/tools/lane-upsert.ts` is byte-unchanged.
