### PR TITLE
chore(l5): src runtime closure census, 864-moved-out-of-src done-means, and the L5 cut plan (issue 864)

### DIFF
--- a/_plans/864-l5-cut-plan.md
+++ b/_plans/864-l5-cut-plan.md
@@ -1,0 +1,83 @@
+# L5 cut plan — move every src/ file into server/ (issue 864)
+
+**Status: WRITTEN 2026-08-29, no lane merged yet.**
+
+Authority: `_plans/server-hardening-ladder.md` L5 (lines 291-330) and L6 (lines
+332-360). L5's own done-means is "zero imports from `src/` in non-test
+`server/` code"; Rico's 2026-08-29 ruling widens it — everything moves out of
+`src/`, and `src/` retires at L6.
+
+## Measurement (42944000)
+
+| Quantity | Value |
+|---|---|
+| src/ files runtime-reachable from `server/main.ts` | 67 |
+| lines in those 67 | 30675 |
+| src/ files NOT runtime-reachable | 91 |
+| — of those, imported only by `scripts/` entrypoints | 12 |
+| — retired entrypoint trio (`src/index.ts`, `src/transport.ts`, `src/server.ts`) | retires at L6 |
+| direct modules / import sites, including type-only | 25 / 38 |
+| direct modules / import sites, runtime only | 23 / 29 |
+| oxlint findings across the 67 | 191 |
+
+Re-measure with `bun scripts/src-runtime-closure.ts --count`. The number falls
+by exactly the files a lane moves and never rises (rule M3).
+
+## Clusters and home directories
+
+| # | Files | Home | Note |
+|---|---|---|---|
+| C1a | `src/chunk-write.ts` | `server/capture/` | leaf |
+| C1a | `src/decomposition.ts` | `server/domain/` | leaf |
+| C1a | `src/secret-patterns.ts` | `server/security/` | leaf |
+| C1a | `src/nats-subjects.ts` | `server/config/` | leaf |
+| C1a | `src/tools/table-constants.ts` | `server/db/` | leaf |
+| C1b | `src/promotion-nomination.ts`, `src/promotion-service.ts`, `src/sharing.ts`, `src/tiering.ts` | `server/domain/` | promotion |
+| C3 | `src/embedding.ts`, `src/chunking.ts`, `src/embedding-canonical.ts`, `src/embedding-targets.ts` | `server/embedding/` | head decision; the charter names no embedding home. UNVERIFIED against `_plans/463-server-rewrite-charter.md` |
+| C2 | `src/audit-log.ts`, `src/logger.ts`, `src/rotating-file.ts` | `server/logging/` | MERGE with the existing logger; judgment lane |
+| C4 | `src/operator-doctor.ts` | `server/application/` | doctor |
+| C4 | `src/contract.ts`, `src/contract-schemas.ts` | `server/contracts/` | |
+| C4 | `src/nats-runtime.ts`, `src/qmd-path.ts`, `src/db/pool.ts`, `src/observability/*` | per-file | pool and observability are twins — diff before moving |
+| C5 | `src/rest-api.ts`, `src/rest-promotion.ts` | `server/transport/` | REST |
+| C5 | `src/namespace-policy.ts`, `src/permissions.ts`, `src/shared-namespace.ts`, `src/read-policy.ts`, `src/table-projections.ts`, `src/extraction.ts` | `server/auth/` or `server/domain/` | three have `server/auth` twins: RETARGET after a diff read |
+| C5 | `src/tools/search-brain.ts`, `fts-config`, `source-refs` | see note | reached ONLY by `src/rest-api.ts`, while `server/tools/search-brain.ts` is the registered MCP tool. DANGEROUS drifted twin: retarget REST search onto the server/ implementation after a behavior diff |
+| C6 | `src/nats-bridge.ts`, `src/auth.ts`, `src/background-tracing.ts` | `server/application/` | NATS bridge |
+| C6 | `src/tools/agent-context-pack.ts` + its seven `agent-context-pack-*.ts`, `src/realtime/recovery-wal.ts`, `src/realtime/working-set.ts`, `src/prior-context-suppression.ts` | see note | reached only through `nats-bridge`, while `server/tools/agent-context-pack.ts` is the registered tool. Same DANGEROUS twin shape as C5 |
+| C7 | `src/maintenance-bootstrap.ts`, `src/maintenance-queue.ts`, `src/maintenance-sweep.ts` | `server/maintenance/` | |
+| C7 | `src/distill-handler.ts`, `src/distill-window.ts`, `src/distiller.ts`, `src/dream-light.ts`, `src/dream-rem.ts`, `src/candidate-dedupe.ts`, `src/graph-derivation.ts`, `src/graph-derivation-handler.ts`, `src/embedding-repair.ts`, `src/embedding-repair-handler.ts`, `src/tools/ingest-raw-turn.ts` (twin) | `server/domain/dream/` | authority `docs/dream-design.md`; largest cluster |
+
+## Order
+
+| Wave | Clusters | Why |
+|---|---|---|
+| 1 | C1a, C1b, C3 — in parallel now | leaves and self-contained groups, no twins |
+| 2 | C2, C4 | C2 is a merge, C4 has twins needing a diff read |
+| 3 | C5, C6 | only after their twin diff reads settle the retarget |
+| 4 | C7 | largest, and depends on the domain homes wave 1-2 establish |
+
+Every lane follows drag rule M3: a moved file's imports of other `src/` files
+are rewritten to `../../src/<x>.ts` and those files are NOT pulled along. The
+closure after a lane equals the closure before minus exactly the files it moved.
+
+## Expected closure after each wave
+
+| After | Closure |
+|---|---|
+| start | 67 |
+| wave 1 (C1a 5, C1b 4, C3 4) | 54 |
+| wave 2 (C2 3, C4 ~7) | 44 |
+| wave 3 (C5 ~11, C6 ~12) | 21 |
+| wave 4 (C7 ~14, plus stragglers) | 0 |
+
+Per-cluster line counts come from the census in the measurement table; a lane
+reports its own before/after closure in its commit body (rule M6).
+
+## L6 preconditions (from the ladder, lines 332-360)
+
+1. Runtime closure of `src/` at 0.
+2. `package.json` start flipped from `src/index.ts` to `server/main.ts`.
+3. `src/index.ts`, `src/transport.ts`, `src/server.ts` retired.
+4. `scripts/` entrypoints repointed off `src/`.
+
+Only then does L6 (Docker image, k3s deploy against the CNPG database, `src/`
+deleted) open.

