### PR TITLE
chore(qmd): point the index models at the fleet llama-swap instead of hf: local models

### DIFF
--- a/.qmd/index.yml
+++ b/.qmd/index.yml
@@ -155,6 +155,6 @@ collections:
       - "**/.env.production"
       - "**/.env.development"
 models:
-  embed: hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf
-  generate: hf:tobil/qmd-query-expansion-1.7B-gguf/qmd-query-expansion-1.7B-q4_k_m.gguf
-  rerank: hf:ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/qwen3-reranker-0.6b-q8_0.gguf
+  embed: https://llama-swap.rodaddy.live/v1#embed-gemma
+  generate: https://llama-swap.rodaddy.live/v1#qmd-query-expansion
+  rerank: https://llama-swap.rodaddy.live/v1#rerank-qwen3

--- a/scripts/done-means/qmd-models-remote.sh
+++ b/scripts/done-means/qmd-models-remote.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# DONE-MEANS check: the qmd index models are remote llama-swap endpoints, not
+# `hf:` local models (PR #959).
+#
+#   bash scripts/done-means/qmd-models-remote.sh
+#
+# qmd 2.6.3 (02c8dcb) refuses local models: with an `hf:` pin the librarian
+# query job exits 3 ("Local models are disabled ... generate role") and
+# `aqmd up` cannot embed. `.qmd/index.yml` beats `QMD_*_MODEL` env
+# (qmd/src/llm.ts:292), so the yml is the thing to judge.
+#
+# Exit 0: all three `models.*` lines are `https://` URLs and none is `hf:`.
+# Exit 1: any `hf:` model or a missing line. Exit 3: harness error.
+set -u
+cd "$(dirname "$0")/../.." || exit 3
+yml=.qmd/index.yml
+[ -f "$yml" ] || { echo "HARNESS ERROR: $yml missing"; exit 3; }
+fail=0
+for role in embed generate rerank; do
+  line=$(rg -n "^  ${role}: " "$yml" | head -1)
+  if [ -z "$line" ]; then echo "FAIL: models.${role} line missing"; fail=1; continue; fi
+  case "$line" in
+    *"${role}: https://"*) echo "ok   $line" ;;
+    *) echo "FAIL $line (expected https://... , got a local or unknown model)"; fail=1 ;;
+  esac
+done
+[ "$fail" -eq 0 ] && echo "PASS: qmd models are remote" && exit 0
+echo "FAIL: qmd models are not all remote"
+exit 1


### PR DESCRIPTION
## Summary

- `.qmd/index.yml` pinned `models.embed/generate/rerank` to `hf:` local models. This qmd build (2.6.3 at 02c8dcb) refuses local models, so the librarian `query` job for this repo exited 3 (`Local models are disabled ... generate role`) and `aqmd up` could not embed here; the yml beats `QMD_*_MODEL` env (`qmd/src/llm.ts:292`). The three lines now match the Development root (`/Volumes/ThunderBolt/Development/.qmd/index.yml:578-581`) and the 53 other repos already on the https form. Reported by the qmd session on 2026-08-28 while clearing the librarian queue.

## Verification

- Done-means: scripts/done-means/qmd-models-remote.sh

`bash scripts/done-means/qmd-models-remote.sh` judges the three `models.*` lines of `.qmd/index.yml`: exit 1 against origin/main `ed85531e` content (three `hf:` pins, the RED receipt, taken on a scratch copy of that blob), exit 0 on this branch at `493aa3f2`. On this branch: `qmd doctor` prints `device mode: remote - models run on the configured server; no local llama backend` with no "set but ignored" line, and `aqmd up` from the root checkout exits 0 (output in the PR comment).

- [x] Relevant Open Brain tests/typecheck/migrations passed — no TypeScript is staged; the pre-commit gate reports lint/typecheck skipped, the pre-push gate runs the Bun suite in the clone that pushes.
- [x] Python package checks passed or are not applicable — not applicable.
- [x] Live Open Brain smoke passed or is not applicable — not applicable, search-index configuration only.

## Critical Self-Review

- Highest-risk behavior: every `aqmd` query and `aqmd up` in this repo now reaches `https://llama-swap.rodaddy.live/v1`; when that ingress shows its ~1-minute 503 windows (HANDOVER-RULES rule 18) a query fails instead of running locally. That is already the state of the other 53 repos.
- Assumptions that could be wrong: that the three model names (`embed-gemma`, `qmd-query-expansion`, `rerank-qwen3`) are served by llama-swap; they are copied from the Development root, which is running.
- Missing/weak tests: none executable in-repo; the receipt is `qmd doctor` and `aqmd up` exit 0.
- Security/permission risk: none; no token, no auth path.
- Migration/deploy risk: none.
- Downstream client/runtime risk: none; `docs/downstream-rollout.md` classifies this as not applicable.
- Rollback/cleanup concern: a plain revert restores the `hf:` pins, which this qmd build refuses anyway.
- Fixes made before PR: none.
- Known residual risk: the `_DOCS/_handover/` and `docs/sme/entries/` allowlist gap (#937) is untouched by this change.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: tool configuration, no review pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: search-index configuration only.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched.
