### PR TITLE
chore(l5): done-means clause A accepts an L5 adapter beside a shim (issue 864)

### DIFF
--- a/_plans/864-l5-cut-plan.md
+++ b/_plans/864-l5-cut-plan.md
@@ -1,6 +1,8 @@
 # L5 cut plan — move every src/ file into server/ (issue 864)
 
-**Status: WRITTEN 2026-08-29, no lane merged yet.**
+**Status: WRITTEN 2026-08-29. Merged lanes: pull requests #967, #968, #969,
+#970, #971, #972, #973, #974, #975, #976, #978.** (#977, contract and
+contract-schemas, was still open when this line was written.)
 
 Authority: `_plans/server-hardening-ladder.md` L5 (lines 291-330) and L6 (lines
 332-360). L5's own done-means is "zero imports from `src/` in non-test
@@ -67,6 +69,41 @@ with `src/` at L6, not by a move lane. `864-moved-out-of-src.sh` accepts a shim
 in clauses A and B and skips clause C for one, because the implementation has
 moved even though the path is still tracked.
 
+
+## L5 adapters
+
+Some legacy callers use a call form the `server/` version cannot keep. Rule M9
+(head decision 2026-08-29 after lanes 1 and 10) covers them, verbatim:
+
+> M9 ADAPTER (head decision 2026-08-29 after lanes 1 and 10): when a legacy
+> src/ or scripts/ caller uses a call form the server/ version cannot keep (a
+> zero-argument form that reads process.env inside, positional legacy
+> arguments, an options object widened with required env fields), the old src/
+> path becomes an ADAPTER instead of a shim: a file under 60 code lines whose
+> header line is `// L5 adapter (issue 864): legacy call form over
+> server/<dir>/<f>.ts; retired with src/ at L6.`, whose every relative import
+> names a server/ path (node and npm imports allowed), which preserves every
+> legacy export and call form, and which may read process.env itself (it is a
+> src/ file, lint-exempt, retired at L6). The server/ version takes its env
+> values as fields of one options parameter, filled by server/main.ts from
+> config. Done-means clause A accepts an adapter by the same test as a shim:
+> every relative import specifier resolves under server/. closure-count.sh
+> excludes shims and adapters alike (header regex `^// L5 (shim|adapter)`).
+
+Three candidates carry a legacy call form that rule M9 covers:
+
+| Path | Why an adapter and not a shim |
+|---|---|
+| `src/operator-doctor.ts` | zero-argument entrypoint reading env inside |
+| `src/promotion-service.ts` | positional legacy arguments its src/ callers pass |
+| `src/audit-log.ts` | options object the server/ version widens with required env fields |
+
+`scripts/done-means/864-moved-out-of-src.sh` accepts an adapter in clauses A
+and B and skips clause C for one, exactly as it does for a shim. Its
+no-argument discovery reports `judged=<n> shims, <m> adapters` once any adapter
+is on the tree, and a file that declares the M9 header while naming a relative
+specifier outside `server/` is judged and fails clause A with the offending
+line printed, rather than dropping out of the set unseen.
 ## Expected closure after each wave
 
 | After | Closure |

--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -2445,3 +2445,40 @@ exact string, which voids the checker itself rather than merely a receipt.
   layout the formatter owns.
 - Re-take RED, the deliberate miss, and GREEN on the committed tree, not on the
   pre-commit working copy.