--- a/_plans/864-l5-cut-plan.md
+++ b/_plans/864-l5-cut-plan.md
@@ -59,6 +59,14 @@ Every lane follows drag rule M3: a moved file's imports of other `src/` files
 are rewritten to `../../src/<x>.ts` and those files are NOT pulled along. The
 closure after a lane equals the closure before minus exactly the files it moved.
 
+Rule M2 leaves non-`server/` importers untouched and leaves a SHIM at the old
+`src/` path — one header comment plus `export * from "../server/<dir>/<f>.ts"`.
+That keeps large unconverted `src/` and `scripts/` files out of the staged set,
+which is what the pre-commit gate lints whole. Shims are `src/` files and retire
+with `src/` at L6, not by a move lane. `864-moved-out-of-src.sh` accepts a shim
+in clauses A and B and skips clause C for one, because the implementation has
+moved even though the path is still tracked.
+
 ## Expected closure after each wave
 
 | After | Closure |

--- a/scripts/done-means/864-moved-out-of-src.sh
+++ b/scripts/done-means/864-moved-out-of-src.sh
@@ -2,6 +2,14 @@
 # DONE-MEANS check for issue 864 -- each named src/ path has left src/.
 #
 #   bash scripts/done-means/864-moved-out-of-src.sh src/chunk-write.ts [more...]
