### PR TITLE
test(pg): the sdk-protocol live suite requires the test database instead of skipping, helpers split out (#878)

### DIFF
--- a/scripts/test-support/shared-namespace-env.ts
+++ b/scripts/test-support/shared-namespace-env.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared-namespace environment isolation for suites that must observe nothing
+ * but their own writes.
+ *
+ * `readableNamespaces()` grants every non-admin role read access to the shared
+ * namespace as well, so a suite running against the real `shared-kb` would also
+ * observe whatever the target database happens to hold there, and its recorded
+ * counts would assert an accident of that database.
+ *
+ * `sharedNamespaceConfig()` re-reads the environment on every call, and Bun runs
+ * every test file in ONE process, so a module-scope assignment leaks into
+ * sibling files and fails them by load order. A suite therefore installs the
+ * isolation in `beforeAll` and removes it in `afterAll`.
+ *
+ * This module lives under `scripts/` deliberately: `.oxlintrc.json` scopes
+ * `node/no-process-env` to `server/**\/*.ts`, so the environment access belongs
+ * in test support rather than beside the tests it serves.
+ */
+
+const KEYS = ["SHARED_NAMESPACE_CANONICAL", "SHARED_NAMESPACE_PHYSICAL"];
+
+let prior: Array<string | undefined> | undefined;
+
+/**
+ * Point both shared-namespace variables at `value`, recording the prior values
+ * once so a later restore returns the process to what it inherited.
+ */
+export function isolateSharedNamespace(value: string): void {
+  if (prior === undefined) {
+    prior = KEYS.map((key) => process.env[key]);
+  }
+  for (const key of KEYS) {
+    process.env[key] = value;
+  }
+}
+
+/** Restore both shared-namespace variables to the values recorded on isolate. */
+export function restoreSharedNamespace(): void {
+  if (prior === undefined) return;
+  KEYS.forEach((key, index) => {
+    const value = prior?.[index];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  });
+  prior = undefined;
+}

--- a/server/application/sdk-protocol-test-helpers.ts
+++ b/server/application/sdk-protocol-test-helpers.ts
@@ -1,0 +1,351 @@
+/**
+ * Shared harness for the real-SDK protocol proof.
+ *
+ * Holds the constants, module state, and helper functions that compose the real
+ * `server/` stack behind a real ephemeral HTTP listener. It holds no test and
+ * creates no pool: every helper that touches the database takes the caller's
+ * `Pool` as its first parameter, so the file that owns the pool also owns
+ * ending it.
+ */
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import express from "express";
+import type { RequestHandler } from "express";
+import pino from "pino";
+import type { Pool } from "pg";
+import { createShadowApplication } from "./index.ts";
+import type { ShadowApplication } from "./index.ts";
+import { parseServerConfig } from "../config.ts";
+import type { ServerConfig } from "../config.ts";
+import type { Database, DatabaseHealth } from "../db/pool.ts";
+import { RecoveryWalStore } from "../realtime/recovery-wal.ts";
+import { WorkingSetStore } from "../realtime/working-set.ts";
+import { registerMemoryTools } from "../tools/index.ts";
+import { DEFAULT_SHARED_NAMESPACE_NAMES } from "../tools/shared-namespace-fixture.ts";
+import { silentLogger } from "../transport/testing/silent-logger.ts";
+
+/**
+ * Assert a value is present and return it narrowed.
+ *
+ * Replaces the non-null assertion operator: `x!` tells the compiler to stop
+ * checking, while this throws a labelled error at the moment the assumption is
+ * actually wrong, which is what a test wants to read in its failure output.
+ */
+export function expectDefined<T>(value: T | null | undefined, label: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(`expected ${label} to be defined`);
+  }
+  return value;
+}
+
+export const TEST_TOKEN = "sdk-protocol-proof-token";
+const CONNECTED: DatabaseHealth = {
+  connected: true,
+  total: 2,
+  idle: 2,
+  waiting: 0,
+};
+
+/**
+ * One namespace per TEST, not per run.
+ *
+ * The parity fixtures record behavior in an EMPTY namespace, so their shapes
+ * (`item_count: 0`, `empty_reason: "no_matches"`, `total_count: 1`) are only
+ * reproducible if a test observes nothing but its own writes. A single
+ * run-scoped namespace does NOT deliver that: measured on the first green run of
+ * this file, the capture and search tests each left a real row behind, and the
+ * later `agent_context_pack` fetch then found them -- `durable_memory` came back
+ * populated where the fixture froze `empty_reason: "no_matches"`, and the search
+ * test matched an earlier test's thought as well as its own. Both passed in
+ * isolation and failed in file order, which is the signature of shared state
+ * rather than a shape defect.
+ *
+ * Each test therefore takes a fresh namespace, and the auth middleware reads
+ * this mutable value so the identity it stamps on `req.auth` follows.
+ */
+let NAMESPACE = "";
+
+export function freshNamespace(): string {
+  NAMESPACE = `sdk-proof-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  return NAMESPACE;
+}
+
+/**
+ * Repoint the shared namespace at a value no row can belong to.
+ *
+ * Same reasoning as `contracts/server-tool-parity.test.ts`: `readableNamespaces()`
+ * grants every non-admin role read access to the shared namespace as well, so
+ * with the real `shared-kb` this suite would also observe whatever the target
+ * database happens to hold there, and the recorded counts would assert an
+ * accident of that database. Scoped to this suite (installed in `beforeAll`,
+ * removed in `afterAll`) because `sharedNamespaceConfig()` re-reads the
+ * environment on every call and Bun runs every test file in ONE process -- a
+ * module-scope assignment leaks into sibling files and fails them by load order.
+ */
+export const SHARED_ISOLATION = `sdk-proof-shared-${process.pid}-${Date.now()}`;
+
+export function testConfig(): ServerConfig {
+  const result = parseServerConfig({
+    DB_HOST: "db.internal",
+    DB_NAME: "open_brain_test",
+    DB_USER: "open_brain",
+    LOG_FILE: "logs/open-brain.log",
+    OPEN_BRAIN_SERVER_IP: "127.0.0.1",
+  });
+  if (!result.ok) {
+    throw new Error(`invalid test configuration: ${JSON.stringify(result.issues)}`);
+  }
+  return result.config;
+}
+
+/**
+ * The health probe is a fake; the TOOLS are not.
+ *
+ * `/health` exists to prove liveness, and pointing it at the real pool would add
+ * a second connection without proving anything this file is about. Every tool
+ * call below runs against the real `Pool`.
+ */
+export function fakeHealthDatabase(): Database {
+  return {
+    pool: {} as Database["pool"],
+    close: async () => {},
+    health: async (): Promise<DatabaseHealth> => CONNECTED,
+  } as Database;
+}
+
+/**
+ * The production-shaped auth seam: a bearer token becomes `req.auth`.
+ *
+ * This is deliberately the SAME placement production uses (`src/index.ts` mounts
+ * `authMiddleware` on `/mcp`), because the placement is what is under test. The
+ * token map is a single fixed token rather than the real loader -- the point is
+ * that SOMETHING sets `req.auth` before the SDK reads it, not how the token is
+ * looked up.
+ */
+export function bearerAuth(): RequestHandler {
+  return (request, response, next) => {
+    if (request.headers.authorization !== `Bearer ${TEST_TOKEN}`) {
+      response.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    (request as { auth?: unknown }).auth = {
+      role: "agent",
+      clientId: NAMESPACE,
+      tokenClientId: NAMESPACE,
+      namespaceSource: "token",
+    };
+    next();
+  };
+}
+
+interface LiveHarness {
+  client: Client;
+  application: ShadowApplication;
+  server: Server;
+  transport: StreamableHTTPClientTransport;
+}
+
+export const live: Partial<LiveHarness> = {};
+
+/**
+ * Extra applications and listeners a single test composed for itself.
+ *
+ * The `live` harness above holds ONE of each, which is right for the tests that
+ * drive a single client. The two-worker front needs three at once (two workers
+ * plus the front), so they are tracked here and torn down by the same
+ * `afterEach`. Without this they would leak a listener per run, and a leaked
+ * listener is the failure that shows up as an unrelated later test hanging.
+ */
+const extraApplications: ShadowApplication[] = [];
+const extraServers: Server[] = [];
+
+/**
+ * Realtime stores, injected per composed application rather than inherited.
+ *
+ * The realtime fixture records `id: "ws-1"` / `"rw-1"`, and those ids come from
+ * a MONOTONIC counter that lives as long as the store does. `realtime-stores.ts`
+ * falls back to a MODULE-scoped store when a composition root injects none --
+ * correct, and deliberately so, because a store rebuilt per request would report
+ * a permanent zero. But Bun runs every test file in ONE process, so an
+ * uninjected suite shares that fallback with every other suite in the run:
+ * measured on this branch, `contracts/server-tool-parity.test.ts` exercises the
+ * same three tools first and this suite then observed `ws-2`, passing alone and
+ * failing in file order.
+ *
+ * Injecting is not a test workaround; it is what a composition root does. The
+ * store is per APPLICATION here, matching one server process owning its own
+ * realtime state, which is exactly the lifetime the fixture recorded against.
+ */
+export function freshRealtimeStores(): {
+  workingSetStore: WorkingSetStore;
+  recoveryWalStore: RecoveryWalStore;
+} {
+  return {
+    workingSetStore: new WorkingSetStore({ logger: pino({ level: "silent" }) }),
+    // `walPath: null` keeps this RAM-only. A path would make the suite replay
+    // whatever a previous run left on disk, reintroducing the same cross-run
+    // contamination one layer down.
+    recoveryWalStore: new RecoveryWalStore({
+      walPath: null,
+      logger: pino({ level: "silent" }),
+    }),
+  };
+}
+
+/**
+ * Compose one real single-worker application and bind it to an ephemeral port.
+ *
+ * Factored out of `connectRealClient` because the two-worker proof needs REAL
+ * worker processes-equivalents behind the front -- the whole point of that test
+ * is that the aggregate reads a genuine `/health` body off a genuine socket
+ * rather than a hand-written `{status}` object from an injected `fetch`.
+ */
+export async function startWorkerApplication(pool: Pool): Promise<{
+  application: ShadowApplication;
+  server: Server;
+  port: number;
+}> {
+  // One store pair per APPLICATION, shared by every session it serves -- the
+  // realtime state belongs to the process, not to a connection.
+  const realtime = freshRealtimeStores();
+  const application = createShadowApplication({
+    config: testConfig(),
+    logger: silentLogger(),
+    database: fakeHealthDatabase(),
+    authenticate: bearerAuth(),
+    parseRequestBody: express.json(),
+    serverFactory: () => {
+      const server = new McpServer({
+        name: "open-brain-rewrite",
+        version: "1.0.0",
+      });
+      registerMemoryTools(server, {
+        pool,
+        embedFn: async () => Array(768).fill(0.01) as number[],
+        logger: pino({ level: "silent" }),
+        sharedNamespaceNames: DEFAULT_SHARED_NAMESPACE_NAMES,
+        embeddingModel: "sdk-protocol-proof",
+        ...realtime,
+      });
+      return server;
+    },
+  });
+  const server = await new Promise<Server>((resolve) => {
+    const listener = application.app.listen(0, "127.0.0.1", () => resolve(listener));
+  });
+  const { port } = server.address() as AddressInfo;
+  extraApplications.push(application);
+  extraServers.push(server);
+  return { application, server, port };
+}
+
+/**
+ * Compose the real stack, bind an ephemeral port, and connect a real SDK client.
+ *
+ * `serverFactory` is the whole point: it builds a REAL `McpServer` and registers
+ * the REAL tool boundary, where `shadow-application.test.ts` passes a stub. The
+ * factory runs per initialize, matching production, so each session gets its own
+ * server instance bound to the shared pool.
+ */
+export async function connectRealClient(pool: Pool): Promise<Client> {
+  freshNamespace();
+  // One store pair per APPLICATION, shared by every session it serves -- the
+  // realtime state belongs to the process, not to a connection.
+  const realtime = freshRealtimeStores();
+  const application = createShadowApplication({
+    config: testConfig(),
+    logger: silentLogger(),
+    database: fakeHealthDatabase(),
+    authenticate: bearerAuth(),
+    parseRequestBody: express.json(),
+    serverFactory: () => {
+      const server = new McpServer({
+        name: "open-brain-rewrite",
+        version: "1.0.0",
+      });
+      registerMemoryTools(server, {
+        pool,
+        embedFn: async () => Array(768).fill(0.01) as number[],
+        logger: pino({ level: "silent" }),
+        sharedNamespaceNames: DEFAULT_SHARED_NAMESPACE_NAMES,
+        embeddingModel: "sdk-protocol-proof",
+        ...realtime,
+      });
+      return server;
+    },
+  });
+  live.application = application;
+
+  // Port 0 asks the kernel for an ephemeral port; nothing well-known is bound.
+  const httpServer = await new Promise<Server>((resolve) => {
+    const listener = application.app.listen(0, "127.0.0.1", () => resolve(listener));
+  });
+  live.server = httpServer;
+  const { port } = httpServer.address() as AddressInfo;
+
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`http://127.0.0.1:${port}/mcp`),
+    { requestInit: { headers: { authorization: `Bearer ${TEST_TOKEN}` } } },
+  );
+  live.transport = transport;
+  const client = new Client({ name: "sdk-protocol-proof", version: "1.0.0" });
+  // `connect` performs the real initialize handshake over HTTP.
+  await client.connect(transport);
+  live.client = client;
+  return client;
+}
+
+/** Call a tool over the wire and parse the single text content block. */
+export async function callTool(
+  client: Client,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ isError: boolean; body: unknown; text: string }> {
+  const result = await client.callTool({ name, arguments: args });
+  const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
+  let body: unknown;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = { text };
+  }
+  return { isError: result.isError === true, body, text };
+}
+
+/**
+ * Tear down everything a single test composed: the `live` harness client,
+ * listener, and application, plus any extra listeners and applications the
+ * two-worker proof stood up. Called from the suite's `afterEach`, so a leaked
+ * listener never surfaces later as an unrelated test hanging.
+ */
+export async function closeExtras(): Promise<void> {
+  if (live.client) {
+    await live.client.close();
+    live.client = undefined;
+  }
+  live.transport = undefined;
+  if (live.server) {
+    const server = live.server;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    live.server = undefined;
+  }
+  if (live.application) {
+    await live.application.close();
+    live.application = undefined;
+  }
+  while (extraServers.length > 0) {
+    const server = expectDefined(extraServers.pop(), "extra server");
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  while (extraApplications.length > 0) {
+    await expectDefined(extraApplications.pop(), "extra application").close();
+  }
+}
+
+/** The namespace the most recent `freshNamespace()` installed. */
+export function currentNamespace(): string {
+  return NAMESPACE;
+}

--- a/server/application/sdk-protocol.pg.test.ts
+++ b/server/application/sdk-protocol.pg.test.ts
@@ -50,281 +50,206 @@
  * Passing here means the rewrite answers the real protocol correctly -- proof
  * that it is RUNNING comes from `/health` on the deployed clone, not from here.
  *
- * DATABASE. Skips loudly (`describe.skip`) without
- * `OPENBRAIN_TEST_DATABASE_URL`, which must point at an isolated test/playground
- * database. Never the dogfood database.
+ * DATABASE. Demands the test database rather than skipping itself: the module
+ * calls `requireTestDatabaseUrl()`, which throws `test_database_required` when
+ * the variable is unset. It must point at an isolated test/playground database.
+ * Never the dogfood database.
  */
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  describe,
-  expect,
-  test,
-} from "bun:test";
-import type { AddressInfo } from "node:net";
-import type { Server } from "node:http";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import express from "express";
-import type { RequestHandler } from "express";
-import pino from "pino";
 import { Pool } from "pg";
