### PR TITLE
test(done-means): 878-program-complete.sh judges the whole program (issue 878)

### DIFF
--- a/scripts/done-means/878-program-complete.sh
+++ b/scripts/done-means/878-program-complete.sh
@@ -40,7 +40,7 @@ BANNED_MACHINERY='describe\.skip|skipIf|dbDescribe'
 # self-skipping this program removes.
 CLAUSE_B_ALLOWED='tests/enforcement.test.ts'
 CLAUSE_C_FILE='src/tools/__tests__/append-session-event.pg.test.ts'
-CLAUSE_C_LOG='/Volumes/ThunderBolt/_tmp/open-brain/_scratch/session13/878-clause-c.log'
+CLAUSE_C_LOG="${OPENBRAIN_SCRATCH:-/Volumes/ThunderBolt/_tmp/open-brain/_scratch}/done-means-878/clause-c.log"
 HARD_FAIL_STRING='test_database_required'
 
 SUBJECT="$(git ls-files -- '*.test.ts' | rg -v '^scripts/test-support/' || true)"

--- a/scripts/done-means/878-program-complete.sh
+++ b/scripts/done-means/878-program-complete.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #878 -- the whole program: every Postgres test
+# demands the test database, none skips itself, and the demand fails loudly.
+#
+#   bash scripts/done-means/878-program-complete.sh
+#
+# Three clauses, all must pass. Subject: tracked `*.test.ts` files outside
+# `scripts/test-support/`, read from the working tree.
+#   A  no code-line `process.env.OPENBRAIN_TEST_DATABASE_URL` read
+#   B  no code-line `describe.skip`, `skipIf`, or `dbDescribe`; the one
+#      allowlisted path is tests/enforcement.test.ts (its `skipIf` guards on
+#      the oxlint config file's presence, not on a database variable)
+#   C  `OPENBRAIN_TEST_DATABASE_URL='' bun test <one pg file>` exits non-zero
+#      and prints `test_database_required`
+# Comment lines (`//`, `/*`, `*`) are exempt in A and B, as in
+# 878-pg-tests-require-database.sh: a converted file's header may still name
+# the variable it demands.
+# Exit 0: all three pass. Exit 1: any clause fails (each hit printed as
+# `<clause> path:line`). Exit 3: harness error, including exit 127 from bun.
+#
+# NO ARGUMENTS. The subject is discovered from `git ls-files`, and the files
+# are read from the WORKING TREE so a deliberate edit is judged before it is
+# ever committed -- which is what makes the RED receipt takeable.
+set -u
+
+cd "$(dirname "$0")/../.." || exit 3
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  printf 'HARNESS-ERROR: not run from a checkout\n' >&2
+  exit 3
+}
+
+command -v rg >/dev/null 2>&1 || { printf 'HARNESS-ERROR: rg not on PATH\n' >&2; exit 3; }
+command -v bun >/dev/null 2>&1 || { printf 'HARNESS-ERROR: bun not on PATH\n' >&2; exit 3; }
+
+ENV_READ='process\.env\.OPENBRAIN_TEST_DATABASE_URL'
+BANNED_MACHINERY='describe\.skip|skipIf|dbDescribe'
+# The single allowlisted clause-B path. `tests/enforcement.test.ts` uses
+# `describe.skipIf(!CONFIG_PRESENT)`, which guards on whether the oxlint
+# config FILE exists -- not on a database variable -- so it is not the
+# self-skipping this program removes.
+CLAUSE_B_ALLOWED='tests/enforcement.test.ts'
+CLAUSE_C_FILE='src/tools/__tests__/append-session-event.pg.test.ts'
+CLAUSE_C_LOG='/Volumes/ThunderBolt/_tmp/open-brain/_scratch/session13/878-clause-c.log'
+HARD_FAIL_STRING='test_database_required'
+
+SUBJECT="$(git ls-files -- '*.test.ts' | rg -v '^scripts/test-support/' || true)"
+if [ -z "$SUBJECT" ]; then
+  printf 'HARNESS-ERROR: git ls-files found no *.test.ts subject\n' >&2
+  exit 3
+fi
+
+A_HITS=""
+B_HITS=""
+while IFS= read -r FILE; do
+  [ -n "$FILE" ] || continue
+  [ -f "$FILE" ] || continue
+  # Comment lines are stripped first, then matches are numbered against the
+  # ORIGINAL file with `rg -n` on the surviving text, so the printed line
+  # numbers are the file's own.
+  CODE="$(rg -n --no-heading '' "$FILE" 2>/dev/null | rg -v '^[0-9]+:[[:space:]]*(//|/\*|\*)' || true)"
+  HIT_A="$(printf '%s\n' "$CODE" | rg "$ENV_READ" | cut -d: -f1 || true)"
+  HIT_B="$(printf '%s\n' "$CODE" | rg "$BANNED_MACHINERY" | cut -d: -f1 || true)"
+  if [ -n "$HIT_A" ]; then
+    A_HITS="$A_HITS$(printf '%s\n' "$HIT_A" | sed "s|^|A $FILE:|")
+"
+  fi
+  if [ -n "$HIT_B" ] && [ "$FILE" != "$CLAUSE_B_ALLOWED" ]; then
+    B_HITS="$B_HITS$(printf '%s\n' "$HIT_B" | sed "s|^|B $FILE:|")
+"
+  fi
+done <<EOSUBJ
+$SUBJECT
+EOSUBJ
+
+A_HITS="$(printf '%s' "$A_HITS" | rg -v '^$' || true)"
+B_HITS="$(printf '%s' "$B_HITS" | rg -v '^$' || true)"
+A_COUNT=0
+B_COUNT=0
+[ -n "$A_HITS" ] && A_COUNT="$(printf '%s\n' "$A_HITS" | rg -c '^')"
+[ -n "$B_HITS" ] && B_COUNT="$(printf '%s\n' "$B_HITS" | rg -c '^')"
+[ -n "$A_HITS" ] && printf '%s\n' "$A_HITS"
+[ -n "$B_HITS" ] && printf '%s\n' "$B_HITS"
+
+# ---------------------------------------------------------------------------
+# CLAUSE C -- the demand is OBSERVED failing, not merely arranged in source.
+# ---------------------------------------------------------------------------
+mkdir -p "$(dirname "$CLAUSE_C_LOG")" || exit 3
+OPENBRAIN_TEST_DATABASE_URL='' bun test "$CLAUSE_C_FILE" >"$CLAUSE_C_LOG" 2>&1
+C_STATUS=$?
+if [ "$C_STATUS" -eq 127 ]; then
+  printf 'HARNESS-ERROR: bun exited 127 running %s; see %s\n' "$CLAUSE_C_FILE" "$CLAUSE_C_LOG" >&2
+  exit 3
+fi
+C_SEEN=absent
+rg -qF "$HARD_FAIL_STRING" "$CLAUSE_C_LOG" && C_SEEN=seen
+
+printf 'A: %s\n' "$A_COUNT"
+printf 'B: %s\n' "$B_COUNT"
+printf 'C: exit %s, %s %s\n' "$C_STATUS" "$HARD_FAIL_STRING" "$C_SEEN"
+
+FAILED=""
+[ "$A_COUNT" -ne 0 ] && FAILED="${FAILED}A"
+[ "$B_COUNT" -ne 0 ] && FAILED="${FAILED}B"
+{ [ "$C_STATUS" -eq 0 ] || [ "$C_SEEN" != seen ]; } && FAILED="${FAILED}C"
+
+if [ -z "$FAILED" ]; then
+  printf 'PASS\n'
+  exit 0
+fi
+printf 'FAIL: %s\n' "$FAILED"
+exit 1