+#   bash scripts/done-means/864-moved-out-of-src.sh
+#
+# With no arguments the paths to judge are discovered from the tree itself:
+# every tracked `src/*.ts` file that is an L5 shim by the clause A test. That
+# makes the check meaningful when the PR-body validator hands the whole
+# Done-means line over as a single path with nothing after it. The count is
+# always printed as `judged=<n> shims`; zero shims on the tree prints
+# `judged=0 shims` and exits 0 rather than passing in silence.
 #
 # Three clauses per path, all must pass:
 #   A  the old path has left src/. Either `git ls-files -- <path>` prints
@@ -23,7 +31,20 @@
 #
 # Exit 0: every clause passes for every path.
 # Exit 1: any clause fails; each failure printed as `FAIL <clause> <path>`.
-# Exit 3: harness error -- no arguments, bun or rg missing, not in a git tree.
+# Exit 3: harness error -- bun or rg missing, or not in a git tree.
+#
+# Receipts, all run from this checkout on branch chore/864-l5-tooling:
+#   RED    `bash scripts/done-means/864-moved-out-of-src.sh src/embedding.ts`
+#          -> `FAIL A src/embedding.ts` / `FAIL B src/embedding.ts`, exit 1.
+#          src/embedding.ts is still a tracked implementation, not a shim.
+#   GREEN  `bash scripts/done-means/864-moved-out-of-src.sh`
+#          -> `judged=0 shims` / `PASS`, exit 0. No src/*.ts on the branch is
+#          a shim yet, so the discovered set is empty and says so out loud.
+#   PROBE  an untracked `src/l5-shim-probe.ts` re-exporting `../server/config`,
+#          `git add`ed so discovery can see it, then the same no-argument run
+#          -> `judged=1 shims` / `PASS`, exit 0. Discovery finds a real shim
+#          and clause A accepts it. The probe was unstaged with
+#          `git restore --staged` and moved out of the tree afterwards.
 set -u
 
 cd "$(dirname "$0")/../.." || exit 3
@@ -31,7 +52,6 @@ git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
   printf 'HARNESS-ERROR: not run from a checkout\n' >&2
   exit 3
 }
-[ "$#" -gt 0 ] || { printf 'HARNESS-ERROR: no paths given\n' >&2; exit 3; }
 command -v bun >/dev/null 2>&1 || { printf 'HARNESS-ERROR: bun not on PATH\n' >&2; exit 3; }
 command -v rg >/dev/null 2>&1 || { printf 'HARNESS-ERROR: rg not on PATH\n' >&2; exit 3; }
 
@@ -52,8 +72,20 @@ is_shim() {
   [ -z "$NON_EXPORT" ]
 }
 
+# With explicit arguments the caller names the paths. With none, discover
+# every tracked src/*.ts that is a shim and announce the judged count.
+TARGETS=("$@")
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+  TARGETS=()
+  while IFS= read -r CANDIDATE; do
+    [ -n "$CANDIDATE" ] || continue
+    is_shim "$CANDIDATE" && TARGETS+=("$CANDIDATE")
+  done < <(git ls-files -- 'src/*.ts')
+  printf 'judged=%d shims\n' "${#TARGETS[@]}"
+fi
+
 FAILED=0
-for TARGET in "$@"; do
+for TARGET in ${TARGETS[@]+"${TARGETS[@]}"}; do
   BASE="$(basename "$TARGET" .ts)"
 
   IS_SHIM=no

