### PR TITLE
docs(handover): session 13 re-probed after #960, the repo-local .qmd retirement and the landed Development wip branch

### DIFF
--- a/_DOCS/_handover/2026-08-28-pg-tests-session13.md
+++ b/_DOCS/_handover/2026-08-28-pg-tests-session13.md
@@ -19,19 +19,20 @@ Read /Volumes/ThunderBolt/Development/_DOCS/HANDOVER-BASE.md in full
   merge pass appended to scripts/done-means/beta-receipts.md.
 
 ## State 1 — ORIENT
-- `origin/main` is `f93a16a0` (#957); session 12 merged #956 (issue 951, one `expectDefined` util) and #957 (append-session-event split, nine files, original retired) — MERGED (`git log --oneline origin/main -1`)
+- `origin/main` is `3a44eece` (#960); session 12 merged #956 (issue 951, one `expectDefined` util), #957 (append-session-event split, nine files, original retired), #958 (this handover, rules 58-61), #959 (qmd model pins to the fleet llama-swap) and #960 (repo-local `.qmd/` retired) — MERGED (`git log --oneline origin/main -1`)
+- `.qmd/` is untracked and gitignored; aqmd resolves this repo from the Development catalogue `/Volumes/ThunderBolt/Development/.qmd/index.yml` (open-brain card at :2879); `scripts/done-means/qmd-repo-config-retired.sh` judges it; a branch cut from a main older than `3a44eece` restores `.qmd/index.yml` on switch and re-scopes aqmd to an empty config — MERGED (#960) / RUNNING (`aqmd search` and `aqmd up` from the root → exit 0)
 - No `*.test.ts` on origin/main self-skips on a database var: the four `describe.skip|skipIf` hits are comment-only plus `tests/enforcement.test.ts:301`, a lint-config guard — RUNNING (`git grep -l 'describe.skip\|skipIf' origin/main -- '*.test.ts'` → 4; each read)
 - Zero code-line `process.env.OPENBRAIN_TEST_DATABASE_URL` reads outside `scripts/test-support/` — RUNNING (`git grep -n 'process.env.OPENBRAIN_TEST_DATABASE_URL' origin/main -- '*.test.ts' | rg -v 'scripts/test-support/' | rg -v ':\s*(//|\*)'` → 0 lines); the #878 plan's literal done-means (`rg -l 'OPENBRAIN_TEST_DATABASE_URL' --glob '*.test.ts'` → 0) still lists 34 files because comments and header docs name the variable
 - Manifest: `append_session_event create_if_missing (live Postgres)` at `scripts/assert-db-tests-ran.ts:40` minTests 8, `MIN_TOTAL_LIVE_TESTCASES = 332` at :520 — MERGED (#957)
 - Head re-ran on origin/main f93a16a0: `CHANGED_FILES=src/tools/__tests__/append-session-event.pg.test.ts bash scripts/done-means/878-pg-tests-require-database.sh` → exit 0, clauses 1-4 PASS — RUNNING
 - `_plans/878-append-session-event-split.md` is executed and stays as the record; its Lane 2-8 done-checks were replaced per rule 60 — MERGED (#952) / RUNNING (#957)
 - #951 CLOSED; #937 #924 #915 #912 #888 #878 OPEN; no open PR — RUNNING (`gh issue list --state open`, `gh pr list --state open`)
-- Development `wip/2026-08-27` carries five unmerged commits over Development `origin/main` (graph-mode lane-report clause 4, check-drained ignores .qmd/index.yml, qmd-wrapper temp-workspace refusal and node@24 keg, aqmd root-only rule) — WRITTEN (`git -C /Volumes/ThunderBolt/Development log --oneline origin/main..wip/2026-08-27` → 5)
+- Development `wip/2026-08-27` is merged into Development `origin/main` (`9698cc3d`) — RUNNING (`git -C /Volumes/ThunderBolt/Development merge-base --is-ancestor wip/2026-08-27 origin/main` → exit 0)
 - Reusable, temp: `/Volumes/ThunderBolt/_tmp/open-brain/_scratch/session12/{lane,step,git,diag,plan,drain,scribe}.workflow.js` (`step.workflow.js` is the no-commit step lane, `lane.workflow.js` takes `setupExisting`), `collect.sh <pr> [CHANGED_FILES]`, `common-rules.txt` R1-R9 (R7 points at the util), `task-*.txt` briefs, `snap-step6/`, `snap-step7/` — WRITTEN
 - Graph mode: converted — RUNNING (`ls scripts/done-means/` has `878-*.sh`, `951-*.sh`, `827-*.sh`)
-- Drain: origin holds `main` plus this docs branch; eleven clones detached at `f93a16a0`, no stash, no extra worktree, only `.qmd/index.yml` drift — RUNNING (`check-drained.sh .` → PASS on the root checkout)
+- Drain: origin holds `main` plus this docs branch; lane-11 detached at `3a44eece`, ten clones at `f93a16a0`, no stash (lane-11 qmd drift archived as `_archive/session12/lane-11-qmd-index-drift.patch`), no extra worktree — RUNNING (`check-drained.sh` → PASS on the root checkout)
 Re-probe before dispatching anything (live state beats this doc):
-- `git log --oneline origin/main -1` → expect f93a16a0 or later with this PR merged
+- `git log --oneline origin/main -1` → expect 3a44eece or later with this PR merged
 - `gh pr list --state open --json number` → empty once this PR merges
 - `rg -n 'MIN_TOTAL_LIVE_TESTCASES =' scripts/assert-db-tests-ran.ts` → 332
 
@@ -62,15 +63,7 @@ Must NOT: edit any file; propose a fix in the comment beyond naming the owning s
 Record: #924 comment
 Done-check: `gh issue view 924 --comments | rg -c 'session 13'` → 1
 
-## State 5 — Development wip/2026-08-27 lands
-Tier: T1 — shared Development tooling (graph-mode checks, check-drained, qmd wrapper)
-Deliverable: one PR from Development `wip/2026-08-27` into Development `main` carrying the five commits, opened by a git lane from a clean clone of Development under `/Volumes/ThunderBolt/_tmp/Development/_worktrees/`, its checks green, merged by the head
-Scope: the Development repo only; the existing branch, no new commits unless a check demands one
-Must NOT: rebase or squash the five commits away; touch `/Volumes/ThunderBolt/Development` working tree (it carries user-owned `.claude/commands/get-on-track.md` untracked); `--no-verify`
-Record: #878 comment with the Development PR number and merge sha
-Done-check: `git -C /Volumes/ThunderBolt/Development log --oneline origin/main..wip/2026-08-27 | wc -l` → 0 after the merge (RED: not yet run)
-
-## State 6 — WAYFINDER
+## State 5 — WAYFINDER
 Close: https://github.com/rodaddy/open-brain/issues/878 — after State 3 merges
 and its check exits 0 on origin/main, the head posts the three plan done-means
 receipts (the new check, `bun run test:isolated` green on origin/main, the
@@ -84,7 +77,9 @@ Invoke the handover-author skill; next handover passes the validator; `aqmd up`.
 
 ## HANDED-OVER UNKNOWNS
 - ratchet-bound: round 42 takes live from 15 to 16 over the rule value 15 (decisions row 6 graduated round 27 for 15); graduating another round or raising the value is Rico's.
-- #937 (aqmd allowlist) was filed from the `.qmd/index.sqlite` view; Rico says the index now lives in Postgres — close or keep is his call.
+- #937 (aqmd allowlist) now points at the Development catalogue card (`/Volumes/ThunderBolt/Development/.qmd/index.yml:2879` lists no `_DOCS/_handover/` or `docs/sme/entries/` pattern); the regen line is on the issue; close or keep is Rico's call.
+- `aqmd research` reads `<repo>/.qmd/references.yml` (`_ob/bin/aqmd:378`); since #960 this repo declares no prior-art clones. The old file is at `58bf1b2a` and `_archive/session12/qmd-references.yml`; where a repo declares references under one store is Rico's call.
+- `_DOCS/STANDARDS-repo-search.md:139` (generated, source-hash 1f45b7a4503e) still says keep `.qmd/index.yml` tracked, and the AGENTS.md sync banner names `sqlite3 .qmd/index.sqlite`; both regenerate from Development `_DOCS/`, Rico's repo.
 - #915: the self-hosted `check` runner's PostgreSQL 17 versus the stack's 18 is a runner change (Rico's); `scripts/local-clone.test.ts` asserts `>= 17` until then.
 - #912: retire-collab-migration intermittent in the full isolated run; unowned.
 - #888 Forge migration — Rico decides when planning starts.


### PR DESCRIPTION
## Summary

- `_DOCS/_handover/2026-08-28-pg-tests-session13.md` re-probed after #960 (repo-local `.qmd/` retired) and after Development `wip/2026-08-27` reached Development `origin/main` (`9698cc3d`, checked with `git merge-base --is-ancestor`). State 1 reads `origin/main` at `3a44eece`, the drain line reflects lane-11 at `3a44eece` with its qmd drift archived, the State that would have opened the Development PR is removed and WAYFINDER is State 5, and three handed-over unknowns follow the retirement (#937 now points at the catalogue card, the prior-art references declaration has no home in this repo, two generated Development docs still describe a tracked `.qmd/index.yml`).

## Verification

- Done-means: scripts/done-means/handover-validates.sh

`bash scripts/done-means/handover-validates.sh` runs the handover-author validator over the handover this branch adds or changes; PASS at 93 lines (validator 2026-08-27.1). Exit grammar: `0` pass, `1` a handover fails the validator, `3` harness error.

- [x] Relevant Open Brain tests/typecheck/migrations passed — documentation only; no TypeScript is staged, the pre-commit gate reports lint/typecheck skipped.
- [x] Python package checks passed or are not applicable — not applicable.
- [x] Live Open Brain smoke passed or is not applicable — not applicable, a handover document.

## Critical Self-Review

- Highest-risk behavior: the incoming session acts on a stale map. Every State 1 line changed here was re-probed this session (`git log --oneline origin/main -1` → 3a44eece; `check-drained.sh` → PASS; `merge-base --is-ancestor` on the Development branch → exit 0).
- Assumptions that could be wrong: that Development `wip/2026-08-27` reaching `origin/main` means its five commits are live there; the ancestor check proves inclusion, not that another session has run the tooling since.
- Missing/weak tests: the validator checks shape, not the truth of the map lines; the re-probe list in State 1 exists for that.
- Security/permission risk: none.
- Migration/deploy risk: none.
- Downstream client/runtime risk: none; `docs/downstream-rollout.md` classifies a handover as not applicable.
- Rollback/cleanup concern: a revert restores the pre-#960 map; nothing else depends on this file.
- Fixes made before PR: none.
- Known residual risk: the ten clones other than lane-11 still sit at `f93a16a0` with qmd-generated `.qmd/index.yml` drift; the next drain detaches them at `3a44eece` after clearing that drift (stash push per file, then archive and drop), which the State 1 drain line names.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: handover document, no review pattern.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: handover document.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched.