+
+
+## [2026-08-29] A self-discovering checker must judge everything that CLAIMS to be in scope
+
+**Severity:** MEDIUM
+**Source:** #979 (issue 864)
+**Scope:** any check that builds its own target set from the tree —
+`scripts/done-means/*.sh`, manifest sweepers, lint discovery
+**Status:** active
+
+### Pattern
+
+`scripts/done-means/864-moved-out-of-src.sh` discovers its targets by testing
+each tracked `src/*.ts` and keeping the ones that pass. Extending it to accept
+an L5 adapter, the first implementation discovered on `is_adapter` — the same
+predicate clause A uses to accept. A probe file that declared the M9 header but
+named a non-`server/` relative specifier therefore failed `is_adapter`, was
+dropped from the target set, and the run printed `judged=19 shims / PASS,
+exit 0`. The malformed file made the check greener, not redder.
+
+The general form: when the discovery filter and the accept test are the same
+predicate, nothing can ever fail. A candidate either satisfies the rule and
+passes, or fails the rule and is not judged.
+
+### Check
+
+- Discovery keys on the DECLARATION (`declares_l5_header`: the file's first
+  line claims to be an adapter), and the accept test keys on the SUBSTANCE
+  (every relative specifier resolves under `server/`). A file that claims the
+  header and breaks the rule is judged and fails `FAIL A` with the offending
+  line printed.
+- When adding a clause to a self-discovering checker, write the probe that
+  SHOULD fail before the one that should pass, and confirm the exit code is 1
+  and the path is named in the output. A silent `PASS` on a deliberately
+  broken fixture is the defect, not a clean run.
+- Ask of any discovery loop: what does a malformed candidate do here — fail, or
+  vanish? Vanishing is the bug.

--- a/docs/sme/entries/2026-08-29-a-self-discovering-checker-must-judge-everything-that-claims-to-be-in-scope.md
+++ b/docs/sme/entries/2026-08-29-a-self-discovering-checker-must-judge-everything-that-claims-to-be-in-scope.md
@@ -1,0 +1,40 @@
+---
+lane: correctness
+order: 104
+---
+
+## [2026-08-29] A self-discovering checker must judge everything that CLAIMS to be in scope
+
+**Severity:** MEDIUM
+**Source:** #979 (issue 864)
+**Scope:** any check that builds its own target set from the tree —
+`scripts/done-means/*.sh`, manifest sweepers, lint discovery
+**Status:** active
+
+### Pattern
+
+`scripts/done-means/864-moved-out-of-src.sh` discovers its targets by testing
+each tracked `src/*.ts` and keeping the ones that pass. Extending it to accept
+an L5 adapter, the first implementation discovered on `is_adapter` — the same
+predicate clause A uses to accept. A probe file that declared the M9 header but
+named a non-`server/` relative specifier therefore failed `is_adapter`, was
+dropped from the target set, and the run printed `judged=19 shims / PASS,
+exit 0`. The malformed file made the check greener, not redder.
+
+The general form: when the discovery filter and the accept test are the same
+predicate, nothing can ever fail. A candidate either satisfies the rule and
+passes, or fails the rule and is not judged.
+
+### Check
+
+- Discovery keys on the DECLARATION (`declares_l5_header`: the file's first
+  line claims to be an adapter), and the accept test keys on the SUBSTANCE
+  (every relative specifier resolves under `server/`). A file that claims the
+  header and breaks the rule is judged and fails `FAIL A` with the offending
+  line printed.
+- When adding a clause to a self-discovering checker, write the probe that
+  SHOULD fail before the one that should pass, and confirm the exit code is 1
+  and the path is named in the output. A silent `PASS` on a deliberately
+  broken fixture is the defect, not a clean run.
+- Ask of any discovery loop: what does a malformed candidate do here — fail, or
+  vanish? Vanishing is the bug.

--- a/scripts/done-means/864-moved-out-of-src.sh
+++ b/scripts/done-means/864-moved-out-of-src.sh
@@ -5,10 +5,14 @@
 #   bash scripts/done-means/864-moved-out-of-src.sh
 #
 # With no arguments the paths to judge are discovered from the tree itself:
-# every tracked `src/*.ts` file that is an L5 shim by the clause A test. That
-# makes the check meaningful when the PR-body validator hands the whole
-# Done-means line over as a single path with nothing after it. The count is
-# always printed as `judged=<n> shims`; zero shims on the tree prints
+# every tracked `src/*.ts` file that is an L5 shim by the re-export test, plus
+# every one whose first line DECLARES the L5 header. A file that claims the
+# header but names a non-server/ relative specifier is therefore judged and
+# fails clause A out loud, rather than being dropped from the set in silence.
+# Discovery makes the check meaningful when the PR-body validator hands the
+# whole Done-means line over as a single path with nothing after it.
+# The count prints as `judged=<n> shims` when no adapter was found, and as
+# `judged=<n> shims, <m> adapters` when at least one was; zero of both prints
 # `judged=0 shims` and exits 0 rather than passing in silence.
 #
 # Three clauses per path, all must pass:
@@ -17,34 +21,54 @@
 #      `export` re-export naming a `server/` path, and nothing else survives
 #      comment stripping. A shim holds no logic, so the module has moved even
 #      though the path is still tracked; shims retire with src/ at L6.
+#      An ADAPTER (rule M9) is accepted the same way: its first line matches
+#      `^// L5 (shim|adapter) \(issue 864\)` AND every relative import or
+#      export specifier it names -- `from "./..."`, `from "../..."`,
+#      `import("../...")` -- resolves under a `server/` path. An adapter keeps
+#      a legacy call form the server/ version cannot, so it holds its own
+#      code; what makes it accepted is that every relative dependency it has
+#      is already under server/. Node and npm specifiers are not relative and
+#      are not judged. Any relative specifier NOT naming server/ fails A and
+#      the offending line is printed.
 #   B  <path> is absent from `bun scripts/src-runtime-closure.ts` output, or
-#      it is a shim by the same test as clause A. A shim re-exports at runtime
-#      so it stays reachable; what left src/ is the implementation, and the
-#      closure number a lane reports counts shims as already gone.
+#      it is a shim or an adapter by the same test as clause A. A shim
+#      re-exports at runtime so it stays reachable, and an adapter keeps a
+#      legacy call form over code that has moved; what left src/ is the
+#      implementation, and the closure number a lane reports counts both as
+#      already gone.
 #   C  no TypeScript importer still names the old module. Matches every quoted
 #      specifier ending in the basename, and fails on any whose specifier does
 #      NOT contain `server/` -- a src/ importer must now say `../server/...`,
 #      and a server/ importer says `./` or `../` from inside server/. Every
-#      offending line is printed. Skipped when the old path is a shim: rule M2
-#      leaves those importers' lines untouched on purpose, and the shim is
-#      what makes them correct.
+#      offending line is printed. Skipped when the old path is a shim or an
+#      adapter: rule M2 and rule M9 leave those importers' lines untouched on
+#      purpose, and the shim or adapter is what makes them correct.
 #
 # Exit 0: every clause passes for every path.
 # Exit 1: any clause fails; each failure printed as `FAIL <clause> <path>`.
 # Exit 3: harness error -- bun or rg missing, or not in a git tree.
 #
-# Receipts, all run from this checkout on branch chore/864-l5-tooling:
+# Receipts, all run from this checkout on branch chore/864-l5-adapter-clause:
 #   RED    `bash scripts/done-means/864-moved-out-of-src.sh src/embedding.ts`
 #          -> `FAIL A src/embedding.ts` / `FAIL B src/embedding.ts`, exit 1.
 #          src/embedding.ts is still a tracked implementation, not a shim.
 #   GREEN  `bash scripts/done-means/864-moved-out-of-src.sh`
