### PR TITLE
feat(config): parse the env keys the remaining src/ modules read so they can move under server/ (issue 864)

### DIFF
--- a/server/config-src-readers.test.ts
+++ b/server/config-src-readers.test.ts
@@ -1,0 +1,196 @@
+/**
+ * The env keys the remaining non-`server/` modules read, parsed at the door.
+ *
+ * Split into its own file rather than grown onto `server/config.test.ts` for
+ * the same reason #868 split `config-equivalence.test.ts` out: each file stays
+ * under the max-lines rule, so the shared REQUIRED baseline is repeated.
+ *
+ * Every expectation names the reader it mirrors by file and line. The readers
+ * live under `src/`, which `server/` must not import, so a module-private
+ * expression is written out beside its coordinates instead of being called —
+ * an edit to either side then fails a test rather than drifting apart quietly.
+ */
+import { describe, expect, it } from "bun:test";
+import { parseServerConfig } from "./config.ts";
+
+const REQUIRED = {
+  DB_HOST: "db.internal",
+  DB_NAME: "open_brain_test",
+  DB_USER: "open_brain",
+  LOG_FILE: "logs/open-brain.log",
+};
+
+function configFrom(overrides: Record<string, string | undefined> = {}) {
+  const result = parseServerConfig({ ...REQUIRED, ...overrides });
+  if (!result.ok) {
+    throw new Error(`expected valid configuration: ${JSON.stringify(result.issues)}`);
+  }
+  return result.config;
+}
+
+describe("embedding keys — src/embedding.ts", () => {
+  it("defaults to the module constants when every key is unset", () => {
+    const embedding = configFrom().embedding;
+    // `:6-9`, `:36`, `:99-112`.
+    expect(embedding.timeoutMs).toBe(8_000);
+    expect(embedding.dimensions).toBe(768);
+    expect(embedding.model).toBe("gemini-embedding-001");
+    expect(embedding.watchdog.failureThreshold).toBe(2);
+    expect(embedding.watchdog.cooldownMs).toBe(300_000);
+    expect("restartScript" in embedding.watchdog).toBe(false);
+  });
+
+  it("carries a set value through", () => {
+    const embedding = configFrom({
+      EMBEDDING_TIMEOUT_MS: "1200",
+      EMBEDDING_DIMENSIONS: "1536",
+      EMBEDDING_MODEL: "embed-gemma-dense",
+      EMBEDDING_WATCHDOG_FAILURE_THRESHOLD: "5",
+      EMBEDDING_WATCHDOG_COOLDOWN_MS: "0",
+      EMBEDDING_WATCHDOG_RESTART_SCRIPT: "/opt/bounce.sh",
+    }).embedding;
+    expect(embedding.timeoutMs).toBe(1_200);
+    expect(embedding.dimensions).toBe(1_536);
+    expect(embedding.model).toBe("embed-gemma-dense");
+    expect(embedding.watchdog.failureThreshold).toBe(5);
+    // Zero is a legal cooldown: the reader guards `< 0`, not `<= 0` (`:111`).
+    expect(embedding.watchdog.cooldownMs).toBe(0);
+    expect(embedding.watchdog.restartScript).toBe("/opt/bounce.sh");
+  });
+
+  it("falls back on a malformed value instead of rejecting it", () => {
+    // Every reader here answers its default on `NaN` rather than throwing, so
+    // an environment that boots today must still boot.
+    const embedding = configFrom({
+      EMBEDDING_TIMEOUT_MS: "abc",
+      EMBEDDING_DIMENSIONS: "0",
+      EMBEDDING_WATCHDOG_FAILURE_THRESHOLD: "-1",
+      EMBEDDING_WATCHDOG_COOLDOWN_MS: "-1",
+    }).embedding;
+    expect(embedding.timeoutMs).toBe(8_000);
+    expect(embedding.dimensions).toBe(768);
+    expect(embedding.watchdog.failureThreshold).toBe(2);
+    expect(embedding.watchdog.cooldownMs).toBe(300_000);
+  });
+
+  it("keeps `parseInt` semantics rather than `Number` ones", () => {
+    // `parseInt("8000ms", 10)` is 8000 and `parseInt("1e3", 10)` is 1. A
+    // `z.coerce.number()` mirror would answer NaN and 1000 — the second is a
+    // thousand-fold divergence from a live deployment.
+    const embedding = configFrom({
+      EMBEDDING_TIMEOUT_MS: "9000ms",
+      EMBEDDING_DIMENSIONS: "1e3",
+    }).embedding;
+    expect(embedding.timeoutMs).toBe(9_000);
+    expect(embedding.dimensions).toBe(1);
+  });
+
+  it("treats a blank restart script as no restart configured", () => {
+    // `:141` returns early on any falsy value.
+    const embedding = configFrom({
+      EMBEDDING_WATCHDOG_RESTART_SCRIPT: "",
+    }).embedding;
+    expect("restartScript" in embedding.watchdog).toBe(false);
+  });
+});
+
+describe("promotion kill switch — src/promotion-service.ts:235", () => {
+  it("is off when unset", () => {
+    expect(configFrom().promotion.killSwitch).toBe(false);
+  });
+
+  it("is on for exactly `1`", () => {
+    expect(
+      configFrom({ OPENBRAIN_PROMOTION_KILL_SWITCH: "1" }).promotion.killSwitch,
+    ).toBe(true);
+  });
+
+  it("stays off for any other truthy-looking value", () => {
+    // The reader is `=== "1"`, so `true` does NOT stop promotion today.
+    for (const value of ["true", "yes", "on", "0", ""]) {
+      expect(
+        configFrom({ OPENBRAIN_PROMOTION_KILL_SWITCH: value }).promotion.killSwitch,
+      ).toBe(false);
+    }
+  });
+});
+
+describe("mcp audit — readMcpAuditConfig, src/audit-log.ts:134-157", () => {
+  it("defaults to enabled with the constants at `:6-11`", () => {
+    const audit = configFrom().mcpAudit;
+    expect(audit.enabled).toBe(true);
+    expect(audit.retentionDays).toBe(30);
+    expect(audit.cleanupIntervalMs).toBe(60 * 60 * 1_000);
+    expect(audit.writeTimeoutMs).toBe(1_000);
+  });
+
+  it("disables on exactly `0` and stays on otherwise", () => {
+    expect(configFrom({ OPENBRAIN_MCP_AUDIT_ENABLED: "0" }).mcpAudit.enabled).toBe(
+      false,
+    );
+    // Audit is on unless explicitly disabled: an omitted or unrecognized value
+    // must never silently stop the record of who called what.
+    expect(configFrom({ OPENBRAIN_MCP_AUDIT_ENABLED: "false" }).mcpAudit.enabled).toBe(
+      true,
+    );
+  });
+
+  it("carries an in-range value through", () => {
+    const audit = configFrom({
+      OPENBRAIN_MCP_AUDIT_RETENTION_DAYS: "366",
+      OPENBRAIN_MCP_AUDIT_CLEANUP_INTERVAL_MS: "60000",
+      OPENBRAIN_MCP_AUDIT_WRITE_TIMEOUT_MS: "50",
+    }).mcpAudit;
+    expect(audit.retentionDays).toBe(366);
+    expect(audit.cleanupIntervalMs).toBe(60_000);
+    expect(audit.writeTimeoutMs).toBe(50);
+  });
+
+  it("falls back outside the range and on a non-digit value", () => {
+    // `readBoundedInt` tests `/^[0-9]+$/` BEFORE parsing (`:166`), so `1.5` and
+    // `1000ms` fall back here where bare `parseInt` would answer 1 and 1000.
+    const audit = configFrom({
+      OPENBRAIN_MCP_AUDIT_RETENTION_DAYS: "367",
+      OPENBRAIN_MCP_AUDIT_CLEANUP_INTERVAL_MS: "1000ms",
+      OPENBRAIN_MCP_AUDIT_WRITE_TIMEOUT_MS: "1.5",
+    }).mcpAudit;
+    expect(audit.retentionDays).toBe(30);
+    expect(audit.cleanupIntervalMs).toBe(60 * 60 * 1_000);
+    expect(audit.writeTimeoutMs).toBe(1_000);
+  });
+});
+
+describe("doctor — src/operator-doctor.ts", () => {
+  it("has no index path and an unknown node environment when unset", () => {
+    const doctor = configFrom().doctor;
+    // `:433` branches on `!== undefined`, so absent means the doctor's own
+    // default rather than a value chosen here.
+    expect("qmdIndexPath" in doctor).toBe(false);
+    expect(doctor.nodeEnvironment).toBe("unknown");
+    expect(doctor.rotationConfigured).toBe(false);
+  });
+
+  it("carries a set index path through untrimmed, blank included", () => {
+    expect(configFrom({ QMD_INDEX_PATH: "/srv/i.sqlite" }).doctor.qmdIndexPath).toBe(
+      "/srv/i.sqlite",
+    );
+    // Deliberately not blank-as-absent: `:433` sees a present variable.
+    expect(configFrom({ QMD_INDEX_PATH: "" }).doctor.qmdIndexPath).toBe("");
+  });
+
+  it("recognizes only the three node environments at `:649-652`", () => {
+    for (const value of ["production", "development", "test"] as const) {
+      expect(configFrom({ NODE_ENV: value }).doctor.nodeEnvironment).toBe(value);
+    }
+    expect(configFrom({ NODE_ENV: "staging" }).doctor.nodeEnvironment).toBe("unknown");
+  });
+
+  it("reports rotation configured when either variable carries a value", () => {
+    // `:685-686` is an OR over two `Boolean(...)` tests.
+    expect(configFrom({ LOG_MAX_BYTES: "1048576" }).doctor.rotationConfigured).toBe(
+      true,
+    );
+    expect(configFrom({ LOG_MAX_FILES: "5" }).doctor.rotationConfigured).toBe(true);
+    expect(configFrom({ LOG_MAX_BYTES: "" }).doctor.rotationConfigured).toBe(false);
+  });
+});