### PR DESCRIPTION
## Summary

- Adds `scripts/done-means/878-program-complete.sh`, the executable done-means for the whole issue 878 program. It takes no argv and discovers its own subject, so it answers the question the per-file check cannot: has EVERY Postgres test been converted, or only the ones a branch happened to touch?
- `scripts/done-means/878-pg-tests-require-database.sh` judges the files one lane changed, discovered from that branch's merge-base diff. A branch that converted nothing has an empty diff, and a check scoped to a branch diff reports on nothing. This one enumerates the tree with `git ls-files -- '*.test.ts'` minus `scripts/test-support/`, and reads each file from the WORKING TREE so a deliberate edit is judged before it is ever committed — which is what makes the red receipt takeable without a commit.
- Three clauses, all must pass. **A**: zero code-line `process.env.OPENBRAIN_TEST_DATABASE_URL` reads — the environment read belongs in `scripts/test-support/require-test-database.ts`, not beside the tests it serves. **B**: zero code-line `describe.skip`, `skipIf`, or `dbDescribe`, with the single allowlisted path `tests/enforcement.test.ts`, whose `describe.skipIf(!CONFIG_PRESENT)` (line 301) guards on the oxlint config file's presence rather than on a database variable; the reason sits in a comment beside the allowlist. **C**: the demand is OBSERVED firing rather than merely arranged in source — one pg suite run with the variable emptied must exit non-zero AND print `test_database_required`. Either half alone is satisfiable by accident: a non-zero exit by any unrelated crash, the string by a run that still exited 0.
- Comment lines (`//`, `/*`, `*`) are exempt in A and B, matching the per-file check: a converted file's header still names the variable it demands, and reading prose as machinery would push authors to delete the explanation.
- Exit grammar: 0 all three pass, 1 any clause fails with each hit printed as `<clause> path:line`, 3 harness error. A 127 from bun is a missing runtime and is mapped to 3, never a pass — the failure this whole family of checks exists to avoid is a check that examines nothing and reports success.
- No test file changed and no manifest edit. `scripts/assert-db-tests-ran.ts` is untouched; no `describe()` was renamed, split, or merged.