+import pino from "pino";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { createShadowApplication } from "./index.ts";
-import type { ShadowApplication } from "./index.ts";
-import { parseServerConfig } from "../config.ts";
-import type { ServerConfig } from "../config.ts";
-import type { Database, DatabaseHealth } from "../db/pool.ts";
-import { RecoveryWalStore } from "../realtime/recovery-wal.ts";
-import { WorkingSetStore } from "../realtime/working-set.ts";
-import { SERVER_REWRITE_STATE } from "../state.ts";
 import { registerMemoryTools } from "../tools/index.ts";
 import { DEFAULT_SHARED_NAMESPACE_NAMES } from "../tools/shared-namespace-fixture.ts";
+import { SERVER_REWRITE_STATE } from "../state.ts";
+import type { AggregateHealth, SingleWorkerHealth } from "../transport/index.ts";
 import { createWorkerProxyHandler } from "../transport/index.ts";
-import type {
-  AggregateHealth,
-  SingleWorkerHealth,
-} from "../transport/index.ts";
 import { silentLogger } from "../transport/testing/silent-logger.ts";
+import express from "express";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import {
   expectRecordedShape,
   loadServerFixture,
 } from "../../contracts/fixture-shape.ts";
+import { requireTestDatabaseUrl } from "../../scripts/test-support/require-test-database.ts";
+import {
+  isolateSharedNamespace,
+  restoreSharedNamespace,
+} from "../../scripts/test-support/shared-namespace-env.ts";
+import {
+  callTool,
+  currentNamespace,
+  bearerAuth,
+  fakeHealthDatabase,
+  testConfig,
+  closeExtras,
+  connectRealClient,
+  expectDefined,
+  freshNamespace,
+  live,
+  SHARED_ISOLATION,
+  startWorkerApplication,
+  TEST_TOKEN,
+} from "./sdk-protocol-test-helpers.ts";
 