-#          -> `judged=0 shims` / `PASS`, exit 0. No src/*.ts on the branch is
-#          a shim yet, so the discovered set is empty and says so out loud.
-#   PROBE  an untracked `src/l5-shim-probe.ts` re-exporting `../server/config`,
-#          `git add`ed so discovery can see it, then the same no-argument run
-#          -> `judged=1 shims` / `PASS`, exit 0. Discovery finds a real shim
-#          and clause A accepts it. The probe was unstaged with
-#          `git restore --staged` and moved out of the tree afterwards.
+#          -> `judged=19 shims` / `PASS`, exit 0. The 19 shims already on main
+#          are unaffected by the adapter clause: none carries the M9 header
+#          and all 19 stay accepted by the re-export test.
+#   PROBE  an untracked `src/l5-adapter-probe.ts` carrying the M9 header line,
+#          `import { x } from "../server/config.ts"`-style lines and one
+#          `export function legacy() {}`, `git add`ed so discovery sees it,
+#          then the no-argument run -> `judged=19 shims, 1 adapters` / `PASS`,
+#          exit 0. Discovery finds the adapter and clause A accepts it.
+#   PROBE  the same file with its second import rewritten to
+#          `from "./logger.ts"` -> `judged=19 shims, 1 adapters`,
+#          `FAIL A src/l5-adapter-probe.ts`, the offending line
+#          `3:import { z } from "./logger.ts";`, exit 1. A relative specifier
+#          that does not name server/ is what the clause exists to reject, and
+#          discovery keeps the file in the judged set so the failure is loud.
+#          Both probes were unstaged with `git restore --staged` and moved out
+#          of the tree afterwards.
 set -u
 
 cd "$(dirname "$0")/../.." || exit 3
@@ -72,17 +96,58 @@ is_shim() {
   [ -z "$NON_EXPORT" ]
 }
 
+# An adapter (rule M9) keeps a legacy call form the server/ version cannot, so
+# unlike a shim it holds its own code. What makes it accepted is dependency
+# direction: its first line declares it, and every RELATIVE specifier it names
+# resolves under server/. Node and npm specifiers are absolute names, not
+# relative, and are not judged. Prints nothing; use adapter_bad_specifiers for
+# the offending lines. Returns 0 when the file is an adapter.
+adapter_bad_specifiers() {
+  rg -n '(from|import\()[[:space:]]*["'"'"']\.[^"'"'"']*["'"'"']' "$1" \
+    | rg -v 'server/' || true
+}
+
+# Returns 0 when the file DECLARES itself an L5 shim or adapter on its first
+# line. Discovery uses this rather than is_adapter so that a file claiming the
+# header but naming a non-server/ relative specifier is judged and fails clause
+# A out loud, instead of being dropped from the set in silence.
+declares_l5_header() {
+  [ -f "$1" ] || return 1
+  head -n 1 "$1" | rg -q '^// L5 (shim|adapter) \(issue 864\)'
+}
+
+is_adapter() {
+  ADAPTER_PATH="$1"
+  declares_l5_header "$ADAPTER_PATH" || return 1
+  [ -z "$(adapter_bad_specifiers "$ADAPTER_PATH")" ]
+}
+
 # With explicit arguments the caller names the paths. With none, discover
-# every tracked src/*.ts that is a shim and announce the judged count.
+# every tracked src/*.ts that is a shim or an adapter and announce the judged
+# counts. Adapters are only reported when at least one was found, so the
+# established `judged=<n> shims` line is unchanged on a shim-only tree.
+SHIM_COUNT=0
+ADAPTER_COUNT=0
 TARGETS=("$@")
 if [ "${#TARGETS[@]}" -eq 0 ]; then
   TARGETS=()
   while IFS= read -r CANDIDATE; do
     [ -n "$CANDIDATE" ] || continue
-    is_shim "$CANDIDATE" && TARGETS+=("$CANDIDATE")
+    if is_shim "$CANDIDATE"; then
+      TARGETS+=("$CANDIDATE")
+      SHIM_COUNT=$((SHIM_COUNT + 1))
+    elif declares_l5_header "$CANDIDATE"; then
+      TARGETS+=("$CANDIDATE")
+      ADAPTER_COUNT=$((ADAPTER_COUNT + 1))
+    fi
   done < <(git ls-files -- 'src/*.ts')
-  printf 'judged=%d shims\n' "${#TARGETS[@]}"
+  if [ "$ADAPTER_COUNT" -gt 0 ]; then
+    printf 'judged=%d shims, %d adapters\n' "$SHIM_COUNT" "$ADAPTER_COUNT"
+  else
+    printf 'judged=%d shims\n' "$SHIM_COUNT"
+  fi
 fi