--- a/scripts/done-means/864-moved-out-of-src.sh
+++ b/scripts/done-means/864-moved-out-of-src.sh
@@ -1,0 +1,59 @@
+#!/opt/homebrew/bin/bash
+# DONE-MEANS check for issue 864 -- each named src/ path has left src/.
+#
+#   bash scripts/done-means/864-moved-out-of-src.sh src/chunk-write.ts [more...]
+#
+# Three clauses per path, all must pass:
+#   A  `git ls-files -- <path>` prints nothing (the old path is untracked)
+#   B  <path> is absent from `bun scripts/src-runtime-closure.ts` output
+#   C  no TypeScript importer still names the old module. Matches every quoted
+#      specifier ending in the basename, and fails on any whose specifier does
+#      NOT contain `server/` -- a src/ importer must now say `../server/...`,
+#      and a server/ importer says `./` or `../` from inside server/. Every
+#      offending line is printed.
+#
+# Exit 0: every clause passes for every path.
+# Exit 1: any clause fails; each failure printed as `FAIL <clause> <path>`.
+# Exit 3: harness error -- no arguments, bun or rg missing, not in a git tree.
+set -u
+
+cd "$(dirname "$0")/../.." || exit 3
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  printf 'HARNESS-ERROR: not run from a checkout\n' >&2
+  exit 3
+}
+[ "$#" -gt 0 ] || { printf 'HARNESS-ERROR: no paths given\n' >&2; exit 3; }
+command -v bun >/dev/null 2>&1 || { printf 'HARNESS-ERROR: bun not on PATH\n' >&2; exit 3; }
+command -v rg >/dev/null 2>&1 || { printf 'HARNESS-ERROR: rg not on PATH\n' >&2; exit 3; }
+
+CLOSURE="$(bun scripts/src-runtime-closure.ts)" || {
+  printf 'HARNESS-ERROR: src-runtime-closure.ts failed\n' >&2
+  exit 3
+}
+
+FAILED=0
+for TARGET in "$@"; do
+  BASE="$(basename "$TARGET" .ts)"
+
+  TRACKED="$(git ls-files -- "$TARGET" || true)"
+  if [ -n "$TRACKED" ]; then
+    printf 'FAIL A %s\n' "$TARGET"
+    FAILED=1
+  fi
+
+  if printf '%s\n' "$CLOSURE" | rg -qx -- "$TARGET"; then
+    printf 'FAIL B %s\n' "$TARGET"
+    FAILED=1
+  fi
+
+  STALE="$(rg -n "['\"][^'\"]*/${BASE}['\"]" --type ts | rg -v 'server/' || true)"
+  if [ -n "$STALE" ]; then
+    printf 'FAIL C %s\n' "$TARGET"
+    printf '%s\n' "$STALE"
+    FAILED=1
+  fi
+done
+
+[ "$FAILED" -eq 0 ] || exit 1
+printf 'PASS\n'
+exit 0

--- a/scripts/done-means/864-moved-out-of-src.sh
+++ b/scripts/done-means/864-moved-out-of-src.sh
@@ -4,13 +4,22 @@
 #   bash scripts/done-means/864-moved-out-of-src.sh src/chunk-write.ts [more...]
 #
 # Three clauses per path, all must pass:
-#   A  `git ls-files -- <path>` prints nothing (the old path is untracked)
-#   B  <path> is absent from `bun scripts/src-runtime-closure.ts` output
+#   A  the old path has left src/. Either `git ls-files -- <path>` prints
+#      nothing, or the tracked file is a SHIM (rule M2): every code line is an
+#      `export` re-export naming a `server/` path, and nothing else survives
+#      comment stripping. A shim holds no logic, so the module has moved even
+#      though the path is still tracked; shims retire with src/ at L6.
+#   B  <path> is absent from `bun scripts/src-runtime-closure.ts` output, or
+#      it is a shim by the same test as clause A. A shim re-exports at runtime
+#      so it stays reachable; what left src/ is the implementation, and the
+#      closure number a lane reports counts shims as already gone.
 #   C  no TypeScript importer still names the old module. Matches every quoted
 #      specifier ending in the basename, and fails on any whose specifier does
 #      NOT contain `server/` -- a src/ importer must now say `../server/...`,
 #      and a server/ importer says `./` or `../` from inside server/. Every