--- a/server/config.ts
+++ b/server/config.ts
@@ -33,6 +33,17 @@ import {
   type TracingConfigGroup,
 } from "./config/env-groups.ts";
 import {
+  doctorGroup,
+  embeddingGroup,
+  mcpAuditGroup,
+  promotionGroup,
+  srcReaderEnvironmentFields,
+  type DoctorConfigGroup,
+  type EmbeddingConfigGroup,
+  type McpAuditConfigGroup,
+  type PromotionConfigGroup,
+} from "./config/src-readers.ts";
+import {
   readDeployedRevision,
   resolveServerIdentity,
 } from "./transport/server-identity.ts";
@@ -51,6 +62,13 @@ export type {
   SharedNamespaceGroup,
   TracingConfigGroup,
 } from "./config/env-groups.ts";
+export type {
+  DoctorConfigGroup,
+  EmbeddingConfigGroup,
+  EmbeddingWatchdogGroup,
+  McpAuditConfigGroup,
+  PromotionConfigGroup,
+} from "./config/src-readers.ts";
 
 const LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
 const ROLE_NAMES = [
@@ -124,8 +142,7 @@ export const OPTIONAL_SECRET_KEYS = [
  * rather than an omission.
  */
 const optionalSecret = z.preprocess(
-  (value) =>
-    typeof value === "string" && value.trim() === "" ? undefined : value,
+  (value) => (typeof value === "string" && value.trim() === "" ? undefined : value),
   z.string().min(1).optional(),
 );
 const userTokenValue = z
@@ -176,6 +193,10 @@ const environmentSchema = z
     // `process.env`. Declarations and the reasoning behind each parser live in
     // `./config/env-groups.ts`; the readers themselves are rewired by L2b/L2c.
     ...extendedEnvironmentFields,
+    // The keys the remaining non-`server/` modules read. Declared so an L5
+    // move lane can hand the module a value instead of leaving it reaching for
+    // `process.env` behind the door. See `./config/src-readers.ts`.
+    ...srcReaderEnvironmentFields,
   })
   .catchall(z.string().optional());
 
