### PR TITLE
test(ob-backfill): size the growth-scan allowance to the measured runner tail (issue 962)

### DIFF
--- a/scripts/done-means/962-growth-scan-allowance.sh
+++ b/scripts/done-means/962-growth-scan-allowance.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# DONE-MEANS check for issue #962 -- the two growth-shape scans in
+# scripts/ob-backfill.test.ts carry an explicit per-test allowance sized to
+# the measured runner tail instead of bun's 5000 ms default.
+#
+#   bash scripts/done-means/962-growth-scan-allowance.sh
+#
+# Subject: `scripts/ob-backfill.test.ts` in the working tree, or the file
+# named by `SUBJECT_FILE` (how the deliberate-miss receipt is taken).
+#   1  a `const GROWTH_SCAN_ALLOWANCE_MS = <n>;` line exists with n >= 20000
+#   2  the four comment lines directly above it name issue 962 and the
+#      measured value 7637 (ms), so the number is traceable to its measurement
+#   3  exactly two test titles starting with "scans " exist and exactly two
+#      lines pass GROWTH_SCAN_ALLOWANCE_MS as the third `it()` argument.
+#      Prettier owns the call layout: it expands a three-argument `it()` onto
+#      separate lines, so the allowance argument is matched wherever the
+#      formatter puts it rather than at one hand-written column.
+# Exit 0: all three pass. Exit 1: any fails (prints which). Exit 3: harness.
+set -u
+cd "$(dirname "$0")/../.." || exit 3
+SUBJECT_FILE="${SUBJECT_FILE:-scripts/ob-backfill.test.ts}"
+[ -r "$SUBJECT_FILE" ] || { echo "HARNESS ERROR: cannot read $SUBJECT_FILE"; exit 3; }
+
+failed=""
+
+# Clause 1 -- the constant exists and is at least 20000 ms.
+const_line=$(rg -n '^const GROWTH_SCAN_ALLOWANCE_MS = [0-9_]+;$' "$SUBJECT_FILE" | head -1)
+if [ -z "$const_line" ]; then
+  echo "1: FAIL no 'const GROWTH_SCAN_ALLOWANCE_MS = <n>;' line in $SUBJECT_FILE"
+  failed="$failed 1"
+  const_no=""
+else
+  const_no=${const_line%%:*}
+  value=$(printf '%s\n' "$const_line" | sed 's/.*= *//; s/;.*//; s/_//g')
+  if [ "$value" -ge 20000 ] 2>/dev/null; then
+    echo "1: PASS GROWTH_SCAN_ALLOWANCE_MS = $value ms at line $const_no"
+  else
+    echo "1: FAIL GROWTH_SCAN_ALLOWANCE_MS = $value ms, under the 20000 ms floor"
+    failed="$failed 1"
+  fi
+fi
+
+# Clause 2 -- the four lines above it trace the number to its measurement.
+if [ -z "$const_no" ]; then
+  echo "2: FAIL no constant line to read the comment above"
+  failed="$failed 2"
+else
+  start=$((const_no - 4))
+  [ "$start" -lt 1 ] && start=1
+  above=$(sed -n "${start},$((const_no - 1))p" "$SUBJECT_FILE")
+  has962=$(printf '%s\n' "$above" | rg -c '962' || true)
+  has7637=$(printf '%s\n' "$above" | rg -c '7637' || true)
+  if [ "${has962:-0}" -ge 1 ] && [ "${has7637:-0}" -ge 1 ]; then
+    echo "2: PASS the four lines above name issue 962 and the measured 7637 ms"
+  else
+    echo "2: FAIL the four lines above lack 962 and/or 7637 (962=${has962:-0} 7637=${has7637:-0})"
+    failed="$failed 2"
+  fi
+fi
+
+# Clause 3 -- both growth scans are declared with the allowance and close with it.
+scans=$(rg -c '^\s*"scans .*",$|^\s*it\("scans ' "$SUBJECT_FILE" || true)
+closers=$(rg -c '^\s*\}, GROWTH_SCAN_ALLOWANCE_MS\);$|^\s*GROWTH_SCAN_ALLOWANCE_MS,$' "$SUBJECT_FILE" || true)
+if [ "${scans:-0}" -eq 2 ] && [ "${closers:-0}" -eq 2 ]; then
+  echo "3: PASS 2 'scans ' tests, each passing GROWTH_SCAN_ALLOWANCE_MS to it()"
+else
+  echo "3: FAIL expected 2 and 2, got scans=${scans:-0} allowance-args=${closers:-0}"
+  failed="$failed 3"
+fi
+
+if [ -z "$failed" ]; then
+  echo "PASS"
+  exit 0
+fi
+echo "FAIL:$failed"
+exit 1