-const DB_URL = process.env.OPENBRAIN_TEST_DATABASE_URL;
-const dbDescribe = DB_URL ? describe : describe.skip;
-const pool = DB_URL ? new Pool({ connectionString: DB_URL }) : null;
+const pool = new Pool({ connectionString: requireTestDatabaseUrl() });
 
-const TEST_TOKEN = "sdk-protocol-proof-token";
-const CONNECTED: DatabaseHealth = {
-  connected: true,
-  total: 2,
-  idle: 2,
-  waiting: 0,
-};
+afterEach(async () => {
+  await closeExtras();
+});
 
-/**
- * One namespace per TEST, not per run.
- *
- * The parity fixtures record behavior in an EMPTY namespace, so their shapes
- * (`item_count: 0`, `empty_reason: "no_matches"`, `total_count: 1`) are only
- * reproducible if a test observes nothing but its own writes. A single
- * run-scoped namespace does NOT deliver that: measured on the first green run of
- * this file, the capture and search tests each left a real row behind, and the
- * later `agent_context_pack` fetch then found them -- `durable_memory` came back
- * populated where the fixture froze `empty_reason: "no_matches"`, and the search
- * test matched an earlier test's thought as well as its own. Both passed in
- * isolation and failed in file order, which is the signature of shared state
- * rather than a shape defect.
- *
- * Each test therefore takes a fresh namespace, and the auth middleware reads
- * this mutable value so the identity it stamps on `req.auth` follows.
- */
-let NAMESPACE = "";
+afterAll(async () => {
+  restoreSharedNamespace();
+  await pool.end();
+});
 