@@ -246,6 +267,10 @@ export interface ServerConfig {
   readonly tracing: TracingConfigGroup;
   readonly captureHealth: CaptureHealthGroup;
   readonly http: HttpConfigGroup;
+  readonly embedding: EmbeddingConfigGroup;
+  readonly promotion: PromotionConfigGroup;
+  readonly mcpAudit: McpAuditConfigGroup;
+  readonly doctor: DoctorConfigGroup;
 }
 
 export interface ConfigIssue {
@@ -283,10 +308,16 @@ function parseUserTokens(environment: Environment): ConfigResult | AuthTokenConf
     if (!key.startsWith("AUTH_TOKEN_USER_") || value === undefined) continue;
     const parsed = userTokenValue.safeParse(value);
     if (!parsed.success) {
-      issues.push({ path: key, message: parsed.error.issues[0]?.message ?? "invalid user token" });
+      issues.push({
+        path: key,
+        message: parsed.error.issues[0]?.message ?? "invalid user token",
+      });
       continue;
     }
-    const clientId = key.slice("AUTH_TOKEN_USER_".length).toLowerCase().replaceAll("_", "-");
+    const clientId = key
+      .slice("AUTH_TOKEN_USER_".length)
+      .toLowerCase()
+      .replaceAll("_", "-");
     configured.push({ ...parsed.data, clientId });
   }
   return issues.length > 0 ? { ok: false, issues } : configured;
