### PR TITLE
test(support): one expectDefined util in scripts/test-support, nine helper modules import it (issue 951)

### DIFF
--- a/scripts/__tests__/backup-restore-live-helpers.ts
+++ b/scripts/__tests__/backup-restore-live-helpers.ts
@@ -19,6 +19,9 @@ import {
   requireLocalCloneTestDatabaseUrl,
   requireTestDatabaseUrl,
 } from "../test-support/require-test-database.ts";
+import { expectDefined } from "../test-support/expect-defined.ts";
+
+export { expectDefined };
 
 export const REPO_ROOT = join(import.meta.dir, "..", "..");
 export const MIGRATIONS_DIR = join(REPO_ROOT, "src", "db", "migrations");
@@ -79,15 +82,6 @@ export interface CliResult {
   stdout: string;
   stderr: string;
 }
-
-/** Throws when a value is null or undefined, so callers need no `!`. */
-export function expectDefined<T>(value: T | null | undefined, label: string): T {
-  if (value === null || value === undefined) {
-    throw new Error(`expected ${label} to be defined`);
-  }
-  return value;
-}
-
 export function parseAdminUrl(url: string): Conn & { database: string } {
   const parsed = new URL(url);
   return {

--- a/scripts/done-means/951-expect-defined-single-util.sh
+++ b/scripts/done-means/951-expect-defined-single-util.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #951 -- `expectDefined` is defined exactly once,
+# in scripts/test-support/expect-defined.ts; every lane helper module imports
+# it instead of carrying its own copy (HANDOVER-RULES rule 27).
+#
+#   bash scripts/done-means/951-expect-defined-single-util.sh
+#
+# Exit 0: exactly one `export function expectDefined` in the tree, at the util
+# path. Exit 1: any other count or any other location. Exit 3: harness error.
+set -u
+cd "$(dirname "$0")/../.." || exit 3
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "HARNESS ERROR: not run from a checkout"; exit 3; }
+hits=$(rg -l --glob '*.ts' 'export function expectDefined' . | sort)
+count=$(printf '%s\n' "$hits" | sed '/^$/d' | wc -l | tr -d ' ')
+echo "definitions: $count"
+printf '%s\n' "$hits"
+if [ "$count" -eq 1 ] && [ "$hits" = "./scripts/test-support/expect-defined.ts" ]; then
+  echo "PASS: one definition at scripts/test-support/expect-defined.ts"
+  exit 0
+fi
+echo "FAIL: expected exactly one definition at ./scripts/test-support/expect-defined.ts"
+exit 1

--- a/scripts/test-support/expect-defined.ts
+++ b/scripts/test-support/expect-defined.ts
@@ -1,0 +1,7 @@
+/** Narrows an optional value, throwing a labelled error when it is absent. */
+export function expectDefined<T>(value: T | null | undefined, label: string): T {
+  if (value === null || value === undefined) {
+    throw new Error(`expected ${label} to be defined`);
+  }
+  return value;
+}

--- a/scripts/test-support/promote-lane-shared-helpers.ts
+++ b/scripts/test-support/promote-lane-shared-helpers.ts
@@ -10,6 +10,9 @@ import { readFileSync } from "node:fs";
 import type { Pool } from "pg";
 import { parseArgs } from "../promote-lane-shared.ts";
 import { sharedNamespaceConfig } from "../../src/shared-namespace.ts";
+import { expectDefined } from "./expect-defined.ts";
+
+export { expectDefined };
 
 export const DEFAULT_MIN = 24;
 // minLen <= len < minLen*1.5 → manual-review. minLen=24 → [24, 36).
@@ -18,15 +21,6 @@ export const MANUAL_REVIEW_CONTENT = "x".repeat(30); // len 30, in the ambiguity
 export const SHARE_CONTENT =
   "This is a substantive shared-worthy decision about the schema design choices.";
 export const TEST_NAMESPACE = "test-promote-lane-shared-live";
-
-/** Narrows an optional value, throwing a labelled error when it is absent. */
-export function expectDefined<T>(value: T | null | undefined, label: string): T {
-  if (value === null || value === undefined) {
-    throw new Error(`expected ${label} to be defined`);
-  }
-  return value;
-}
-
 export interface PromoterHarness {
   ns: string;
   applyDbEnv: () => void;

--- a/server/application/sdk-protocol-test-helpers.ts
+++ b/server/application/sdk-protocol-test-helpers.ts
@@ -26,21 +26,9 @@ import { WorkingSetStore } from "../realtime/working-set.ts";
 import { registerMemoryTools } from "../tools/index.ts";
 import { DEFAULT_SHARED_NAMESPACE_NAMES } from "../tools/shared-namespace-fixture.ts";
 import { silentLogger } from "../transport/testing/silent-logger.ts";
+import { expectDefined } from "../../scripts/test-support/expect-defined.ts";
 
-/**
- * Assert a value is present and return it narrowed.
- *
- * Replaces the non-null assertion operator: `x!` tells the compiler to stop
- * checking, while this throws a labelled error at the moment the assumption is
- * actually wrong, which is what a test wants to read in its failure output.
- */
-export function expectDefined<T>(value: T | null | undefined, label: string): T {
-  if (value === null || value === undefined) {
-    throw new Error(`expected ${label} to be defined`);
-  }
-  return value;
-}
-
+export { expectDefined };
 export const TEST_TOKEN = "sdk-protocol-proof-token";
 const CONNECTED: DatabaseHealth = {
   connected: true,

--- a/src/db/migrations/026_maintenance_queue-test-helpers.ts
+++ b/src/db/migrations/026_maintenance_queue-test-helpers.ts
@@ -13,6 +13,9 @@
  */
 import type { Pool } from "pg";
 import { MaintenanceQueue } from "../../maintenance-queue.ts";
+import { expectDefined } from "../../../scripts/test-support/expect-defined.ts";
+
+export { expectDefined };
 
 const migrationUrl = new URL("026_maintenance_queue.sql", import.meta.url);
 
@@ -50,18 +53,4 @@ export async function enqueue(
     runAfter: new Date("2000-01-01T00:00:00.000Z"),
     ...input,
   });
-}
-
-/**
- * Narrows an optional value, throwing a labelled error when it is absent.
- *
- * Same assertion meaning as a non-null assertion -- a missing value still
- * fails the test -- except the failure names which value went missing instead
- * of surfacing as a bare TypeError on the next property read.
- */
-export function expectDefined<T>(value: T | null | undefined, label: string): T {
-  if (value === null || value === undefined) {
-    throw new Error(`${label} is undefined`);
-  }
-  return value;
 }

--- a/src/embedding-repair-test-helpers.ts
+++ b/src/embedding-repair-test-helpers.ts
@@ -15,6 +15,9 @@ import {
 } from "./embedding-canonical.ts";
 import type { EmbedWithMetaFn } from "./embedding-repair.ts";
 import type { MaintenanceQueueLogger } from "./maintenance-queue.ts";
+import { expectDefined } from "../scripts/test-support/expect-defined.ts";
+
+export { expectDefined };
 
 // Deterministic, provider-free embedding: a fixed unit vector. Repair only needs
 // a valid halfvec(768); content correctness is the provider's concern, not ours.
@@ -184,12 +187,4 @@ export async function embeddingIsNull(
     [id],
   );
   return rows[0].is_null as boolean;
-}
-
-/** Narrow a nullable value at a test boundary without a non-null assertion. */
-export function expectDefined<T>(value: T | null | undefined, label: string): T {
-  if (value === null || value === undefined) {
-    throw new Error(`${label} is undefined`);
-  }
-  return value;
 }

