### PR TITLE
docs(rules): rule 57 lists every tense of the closing keywords

### DIFF
--- a/_DOCS/HANDOVER-RULES.md
+++ b/_DOCS/HANDOVER-RULES.md
@@ -407,4 +407,9 @@ only when a session actually needed it.
     body merely said session 12 "closes #951". Write "session 12 finishes
     #951" or "wayfinder: #951"; a closing keyword appears only in the PR
     that lands the fix, and the head confirms `gh issue view N --json state`
-    after every merge that mentions an issue.
+    after every merge that mentions an issue. The keyword list is every
+    tense: close, closes, closed, fix, fixes, fixed, resolve, resolves,
+    resolved, each followed by `#N`. The PR that added this rule (#953)
+    re-closed #951 with the past-tense form in its own body, so the safe
+    shape in commit and PR text is the bare number ("issue 951", "#951 was
+    auto-closed" is NOT safe) or the verb without the number.


### PR DESCRIPTION
## Summary

- `_DOCS/HANDOVER-RULES.md` rule 57 now lists every tense of the closing keywords (close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved) and names the safe shape in commit and PR text: the bare number, never a closing verb directly in front of `#N`. The PR that added the rule (#953) re-triggered the auto-close on issue 951 with the past-tense form in its own body; the issue is reopened.
- Documentation only; no code, tests, or config. This body deliberately writes "issue 951" without a verb in front of a number sign.

## Verification

- Done-means: scripts/done-means/handover-validates.sh

`scripts/done-means/handover-validates.sh` validates the newest handover (`_DOCS/_handover/2026-08-28-pg-tests-session12.md`, unchanged by this PR) because the rules layer changed, then runs the skill's `check-drained.sh`. On this branch: `PASS: ... conforms (93 lines) [validator 2026-08-27.1]`, `PASS: drained`, exit 0. Exit grammar: `0` pass, `1` the thing under test failed, `3` harness error.

- [x] Relevant Open Brain tests/typecheck/migrations passed — the pre-push gate ran the Bun suite in the clean clone that pushed the branch (rule 53); no TypeScript is staged.
- [x] Python package checks passed or are not applicable — not applicable, no Python touched.
- [x] Live Open Brain smoke passed or is not applicable — not applicable, documentation only.

## Critical Self-Review

- Highest-risk behavior: none in code; the rule briefs every later head. Its receipt is the issue 951 timeline: two `closed` events, from commits 1ce3f8e3 and d8e4c236, both reopened by the head.
- Assumptions that could be wrong: that GitHub's keyword set is exactly the nine listed; GitHub's documented list is those nine, each requiring `#N` or a full issue URL directly after it.
- Missing/weak tests: none apply; the validator does not test rule text, and no hook scans PR bodies for the pattern (a candidate for a later gate).
- Security/permission risk: none.
- Migration/deploy risk: none.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classifies this as not applicable.
- Rollback/cleanup concern: a plain revert restores the previous rules file.
- Fixes made before PR: issue 951 reopened with the reason on the issue; recorded on #878.
- Known residual risk: prose only; a third occurrence is the signal to add a PR-body gate.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the lesson is a repo-standing rule in HANDOVER-RULES, not a review-lane pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: documentation only.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched.