@@ -352,9 +383,7 @@ function buildConfig(
     // the whole point of the config boundary: one env read, at the composition
     // root, and no module behind it touching global state.
     nats: parseNatsConfig(parsed as Record<string, string | undefined>),
-    maintenance: parseMaintenanceConfig(
-      parsed as Record<string, string | undefined>,
-    ),
+    maintenance: parseMaintenanceConfig(parsed as Record<string, string | undefined>),
     sharedNamespace: parsed.SHARED_NAMESPACE_CANONICAL,
     search: searchGroup(parsed),
     fts: ftsGroup(parsed),
@@ -367,6 +396,10 @@ function buildConfig(
     tracing: tracingGroup(parsed),
     captureHealth: captureHealthGroup(parsed),
     http: httpGroup(parsed),
+    embedding: embeddingGroup(parsed),
+    promotion: promotionGroup(parsed),
+    mcpAudit: mcpAuditGroup(parsed),
+    doctor: doctorGroup(parsed),
   };
 }
 
@@ -415,6 +448,8 @@ function readDeployStamp(): string | undefined {
 export function loadServerConfig(): ServerConfig {
   const result = parseServerConfig(process.env, readDeployStamp());
   if (result.ok) return result.config;
-  const summary = result.issues.map((issue) => `${issue.path}: ${issue.message}`).join("; ");
+  const summary = result.issues
+    .map((issue) => `${issue.path}: ${issue.message}`)
+    .join("; ");
   throw new Error(`server_configuration_invalid: ${summary}`);
 }

--- a/server/config/src-readers.ts
+++ b/server/config/src-readers.ts
@@ -1,0 +1,224 @@
+/**
+ * The env fields still read by non-`server/` modules, declared here so the
+ * composition root can hand them inward when those modules move under
+ * `server/`.
+ *
+ * Design authority: `_plans/server-hardening-ladder.md` L2 made
+ * `server/config.ts` the single place the environment is parsed, and
+ * `.oxlintrc.json` permits `process.env` only in `server/config.ts` and
+ * `server/main.ts`. Four L5 move lanes stopped because the module they were
+ * moving reads a key the door does not parse. This module widens the door; it
+ * moves nothing, and no `src/` reader is edited.
+ *
+ * WHY THE PARSERS MIRROR THEIR READER RATHER THAN BEING TIDIED. The bar is
+ * start-equivalence, exactly as in `./env-groups.ts`: an environment that boots
+ * the server today must still boot it, with the same values. Every reader below
+ * ignores an unusable value and falls back, so none of these fields rejects.
+ * Turning one into a hard rejection would convert a currently-booting
+ * deployment into `server_configuration_invalid`, which is a behavior change
+ * smuggled in under a typing change.
+ *
+ * WHICH PARSE FUNCTION MATTERS. `src/embedding.ts` uses bare `parseInt`, which
+ * accepts a trailing suffix (`8000ms` is 8000) and rejects exponent notation
+ * (`1e3` is 1). `src/audit-log.ts` uses `readBoundedInt`, which tests
+ * `/^[0-9]+$/` FIRST and so rejects both of those, plus every negative and
+ * fractional value, before applying an inclusive range. They are different
+ * functions and are reproduced separately.
+ *
+ * LAZY READERS. `src/embedding.ts` reads its watchdog keys inside the functions
+ * `watchdogFailureThreshold` (`:99`) and `watchdogCooldownMs` (`:107`), so a
+ * test flipping `process.env` mid-process changes the answer there; the module
+ * constants at `:6-10` and `:36` are read once at import instead. A parse at
+ * the boundary is necessarily the once-at-startup shape. The value and the
+ * default are identical either way, so the consumer lane decides how to thread
+ * it.
+ */
+import { z } from "zod";
+
+/**
+ * A `parseInt`-shaped integer, falling back unless it satisfies `accept`.
+ *
+ * Reproduces `parseInt(raw ?? "<default>", 10)` followed by an
+ * `Number.isNaN(...) || <guard>` test, which is the shape every integer reader
+ * in `src/embedding.ts` uses (`:6`, `:8`, `:99-104`, `:107-112`). Base-10
+ * `parseInt` is NOT `Number`: `8000ms` is 8000 to those readers and must stay
+ * 8000 here, and `1e3` is 1 rather than 1000.
+ *
+ * Absent and blank both take the fallback: `?? "<default>"` covers absent, and
+ * `parseInt("", 10)` is `NaN`, which the reader's own `isNaN` branch already
+ * sends to the fallback.
+ */
+function embeddingInteger(fallback: number, accept: (value: number) => boolean) {
+  return z.preprocess((value) => {
+    if (typeof value !== "string") return fallback;
+    const parsed = Number.parseInt(value, 10);
+    return Number.isNaN(parsed) || !accept(parsed) ? fallback : parsed;
+  }, z.number().int());
+}
+
+/**
+ * An inclusive-range integer parsed the way `readBoundedInt` parses one.
+ *
+ * Mirrors `src/audit-log.ts:159-172` line for line, including the order: the
+ * `/^[0-9]+$/` test runs BEFORE the parse, which is what makes `1.5` and
+ * `1000ms` fall back there instead of becoming 1 and 1000 the way `parseInt`
+ * alone would. A blank value fails that test and falls back too.
+ */
+function boundedInteger(minimum: number, maximum: number, fallback: number) {
+  return z.preprocess((value) => {
+    if (typeof value !== "string" || !/^[0-9]+$/.test(value)) return fallback;
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed < minimum || parsed > maximum) {
+      return fallback;
+    }
+    return parsed;
+  }, z.number().int());
+}
+
+/**
+ * A raw optional string, absent only when the variable itself is absent.
+ *
+ * Deliberately NOT blank-as-absent: `resolveQmdPath` (`src/qmd-path.ts:19`) and
+ * `resolveQmdIndexPath` (`src/operator-doctor.ts:433`) both branch on
+ * `=== undefined` and pass the value through untrimmed, so `QMD_PATH=""` means
+ * an empty path to them rather than the default.
+ */
+const rawOptional = z.string().optional();
+
+/** Exactly `"1"` enables; every other value, absent included, disables. */
+const strictOneFlag = z.preprocess((value) => value === "1", z.boolean());
+
+/** Exactly `"0"` disables; every other value, absent included, enables. */
+const strictZeroDisablesFlag = z.preprocess((value) => value !== "0", z.boolean());
+
+/** Fields added by this rung, merged into `environmentSchema`. */
+export const srcReaderEnvironmentFields = {
+  // embedding — `src/embedding.ts:6-9` (timeout, dimensions), `:36` (model),
+  // `:99-112` (watchdog thresholds), `:140` (restart script). The timeout
+  // guards on NaN only, so a negative value is passed through today; the
+  // dimensions and threshold guards add `<= 0`, and the cooldown guard `< 0`.
+  EMBEDDING_TIMEOUT_MS: embeddingInteger(8_000, () => true),
+  EMBEDDING_DIMENSIONS: embeddingInteger(768, (value) => value > 0),
+  EMBEDDING_MODEL: rawOptional,
+  EMBEDDING_WATCHDOG_FAILURE_THRESHOLD: embeddingInteger(2, (value) => value > 0),
+  EMBEDDING_WATCHDOG_COOLDOWN_MS: embeddingInteger(300_000, (value) => value >= 0),
+  EMBEDDING_WATCHDOG_RESTART_SCRIPT: rawOptional,
+  // promotion — `src/promotion-service.ts:235`, an exact `=== "1"` test.
+  OPENBRAIN_PROMOTION_KILL_SWITCH: strictOneFlag,
+  // mcp audit — `readMcpAuditConfig` (`src/audit-log.ts:134-157`) with the
+  // range constants at `:6-11`. Audit is ON unless explicitly disabled, the
+  // opposite default to tracing: an omitted variable must never silently stop
+  // the record of who called what.
+  OPENBRAIN_MCP_AUDIT_ENABLED: strictZeroDisablesFlag,
+  OPENBRAIN_MCP_AUDIT_RETENTION_DAYS: boundedInteger(1, 366, 30),
+  OPENBRAIN_MCP_AUDIT_CLEANUP_INTERVAL_MS: boundedInteger(
+    60_000,
+    24 * 60 * 60 * 1_000,
+    60 * 60 * 1_000,
+  ),
+  OPENBRAIN_MCP_AUDIT_WRITE_TIMEOUT_MS: boundedInteger(50, 5_000, 1_000),
+  // doctor — `src/operator-doctor.ts:433` (index path), `:649-652` (node env),
+  // `:685-686` (rotation). `QMD_PATH` and `LOG_FILE` are already declared in
+  // `server/config.ts`, so they are not repeated here.
+  QMD_INDEX_PATH: rawOptional,
+  NODE_ENV: rawOptional,
+  LOG_MAX_BYTES: rawOptional,
+  LOG_MAX_FILES: rawOptional,
+} as const;
+
+type SrcReaderEnvironment = z.infer<z.ZodObject<typeof srcReaderEnvironmentFields>>;
+
+/** Default embedding model identifier — `src/embedding.ts:36`. */
+const DEFAULT_EMBEDDING_MODEL = "gemini-embedding-001";
+/** The three values `src/operator-doctor.ts:649-652` recognizes. */
+const KNOWN_NODE_ENVIRONMENTS = ["production", "development", "test"] as const;
+
+export interface EmbeddingWatchdogGroup {
+  /** Consecutive restartable failures before a restart is attempted. */
+  readonly failureThreshold: number;
+  /** Milliseconds between restart attempts. */
+  readonly cooldownMs: number;
+  /** Absent means the watchdog observes and never restarts anything. */
+  readonly restartScript?: string;
+}
+
+export interface EmbeddingConfigGroup {
+  /** Milliseconds a provider call may take before it is abandoned. */
+  readonly timeoutMs: number;
+  /** Vector width, which must match the stored halfvec space. */
+  readonly dimensions: number;
+  /** Provider deployment name, stored in `embedding_model` columns. */
+  readonly model: string;
+  readonly watchdog: EmbeddingWatchdogGroup;
+}
+
+export interface PromotionConfigGroup {
+  /** True stops every promotion — `src/promotion-service.ts:235`. */
+  readonly killSwitch: boolean;
+}
+
+export interface McpAuditConfigGroup {
+  readonly enabled: boolean;
+  readonly retentionDays: number;
+  readonly cleanupIntervalMs: number;
+  readonly writeTimeoutMs: number;
+}
+
+export interface DoctorConfigGroup {
+  /** Absent means the doctor falls back to its own default index path. */
+  readonly qmdIndexPath?: string;
+  /** One of the three known values, or `unknown` for anything else. */
+  readonly nodeEnvironment: (typeof KNOWN_NODE_ENVIRONMENTS)[number] | "unknown";
+  /** Whether either rotation variable carries a non-blank value. */
+  readonly rotationConfigured: boolean;
+}
+
+export function embeddingGroup(parsed: SrcReaderEnvironment): EmbeddingConfigGroup {
+  const restartScript = parsed.EMBEDDING_WATCHDOG_RESTART_SCRIPT;
+  return {
+    timeoutMs: parsed.EMBEDDING_TIMEOUT_MS,
+    dimensions: parsed.EMBEDDING_DIMENSIONS,
+    model: parsed.EMBEDDING_MODEL ?? DEFAULT_EMBEDDING_MODEL,
+    watchdog: {
+      failureThreshold: parsed.EMBEDDING_WATCHDOG_FAILURE_THRESHOLD,
+      cooldownMs: parsed.EMBEDDING_WATCHDOG_COOLDOWN_MS,
+      // Truthiness, not presence: `src/embedding.ts:141` returns early on any
+      // falsy value, so an empty script name configures no restart.
+      ...(restartScript ? { restartScript } : {}),
+    },
+  };
+}
+
+export function promotionGroup(parsed: SrcReaderEnvironment): PromotionConfigGroup {
+  return { killSwitch: parsed.OPENBRAIN_PROMOTION_KILL_SWITCH };
+}
+
+export function mcpAuditGroup(parsed: SrcReaderEnvironment): McpAuditConfigGroup {
+  return {
+    enabled: parsed.OPENBRAIN_MCP_AUDIT_ENABLED,
+    retentionDays: parsed.OPENBRAIN_MCP_AUDIT_RETENTION_DAYS,
+    cleanupIntervalMs: parsed.OPENBRAIN_MCP_AUDIT_CLEANUP_INTERVAL_MS,
+    writeTimeoutMs: parsed.OPENBRAIN_MCP_AUDIT_WRITE_TIMEOUT_MS,
+  };
+}
+
+/**
+ * Doctor coordinates.
+ *
+ * `rotationConfigured` reproduces only the ROTATION half of
+ * `src/operator-doctor.ts:683-686`; the reader ANDs it with
+ * `fileLogConfigured`, which derives from `LOG_FILE` and is already available
+ * as `ServerConfig.logging.file`, so combining the two here would duplicate a
+ * value the consumer already holds.
+ */
+export function doctorGroup(parsed: SrcReaderEnvironment): DoctorConfigGroup {
+  const qmdIndexPath = parsed.QMD_INDEX_PATH;
+  const nodeEnvironment = KNOWN_NODE_ENVIRONMENTS.find(
+    (known) => known === parsed.NODE_ENV,
+  );
+  return {
+    ...(qmdIndexPath !== undefined ? { qmdIndexPath } : {}),
+    nodeEnvironment: nodeEnvironment ?? "unknown",
+    rotationConfigured: Boolean(parsed.LOG_MAX_BYTES) || Boolean(parsed.LOG_MAX_FILES),
+  };
+}