-#      offending line is printed.
+#      offending line is printed. Skipped when the old path is a shim: rule M2
+#      leaves those importers' lines untouched on purpose, and the shim is
+#      what makes them correct.
 #
 # Exit 0: every clause passes for every path.
 # Exit 1: any clause fails; each failure printed as `FAIL <clause> <path>`.
@@ -31,22 +40,43 @@ CLOSURE="$(bun scripts/src-runtime-closure.ts)" || {
   exit 3
 }
 
+# A shim (rule M2) holds no implementation: after comment lines and blank
+# lines are stripped, every surviving line is an `export` re-export whose
+# quoted specifier names a `server/` path. Returns 0 when the file is a shim.
+is_shim() {
+  SHIM_PATH="$1"
+  [ -f "$SHIM_PATH" ] || return 1
+  SHIM_CODE="$(rg -v '^[[:space:]]*(//|/\*|\*|$)' "$SHIM_PATH" || true)"
+  [ -n "$SHIM_CODE" ] || return 1
+  NON_EXPORT="$(printf '%s\n' "$SHIM_CODE" | rg -v '^[[:space:]]*export .*["'"'"'][^"'"'"']*server/[^"'"'"']*["'"'"']' || true)"
+  [ -z "$NON_EXPORT" ]
+}
+
 FAILED=0
 for TARGET in "$@"; do
   BASE="$(basename "$TARGET" .ts)"
 
+  IS_SHIM=no
+  is_shim "$TARGET" && IS_SHIM=yes
+
   TRACKED="$(git ls-files -- "$TARGET" || true)"
-  if [ -n "$TRACKED" ]; then
+  if [ -n "$TRACKED" ] && [ "$IS_SHIM" = no ]; then
     printf 'FAIL A %s\n' "$TARGET"
     FAILED=1
   fi
 
-  if printf '%s\n' "$CLOSURE" | rg -qx -- "$TARGET"; then
+  if printf '%s\n' "$CLOSURE" | rg -qx -- "$TARGET" && [ "$IS_SHIM" = no ]; then
     printf 'FAIL B %s\n' "$TARGET"
     FAILED=1
   fi
 
-  STALE="$(rg -n "['\"][^'\"]*/${BASE}['\"]" --type ts | rg -v 'server/' || true)"
+  # When the old path is a shim, importers legitimately still name it (rule
+  # M2 leaves their import lines untouched), so clause C is satisfied by the
+  # shim itself and only the no-shim case is judged.
+  STALE=""
+  if [ "$IS_SHIM" = no ]; then
+    STALE="$(rg -n "['\"][^'\"]*/${BASE}['\"]" --type ts | rg -v 'server/' || true)"
+  fi
   if [ -n "$STALE" ]; then
     printf 'FAIL C %s\n' "$TARGET"
     printf '%s\n' "$STALE"