-function freshNamespace(): string {
-  NAMESPACE = `sdk-proof-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  return NAMESPACE;
+function provesServingTarget(): void {
+  expect(SERVER_REWRITE_STATE.servesTraffic).toBe(true);
+  expect(SERVER_REWRITE_STATE.cutoverStarted).toBe(true);
 }
 
-/**
- * Repoint the shared namespace at a value no row can belong to.
- *
- * Same reasoning as `contracts/server-tool-parity.test.ts`: `readableNamespaces()`
- * grants every non-admin role read access to the shared namespace as well, so
- * with the real `shared-kb` this suite would also observe whatever the target
- * database happens to hold there, and the recorded counts would assert an
- * accident of that database. Scoped to this suite (installed in `beforeAll`,
- * removed in `afterAll`) because `sharedNamespaceConfig()` re-reads the
- * environment on every call and Bun runs every test file in ONE process -- a
- * module-scope assignment leaks into sibling files and fails them by load order.
- */
-const SHARED_ISOLATION = `sdk-proof-shared-${process.pid}-${Date.now()}`;
-const priorSharedEnv = {
-  canonical: process.env.SHARED_NAMESPACE_CANONICAL,
-  physical: process.env.SHARED_NAMESPACE_PHYSICAL,
-};
+async function completesHandshake(): Promise<void> {
+  const client = await connectRealClient(pool);
 
-function restoreEnv(key: string, value: string | undefined): void {
-  if (value === undefined) delete process.env[key];
-  else process.env[key] = value;
+  // A server-assigned session id only exists if the handshake really happened:
+  // the SDK client reads it off the `Mcp-Session-Id` response header, and the
+  // session manager only sets one from `onsessioninitialized`.
+  expect(live.transport?.sessionId).toBeString();
+  expect(
+    expectDefined(
+      expectDefined(live.transport, "live transport").sessionId,
+      "session id",
+    ),
+  ).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+  // The composed session boundary now holds exactly this one live session.
+  expect(live.application?.sessions.sessionCount()).toBe(1);
+  expect(client.getServerVersion()?.name).toBe("open-brain-rewrite");
 }
 
-function testConfig(): ServerConfig {
-  const result = parseServerConfig({
-    DB_HOST: "db.internal",
-    DB_NAME: "open_brain_test",
-    DB_USER: "open_brain",
-    LOG_FILE: "logs/open-brain.log",
-    OPEN_BRAIN_SERVER_IP: "127.0.0.1",
-  });
-  if (!result.ok) {
-    throw new Error(
-      `invalid test configuration: ${JSON.stringify(result.issues)}`,
-    );
+async function listsToolSurface(): Promise<void> {
+  const client = await connectRealClient(pool);
+  const listed = await client.listTools();
+  const names = listed.tools.map((tool) => tool.name);
+
+  // Every tool exercised below must be reachable through protocol discovery,
+  // not merely present in the registry: a tool that is registered but not
+  // advertised is invisible to a real client.
+  for (const required of [
+    "session_start",
+    "append_session_event",
+    "session_context",
+    "session_wrap",
+    "log_thought",
+    "search_all",
+    "agent_context_pack",
+  ]) {
+    expect(names).toContain(required);
   }
-  return result.config;
+  // Discovery must return real schemas, not bare names.
+  const sessionStart = listed.tools.find((tool) => tool.name === "session_start");
+  expect(sessionStart?.inputSchema).toBeObject();
 }
 
-/**
- * The health probe is a fake; the TOOLS are not.
- *
- * `/health` exists to prove liveness, and pointing it at the real pool would add
- * a second connection without proving anything this file is about. Every tool
- * call below runs against the real `Pool`.
- */
-function fakeHealthDatabase(): Database {
-  return {
-    pool: {} as Database["pool"],
-    close: async () => {},
-    health: async (): Promise<DatabaseHealth> => CONNECTED,
-  } as Database;
+async function roundTripsLifecycle(): Promise<void> {
+  const client = await connectRealClient(pool);
+  const fixture = await loadServerFixture("server-session-lifecycle");
+  const sessionKey = `sdk-proof/lifecycle-${Date.now()}`;
+
+  for (const step of fixture.steps) {
+    const args = { ...step.arguments, session_key: sessionKey };
+    const observed = await callTool(client, step.tool, args);
+
+    expect(observed.isError).toBe(step.expectation.is_error);
+    expectRecordedShape(observed.body, step.expectation.json, {
+      "{{namespace}}": currentNamespace(),
+      "parity/lifecycle": sessionKey,
+    });
+  }
 }
 
-/**
- * The production-shaped auth seam: a bearer token becomes `req.auth`.
- *
- * This is deliberately the SAME placement production uses (`src/index.ts` mounts
- * `authMiddleware` on `/mcp`), because the placement is what is under test. The
- * token map is a single fixed token rather than the real loader -- the point is
- * that SOMETHING sets `req.auth` before the SDK reads it, not how the token is
- * looked up.
- */
-function bearerAuth(): RequestHandler {
-  return (request, response, next) => {
-    if (request.headers.authorization !== `Bearer ${TEST_TOKEN}`) {
-      response.status(401).json({ error: "Unauthorized" });
-      return;
-    }
-    (request as { auth?: unknown }).auth = {
-      role: "agent",
-      clientId: NAMESPACE,
-      tokenClientId: NAMESPACE,
-      namespaceSource: "token",
-    };
-    next();
-  };
-}
+async function performsCaptureWrite(): Promise<void> {
+  const client = await connectRealClient(pool);
+  const fixture = await loadServerFixture("server-capture-checkpoint");
+  const logThought = fixture.steps.find((step) => step.tool === "log_thought");
+  if (!logThought) throw new Error("fixture no longer records a log_thought step");
 
-interface LiveHarness {
-  client: Client;
-  application: ShadowApplication;
-  server: Server;
-  transport: StreamableHTTPClientTransport;
-}
-
-const live: Partial<LiveHarness> = {};
-
-/**
- * Extra applications and listeners a single test composed for itself.
- *
- * The `live` harness above holds ONE of each, which is right for the tests that
- * drive a single client. The two-worker front needs three at once (two workers
- * plus the front), so they are tracked here and torn down by the same
- * `afterEach`. Without this they would leak a listener per run, and a leaked
- * listener is the failure that shows up as an unrelated later test hanging.
- */
-const extraApplications: ShadowApplication[] = [];
-const extraServers: Server[] = [];
-
-/**
- * Realtime stores, injected per composed application rather than inherited.
- *
- * The realtime fixture records `id: "ws-1"` / `"rw-1"`, and those ids come from
- * a MONOTONIC counter that lives as long as the store does. `realtime-stores.ts`
- * falls back to a MODULE-scoped store when a composition root injects none --
- * correct, and deliberately so, because a store rebuilt per request would report
- * a permanent zero. But Bun runs every test file in ONE process, so an
- * uninjected suite shares that fallback with every other suite in the run:
- * measured on this branch, `contracts/server-tool-parity.test.ts` exercises the
- * same three tools first and this suite then observed `ws-2`, passing alone and
- * failing in file order.
- *
- * Injecting is not a test workaround; it is what a composition root does. The
- * store is per APPLICATION here, matching one server process owning its own
- * realtime state, which is exactly the lifetime the fixture recorded against.
- */
-function freshRealtimeStores(): {
-  workingSetStore: WorkingSetStore;
-  recoveryWalStore: RecoveryWalStore;
-} {
-  return {
-    workingSetStore: new WorkingSetStore({ logger: pino({ level: "silent" }) }),
-    // `walPath: null` keeps this RAM-only. A path would make the suite replay
-    // whatever a previous run left on disk, reintroducing the same cross-run
-    // contamination one layer down.
-    recoveryWalStore: new RecoveryWalStore({
-      walPath: null,
-      logger: pino({ level: "silent" }),
-    }),
-  };
-}
-
-/**
- * Compose one real single-worker application and bind it to an ephemeral port.
- *
- * Factored out of `connectRealClient` because the two-worker proof needs REAL
- * worker processes-equivalents behind the front -- the whole point of that test
- * is that the aggregate reads a genuine `/health` body off a genuine socket
- * rather than a hand-written `{status}` object from an injected `fetch`.
- */
-async function startWorkerApplication(): Promise<{
-  application: ShadowApplication;
-  server: Server;
-  port: number;
-}> {
-  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
-  // One store pair per APPLICATION, shared by every session it serves -- the
-  // realtime state belongs to the process, not to a connection.
-  const realtime = freshRealtimeStores();
-  const application = createShadowApplication({
-    config: testConfig(),
-    logger: silentLogger(),
-    database: fakeHealthDatabase(),
-    authenticate: bearerAuth(),
-    parseRequestBody: express.json(),
-    serverFactory: () => {
-      const server = new McpServer({
-        name: "open-brain-rewrite",
-        version: "1.0.0",
-      });
-      registerMemoryTools(server, {
-        pool,
-        embedFn: async () => Array(768).fill(0.01) as number[],
-        logger: pino({ level: "silent" }),
-        sharedNamespaceNames: DEFAULT_SHARED_NAMESPACE_NAMES,
-        embeddingModel: "sdk-protocol-proof",
-        ...realtime,
-      });
-      return server;
-    },
+  const content = `sdk protocol proof capture ${Date.now()}`;
+  const observed = await callTool(client, "log_thought", {
+    ...logThought.arguments,
+    content,
   });
-  const server = await new Promise<Server>((resolve) => {
-    const listener = application.app.listen(0, "127.0.0.1", () =>
-      resolve(listener),
-    );
+
+  expect(observed.isError).toBe(false);
+  expectRecordedShape(observed.body, logThought.expectation.json, {
+    "{{namespace}}": currentNamespace(),
   });
-  const { port } = server.address() as AddressInfo;
-  extraApplications.push(application);
-  extraServers.push(server);
-  return { application, server, port };
+
+  // The wire said it wrote; Postgres is the authority on whether it did.
+  // "A row was written" is an assertion, not an assumption.
+  const written = (observed.body as { id: string }).id;
+  const { rows } = await pool.query(
+    "SELECT namespace, content FROM thoughts WHERE id = $1 AND archived_at IS NULL",
+    [written],
+  );
+  expect(rows.length).toBe(1);
+  expect(rows[0].namespace).toBe(currentNamespace());
+  expect(rows[0].content).toBe(content);
 }
 
-/**
- * Compose the real stack, bind an ephemeral port, and connect a real SDK client.
- *
- * `serverFactory` is the whole point: it builds a REAL `McpServer` and registers
- * the REAL tool boundary, where `shadow-application.test.ts` passes a stub. The
- * factory runs per initialize, matching production, so each session gets its own
- * server instance bound to the shared pool.
- */
-async function connectRealClient(): Promise<Client> {
-  if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
+async function performsSearchRead(): Promise<void> {
+  const client = await connectRealClient(pool);
+  const content = `sdk protocol proof searchable ${Date.now()}`;
+  const write = await callTool(client, "log_thought", {
+    content,
+    tags: ["parity"],
+  });
+  expect(write.isError).toBe(false);
+  const writtenId = (write.body as { id: string }).id;
+
+  const observed = await callTool(client, "search_all", { query: content });
+  expect(observed.isError).toBe(false);
+
+  // Compared against the recall fixture's recorded envelope, with the ids and
+  // content this run actually produced substituted in.
+  const fixture = await loadServerFixture("server-recall-family");
+  const searchStep = fixture.steps.find((step) => step.tool === "search_all");
+  if (!searchStep) throw new Error("fixture no longer records a search_all step");
+  expectRecordedShape(observed.body, searchStep.expectation.json, {
+    "{{namespace}}": currentNamespace(),
+    "{{thought_id}}": writtenId,
+    "parity recall probe thought": content,
+  });
+}
+
+async function fetchesContextPack(): Promise<void> {
+  const client = await connectRealClient(pool);
+  const fixture = await loadServerFixture("server-context-pack-sections");
+  const packStep = fixture.steps.find((step) => step.tool === "agent_context_pack");
+  if (!packStep)
+    throw new Error("fixture no longer records an agent_context_pack step");
+
+  const sessionKey = `sdk-proof/pack-${Date.now()}`;
+  const observed = await callTool(client, "agent_context_pack", {
+    ...packStep.arguments,
+    session_key: sessionKey,
+  });
+
+  expect(observed.isError).toBe(false);
+  expectRecordedShape(observed.body, packStep.expectation.json, {
+    "{{namespace}}": currentNamespace(),
+    "parity/pack": sessionKey,
+  });
+}
+
+async function refusesUnauthenticated(): Promise<void> {
+  // The identity chain is the thing this file exists to prove, so its failure
+  // path is behavior too: no token means no `req.auth`, and the SDK must never
+  // reach a handler. Asserted as a rejected connect, not a tool-level error.
   freshNamespace();
-  // One store pair per APPLICATION, shared by every session it serves -- the
-  // realtime state belongs to the process, not to a connection.
-  const realtime = freshRealtimeStores();
   const application = createShadowApplication({
     config: testConfig(),
     logger: silentLogger(),
@@ -342,79 +267,246 @@ async function connectRealClient(): Promise<Client> {
         logger: pino({ level: "silent" }),
         sharedNamespaceNames: DEFAULT_SHARED_NAMESPACE_NAMES,
         embeddingModel: "sdk-protocol-proof",
-        ...realtime,
       });
       return server;
     },
   });
   live.application = application;
-
-  // Port 0 asks the kernel for an ephemeral port; nothing well-known is bound.
   const httpServer = await new Promise<Server>((resolve) => {
-    const listener = application.app.listen(0, "127.0.0.1", () =>
-      resolve(listener),
-    );
+    const listener = application.app.listen(0, "127.0.0.1", () => resolve(listener));
   });
   live.server = httpServer;
   const { port } = httpServer.address() as AddressInfo;
 
   const transport = new StreamableHTTPClientTransport(
     new URL(`http://127.0.0.1:${port}/mcp`),
-    { requestInit: { headers: { authorization: `Bearer ${TEST_TOKEN}` } } },
   );