--- a/src/graph-derivation-handler-test-helpers.ts
+++ b/src/graph-derivation-handler-test-helpers.ts
@@ -18,6 +18,9 @@ import {
 } from "./graph-derivation-handler.ts";
 import { type MaintenanceJob } from "./maintenance-queue.ts";
 import type { AuthInfo } from "./types.ts";
+import { expectDefined } from "../scripts/test-support/expect-defined.ts";
+
+export { expectDefined };
 
 export const ns = "test-graph-derivation-maint";
 export const otherNs = "test-graph-derivation-maint-other";
@@ -30,23 +33,6 @@ export const auth: AuthInfo = {
 
 export const hashA = "a".repeat(64);
 export const hashB = "b".repeat(64);
-
-/**
- * Narrows a possibly-absent value, throwing with a caller-supplied label.
- *
- * Replaces the `x!` non-null assertions the oxlint standard forbids: the
- * assertion's runtime meaning (throw when absent) is kept, and the label says
- * which expectation went missing instead of a bare TypeError.
- *
- * @throws {Error} when `value` is null or undefined.
- */
-export function expectDefined<T>(value: T | null | undefined, label: string): T {
-  if (value === null || value === undefined) {
-    throw new Error(`expected ${label} to be defined`);
-  }
-  return value;
-}
-
 export async function cleanup(pool: Pool): Promise<void> {
   for (const namespace of [ns, otherNs]) {
     await pool.query("DELETE FROM ob_links WHERE namespace = $1", [namespace]);

--- a/src/source-sync-test-helpers.ts
+++ b/src/source-sync-test-helpers.ts
@@ -10,15 +10,9 @@ import type { Pool } from "pg";
 import { registerSource } from "./source-registry.ts";
 import type { SourceObservation } from "./source-sync.ts";
 import type { AuthInfo } from "./types.ts";
+import { expectDefined } from "../scripts/test-support/expect-defined.ts";
 
-/** Narrows an optional value, throwing a labelled error when it is absent. */
-export function expectDefined<T>(value: T | null | undefined, label: string): T {
-  if (value === null || value === undefined) {
-    throw new Error(`expected ${label} to be defined`);
-  }
-  return value;
-}
-
+export { expectDefined };
 export const H = (n: number): string => n.toString(16).padStart(64, "0");
 
 export function obs(files: Array<[string, string]>): SourceObservation {

--- a/src/tools/__tests__/agent-context-pack-durable-lane-test-helpers.ts
+++ b/src/tools/__tests__/agent-context-pack-durable-lane-test-helpers.ts
@@ -1,4 +1,7 @@
 import type { setupAgentContextPackToolClient } from "./agent-context-pack-test-helpers.ts";
+import { expectDefined } from "../../../scripts/test-support/expect-defined.ts";
+
+export { expectDefined };
 
 /**
  * The structural pool shape the agent_context_pack tool client accepts. Named
@@ -15,19 +18,6 @@ export interface PackEvent {
   content: string;
   [key: string]: unknown;
 }
-
-/**
- * Returns `value` when it is neither null nor undefined, and throws otherwise.
- * Replaces the non-null assertions the oxlint standard forbids while keeping
- * the assertion that follows it reading against a defined value.
- */
-export function expectDefined<T>(value: T | null | undefined, label: string): T {
-  if (value === null || value === undefined) {
-    throw new Error(`expected ${label} to be defined`);
-  }
-  return value;
-}
-
 /**
  * The parts of an agent_context_pack result these suites assert against. Only
  * the read properties are declared, so a typo in a test is a typecheck error

--- a/src/tools/__tests__/lane-upsert-test-helpers.ts
+++ b/src/tools/__tests__/lane-upsert-test-helpers.ts
@@ -12,6 +12,9 @@ import { registerLaneUpsert } from "../lane-upsert.ts";
 import { createMockEmbed, type MockPool } from "./test-helpers.ts";
 import type { ToolDeps } from "../index.ts";
 import type { AuthInfo as ObAuthInfo } from "../../types.ts";
+import { expectDefined } from "../../../scripts/test-support/expect-defined.ts";
+
+export { expectDefined };
 
 export type { ObAuthInfo };
 
@@ -20,15 +23,6 @@ type SendMessage = Parameters<TransportSend>[0];
 type SendOptions = Parameters<TransportSend>[1];
 
 export type ToolResult = Awaited<ReturnType<Client["callTool"]>>;
-
-/** Narrowing guard replacing the non-null assertions in the moved bodies. */
-export function expectDefined<T>(value: T | null | undefined, label: string): T {
-  if (value === null || value === undefined) {
-    throw new Error(`expected ${label} to be defined`);
-  }
-  return value;
-}
-
 /** Typed read of the first text block of a tool result. */
 export function firstText(result: ToolResult): string {
   const content = expectDefined(


### PR DESCRIPTION
## Summary

- `expectDefined<T>(value, label)` was defined nine times across the lane helper modules with byte-identical bodies. It now lives once, at `scripts/test-support/expect-defined.ts` (issue 951).
- Each of the nine helper modules imports the util and re-exports it (`export { expectDefined };`), so every test file that imports the name from its own helper module keeps working: no `*.test.ts` was edited in this change.
- Two of the nine copies (`src/embedding-repair-test-helpers.ts`, `src/db/migrations/026_maintenance_queue-test-helpers.ts`) threw `` `${label} is undefined` `` where the other seven threw `` `expected ${label} to be defined` ``. No test asserts either string, so the seven-copy message is what the util keeps and those two call sites now raise it too. The per-copy doc comments are dropped with the copies.
- Test-support only. No product code, no behavior change, no migration.

## Verification

- Done-means: scripts/done-means/951-expect-defined-single-util.sh
- Run it as `bash scripts/done-means/951-expect-defined-single-util.sh`. RED at origin/main 494fb1a2: exit 1, `definitions: 9`. GREEN on the committed tree: exit 0, `definitions: 1`, at `./scripts/test-support/expect-defined.ts`.
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bunx tsc --noEmit` exit 0. `./node_modules/.bin/oxlint --deny-warnings` over all eleven touched paths exit 0. `bun run test:isolated` over the nineteen test files that import from a touched helper module: 108 pass, 0 fail, 606 expect() calls, exit 0. Python package untouched, so its gate is not applicable; no runtime surface changes, so no live smoke applies.

## Critical Self-Review

- Highest-risk behavior: the re-export. If a helper module's re-export line were dropped, every test importing `expectDefined` from that module would fail to resolve. All nine carry `export { expectDefined };` and the nineteen dependent test files run green, which is the direct proof.
- Assumptions that could be wrong: that no test asserts the thrown message text. Checked by searching for both message strings across `*.test.ts`; neither appears. If a future test asserted `is undefined` against those two modules it would now fail, which is the intended unification.
- Missing/weak tests: the util has no test of its own. It is a two-branch narrowing guard exercised by 606 expect() calls across nineteen suites, so a dedicated unit test would restate what those already prove.
- Security/permission risk: none. Test-support code, no auth, no namespace predicate, no SQL.
- Migration/deploy risk: none. No migration, no schema, nothing shipped to core01.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface is touched, so `docs/downstream-rollout.md` classifies this as not applicable.
- Rollback/cleanup concern: a single revert restores the nine local definitions; there is no state to unwind.
- Fixes made before PR: the two divergent message strings were reconciled onto the seven-copy wording rather than left as a silent behavior difference between call sites.
- Known residual risk: the two reconciled call sites now report `expected X to be defined` instead of `X is undefined` in a failing test's output. Message text only; no assertion reads it.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical de-duplication of test-support code with no review finding behind it, and no new failure pattern was discovered.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: nothing in this change reaches a running service.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched; the change is confined to test-support helper modules.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Every downstream item is not applicable: the diff is eleven test-support files plus one done-means script, and no MCP tool, schema, transport, or client contract appears in it.