### PR DESCRIPTION
## Summary

- L2 of `_plans/server-hardening-ladder.md` made `server/config.ts` the single place the environment is parsed, and `.oxlintrc.json` permits `process.env` only in `server/config.ts` and `server/main.ts`. Four L5 move lanes stopped there: the module each was moving reads a key the door does not parse, so moving it would have put a `process.env` read behind a rule that forbids one. **This lane widens the door. It moves nothing**, edits no `src/` file, and changes no existing parsed key or default.
- New fields live in `server/config/src-readers.ts`, following the split `server/config/nats.ts` and `server/config/maintenance.ts` already use: `server/config.ts` is under the 500-code-line rule and lands at 450 as it is, so a new section went in its own module rather than onto the end.
- Keys added, each with the same default and coercion its current `src/` reader applies:

| Key | `src/` reader | Default | Coercion |
|---|---|---|---|
| `EMBEDDING_TIMEOUT_MS` | `src/embedding.ts:6-7` | `8000` | `parseInt` base 10; `NaN` falls back, a negative value passes through (the guard is `isNaN` only) |
| `EMBEDDING_DIMENSIONS` | `src/embedding.ts:8-10` | `768` | `parseInt`; `NaN` or `<= 0` falls back |
| `EMBEDDING_MODEL` | `src/embedding.ts:36` | `gemini-embedding-001` | raw string, `??` on absent |
| `EMBEDDING_WATCHDOG_FAILURE_THRESHOLD` | `src/embedding.ts:99-104` | `2` | `parseInt`; `NaN` or `<= 0` falls back |
| `EMBEDDING_WATCHDOG_COOLDOWN_MS` | `src/embedding.ts:107-112` | `300000` | `parseInt`; `NaN` or `< 0` falls back, so `0` is legal |
| `EMBEDDING_WATCHDOG_RESTART_SCRIPT` | `src/embedding.ts:140-141` | absent | raw string, absent when falsy (`:141` returns early) |
| `OPENBRAIN_PROMOTION_KILL_SWITCH` | `src/promotion-service.ts:235` | `false` | exact `=== "1"`; `true`/`yes` do NOT enable |
| `OPENBRAIN_MCP_AUDIT_ENABLED` | `src/audit-log.ts:138` | `true` | exact `!== "0"` — audit is on unless explicitly disabled |
| `OPENBRAIN_MCP_AUDIT_RETENTION_DAYS` | `src/audit-log.ts:139-144` | `30` | `readBoundedInt` 1..366 |
| `OPENBRAIN_MCP_AUDIT_CLEANUP_INTERVAL_MS` | `src/audit-log.ts:145-150` | `3600000` | `readBoundedInt` 60000..86400000 |
| `OPENBRAIN_MCP_AUDIT_WRITE_TIMEOUT_MS` | `src/audit-log.ts:151-156` | `1000` | `readBoundedInt` 50..5000 |
| `QMD_INDEX_PATH` | `src/operator-doctor.ts:433-434` | absent | raw string, branch is `!== undefined`, untrimmed |
| `NODE_ENV` | `src/operator-doctor.ts:649-652` | `unknown` | one of `production`/`development`/`test`, else `unknown`; it was NOT already exposed by `server/config.ts` |
| `LOG_MAX_BYTES`, `LOG_MAX_FILES` | `src/operator-doctor.ts:685-686` | `false` | `Boolean(a) \|\| Boolean(b)` as `doctor.rotationConfigured` |