--- a/scripts/ob-backfill.test.ts
+++ b/scripts/ob-backfill.test.ts
@@ -48,6 +48,12 @@ const GROWTH_RATIO_MAX = 8;
 const TOKEN_DENSE_N = 12_000;
 const URL_DENSE_N = 4_000;
 
+// Per-test allowance for the two growth-shape scans. The self-hosted CI
+// runner measured the URL-dense scan at 5152, 6306, 6697, 6909 and 7637 ms
+// on 2026-08-29 (issue 962) against bun's 5000 ms default; the ratio
+// assertion never failed. About four times the 7637 ms tail.
+const GROWTH_SCAN_ALLOWANCE_MS = 30_000;
+
 const tokenDenseInput = (size: number): string =>
   Array.from({ length: size }, (_, index) => `Ab${index % 10}cd`).join(" ");
 
@@ -296,27 +302,35 @@ describe("ob-backfill sanitize wrapped secrets", () => {
 // The two growth-shape scans get their own describe so each body stays under
 // the length rule.
 describe("ob-backfill sanitize scan growth", () => {
-  it("scans token-dense transcripts, growing about linearly with input size", () => {
-    const small = measureSanitize(tokenDenseInput(TOKEN_DENSE_N));
-    const large = measureSanitize(tokenDenseInput(TOKEN_DENSE_N * 4));
+  it(
+    "scans token-dense transcripts, growing about linearly with input size",
+    () => {
+      const small = measureSanitize(tokenDenseInput(TOKEN_DENSE_N));
+      const large = measureSanitize(tokenDenseInput(TOKEN_DENSE_N * 4));
 
-    expect(small.sanitized).toContain("Ab0cd");
-    expect(large.sanitized).toContain("Ab0cd");
+      expect(small.sanitized).toContain("Ab0cd");
+      expect(large.sanitized).toContain("Ab0cd");
 
-    const ratio = large.elapsedMs / Math.max(small.elapsedMs, 1);
-    expect(ratio).toBeLessThan(GROWTH_RATIO_MAX);
-  });
+      const ratio = large.elapsedMs / Math.max(small.elapsedMs, 1);
+      expect(ratio).toBeLessThan(GROWTH_RATIO_MAX);
+    },
+    GROWTH_SCAN_ALLOWANCE_MS,
+  );
 
-  it("scans URL-dense transcripts, growing about linearly with input size", () => {
-    const small = measureSanitize(urlDenseInput(URL_DENSE_N));
-    const large = measureSanitize(urlDenseInput(URL_DENSE_N * 4));
+  it(
+    "scans URL-dense transcripts, growing about linearly with input size",
+    () => {
+      const small = measureSanitize(urlDenseInput(URL_DENSE_N));
+      const large = measureSanitize(urlDenseInput(URL_DENSE_N * 4));
 
-    expect(small.sanitized).toContain("https://example.com/0");
-    expect(large.sanitized).toContain("https://example.com/0");
+      expect(small.sanitized).toContain("https://example.com/0");
+      expect(large.sanitized).toContain("https://example.com/0");
 
-    const ratio = large.elapsedMs / Math.max(small.elapsedMs, 1);
-    expect(ratio).toBeLessThan(GROWTH_RATIO_MAX);
-  });
+      const ratio = large.elapsedMs / Math.max(small.elapsedMs, 1);
+      expect(ratio).toBeLessThan(GROWTH_RATIO_MAX);
+    },
+    GROWTH_SCAN_ALLOWANCE_MS,
+  );
 });
 
 describe("ob-backfill decision params", () => {


### PR DESCRIPTION
## Summary

- The two growth-shape scans in `scripts/ob-backfill.test.ts` ran under bun's 5000 ms per-test default. On the self-hosted runner the URL-dense scan was measured at 5152, 6306, 6697, 6909 and 7637 ms on 2026-08-29 (issue 962), all four runners idle at the last one; the growth-ratio assertion itself never failed, so the red runs were the default expiring rather than a regression in the scan.
- Both scans now pass an explicit per-test allowance, `GROWTH_SCAN_ALLOWANCE_MS = 30_000`, about four times the 7637 ms tail. The four comment lines above the constant carry the measurement so the number stays traceable to where it came from.
- No assertion and no other constant changed: `GROWTH_RATIO_MAX`, `TOKEN_DENSE_N` and `URL_DENSE_N` are untouched, and the shape assertion is still what decides both tests.
- Prettier expands a three-argument `it()` call onto separate lines, so the pre-commit gate reformatted the two calls; the committed layout is the formatter's, and the done-means matches the allowance argument wherever prettier places it rather than at one hand-written column.

## Verification

- Done-means: scripts/done-means/962-growth-scan-allowance.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Run it with `bash scripts/done-means/962-growth-scan-allowance.sh`. It checks three clauses against `scripts/ob-backfill.test.ts`, or against the file named by `SUBJECT_FILE`: the constant exists and is at least 20000 ms, the four lines directly above it name issue 962 and the measured 7637, and exactly two `"scans "` tests each pass `GROWTH_SCAN_ALLOWANCE_MS` to `it()`.

Receipts, all taken on the committed tree:

- RED, at `origin/main`: `SUBJECT_FILE=<scratch>/962-red.ts bash scripts/done-means/962-growth-scan-allowance.sh` -> exit 1, all three clauses fail (constant absent).
- Deliberate miss: a copy of the committed file with one `GROWTH_SCAN_ALLOWANCE_MS,` argument line deleted -> exit 1, clause 3 alone fails with `scans=2 allowance-args=1`. The check does not pass a file where only one of the two scans carries the allowance.
- GREEN: `bash scripts/done-means/962-growth-scan-allowance.sh` -> exit 0, all three clauses pass.
- `./node_modules/.bin/oxlint --deny-warnings scripts/ob-backfill.test.ts` -> exit 0.
- `bunx tsc --noEmit` -> exit 0.
- `bun run test:isolated scripts/ob-backfill.test.ts` -> 22 pass, 0 fail.
- Pre-push full suite -> 4005 pass, 0 fail.

## Critical Self-Review

- Highest-risk behavior: a per-test allowance that is too generous hides a real slowdown, since a genuinely quadratic scan would now be given 30 s to finish instead of failing at 5 s. The growth-ratio assertion is what catches that class of regression and it is unchanged; the allowance only decides whether the test gets to reach its assertion at all.
- Assumptions that could be wrong: that 7637 ms is the real tail rather than the worst sample seen so far. If the runner degrades further, 30_000 could itself expire. The comment records the five measurements so the next person can re-size from data instead of guessing.
- Missing/weak tests: no test asserts the allowance value itself; the done-means covers that instead, including a floor of 20000 ms so a later edit cannot quietly shrink it back toward the default.
- Security/permission risk: none. Test-only change plus a new read-only shell check; no runtime, auth, namespace, or SQL path is touched.
- Migration/deploy risk: none. No migration, no schema, no service change.
- Downstream client/runtime risk: none per `docs/downstream-rollout.md`. No MCP tool, schema, transport, protocol, or Python client surface changes, so rtech-mcps, mcp2cli, and Hermes are unaffected.
- Rollback/cleanup concern: revert the single commit; nothing else carries state. The scratch files used for the RED and deliberate-miss receipts live under the temp workspace and are not part of the tree.
- Fixes made before PR: the first commit attempt was refused by the pre-commit prettier check, which reformatted the two `it()` calls onto separate lines. That invalidated clause 3, which had been written against the hand-written `}, GROWTH_SCAN_ALLOWANCE_MS);` closer. Clause 3 was rewritten to match the allowance argument in either layout, and RED, the deliberate miss, and GREEN were all re-taken on the formatted file.
- Known residual risk: the pre-push full suite failed once on `backup-restore-live.test.ts` with `Connection terminated unexpectedly` from `pg`. That file is not touched here; it passed 3/3 on its own immediately after, and the full suite passed 4005/0 on the retry. Reported as a load-dependent flake in a live-Postgres drill, not investigated further in this lane.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the prettier interaction is a lane-process lesson for the harvest, not a reviewer-facing code pattern, and no MEDIUM+ code finding came out of this change.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this is a test-only change with no live service surface.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is involved; the change is a per-test allowance in one test file.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Test-only change plus a new done-means script. No MCP tool, schema, transport, or Python client surface is touched, so every downstream row above is not applicable.