## Verification

- Done-means: scripts/done-means/878-program-complete.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Run it with `bash scripts/done-means/878-program-complete.sh` from the repo root.

The check is green on `origin/main` by construction — the conversion program has already landed — so the red receipt is a **deliberate miss**. Appending `const dbDescribe = describe.skip;` after the imports of `src/tools/__tests__/append-session-event-share-gate.test.ts` in the working tree made it exit 1 and print `B src/tools/__tests__/append-session-event-share-gate.test.ts:13`. Removing that one line again returned it to exit 0 with `A: 0`, `B: 0`, `C: exit 1, test_database_required seen`, and `git status --short` then listed only the new script. The green receipt was re-taken on the COMMITTED tree after the pre-commit hook ran, and is also exit 0.

`shellcheck scripts/done-means/878-program-complete.sh` exits 0. `bunx tsc --noEmit` exits 0, unchanged. oxlint does not apply to a shell file, and the pre-commit gate reported no staged TypeScript. Python package checks are not applicable: nothing under `python/openbrain-memory/` is touched. A live Open Brain smoke is not applicable: this adds a repository-local shell check with no runtime, transport, schema, or client surface.

## Critical Self-Review

- Highest-risk behavior: clause C shells out to `bun test` and judges the program on one file's exit status and log text. A bun failure for an unrelated reason (a broken import elsewhere in the module graph, a machine without the runtime) would still exit non-zero, so the string match is what keeps a coincidental failure from reading as proof. Exit 127 is separated out and mapped to harness error 3 for exactly that reason.
- Assumptions that could be wrong: that the comment-line exemption is line-shaped. A banned identifier buried mid-expression on a line whose first characters are `//` would be missed. That matches the per-file check's exemption deliberately, and the alternative — parsing TypeScript — is not what a done-means should be.
- Missing/weak tests: the check has no test of its own; its red receipt IS its test, and it was taken by deliberate miss rather than by a naturally failing tree. The allowlist has no negative case proving a SECOND allowlisted path would be rejected, because there is only one and adding a second to test it would defeat the clause.
- Security/permission risk: none. The script reads tracked files and runs the repository's own test runner. It writes one log to the temp workspace, no secrets are read or printed, and it makes no network call.
- Migration/deploy risk: none. No migration, no schema, no runtime change.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md` — no MCP tool, schema, protocol, transport, or Python client surface changes, so rtech-mcps, mcp2cli, and rtech-hermes are unaffected.
- Rollback/cleanup concern: one new file, deletable with no side effects. The clause C log lives at a fixed path under the temp workspace and is overwritten on each run rather than accumulating.
- Fixes made before PR: the first draft numbered its hits by re-deriving line numbers with a `sed` back-reference after stripping comment lines, which would have printed the wrong line. It was rewritten to number with `rg -n` FIRST, then drop comment lines by matching the text after the number, so a printed number is the file's own. The red receipt at `:13` is what confirms it.
- Known residual risk: clause C names one pg file explicitly. If that file is renamed or removed, the clause becomes a harness error rather than silently passing, which is the intended direction, but it does need updating with the file.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this lane adds a check and found no new review-missed pattern; the deliberate-miss receipt convention it exercises is already recorded in the lane contract's Tightenings (round 40).

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or client surface is touched by a repository-local shell check.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or tool schema is involved — this adds a shell check under `scripts/done-means/` only.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Classified not applicable across every downstream row: the change is one new shell script under `scripts/done-means/`. No MCP tool, schema, protocol, transport, auth, namespace, or Python client behavior changes, which is the trigger set `docs/downstream-rollout.md` names.
- Relates to issue 878.