- `QMD_PATH` (`src/qmd-path.ts:17`) and `LOG_FILE` (`src/operator-doctor.ts:637`) were checked and are **already parsed** by `server/config.ts` (`QMD_PATH` via `server/config/env-groups.ts`, `LOG_FILE` in the base schema), so they are not duplicated. `EMBEDDING_BASE_URL` and `EMBEDDING_API_KEY` were likewise already parsed and are untouched.
- Exposed as `config.embedding` (with a nested `watchdog`), `config.promotion`, `config.mcpAudit`, `config.doctor` — typed, in the sections where they belong.
- **Which parse function matters, and the parsers mirror rather than tidy.** `src/embedding.ts` uses bare `parseInt`, so `9000ms` is 9000 and `1e3` is 1; `src/audit-log.ts` `readBoundedInt` tests `/^[0-9]+$/` *before* parsing, so both of those fall back there. They are reproduced as two separate helpers. Every reader here falls back on an unusable value instead of failing, so no new field rejects: tightening one would turn a currently-booting deployment into `server_configuration_invalid`, a behavior change smuggled in under a typing change.
- **One behavior cannot be reproduced in a pure parse, and is called out here rather than papered over.** `src/embedding.ts` reads its two watchdog integers *lazily*, inside `watchdogFailureThreshold` (`:99`) and `watchdogCooldownMs` (`:107`), so a test that flips `process.env` mid-process changes the answer there. A parse at the composition root is necessarily the read-once-at-startup shape. The default and the coercion are identical either way, so the key is parsed with the same default and the consumer lane decides how to thread it. (`EMBEDDING_MODEL` and the two module constants at `:6-10` are already read once at import, so they have no such gap.)
- `server/config-equivalence.test.ts` was read before touching anything: it drives its assertions from the real readers — importing exported ones (`resolveFtsConfig`, `sharedNamespaceConfig`, `parseAllowedOrigins`, `readMcpTracingConfig`) and writing out module-private expressions beside their file and line — over a fixed `DIVERGENCE_INPUTS` set, so the start-equivalence claim is falsifiable. Every reader it covers lives under `server/`. The readers this lane mirrors live under `src/`, which `server/` must not import, so it needed no change; the equivalent coverage is written out beside its coordinates in the new test file instead.