+
 
 FAILED=0
 for TARGET in ${TARGETS[@]+"${TARGETS[@]}"}; do
@@ -91,13 +156,19 @@ for TARGET in ${TARGETS[@]+"${TARGETS[@]}"}; do
   IS_SHIM=no
   is_shim "$TARGET" && IS_SHIM=yes
 
+  IS_ADAPTER=no
+  [ "$IS_SHIM" = no ] && is_adapter "$TARGET" && IS_ADAPTER=yes
+
   TRACKED="$(git ls-files -- "$TARGET" || true)"
-  if [ -n "$TRACKED" ] && [ "$IS_SHIM" = no ]; then
+  if [ -n "$TRACKED" ] && [ "$IS_SHIM" = no ] && [ "$IS_ADAPTER" = no ]; then
     printf 'FAIL A %s\n' "$TARGET"
+    if head -n 1 "$TARGET" 2>/dev/null | rg -q '^// L5 (shim|adapter) \(issue 864\)'; then
+      adapter_bad_specifiers "$TARGET"
+    fi
     FAILED=1
   fi
 
-  if printf '%s\n' "$CLOSURE" | rg -qx -- "$TARGET" && [ "$IS_SHIM" = no ]; then
+  if printf '%s\n' "$CLOSURE" | rg -qx -- "$TARGET" && [ "$IS_SHIM" = no ] && [ "$IS_ADAPTER" = no ]; then
     printf 'FAIL B %s\n' "$TARGET"
     FAILED=1
   fi
@@ -106,7 +177,7 @@ for TARGET in ${TARGETS[@]+"${TARGETS[@]}"}; do
   # M2 leaves their import lines untouched), so clause C is satisfied by the
   # shim itself and only the no-shim case is judged.
   STALE=""
-  if [ "$IS_SHIM" = no ]; then
+  if [ "$IS_SHIM" = no ] && [ "$IS_ADAPTER" = no ]; then
     STALE="$(rg -n "['\"][^'\"]*/${BASE}['\"]" --type ts | rg -v 'server/' || true)"
   fi
   if [ -n "$STALE" ]; then


### PR DESCRIPTION
## Summary

- Rule M9 lets a legacy `src/` path become an ADAPTER rather than a shim when the caller uses a call form the `server/` version cannot keep. An adapter holds its own code, so the shim re-export test rejects it; clause A of `scripts/done-means/864-moved-out-of-src.sh` needed a second way to accept one.
- `is_adapter`: the file's first line matches `^// L5 (shim|adapter) \(issue 864\)` AND every relative specifier it names -- `from "./..."`, `from "../..."`, `import("../...")` -- resolves under a `server/` path. Node and npm specifiers are not relative and are not judged.
- `adapter_bad_specifiers` prints the offending lines, so a `FAIL A` on a declared adapter names the specifier that broke it instead of just the path.
- `declares_l5_header` drives the no-argument discovery, so a file that claims the M9 header while naming a non-`server/` relative specifier stays in the judged set and fails out loud, rather than dropping out of the set unseen. That was a real defect found by the second probe, not a theoretical one.
- Clauses B and C skip an adapter exactly as they already skip a shim: rule M9 leaves those importers' lines untouched on purpose, and the adapter is what makes them correct.
- The count line stays `judged=<n> shims` on a shim-only tree and becomes `judged=<n> shims, <m> adapters` once any adapter is present. Nothing exported by the script is renamed.
- `_plans/864-l5-cut-plan.md`: new `## L5 adapters` section carrying rule M9 verbatim plus the three candidates (`src/operator-doctor.ts`, `src/promotion-service.ts`, `src/audit-log.ts`), and the stale `no lane merged yet` status replaced with the merged pull requests #967-#976 and #978.
- No `src/` or `server/` file is touched. The 19 shims already on `main` are unaffected -- none carries the M9 header and all 19 stay accepted by the existing re-export test.

## Verification