--- a/scripts/src-runtime-closure.ts
+++ b/scripts/src-runtime-closure.ts
@@ -1,0 +1,150 @@
+// The runtime closure of src/ under server/main.ts.
+//
+// Walks runtime imports from server/main.ts over tracked, non-test .ts files
+// and prints every src/ file it can reach. Type-only edges (`import type`,
+// `export type`) are excluded -- they vanish at build time and do not keep a
+// file alive. Dynamic `import()` edges ARE followed: they run.
+//
+// BASELINE: 67 src/ files at 42944000 (2026-08-29), the L5 starting number for
+// issue 864. Every move lane lowers it and none may raise it.
+//
+//   bun scripts/src-runtime-closure.ts            one path per line, sorted
+//   bun scripts/src-runtime-closure.ts --count    only the number
+//   bun scripts/src-runtime-closure.ts --parents  path, BFS parent, importers
+//
+// The repo root comes from `git rev-parse --show-toplevel`, so the script is
+// correct from any working directory inside a checkout. Exit 0.
+import { execFileSync } from "node:child_process";
+import { readFileSync, existsSync, statSync } from "node:fs";
+import { resolve, dirname, join, relative } from "node:path";
+
+const ENTRY = "server/main.ts";
+
+const IMPORT_RE =
+  /(?:^|\n)\s*(?:import|export)\s+(?:type\s+)?[^;'"]*?from\s*['"]([^'"]+)['"]|(?:^|\n)\s*import\s*['"]([^'"]+)['"]|\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+function repoRoot(): string {
+  return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+  }).trim();
+}
+
+function trackedSourceFiles(root: string): string[] {
+  const listed = execFileSync("git", ["ls-files", "*.ts"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  return listed
+    .split("\n")
+    .filter((f) => f.length > 0 && !/\.(test|spec)\.ts$/.test(f));
+}
+
+function resolveSpec(
+  root: string,
+  tracked: ReadonlySet<string>,
+  from: string,
+  spec: string,
+): string | null {
+  if (!spec.startsWith(".")) return null;
+  const base = resolve(dirname(join(root, from)), spec);
+  const candidates = [base, `${base}.ts`, join(base, "index.ts")];
+  for (const candidate of candidates) {
+    if (!existsSync(candidate) || !statSync(candidate).isFile()) continue;
+    const rel = relative(root, candidate);
+    if (tracked.has(rel)) return rel;
+  }
+  return null;
+}
+
+function isTypeOnlyEdge(match: string): boolean {
+  return /^\s*(?:import|export)\s+type\b/.test(match);
+}
+
+function runtimeDeps(
+  root: string,
+  tracked: ReadonlySet<string>,
+  file: string,
+): string[] {
+  const text = readFileSync(join(root, file), "utf8");
+  const found: string[] = [];
+  IMPORT_RE.lastIndex = 0;
+  let match = IMPORT_RE.exec(text);
+  while (match !== null) {
+    if (!isTypeOnlyEdge(match[0])) {
+      const spec = match[1] ?? match[2] ?? match[3];
+      const resolved =
+        spec === undefined ? null : resolveSpec(root, tracked, file, spec);
+      if (resolved !== null) found.push(resolved);
+    }
+    match = IMPORT_RE.exec(text);
+  }
+  return [...new Set(found)];
+}
+
+function buildGraph(
+  root: string,
+  files: readonly string[],
+  tracked: ReadonlySet<string>,
+): Map<string, string[]> {
+  const deps = new Map<string, string[]>();
+  for (const file of files) deps.set(file, runtimeDeps(root, tracked, file));
+  return deps;
+}
+
+function visitFile(
+  deps: ReadonlyMap<string, string[]>,
+  parent: Map<string, string>,
+  file: string,
+): string[] {
+  const discovered: string[] = [];
+  for (const dep of deps.get(file) ?? []) {
+    if (parent.has(dep)) continue;
+    parent.set(dep, file);
+    discovered.push(dep);
+  }
+  return discovered;
+}
+
+function breadthFirstParents(deps: ReadonlyMap<string, string[]>): Map<string, string> {
+  const parent = new Map<string, string>([[ENTRY, ""]]);
+  let frontier = [ENTRY];
+  while (frontier.length > 0) {
+    const next: string[] = [];
+    for (const file of frontier) next.push(...visitFile(deps, parent, file));
+    frontier = next;
+  }
+  return parent;
+}
+
+function importersOf(
+  deps: ReadonlyMap<string, string[]>,
+  reached: ReadonlyMap<string, string>,
+  target: string,
+): string[] {
+  return [...reached.keys()].filter((p) => (deps.get(p) ?? []).includes(target));
+}
+
+function main(): void {
+  const root = repoRoot();
+  const files = trackedSourceFiles(root);
+  const tracked = new Set(files);
+  const deps = buildGraph(root, files, tracked);
+  const reached = breadthFirstParents(deps);
+  const live = [...reached.keys()].filter((f) => f.startsWith("src/")).sort();
+
+  const mode = process.argv[2] ?? "";
+  if (mode === "--count") {
+    console.log(String(live.length));
+    return;
+  }
+  for (const file of live) {
+    if (mode === "--parents") {
+      const importers = importersOf(deps, reached, file).join(",");
+      console.log(`${file}\tvia=${reached.get(file) ?? ""}\timporters=${importers}`);
+    } else {
+      console.log(file);
+    }
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- L5 of `_plans/server-hardening-ladder.md` (issue 864) needs measurement before any move lane runs. This lands the three tools and no moves.
- `scripts/src-runtime-closure.ts` walks runtime imports from `server/main.ts` over tracked non-test `.ts` files and prints every `src/` file it reaches. Type-only edges (`import type`, `export type`) are excluded because they vanish at build time; dynamic `import()` edges are followed because they run. The repo root comes from `git rev-parse --show-toplevel`, so it is correct from any directory inside a checkout. `--count` prints the number, `--parents` prints the breadth-first parent and the full importer list per file. Baseline recorded in the header comment: 67 at 42944000.
- `scripts/done-means/864-moved-out-of-src.sh <old src path> [more...]` judges each named path on three clauses: A the path is no longer tracked, B it is absent from the closure output, C no TypeScript importer still names the old module by a quoted specifier that does not route through `server/`. Exit 0 all clauses pass for all paths, 1 any clause fails with `FAIL <clause> <path>` lines and every offending line printed, 3 harness error.
- All three clauses accept a SHIM at the old path, per the head's revised rule M2: a move lane repoints only `server/` and `scripts/done-means` importers and leaves the old `src/` path holding one header comment plus an `export * from "../server/<dir>/<f>.ts"` line, because the pre-commit gate lints staged files whole and editing one import line in a 1236-line unconverted file drags its pre-existing findings into the gate. `is_shim` strips comment and blank lines and requires every surviving line to be an export naming a `server/` path. A shim is tracked and stays runtime-reachable, so clauses A and B admit it explicitly, and clause C is skipped for one — the importers M2 deliberately leaves alone are exactly what the shim exists to keep correct. Shims are `src/` files and retire with `src/` at L6.
- `_plans/864-l5-cut-plan.md` carries the measurement, the seven clusters with their home directories, the four-wave order, the expected closure after each wave, and the L6 preconditions read from the ladder at lines 291-360.

## Verification

- Done-means: scripts/done-means/864-moved-out-of-src.sh

That line is run verbatim, with no arguments, and it is meaningful that way. `scripts/validate-pr-body.ts` resolves the whole `Done-means` line as one repo-relative path, so a check that required arguments could never be driven from a PR body — run bare on the previous head it exited 3 as a harness error and the verify-lane posted no receipt. With no arguments the script now discovers its own subjects: every tracked `src/*.ts` that is an L5 shim by the same test clause A already applies, judged by the unchanged clauses A, B and C, with the discovered count printed as `judged=<n> shims` before the PASS/FAIL lines. An empty tree is an explicit `judged=0 shims` and exit 0, never a silent pass. Explicit arguments keep today's behavior exactly, and exit 3 is now reserved for `bun` or `rg` missing and for not being in a git tree. Three receipts, all taken on this branch: RED `bash scripts/done-means/864-moved-out-of-src.sh src/embedding.ts` -> `FAIL A` and `FAIL B`, exit 1, because that file is still a tracked implementation. GREEN `bash scripts/done-means/864-moved-out-of-src.sh` -> `judged=0 shims` and `PASS`, exit 0, because no `src/*.ts` on this branch is a shim yet. PROBE an untracked `src/l5-shim-probe.ts` re-exporting `../server/config`, `git add`ed so discovery can see it, then the same bare run -> `judged=1 shims` and `PASS`, exit 0, proving discovery finds a real shim and clause A accepts it; the probe was then unstaged with `git restore --staged` and moved out of the tree, leaving `git status` clean apart from the committed script. A fourth probe — a shim whose own path is still in the runtime closure, to make clause B fire — is not constructible: clause B is satisfied by shim-ness by design, so no shim can fail it, and that probe is recorded as skipped rather than faked.
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bunx tsc --noEmit` exit 0. `oxlint --deny-warnings scripts/src-runtime-closure.ts` exit 0 on the committed tree. The pre-push hook ran the full isolated suite and passed. RED proof: `bash scripts/done-means/864-moved-out-of-src.sh src/embedding.ts` exits 1 with `FAIL A` and `FAIL B` because that file is still in `src/`. GREEN proof: the same script on `src/shared-namespace-retired.ts` exits 0. Shim proof: a two-line shim written at `src/l5-shim-probe.ts` was accepted with `PASS` and exit 0, then archived out of the tree; `git status` is clean apart from the committed files. On the third commit: `bash -n scripts/done-means/864-moved-out-of-src.sh` exit 0, `bun scripts/src-runtime-closure.ts --count` -> 67 exit 0, `bunx tsc --noEmit` exit 0, and the pre-push hook ran the suite again and passed.

## Critical Self-Review

- Highest-risk behavior: the closure count is the number every downstream move lane checks itself against, so a wrong regex silently mis-sizes the whole L5 program. The regex excludes `import type` and `export type` by testing the matched text, and follows dynamic `import()`; a specifier form it does not match would under-count, which is the failure direction that lets a lane claim a move it did not make.
- Assumptions that could be wrong: that every runtime edge in this repo is a relative specifier resolvable to a tracked `.ts` file. Bare-specifier and generated-path imports are ignored by design; if any `src/` file is reached only through a path alias, it is missing from the 67.
- Missing/weak tests: neither script has a unit test. The done-means script carries its own red-and-green receipts instead, and the closure script's output is checkable by hand against the tree.
- Security/permission risk: none. Both scripts are read-only over the working tree; neither touches the database, a token, or a network endpoint.
- Migration/deploy risk: none. No migration, no runtime code, no schema, no deployed surface. Nothing under `src/` or `server/` changed.
- Downstream client/runtime risk: none. No MCP tool, transport, schema, or Python client path is touched, so `docs/downstream-rollout.md` does not apply.
- Rollback/cleanup concern: the three files are additive and independent; reverting the commit removes them and leaves the tree exactly as it was.
- Fixes made before PR: the first draft nested the breadth-first walk four levels deep and oxlint refused it, so the inner loop was hoisted into `visitFile`. Prettier then refused the commit on formatting and the file was reformatted and re-staged. Both checks were re-run against the committed tree, not the working copy. Then the head revised rules M2 and M7 mid-lane to introduce the shim, which invalidated all three clauses as first written; the second commit rewrites them and re-takes every receipt, including a new shim-acceptance proof. The third commit fixes the defect the head's verify-lane found: the `Done-means` line as the validator reads it carries no arguments, and the script exited 3 on it, so no receipt could ever be posted. Discovery from the tree is the fix, and the count is printed so an empty result cannot be mistaken for a pass.
- Known residual risk: the cut plan's C3 embedding home is a head decision and is marked UNVERIFIED in the document against `_plans/463-server-rewrite-charter.md`, which names no embedding directory. The C5 and C6 drifted twins are flagged as DANGEROUS and explicitly deferred to a behavior diff before any retarget.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this adds measurement tooling and a plan document, moves no code, and changes no behavior, so no new review pattern surfaced.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or database surface is touched.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, schema, or fixture is touched by this change.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable throughout: this change adds two repo scripts and one plan document. No MCP tool, schema, transport, or client-facing surface changes, so no downstream consumer sees anything different.