-  live.transport = transport;
-  const client = new Client({ name: "sdk-protocol-proof", version: "1.0.0" });
-  // `connect` performs the real initialize handshake over HTTP.
-  await client.connect(transport);
-  live.client = client;
-  return client;
+  const client = new Client({
+    name: "sdk-protocol-proof-anon",
+    version: "1.0.0",
+  });
+  await expect(client.connect(transport)).rejects.toThrow();
+  // Nothing was admitted: the session boundary stayed empty.
+  expect(application.sessions.sessionCount()).toBe(0);
 }
 
-/** Call a tool over the wire and parse the single text content block. */
-async function callTool(
-  client: Client,
-  name: string,
-  args: Record<string, unknown>,
-): Promise<{ isError: boolean; body: unknown; text: string }> {
-  const result = await client.callTool({ name, arguments: args });
-  const text = (result.content as Array<{ text: string }>)[0]?.text ?? "";
-  let body: unknown;
-  try {
-    body = JSON.parse(text);
-  } catch {
-    body = { text };
+async function appendsRealtimeState(): Promise<void> {
+  // The realtime WRITE half only became reachable in this wave. Before it, the
+  // fixture was marked `scaffold-declared` for the rewrite provider: the
+  // stores existed and the context pack READ them, but no tool could put
+  // anything in, so every recorded shape here was asserted against
+  // `current-src` alone.
+  const client = await connectRealClient(pool);
+  const fixture = await loadServerFixture("server-realtime-working-recovery");
+  const sessionKey = `sdk-proof/realtime-${Date.now()}`;
+
+  for (const step of fixture.steps) {
+    const observed = await callTool(client, step.tool, {
+      ...step.arguments,
+      session_key: sessionKey,
+    });
+    expect(observed.isError).toBe(step.expectation.is_error);
+    expectRecordedShape(observed.body, step.expectation.json, {
+      "{{namespace}}": currentNamespace(),
+      "parity/realtime": sessionKey,
+    });
   }
-  return { isError: result.isError === true, body, text };
 }
 
-afterEach(async () => {
-  if (live.client) {
-    await live.client.close();
-    live.client = undefined;
-  }
-  live.transport = undefined;
-  if (live.server) {
-    await new Promise<void>((resolve) => live.server!.close(() => resolve()));
-    live.server = undefined;
-  }
-  if (live.application) {
-    await live.application.close();
-    live.application = undefined;
-  }
-  while (extraServers.length > 0) {
-    const server = extraServers.pop()!;
-    await new Promise<void>((resolve) => server.close(() => resolve()));
-  }
-  while (extraApplications.length > 0) {
-    await extraApplications.pop()!.close();
-  }
-});
+async function workingSetVisibleToPack(): Promise<void> {
+  // This is the join the two halves share and neither one proves alone. The
+  // stores are RAM-only and process-lifetime, so a write that landed in a
+  // DIFFERENT store object than the pack reads would still return
+  // `accepted: true` and then be invisible forever -- and nothing durable
+  // would ever contradict it, because nothing about this state is durable.
+  // Asserting the append's own response cannot catch that; only reading it
+  // back through the other tool can.
+  const client = await connectRealClient(pool);
+  const sessionKey = `sdk-proof/join-${Date.now()}`;
+  const scope = {
+    agent: "fixture-agent",
+    platform: "test",
+    server_id: "server-1",
+    channel_id: "channel-1",
+    session_key: sessionKey,
+  };
+  const content = `working-set join proof ${Date.now()}`;
 
-afterAll(async () => {
-  restoreEnv("SHARED_NAMESPACE_CANONICAL", priorSharedEnv.canonical);
-  restoreEnv("SHARED_NAMESPACE_PHYSICAL", priorSharedEnv.physical);
-  await pool?.end();
-});
+  const appended = await callTool(client, "working_set_append", {
+    ...scope,
+    kind: "current_intent",
+    content,
+  });
+  expect(appended.isError).toBe(false);
+  expect((appended.body as { accepted: boolean }).accepted).toBe(true);
+
+  const pack = await callTool(client, "agent_context_pack", {
+    ...scope,
+    requested_sections: ["working_set"],
+  });
+  expect(pack.isError).toBe(false);
+  // The exact content must come back, not merely a non-empty section: a
+  // section that happened to be populated by anything else would pass a
+  // count-only assertion while proving nothing about THIS write.
+  expect(pack.text).toContain(content);
+}
+
+async function aggregatesWorkerHealth(): Promise<void> {
+  // Charter section 1.5: production-host runs the aggregate front and each nested
+  // worker body must be preserved. `server/transport/worker-proxy.test.ts`
+  // proves the aggregation logic, but only against an injected `fetch` that
+  // returns a hand-written `{status}` object -- so the thing it never checks
+  // is that a REAL single-worker `/health` payload survives nesting. That is
+  // the join, and this binds two real listeners to prove it.
+  const workerOne = await startWorkerApplication(pool);
+  const workerTwo = await startWorkerApplication(pool);
+  const workers = [
+    {
+      name: "open-brain-worker-1",
+      port: workerOne.port,
+      baseUrl: `http://127.0.0.1:${workerOne.port}`,
+    },
+    {
+      name: "open-brain-worker-2",
+      port: workerTwo.port,
+      baseUrl: `http://127.0.0.1:${workerTwo.port}`,
+    },
+  ];
+  const front = createWorkerProxyHandler({
+    workers,
+    hostname: "test-host",
+    serverIp: "127.0.0.1",
+    serverIps: ["127.0.0.1"],
+    healthProbeTimeoutMs: 2_000,
+    logger: silentLogger(),
+  });
+
+  const response = await front(new Request("http://127.0.0.1/health"));
+  const aggregate = (await response.json()) as AggregateHealth;
+
+  expect(response.status).toBe(200);
+  expect(aggregate.status).toBe("healthy");
+  expect(aggregate.workers.map((worker) => worker.name)).toEqual([
+    "open-brain-worker-1",
+    "open-brain-worker-2",
+  ]);
+  // Every nested body is a REAL single-worker payload, not a stub: it carries
+  // the fields the charter freezes for the single-worker surface.
+  for (const worker of aggregate.workers) {
+    expect(worker.ok).toBe(true);
+    const body = worker.body as SingleWorkerHealth;
+    expect(body.status).toBe("healthy");
+    expect(body.database.connected).toBe(true);
+    expect(body.nats.requested_transport).toBe("http");
+    expect(typeof body.timestamp).toBe("string");
+  }
+}
+
+async function pinsSessionToWorker(): Promise<void> {
+  // Session affinity is the reason the front exists at all: sessions live in
+  // a PROCESS-LOCAL map per worker (charter 1.5), so a follow-up request
+  // routed to the other worker finds no session and the client breaks. Proven
+  // over real sockets with a real SDK handshake, because the session id being
+  // pinned is one the SDK server assigned, not one the test made up.
+  const workerOne = await startWorkerApplication(pool);
+  const workerTwo = await startWorkerApplication(pool);
+  const front = createWorkerProxyHandler({
+    workers: [
+      {
+        name: "open-brain-worker-1",
+        port: workerOne.port,
+        baseUrl: `http://127.0.0.1:${workerOne.port}`,
+      },
+      {
+        name: "open-brain-worker-2",
+        port: workerTwo.port,
+        baseUrl: `http://127.0.0.1:${workerTwo.port}`,
+      },
+    ],
+    hostname: "test-host",
+    serverIp: "127.0.0.1",
+    serverIps: ["127.0.0.1"],
+    healthProbeTimeoutMs: 2_000,
+    logger: silentLogger(),
+  });
+  freshNamespace();
+
+  const initialize = await front(
+    new Request("http://127.0.0.1/mcp", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${TEST_TOKEN}`,
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "two-worker-affinity", version: "1.0.0" },
+        },
+      }),
+    }),
+  );
+  expect(initialize.status).toBe(200);
+  const sessionId = initialize.headers.get("mcp-session-id");
+  expect(sessionId).toBeString();
+
+  // Exactly one worker admitted the session; the other saw nothing. That
+  // asymmetry is what makes affinity load-bearing rather than cosmetic.
+  const admitted = [workerOne, workerTwo].filter(
+    (worker) => worker.application.sessions.sessionCount() === 1,
+  );
+  expect(admitted.length).toBe(1);
+
+  // Each follow-up must SUCCEED, and success is the assertion that matters.
+  //
+  // The obvious version of this test compares the front's own
+  // `x-open-brain-worker` value across requests -- and it proves nothing: that
+  // header is set on the OUTBOUND request the front sends to a worker, never
+  // on the response handed back, so reading it here yields `null` on every
+  // request and `null === null` passes with affinity deliberately broken.
+  // Measured on this branch: disabling the `sessionWorkers` lookup outright
+  // left that version 12/12 green.
+  //
+  // Reaching the wrong worker is instead observable in the only place it is
+  // real -- the session map is PROCESS-LOCAL, so the other worker has never
+  // heard of this session id and answers a JSON-RPC error rather than a
+  // result. Asserting on the answered payload cannot be satisfied by routing
+  // to the wrong process.
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const followUp = await front(
+      new Request("http://127.0.0.1/mcp", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${TEST_TOKEN}`,
+          "content-type": "application/json",
+          accept: "application/json, text/event-stream",
+          "mcp-session-id": expectDefined(sessionId, "session id"),
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: attempt + 2,
+          method: "tools/list",
+        }),
+      }),
+    );
+    expect(followUp.status).toBe(200);
+    const answered = await followUp.text();
+    expect(answered).toContain('"result"');
+    expect(answered).toContain("working_set_append");
+    expect(answered).not.toContain("Session not found");
+  }
+  // Still exactly one session in the fleet: affinity routed, it did not
+  // create a second session on the other worker.
+  expect(
+    workerOne.application.sessions.sessionCount() +
+      workerTwo.application.sessions.sessionCount(),
+  ).toBe(1);
+}
 
 // The "(live Postgres)" marker is REQUIRED, not decorative: the anti-skip guard
 // in `scripts/assert-db-tests-ran.ts` selects suites by that literal substring