- Done-means: scripts/done-means/864-moved-out-of-src.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts:

```
bash scripts/done-means/864-moved-out-of-src.sh   (at origin/main, before the change)
  -> judged=19 shims / PASS, exit 0

bash scripts/done-means/864-moved-out-of-src.sh   (committed tree, after the change)
  -> judged=19 shims / PASS, exit 0   -- same set, unchanged

PROBE (accepted): untracked src/l5-adapter-probe.ts, git add-ed so discovery sees it
  // L5 adapter (issue 864): legacy call form over server/config.ts; retired with src/ at L6.
  import { x } from "../server/config.ts";
  import { y } from "../server/logging/logger.ts";
  export function legacy() {}
  -> judged=19 shims, 1 adapters / PASS, exit 0

PROBE (rejected): the same file with its second import rewritten to "./logger.ts"
  -> judged=19 shims, 1 adapters
     FAIL A src/l5-adapter-probe.ts
     3:import { z } from "./logger.ts";
     exit 1

shellcheck scripts/done-means/864-moved-out-of-src.sh -> exit 0
bunx tsc --noEmit -> exit 0
prettier --write _plans/864-l5-cut-plan.md -> exit 0
pre-push hook (full isolated suite) -> passed
```

Both probes were unstaged with `git restore --staged` and moved out of the tree before staging; they live at `{temp_workspace}/open-brain/_scratch/session14/lane-3-probes/`.

## Critical Self-Review

- Highest-risk behavior: widening clause A could accept a `src/` file that has NOT really moved -- the whole point of the check. The accept test is dependency direction, not the header alone: a file must both declare the M9 header and name only `server/` relative specifiers. The rejecting probe proves the second half is what decides.
- Assumptions that could be wrong: `adapter_bad_specifiers` matches `from "..."` and `import("...")` with a leading `.`; a relative specifier reached some other way (a `require()`, a template-literal dynamic import, a re-export written across two physical lines) would not be seen. That is the same shape of assumption the pre-existing shim test already makes, and rule M9 describes adapters as small files under 60 code lines where this does not arise.
- Missing/weak tests: there is no committed automated test for the script -- it is itself the done-means check, and its receipts are the two probes run by hand and recorded in its header. A committed fixture pair would be stronger and is worth doing when a real adapter first lands.
- Security/permission risk: none. The script reads tracked files and runs `rg`, `git ls-files`, and one `bun` script; it writes nothing and takes no credentials.
- Migration/deploy risk: none. No runtime code, no schema, no config. The script runs in CI and by hand only.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface is touched, so `docs/downstream-rollout.md` classifies this as not applicable.
- Rollback/cleanup concern: reverting the commit restores the shim-only clause A exactly; the 19 shims judged today are judged identically before and after, so a revert cannot strand a passing lane. The probe files are outside the repo.
- Fixes made before PR: the first probe run hung, because an adapter left `IS_SHIM=no` and so fell into clause C's whole-tree `rg --type ts` scan. Fixed by skipping clauses B and C for an adapter, matching how a shim is handled. The second probe then passed when it should have failed -- discovery had dropped the malformed file silently. Fixed by discovering on the declared header rather than on a successful adapter test, which is what makes the failure loud.
- Known residual risk: an adapter is accepted on dependency direction, not on being small or on genuinely preserving the legacy call form. Rule M9's under-60-code-lines and preserves-every-legacy-export conditions are reviewer-enforced, not machine-checked, and this change does not add that.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because: a discovery filter that drops a malformed candidate instead of failing it turns a check silently green -- the second probe passed for the wrong reason until discovery keyed on the declared header rather than on the successful test, and the general form is that a self-discovering checker must judge everything that CLAIMS to be in scope, never only what already satisfies the rule.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, schema, or service surface changes -- a shell check script and a plan document.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing surface is touched.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, transport, event vocabulary, or Python client surface changes. The diff is `scripts/done-means/864-moved-out-of-src.sh` and `_plans/864-l5-cut-plan.md` only.
