### PR TITLE
docs(rules): HANDOVER-RULES 57, no closing keyword for work a change does not land

### DIFF
--- a/_DOCS/HANDOVER-RULES.md
+++ b/_DOCS/HANDOVER-RULES.md
@@ -400,3 +400,11 @@ only when a session actually needed it.
     tree where it exits 1 (live=16 over the rule value 15). A lane's exit
     column is PROPOSED; the head runs the same command on the committed tree
     and corrects the row, announcing the correction in the pilot findings.
+57. **A closing keyword in any commit or PR text closes the issue at merge,
+    whether or not the change did the work.** GitHub reads `closes #N`,
+    `fixes #N`, `resolves #N` in the squash message (which carries the PR
+    title and body) and closed #951 from the #952 handover commit, whose
+    body merely said session 12 "closes #951". Write "session 12 finishes
+    #951" or "wayfinder: #951"; a closing keyword appears only in the PR
+    that lands the fix, and the head confirms `gh issue view N --json state`
+    after every merge that mentions an issue.


### PR DESCRIPTION
## Summary

- `_DOCS/HANDOVER-RULES.md` gains rule 57: a closing keyword anywhere in commit or PR text closes the named issue at merge whether or not the change did the work. The #952 squash message said session 12 "closes #951" and GitHub closed #951 with nothing done; it is reopened. The rule names the safe phrasings ("finishes", "wayfinder") and the post-merge `gh issue view N --json state` check.
- Documentation only; no code, tests, or config.

## Verification

- Done-means: scripts/done-means/handover-validates.sh

`scripts/done-means/handover-validates.sh` validates the newest handover (`_DOCS/_handover/2026-08-28-pg-tests-session12.md`, unchanged by this PR) because the rules layer changed, then runs the skill's `check-drained.sh`. On this branch: `PASS: ... conforms (93 lines) [validator 2026-08-27.1]`, `PASS: drained`, exit 0. Exit grammar: `0` pass, `1` the thing under test failed, `3` harness error.

- [x] Relevant Open Brain tests/typecheck/migrations passed — the pre-push gate ran the Bun suite in the clean clone that pushed the branch (rule 53); no TypeScript is staged.
- [x] Python package checks passed or are not applicable — not applicable, no Python touched.
- [x] Live Open Brain smoke passed or is not applicable — not applicable, documentation only.

## Critical Self-Review

- Highest-risk behavior: none in code; the rule briefs every later head. Its receipt is the #951 timeline (closed by commit 1ce3f8e3 at 04:34:53Z, reopened by the head).
- Assumptions that could be wrong: that the squash message was the closing source; the timeline's `closed` event names commit 1ce3f8e3 and no PR reference, which is the squash.
- Missing/weak tests: none apply; the validator does not test rule text.
- Security/permission risk: none.
- Migration/deploy risk: none.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classifies this as not applicable.
- Rollback/cleanup concern: a plain revert restores the previous rules file.
- Fixes made before PR: #951 reopened with the reason on the issue; recorded on #878.
- Known residual risk: the same auto-close can fire from any future PR body; the rule is prose, not a hook.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the lesson is a repo-standing rule in HANDOVER-RULES, not a review-lane pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: documentation only.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched.
