### PR TITLE
refactor(l5): move table-projections from src/ into server/domain (issue 864)

### DIFF
--- a/server/domain/table-projections.ts
+++ b/server/domain/table-projections.ts
@@ -1,0 +1,14 @@
+import type { Table } from "../../src/types.ts";
+
+export const TABLE_COLUMNS: Record<Table, string> = {
+  thoughts:
+    "id, content, tags, source, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, source_refs, namespace, promoted_from",
+  decisions:
+    "id, title, rationale, alternatives, context, tags, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, source_refs, namespace, promoted_from",
+  relationships:
+    "id, person_name, context, relationship_type, warmth, email, phone, tags, metadata, source_refs, created_by, created_at, tier, usefulness_score, access_count, namespace, promoted_from",
+  projects:
+    "id, name, status, description, metadata, source_refs, tags, created_by, created_at, tier, usefulness_score, access_count, namespace, promoted_from",
+  sessions:
+    "id, session_id, project, summary, tags, blockers, next_steps, key_decisions, source_refs, created_by, created_at, updated_at, tier, namespace, promoted_from",
+};

--- a/src/table-projections.ts
+++ b/src/table-projections.ts
@@ -1,14 +1,2 @@
-import type { Table } from "./types.ts";
-
-export const TABLE_COLUMNS: Record<Table, string> = {
-  thoughts:
-    "id, content, tags, source, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, source_refs, namespace, promoted_from",
-  decisions:
-    "id, title, rationale, alternatives, context, tags, created_by, created_at, updated_at, tier, usefulness_score, access_count, last_accessed_at, extracted_metadata, source_refs, namespace, promoted_from",
-  relationships:
-    "id, person_name, context, relationship_type, warmth, email, phone, tags, metadata, source_refs, created_by, created_at, tier, usefulness_score, access_count, namespace, promoted_from",
-  projects:
-    "id, name, status, description, metadata, source_refs, tags, created_by, created_at, tier, usefulness_score, access_count, namespace, promoted_from",
-  sessions:
-    "id, session_id, project, summary, tags, blockers, next_steps, key_decisions, source_refs, created_by, created_at, updated_at, tier, namespace, promoted_from",
-};
+// L5 shim (issue 864): moved to server/domain/table-projections.ts; retired with src/ at L6.
+export * from "../server/domain/table-projections.ts";


### PR DESCRIPTION
## Summary

- L5 of issue 864: moves `src/table-projections.ts` to `server/domain/table-projections.ts`. Its import of `src/types.ts` is rewritten relative (`../../src/types.ts`) per rule M3; `types.ts` is not pulled along and belongs to a later lane.
- The old path becomes an L5 shim per rule M2 (one header comment plus one `export * from` line naming the `server/` path), so both importers — `src/rest-api.ts` and `src/tools/get-entry.ts` — keep their import lines untouched and stay out of the pre-commit gate. The shim retires with `src/` at L6.
- `src/` runtime closure under `server/main.ts`: 67 -> 66, exactly the one file moved.
- Five of the six files this lane was briefed to move stayed in `src/`, each because it fails the `server/` standard that rule M4 requires a moved file to meet whole. `src/read-policy.ts` is blocked by environment keys: its test drives `shared-namespace.ts` through `SHARED_NAMESPACE_CANONICAL`, `SHARED_NAMESPACE_PHYSICAL`, and `SHARED_NAMESPACE_LEGACY`, `server/**/*.ts` forbids `process.env`, and the module owning those keys has not moved yet — M4's stated response is to leave the file in `src/` and name the blocking keys. `src/source-refs.ts`, `src/candidate-dedupe.ts`, `src/distill-window.ts`, and `src/distiller.ts` each carry a test file whose `describe()` block exceeds the 100-line function rule and whose bodies hold 88 non-null assertions between them; clearing those means restructuring the suites, which rule M5 forbids (test bodies, names, and assertions stay identical) and which would reach into `scripts/assert-db-tests-ran.ts`.
- `src/extraction.ts` was left in `src/` as the brief directs: `rg` shows its callers include `scripts/bulk-import.ts` and six legacy `src/` files, so an options-object signature change would drag every one of them into the gate.

## Verification

- Done-means: scripts/done-means/864-moved-out-of-src.sh
- `bash scripts/done-means/864-moved-out-of-src.sh` on the committed tree -> exit 0, `judged=1 shims` / `PASS`. `bunx tsc --noEmit` -> exit 0. `./node_modules/.bin/oxlint --no-ignore --deny-warnings --config .oxlintrc.json server/domain/table-projections.ts src/table-projections.ts` -> exit 0, zero findings. `bun run test:isolated src/tools/__tests__/get-entry.test.ts src/tools/__tests__/get-entry.pg.test.ts` -> exit 0, 10 pass / 0 fail across 2 files, exercising the shim through a real importer. Closure script -> 67 before, 66 after. The pre-push hook ran the full isolated suite and passed.
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

## Critical Self-Review

- Highest-risk behavior: the shim's re-export must expose exactly what the old module did. `table-projections.ts` has one named export (`TABLE_COLUMNS`) and no default export, so `export * from` is complete; a default export would have needed its own line and there is none.
- Assumptions that could be wrong: that `rg` found every importer of the old path. Both hits are static `from "…/table-projections.ts"` imports; a dynamic `import()` built from a computed string would not have matched. `tsc --noEmit` over the whole project at exit 0 is the check that covers the static case.
- Missing/weak tests: `table-projections.ts` has no test file of its own and this PR adds none — it is a single constant map, and a test asserting the literal back would only restate it. The behavioral evidence is the importer suite (`get-entry`) passing through the shim.
- Security/permission risk: none. The file is a column allowlist keyed by a Zod-validated `Table` enum; the move changes neither the keys nor the strings, and no auth or namespace predicate is touched.
- Migration/deploy risk: none. No SQL, no migration, no config. The moved constant is compiled into the same bundle from a different path.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface changes; `docs/downstream-rollout.md` classifies this as not applicable.
- Rollback/cleanup concern: revert is the single commit. The shim is deliberate debt with a named retirement point (L6, when `src/` goes) rather than something to clean up separately.
- Fixes made before PR: five briefed files were moved, found to fail the `server/` standard whole, and reverted to `src/` with their original contents restored from HEAD rather than left half-migrated. `bun install --frozen-lockfile` was run after the pre-commit gate failed closed on a missing prettier.
- Known residual risk: this lane delivers one of six briefed moves, so the C5a cluster is not finished and the four test-blocked files still need a lane briefed to restructure their suites alongside `scripts/assert-db-tests-ran.ts`.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the blocking conditions are already written as rules M4 and M5 in the issue 864 lane rules, and no new review pattern surfaced beyond them.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: this is a pure file move with a re-export shim, no runtime, transport, or data behavior changes.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, schema, or client-facing surface is touched; the pre-push contract parity subset was skipped for exactly that reason.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable throughout: no MCP tool, schema, protocol, or client-facing change. The only exported symbol moved is an internal column allowlist, and the old import path continues to resolve through the shim.