@@ -423,425 +515,59 @@ afterAll(async () => {
 // with the job still green. Observed on this branch before the rename: the guard
 // reported this suite as MISSING while the JUnit record showed `tests="8"
 // failures="0" skipped="0"`.
-dbDescribe(
-  "rewrite candidate over the real MCP SDK and real HTTP transport (live Postgres)",
-  () => {
-    beforeAll(() => {
-      process.env.SHARED_NAMESPACE_CANONICAL = SHARED_ISOLATION;
-      process.env.SHARED_NAMESPACE_PHYSICAL = SHARED_ISOLATION;
-    });
+describe("rewrite candidate over the real MCP SDK and real HTTP transport (live Postgres)", () => {
+  beforeAll(() => {
+    isolateSharedNamespace(SHARED_ISOLATION);
+  });
 
-    test("proves protocol behavior for the implementation the cutover made the serving target", () => {
-      expect(SERVER_REWRITE_STATE.servesTraffic).toBe(true);
-      expect(SERVER_REWRITE_STATE.cutoverStarted).toBe(true);
-    });
+  test(
+    "proves protocol behavior for the implementation the cutover made the serving target",
+    provesServingTarget,
+  );
 
-    test("completes a real initialize handshake and issues an Mcp-Session-Id", async () => {
-      const client = await connectRealClient();
+  test(
+    "completes a real initialize handshake and issues an Mcp-Session-Id",
+    completesHandshake,
+  );
 
-      // A server-assigned session id only exists if the handshake really happened:
-      // the SDK client reads it off the `Mcp-Session-Id` response header, and the
-      // session manager only sets one from `onsessioninitialized`.
-      expect(live.transport?.sessionId).toBeString();
-      expect(live.transport!.sessionId!).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
-      );
-      // The composed session boundary now holds exactly this one live session.
-      expect(live.application?.sessions.sessionCount()).toBe(1);
-      expect(client.getServerVersion()?.name).toBe("open-brain-rewrite");
-    });
+  test("lists the registered tool surface over the wire", listsToolSurface);
 
-    test("lists the registered tool surface over the wire", async () => {
-      const client = await connectRealClient();
-      const listed = await client.listTools();
-      const names = listed.tools.map((tool) => tool.name);
+  test(
+    "round-trips the session lifecycle against the recorded fixture shape",
+    roundTripsLifecycle,
+  );
 
-      // Every tool exercised below must be reachable through protocol discovery,
-      // not merely present in the registry: a tool that is registered but not
-      // advertised is invisible to a real client.
-      for (const required of [
-        "session_start",
-        "append_session_event",
-        "session_context",
-        "session_wrap",
-        "log_thought",
-        "search_all",
-        "agent_context_pack",
-      ]) {
-        expect(names).toContain(required);
-      }
-      // Discovery must return real schemas, not bare names.
-      const sessionStart = listed.tools.find(
-        (tool) => tool.name === "session_start",
-      );
-      expect(sessionStart?.inputSchema).toBeObject();
-    });
+  test(
+    "performs a capture write that lands a real row and matches the recorded shape",
+    performsCaptureWrite,
+  );
 
-    test("round-trips the session lifecycle against the recorded fixture shape", async () => {
-      const client = await connectRealClient();
-      const fixture = await loadServerFixture("server-session-lifecycle");
-      const sessionKey = `sdk-proof/lifecycle-${Date.now()}`;
+  test("performs a search read that finds what this session wrote", performsSearchRead);
 
-      for (const step of fixture.steps) {
-        const args = { ...step.arguments, session_key: sessionKey };
-        const observed = await callTool(client, step.tool, args);
+  test(
+    "fetches agent_context_pack with every requested section over the wire",
+    fetchesContextPack,
+  );
 
-        expect(observed.isError).toBe(step.expectation.is_error);
-        expectRecordedShape(observed.body, step.expectation.json, {
-          "{{namespace}}": NAMESPACE,
-          "parity/lifecycle": sessionKey,
-        });
-      }
-    });
+  test(
+    "refuses an unauthenticated client at the transport before any tool runs",
+    refusesUnauthenticated,
+  );
 
-    test("performs a capture write that lands a real row and matches the recorded shape", async () => {
-      const client = await connectRealClient();
-      const fixture = await loadServerFixture("server-capture-checkpoint");
-      const logThought = fixture.steps.find(
-        (step) => step.tool === "log_thought",
-      );
-      if (!logThought)
-        throw new Error("fixture no longer records a log_thought step");
+  test(
+    "appends realtime working-set and recovery state against the recorded shapes",
+    appendsRealtimeState,
+  );
 
-      const content = `sdk protocol proof capture ${Date.now()}`;
-      const observed = await callTool(client, "log_thought", {
-        ...logThought.arguments,
-        content,
-      });
+  test(
+    "a working-set append is visible to the context pack that reads the same store",
+    workingSetVisibleToPack,
+  );
 
-      expect(observed.isError).toBe(false);
-      expectRecordedShape(observed.body, logThought.expectation.json, {
-        "{{namespace}}": NAMESPACE,
-      });
+  test(
+    "the two-worker front aggregates real worker health off real sockets",
+    aggregatesWorkerHealth,
+  );
 
-      // The wire said it wrote; Postgres is the authority on whether it did.
-      // "A row was written" is an assertion, not an assumption.
-      const written = (observed.body as { id: string }).id;
-      const { rows } = await pool!.query(
-        "SELECT namespace, content FROM thoughts WHERE id = $1 AND archived_at IS NULL",
-        [written],
-      );
-      expect(rows.length).toBe(1);
-      expect(rows[0].namespace).toBe(NAMESPACE);
-      expect(rows[0].content).toBe(content);
-    });
-
-    test("performs a search read that finds what this session wrote", async () => {
-      const client = await connectRealClient();
-      const content = `sdk protocol proof searchable ${Date.now()}`;
-      const write = await callTool(client, "log_thought", {
-        content,
-        tags: ["parity"],
-      });
-      expect(write.isError).toBe(false);
-      const writtenId = (write.body as { id: string }).id;
-
-      const observed = await callTool(client, "search_all", { query: content });
-      expect(observed.isError).toBe(false);
-
-      // Compared against the recall fixture's recorded envelope, with the ids and
-      // content this run actually produced substituted in.
-      const fixture = await loadServerFixture("server-recall-family");
-      const searchStep = fixture.steps.find(
-        (step) => step.tool === "search_all",
-      );
-      if (!searchStep)
-        throw new Error("fixture no longer records a search_all step");
-      expectRecordedShape(observed.body, searchStep.expectation.json, {
-        "{{namespace}}": NAMESPACE,
-        "{{thought_id}}": writtenId,
-        "parity recall probe thought": content,
-      });
-    });
-
-    test("fetches agent_context_pack with every requested section over the wire", async () => {
-      const client = await connectRealClient();
-      const fixture = await loadServerFixture("server-context-pack-sections");
-      const packStep = fixture.steps.find(
-        (step) => step.tool === "agent_context_pack",
-      );
-      if (!packStep)
-        throw new Error("fixture no longer records an agent_context_pack step");
-
-      const sessionKey = `sdk-proof/pack-${Date.now()}`;
-      const observed = await callTool(client, "agent_context_pack", {
-        ...packStep.arguments,
-        session_key: sessionKey,
-      });
-
-      expect(observed.isError).toBe(false);
-      expectRecordedShape(observed.body, packStep.expectation.json, {
-        "{{namespace}}": NAMESPACE,
-        "parity/pack": sessionKey,
-      });
-    });
-
-    test("refuses an unauthenticated client at the transport before any tool runs", async () => {
-      // The identity chain is the thing this file exists to prove, so its failure
-      // path is behavior too: no token means no `req.auth`, and the SDK must never
-      // reach a handler. Asserted as a rejected connect, not a tool-level error.
-      if (!pool) throw new Error("OPENBRAIN_TEST_DATABASE_URL is required");
-      freshNamespace();
-      const application = createShadowApplication({
-        config: testConfig(),
-        logger: silentLogger(),
-        database: fakeHealthDatabase(),
-        authenticate: bearerAuth(),
-        parseRequestBody: express.json(),
-        serverFactory: () => {
-          const server = new McpServer({
-            name: "open-brain-rewrite",
-            version: "1.0.0",
-          });
-          registerMemoryTools(server, {
-            pool,
-            embedFn: async () => Array(768).fill(0.01) as number[],
-            logger: pino({ level: "silent" }),
-            sharedNamespaceNames: DEFAULT_SHARED_NAMESPACE_NAMES,
-            embeddingModel: "sdk-protocol-proof",
-          });
-          return server;
-        },
-      });
-      live.application = application;
-      const httpServer = await new Promise<Server>((resolve) => {
-        const listener = application.app.listen(0, "127.0.0.1", () =>
-          resolve(listener),
-        );
-      });
-      live.server = httpServer;
-      const { port } = httpServer.address() as AddressInfo;
-
-      const transport = new StreamableHTTPClientTransport(
-        new URL(`http://127.0.0.1:${port}/mcp`),
-      );
-      const client = new Client({
-        name: "sdk-protocol-proof-anon",
-        version: "1.0.0",
-      });
-      await expect(client.connect(transport)).rejects.toThrow();
-      // Nothing was admitted: the session boundary stayed empty.
-      expect(application.sessions.sessionCount()).toBe(0);
-    });
-
-    test("appends realtime working-set and recovery state against the recorded shapes", async () => {
-      // The realtime WRITE half only became reachable in this wave. Before it, the
-      // fixture was marked `scaffold-declared` for the rewrite provider: the
-      // stores existed and the context pack READ them, but no tool could put
-      // anything in, so every recorded shape here was asserted against
-      // `current-src` alone.
-      const client = await connectRealClient();
-      const fixture = await loadServerFixture(
-        "server-realtime-working-recovery",
-      );
-      const sessionKey = `sdk-proof/realtime-${Date.now()}`;
-
-      for (const step of fixture.steps) {
-        const observed = await callTool(client, step.tool, {
-          ...step.arguments,
-          session_key: sessionKey,
-        });
-        expect(observed.isError).toBe(step.expectation.is_error);
-        expectRecordedShape(observed.body, step.expectation.json, {
-          "{{namespace}}": NAMESPACE,
-          "parity/realtime": sessionKey,
-        });
-      }
-    });
-
-    test("a working-set append is visible to the context pack that reads the same store", async () => {
-      // This is the join the two halves share and neither one proves alone. The
-      // stores are RAM-only and process-lifetime, so a write that landed in a
-      // DIFFERENT store object than the pack reads would still return
-      // `accepted: true` and then be invisible forever -- and nothing durable
-      // would ever contradict it, because nothing about this state is durable.
-      // Asserting the append's own response cannot catch that; only reading it
-      // back through the other tool can.
-      const client = await connectRealClient();
-      const sessionKey = `sdk-proof/join-${Date.now()}`;
-      const scope = {
-        agent: "fixture-agent",
-        platform: "test",
-        server_id: "server-1",
-        channel_id: "channel-1",
-        session_key: sessionKey,
-      };
-      const content = `working-set join proof ${Date.now()}`;
-
-      const appended = await callTool(client, "working_set_append", {
-        ...scope,
-        kind: "current_intent",
-        content,
-      });
-      expect(appended.isError).toBe(false);
-      expect((appended.body as { accepted: boolean }).accepted).toBe(true);
-
-      const pack = await callTool(client, "agent_context_pack", {
-        ...scope,
-        requested_sections: ["working_set"],
-      });
-      expect(pack.isError).toBe(false);
-      // The exact content must come back, not merely a non-empty section: a
-      // section that happened to be populated by anything else would pass a
-      // count-only assertion while proving nothing about THIS write.
-      expect(pack.text).toContain(content);
-    });
-
-    test("the two-worker front aggregates real worker health off real sockets", async () => {
-      // Charter section 1.5: production-host runs the aggregate front and each nested
-      // worker body must be preserved. `server/transport/worker-proxy.test.ts`
-      // proves the aggregation logic, but only against an injected `fetch` that
-      // returns a hand-written `{status}` object -- so the thing it never checks
-      // is that a REAL single-worker `/health` payload survives nesting. That is
-      // the join, and this binds two real listeners to prove it.
-      const workerOne = await startWorkerApplication();
-      const workerTwo = await startWorkerApplication();
-      const workers = [
-        {
-          name: "open-brain-worker-1",
-          port: workerOne.port,
-          baseUrl: `http://127.0.0.1:${workerOne.port}`,
-        },
-        {
-          name: "open-brain-worker-2",
-          port: workerTwo.port,
-          baseUrl: `http://127.0.0.1:${workerTwo.port}`,
-        },
-      ];
-      const front = createWorkerProxyHandler({
-        workers,
-        hostname: "test-host",
-        serverIp: "127.0.0.1",
-        serverIps: ["127.0.0.1"],
-        healthProbeTimeoutMs: 2_000,
-        logger: silentLogger(),
-      });
-
-      const response = await front(new Request("http://127.0.0.1/health"));
-      const aggregate = (await response.json()) as AggregateHealth;
-
-      expect(response.status).toBe(200);
-      expect(aggregate.status).toBe("healthy");
-      expect(aggregate.workers.map((worker) => worker.name)).toEqual([
-        "open-brain-worker-1",
-        "open-brain-worker-2",
-      ]);
-      // Every nested body is a REAL single-worker payload, not a stub: it carries
-      // the fields the charter freezes for the single-worker surface.
-      for (const worker of aggregate.workers) {
-        expect(worker.ok).toBe(true);
-        const body = worker.body as SingleWorkerHealth;
-        expect(body.status).toBe("healthy");
-        expect(body.database.connected).toBe(true);
-        expect(body.nats.requested_transport).toBe("http");
-        expect(typeof body.timestamp).toBe("string");
-      }
-    });
-
-    test("the two-worker front pins one MCP session to one worker", async () => {
-      // Session affinity is the reason the front exists at all: sessions live in
-      // a PROCESS-LOCAL map per worker (charter 1.5), so a follow-up request
-      // routed to the other worker finds no session and the client breaks. Proven
-      // over real sockets with a real SDK handshake, because the session id being
-      // pinned is one the SDK server assigned, not one the test made up.
-      const workerOne = await startWorkerApplication();
-      const workerTwo = await startWorkerApplication();
-      const front = createWorkerProxyHandler({
-        workers: [
-          {
-            name: "open-brain-worker-1",
-            port: workerOne.port,
-            baseUrl: `http://127.0.0.1:${workerOne.port}`,
-          },
-          {
-            name: "open-brain-worker-2",
-            port: workerTwo.port,
-            baseUrl: `http://127.0.0.1:${workerTwo.port}`,
-          },
-        ],
-        hostname: "test-host",
-        serverIp: "127.0.0.1",
-        serverIps: ["127.0.0.1"],
-        healthProbeTimeoutMs: 2_000,
-        logger: silentLogger(),
-      });
-      freshNamespace();
-
-      const initialize = await front(
-        new Request("http://127.0.0.1/mcp", {
-          method: "POST",
-          headers: {
-            authorization: `Bearer ${TEST_TOKEN}`,
-            "content-type": "application/json",
-            accept: "application/json, text/event-stream",
-          },
-          body: JSON.stringify({
-            jsonrpc: "2.0",
-            id: 1,
-            method: "initialize",
-            params: {
-              protocolVersion: "2025-06-18",
-              capabilities: {},
-              clientInfo: { name: "two-worker-affinity", version: "1.0.0" },
-            },
-          }),
-        }),
-      );
-      expect(initialize.status).toBe(200);
-      const sessionId = initialize.headers.get("mcp-session-id");
-      expect(sessionId).toBeString();
-
-      // Exactly one worker admitted the session; the other saw nothing. That
-      // asymmetry is what makes affinity load-bearing rather than cosmetic.
-      const admitted = [workerOne, workerTwo].filter(
-        (worker) => worker.application.sessions.sessionCount() === 1,
-      );
-      expect(admitted.length).toBe(1);
-
-      // Each follow-up must SUCCEED, and success is the assertion that matters.
-      //
-      // The obvious version of this test compares the front's own
-      // `x-open-brain-worker` value across requests -- and it proves nothing: that
-      // header is set on the OUTBOUND request the front sends to a worker, never
-      // on the response handed back, so reading it here yields `null` on every
-      // request and `null === null` passes with affinity deliberately broken.
-      // Measured on this branch: disabling the `sessionWorkers` lookup outright
-      // left that version 12/12 green.
-      //
-      // Reaching the wrong worker is instead observable in the only place it is
-      // real -- the session map is PROCESS-LOCAL, so the other worker has never
-      // heard of this session id and answers a JSON-RPC error rather than a
-      // result. Asserting on the answered payload cannot be satisfied by routing
-      // to the wrong process.
-      for (let attempt = 0; attempt < 3; attempt += 1) {
-        const followUp = await front(
-          new Request("http://127.0.0.1/mcp", {
-            method: "POST",
-            headers: {
-              authorization: `Bearer ${TEST_TOKEN}`,
-              "content-type": "application/json",
-              accept: "application/json, text/event-stream",
-              "mcp-session-id": sessionId!,
-            },
-            body: JSON.stringify({
-              jsonrpc: "2.0",
-              id: attempt + 2,
-              method: "tools/list",
-            }),
-          }),
-        );
-        expect(followUp.status).toBe(200);
-        const answered = await followUp.text();
-        expect(answered).toContain('"result"');
-        expect(answered).toContain("working_set_append");
-        expect(answered).not.toContain("Session not found");
-      }
-      // Still exactly one session in the fleet: affinity routed, it did not
-      // create a second session on the other worker.
-      expect(
-        workerOne.application.sessions.sessionCount() +
-          workerTwo.application.sessions.sessionCount(),
-      ).toBe(1);
-    });
-  },
-);
+  test("the two-worker front pins one MCP session to one worker", pinsSessionToWorker);
+});


### PR DESCRIPTION
## Summary

- `server/application/sdk-protocol.pg.test.ts` read `OPENBRAIN_TEST_DATABASE_URL` itself and swapped in `describe.skip` when it was unset, reporting `0 pass, 13 skip, 0 fail` and exiting 0. At the exit code that is indistinguishable from a suite that ran and passed, so the real-SDK protocol behavior nobody exercised could drift with CI green.
- The module now calls `requireTestDatabaseUrl()` at module scope and builds one `Pool` from it, ended once in the file's `afterAll`. Absent the variable the run fails loudly with `test_database_required`.
- The constants, module state, and seven harness functions move to a new sibling `server/application/sdk-protocol-test-helpers.ts`. That module holds no test and creates no pool: `startWorkerApplication` and `connectRealClient` take the caller's `Pool` as their first parameter, so the file that owns the pool also owns ending it. The `if (!pool) throw` guards go away with it, and an `expectDefined` guard exported from the same module replaces every non-null assertion.
- `node/no-process-env` is scoped to `server/**`, so the shared-namespace isolation moves to a new `scripts/test-support/shared-namespace-env.ts` exporting `isolateSharedNamespace` and `restoreSharedNamespace`. Behavior is identical; the environment access now lives in test support, outside the `server/` scope.
- Every `it` body hoists to a module-scope `async function` called as `test("<same name>", fn)`. That is what clears `max-lines-per-function`: the rule measures the describe callback, and neither splitting the file nor nesting sub-describes moves that number. Test names, order, and assertions are unchanged.
- `scripts/assert-db-tests-ran.ts` is deliberately untouched. The suite name is unchanged and its manifest entry already carried `minTests: 12`, verified against the JUnit record this branch produced.

## Verification

- Done-means: scripts/done-means/878-pg-tests-require-database.sh
- `CHANGED_FILES="server/application/sdk-protocol.pg.test.ts" bash scripts/done-means/878-pg-tests-require-database.sh` — exit 1 at `origin/main` (751c7268: clauses 1, 2, 3 FAIL), exit 0 on the committed tree with all four clauses PASS.
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bun run test:isolated server/application/sdk-protocol.pg.test.ts` — 12 pass, 0 fail, 63 expect() calls, where the same file previously reported 13 skip. `bunx tsc --noEmit` exit 0. `./node_modules/.bin/oxlint --deny-warnings` exit 0 over all three touched files, which on `origin/main` carried 7 `node/no-process-env`, 7 `no-non-null-assertion`, 1 `max-lines`, and 1 `max-lines-per-function`. The pre-push hook ran the whole suite: 4009 pass, 0 fail. Python package and live smoke are not applicable — this branch changes test files and test support only, and touches no client, contract, or runtime path.

## Critical Self-Review

- Highest-risk behavior: the pool lifetime across the split. A helper module that created its own pool would give each half of a future split an `afterAll` ending a connection the other half still uses, so the helpers take `pool` as a parameter and create none; the single module-scope pool in the test file is ended exactly once.
- Assumptions that could be wrong: that `expectDefined` preserves each assertion's meaning. It throws where `!` silently proceeded, so a value that was legitimately absent at that point would now fail rather than surface as a downstream `undefined`. The 12 tests pass, which is the evidence that none of the seven sites relied on that.
- Missing/weak tests: no test covers `shared-namespace-env.ts` directly; it is exercised only through this suite's `beforeAll`/`afterAll`. Its restore path (delete when the prior value was undefined) is not asserted independently.
- Security/permission risk: none identified. No auth, namespace predicate, or token path changed. The `bearerAuth` seam moved verbatim and still stamps the same identity onto `req.auth`, which is the chain this file exists to prove.
- Migration/deploy risk: none. No migration, no schema, no deployed code path — `server/application/sdk-protocol.ts` and `shadow-application` are untouched.
- Downstream client/runtime risk: none. Per `docs/downstream-rollout.md` this is not an MCP tool, schema, protocol, or client-facing change; no rtech-mcps, mcp2cli, or Hermes surface moves.
- Rollback/cleanup concern: reverting the commit restores the skipping suite. The two new files are only imported by this suite, so nothing is stranded.
- Fixes made before PR: raised `MIN_TOTAL_LIVE_TESTCASES` from 328 to 340 on the assumption the newly-executing 12 were additive, and the guard's own unit test failed. That floor is the sum of the manifest's own `minTests`, so this suite's 12 were already inside it while the suite skipped. The change was reverted and `scripts/assert-db-tests-ran.ts` left untouched; `bun test scripts/assert-db-tests-ran.test.ts` then returned 16 pass, 0 fail.
- Known residual risk: the first done-means run failed clause 4 on a transient `pgvector_registration_failed` during database provisioning, not on anything in this change; the immediate re-run and the committed-tree run both passed all four clauses. That provisioning race is real and is not addressed here.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the one lesson here is about the anti-skip guard's floor arithmetic, which belongs in the lane contract's Tightenings for the #878 harvest rather than in a reviewer lane file; it is posted as a harvest comment on this PR.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no deployed surface changes; this is a test-only conversion.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no fixture changed. The suite still compares against the same recorded shapes through the same imported comparator; only the harness composition moved.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Test files and test support only; no MCP tool, schema, transport, or Python client path is touched, so every downstream item is not applicable per the classification in `docs/downstream-rollout.md`.