## Verification

- Done-means: scripts/done-means/864-moved-out-of-src.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

RED, at `origin/main`, with only `server/config.ts` reverted to main's copy: `bun test server/config-src-readers.test.ts` -> `TypeError: undefined is not an object (evaluating 'embedding.timeoutMs')`, the suite failing because the parsed object has no `embedding` section.

GREEN, on the committed tree: `bun run test:isolated server/config.test.ts server/config-equivalence.test.ts server/config-extended.test.ts server/config-src-readers.test.ts server/main.pg.test.ts` -> 113 pass, 0 fail, 355 expect() calls across 5 files. `bunx tsc --noEmit` -> exit 0. `oxlint --deny-warnings --config .oxlintrc.json` on all three staged paths -> exit 0. `bash scripts/done-means/864-moved-out-of-src.sh` -> `judged=14 shims` / `PASS`. Python package untouched; no migration, no schema, no runtime surface changed.

## Critical Self-Review

- Highest-risk behavior: a parser here that silently disagrees with its `src/` reader. When the consumer lane rewires a module to take the injected value, a divergence becomes a live behavior change at the moment of the move rather than at the moment of this PR — so it would land far from its cause. Mitigated by writing each parser against the reader's own parse function and asserting the divergence inputs (`9000ms`, `1e3`, `1.5`, `1000ms`, `-1`, `0`, `""`) rather than only the happy path.
- Assumptions that could be wrong: that `parseInt` versus `/^[0-9]+$/` is the whole of the difference between the two integer families. If a reader has a third behavior I did not read — an implicit trim, a unit suffix handled elsewhere — my mirror is wrong for that input. I read each of the five reader sites in full rather than grepping for the key name, which is the check available without moving anything.
- Missing/weak tests: no test proves the parsed value equals what the live `src/` reader answers on the same input, because `server/` cannot import `src/`. The equivalence is asserted against expressions written out beside their file and line instead, which fails on an edit to this side but not on an edit to the `src/` side. That gap closes when the module moves and the two become one function.
- Security/permission risk: none introduced. No namespace predicate, auth token, or role check is touched. `OPENBRAIN_MCP_AUDIT_ENABLED` was deliberately given the `!== "0"` default-on semantics its reader has, because the failure mode of getting that backwards is silently disabling the record of who called what.
- Migration/deploy risk: none. No field rejects, so no environment that starts the server today stops starting it. Verified by construction — every new parser has a fallback branch and none returns a Zod issue — and by the malformed-value tests, which assert the fallback rather than a throw.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, protocol, or Python client surface changes; `docs/downstream-rollout.md` classifies this as not applicable. The parsed object gains four properties and loses none, so no existing consumer is affected.
- Rollback/cleanup concern: revert of one commit, three files, two of them new. Nothing was deleted and no `src/` reader was edited, so the old path is intact and still the one actually running.
- Fixes made before PR: prettier's reflow of the `NODE_ENV` loop narrowed the inferred element type to `string` and broke the `toBe` overload, caught by re-running `tsc` on the formatted tree rather than the pre-format one; fixed with `as const`. A stray doc comment left over from an earlier draft named a constant that no longer existed and was corrected to describe `KNOWN_NODE_ENVIRONMENTS`.
- Known residual risk: the lazy-read gap named in the Summary. `EMBEDDING_WATCHDOG_FAILURE_THRESHOLD` and `EMBEDDING_WATCHDOG_COOLDOWN_MS` are re-read per call today and would be read once at startup through this config; anything relying on flipping them mid-process would need the consumer lane to keep a lazy accessor. Nothing consumes the new fields yet, so the risk is entirely in the future move, and it is recorded here for the lane that makes it.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: nothing new was learned that a future reviewer of a different PR would need — the one reusable point (mirror the reader's own parse function, `parseInt` and `Number` are not interchangeable) is already the standing rule in `server/config/env-groups.ts`'s header, and this lane followed it rather than discovering it.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: nothing consumes the new fields yet, so no running behavior changes and there is nothing to smoke.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing schema is touched; this is internal config parsing behind the server boundary.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, transport, protocol, or Python client surface changes. The change is confined to `server/config.ts`, a new `server/config/src-readers.ts`, and a new test file.
