### PR TITLE
refactor(l5): move operator-doctor from src/ into server/application behind an L5 adapter (issue 864)

### DIFF
--- a/server/application/operator-doctor-probes.ts
+++ b/server/application/operator-doctor-probes.ts
@@ -1,0 +1,458 @@
+/**
+ * The individual diagnostic probes the doctor fans out over.
+ *
+ * Split out of `./operator-doctor.ts` (issue 864) by responsibility: this file
+ * asks the questions (database, migrations, audit storage, distillation lag,
+ * embedding provider, qmd binary and index), and `./operator-doctor.ts`
+ * assembles the answers into the frozen payload. Every probe here is
+ * self-contained and takes what it needs as an argument.
+ */
+import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type pg from "pg";
+import { embeddingBaseUrl, embeddingApiKey } from "../../src/embedding.ts";
+import { readMcpAuditConfig } from "../../src/audit-log.ts";
+import { resolveQmdPath } from "../../src/qmd-path.ts";
+import { logger } from "../../src/logger.ts";
+import { describeError } from "../../src/observability/index.ts";
+import type { QmdIndexProbeResult } from "../../src/qmd-index-probe-worker.ts";
+import {
+  classifyDistillationLag,
+  OPTIONAL_TIMEOUT_MS,
+  QMD_INDEX_STALE_AFTER_HOURS,
+  type OperatorDoctorBuildOptions,
+  type OperatorDoctorStatus,
+} from "./operator-doctor-types.ts";
+
+const MIGRATIONS_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "db",
+  "migrations",
+);
+const DEFAULT_QMD_INDEX_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  ".qmd",
+  "index.sqlite",
+);
+const PACKAGE_JSON_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "package.json",
+);
+
+let cachedServiceVersion: string | null = null;
+
+/** Test seam: the version is read once per process and memoized. */
+export function resetCachedServiceVersion(): void {
+  cachedServiceVersion = null;
+}
+
+export async function readServiceVersion(fallback: string): Promise<string> {
+  if (cachedServiceVersion !== null) return cachedServiceVersion;
+  try {
+    const pkg = (await Bun.file(PACKAGE_JSON_PATH).json()) as {
+      version?: unknown;
+    };
+    cachedServiceVersion =
+      typeof pkg.version === "string" && pkg.version.length > 0
+        ? pkg.version
+        : fallback;
+  } catch (error) {
+    // Falling back to the caller's value is fine; reporting "unknown" as if it
+    // were the answer is not. A doctor that cannot read its own package.json is
+    // telling the operator something about its deployment.
+    cachedServiceVersion = fallback;
+    logger.warn("doctor_service_version_unreadable", {
+      fallback: cachedServiceVersion,
+      ...describeError(error),
+    });
+  }
+  return cachedServiceVersion;
+}
+
+export async function withTimeout<T>(
+  task: Promise<T>,
+  fallback: T,
+  timeoutMs = OPTIONAL_TIMEOUT_MS,
+): Promise<T> {
+  // Absorb late rejections: if the timeout wins the race, a subsequent
+  // rejection of the abandoned task must not surface as an unhandled
+  // rejection. Absorbing it is right; discarding it was not -- a probe that
+  // always loses the race and always rejects reported its fallback forever
+  // with nothing anywhere saying why.
+  task.catch((error: unknown) => {
+    logger.debug("doctor_probe_late_rejection", describeError(error));
+  });
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      task,
+      new Promise<T>((resolve) => {
+        timeout = setTimeout(() => resolve(fallback), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+/**
+ * Is an HTTP endpoint answering OK? Exported because `/health` in `src/index.ts`
+ * asks the same question of the same provider and had its own byte-identical
+ * private copy -- including the bare `catch { return false }` this one no longer
+ * has. A REST sibling drifting from the module that owns the logic is the exact
+ * shape of the PR #277 failure recorded in docs/sme/correctness.md:475, so the
+ * two call sites now share one implementation instead of two.
+ *
+ * Reports only a boolean by design; which of DNS failure, refused connection,
+ * or timeout it was goes to the log, because that is the whole diagnosis.
+ *
+ * `timeoutMs` is a parameter rather than a shared constant because the two
+ * callers genuinely differ and neither should silently inherit the other's
+ * value: the doctor allows 2s for an optional-dependency probe, `/health`
+ * allowed 3s. Sharing the implementation must not quietly change either one.
+ */
+export async function probeUrl(
+  url: string,
+  headers: Record<string, string>,
+  timeoutMs = OPTIONAL_TIMEOUT_MS,
+): Promise<boolean> {
+  try {
+    const resp = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!resp.ok) {
+      // A reachable endpoint answering 401 or 503 is a different problem from
+      // an unreachable one, and `false` says neither.
+      logger.debug("doctor_probe_not_ok", {
+        status: resp.status,
+        timeout_ms: timeoutMs,
+      });
+    }
+    return resp.ok;
+  } catch (error) {
+    // DNS failure, connection refused, or the timeout firing. The caller gets
+    // only a boolean by design; which of the three it was belongs in the log,
+    // because that is the whole diagnosis.
+    logger.debug("doctor_probe_failed", {
+      timeout_ms: timeoutMs,
+      ...describeError(error),
+    });
+    return false;
+  }
+}
+
+function unknownMigrationStatus(
+  expectedCount: number,
+  latestExpected: string | null,
+): OperatorDoctorStatus["migrations"] {
+  return {
+    status: "unknown",
+    applied_count: null,
+    expected_count: expectedCount,
+    pending_count: null,
+    latest_applied: null,
+    latest_expected: latestExpected,
+  };
+}
+
+export async function readMigrationStatus(
+  pool: pg.Pool,
+): Promise<OperatorDoctorStatus["migrations"]> {
+  let files: string[];
+  try {
+    files = (await readdir(MIGRATIONS_DIR)).filter((f) => f.endsWith(".sql")).sort();
+  } catch (error) {
+    // Never let a filesystem error propagate: thrown messages can carry raw
+    // paths into MCP tool error text or Express error pages. That rule governs
+    // the *response*; the log is where the operator is allowed to learn that
+    // the migrations directory is missing from the deployment entirely, which
+    // "status: unknown" on its own never said.
+    logger.error("doctor_migrations_dir_unreadable", describeError(error));
+    return unknownMigrationStatus(0, null);
+  }
+  const latestExpected = files.at(-1) ?? null;
+  try {
+    const { rows } = await pool.query(
+      "SELECT filename FROM _migrations ORDER BY filename",
+    );
+    const applied = rows.map((row) => String(row.filename));
+    const appliedSet = new Set(applied);
+    const pending = files.filter((file) => !appliedSet.has(file));
+    return {
+      status: pending.length === 0 ? "current" : "pending",
+      applied_count: applied.length,
+      expected_count: files.length,
+      pending_count: pending.length,
+      latest_applied: applied.at(-1) ?? null,
+      latest_expected: latestExpected,
+    };
+  } catch (error) {
+    // Two very different deployments produce this same "unknown": a database
+    // the doctor cannot reach at all, and a reachable database with no
+    // `_migrations` table (SQLSTATE 42P01 -- never migrated). The pg fields say
+    // which; the payload shape cannot.
+    logger.error("doctor_migrations_query_failed", describeError(error));
+    return unknownMigrationStatus(files.length, latestExpected);
+  }
+}
+
+export async function readAuditStorageStatus(
+  pool: pg.Pool,
+): Promise<OperatorDoctorStatus["log_audit"]["audit_storage"]> {
+  if (!readMcpAuditConfig().enabled) return "not_available";
+
+  const query: pg.QueryConfig<[string]> & { query_timeout: number } = {
+    text: "SELECT to_regclass($1) AS table_name",
+    values: ["mcp_tool_audit_log"],
+    query_timeout: OPTIONAL_TIMEOUT_MS,
+  };
+  const reachable = await withTimeout(
+    pool
+      .query(query)
+      .then(({ rows }) => rows[0]?.table_name != null)
+      .catch(() => false),
+    false,
+  );
+  return reachable ? "available" : "not_available";
+}
+
+interface DistillationLagRow {
+  namespace: string;
+  undistilled_depth: string | number;
+  oldest_undistilled_age_seconds: string | number;
+  ratio: string | number;
+}
+
+function distillationLagRow(
+  row: DistillationLagRow,
+): OperatorDoctorStatus["distillation_lag"][number] {
+  const ratio = Number(row.ratio);
+  return {
+    namespace: row.namespace,
+    undistilled_depth: Number(row.undistilled_depth),
+    oldest_undistilled_age_seconds: Number(row.oldest_undistilled_age_seconds),
+    ratio,
+    level: classifyDistillationLag(ratio),
+  };
+}
+
+export async function readDistillationLag(
+  pool: pg.Pool,
+  ttlSeconds: number,
+): Promise<OperatorDoctorStatus["distillation_lag"]> {
+  // created_at is deliberate and must match issue #395 retention/eviction's
+  // column. If #395 expires on occurred_at, this alarm silently stops catching
+  // its near-loss case.
+  const query: pg.QueryConfig<[number, string, string]> & {
+    query_timeout: number;
+  } = {
+    text: `
+      SELECT
+        namespace,
+        COUNT(*)::integer AS undistilled_depth,
+        GREATEST(
+          0,
+          FLOOR(EXTRACT(EPOCH FROM (now() - MIN(created_at))))
+        )::bigint AS oldest_undistilled_age_seconds,
+        GREATEST(0, EXTRACT(EPOCH FROM (now() - MIN(created_at))))
+          / $1::double precision AS ratio
+      FROM ob_raw_turns
+      WHERE distilled_at IS NULL
+        AND retention_tier = $2
+        -- Parity fixtures are not operator-actionable distillation lag.
+        AND namespace NOT LIKE $3
+      GROUP BY namespace
+      ORDER BY namespace
+    `,
+    values: [ttlSeconds, "live", "parity-raw-turn-%"],
+    query_timeout: OPTIONAL_TIMEOUT_MS,
+  };
+  return withTimeout(
+    pool
+      .query<DistillationLagRow>(query)
+      .then(({ rows }) => rows.map(distillationLagRow))
+      .catch((error: unknown) => {
+        logger.warn("doctor_distillation_lag_query_failed", describeError(error));
+        return [];
+      }),
+    [],
+  );
+}
+
+export async function checkEmbeddingAvailability(): Promise<boolean> {
+  const baseUrl = embeddingBaseUrl();
+  if (!baseUrl) return false;
+  const headers: Record<string, string> = {};
+  const apiKey = embeddingApiKey();
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+  return withTimeout(probeUrl(`${baseUrl}/models`, headers), false);
+}
+
+type QmdIndexPathSource = "option" | "env" | "default";
+
+interface ResolvedQmdIndexPath {
+  path: string;
+  source: QmdIndexPathSource;
+}
+
+function resolveQmdIndexPath(
+  options: OperatorDoctorBuildOptions,
+): ResolvedQmdIndexPath {
+  if (options.qmdIndexPath !== undefined) {
+    return {
+      path: options.qmdIndexPath,
+      source: options.qmdIndexPathSource ?? "env",
+    };
+  }
+  return { path: DEFAULT_QMD_INDEX_PATH, source: "default" };
+}
+
+function unavailableQmdIndexStatus(
+  resolved: ResolvedQmdIndexPath,
+  staleAfterHours: number,
+): OperatorDoctorStatus["qmd"]["index"] {
+  return {
+    path: resolved.path,
+    path_source: resolved.source,
+    status: "unavailable",
+    last_updated_at: null,
+    age_hours: null,
+    freshness: "unknown",
+    stale_after_hours: staleAfterHours,
+    document_count: null,
+    collection_count: null,
+  };
+}
+
+// Concurrent callers share one probe per path. Each probe spawns a Worker that
+// boots a module graph and opens the index, and buildOperatorDoctorStatus is
+// called repeatedly under load (the contract parity suite drives it many times
+// in quick succession). Spawning one per call starved the event loop enough
+// that neighbouring fixtures exceeded their 5s query timeout -- measured as
+// 8-10 parity failures against origin/main's stable 7. The entry is cleared on
+// settle, so the next call re-probes rather than serving a stale reading.
+const inFlightQmdIndexProbes = new Map<string, Promise<QmdIndexProbeResult>>();
+
+function spawnQmdIndexProbe(path: string): {
+  task: Promise<QmdIndexProbeResult>;
+  terminate: () => void;
+} {
+  const worker = new Worker(
+    new URL("../../src/qmd-index-probe-worker.ts", import.meta.url),
+    { type: "module" },
+  );
+  const task = new Promise<QmdIndexProbeResult>((resolve, reject) => {
+    worker.onmessage = (event: MessageEvent<QmdIndexProbeResult>) => {
+      resolve(event.data);
+    };
+    worker.onerror = (event: ErrorEvent) => {
+      reject(event.error ?? new Error(event.message));
+    };
+    worker.postMessage({ path });
+  });
+  return { task, terminate: () => worker.terminate() };
+}
+
+function startQmdIndexProbe(path: string): {
+  task: Promise<QmdIndexProbeResult>;
+  terminate: () => void;
+} {
+  const existing = inFlightQmdIndexProbes.get(path);
+  if (existing) return { task: existing, terminate: () => {} };
+  const spawned = spawnQmdIndexProbe(path);
+  const shared = spawned.task.finally(() => {
+    inFlightQmdIndexProbes.delete(path);
+    spawned.terminate();
+  });
+  // Keep the shared promise from surfacing as an unhandled rejection when the
+  // only awaiting caller has already timed out.
+  shared.catch(() => {});
+  inFlightQmdIndexProbes.set(path, shared);
+  return { task: shared, terminate: () => {} };
+}
+
+function availableQmdIndexStatus(
+  options: OperatorDoctorBuildOptions,
+  resolved: ResolvedQmdIndexPath,
+  staleAfterHours: number,
+  result: QmdIndexProbeResult,
+): OperatorDoctorStatus["qmd"]["index"] {
+  const modifiedAt = new Date(result.modified_at_ms);
+  const ageHours = Math.max(
+    0,
+    ((options.now ?? Date.now)() - modifiedAt.getTime()) / 3_600_000,
+  );
+  return {
+    path: resolved.path,
+    path_source: resolved.source,
+    status: "available",
+    last_updated_at: modifiedAt.toISOString(),
+    age_hours: Math.round(ageHours * 100) / 100,
+    freshness: ageHours >= staleAfterHours ? "stale" : "current",
+    stale_after_hours: staleAfterHours,
+    document_count: result.document_count,
+    collection_count: result.collection_count,
+  };
+}
+
+async function readQmdIndexStatus(
+  options: OperatorDoctorBuildOptions,
+): Promise<OperatorDoctorStatus["qmd"]["index"]> {
+  const resolved = resolveQmdIndexPath(options);
+  const staleAfterHours =
+    options.qmdIndexStaleAfterHours ?? QMD_INDEX_STALE_AFTER_HOURS;
+  const fallback = unavailableQmdIndexStatus(resolved, staleAfterHours);
+  const probe = startQmdIndexProbe(resolved.path);
+  try {
+    const result = await withTimeout(probe.task, null);
+    if (result === null) return fallback;
+    return availableQmdIndexStatus(options, resolved, staleAfterHours, result);
+  } catch (error) {
+    logger.warn("doctor_qmd_index_unreadable", {
+      path_source: resolved.source,
+      ...describeError(error),
+    });
+    return fallback;
+  } finally {
+    probe.terminate();
+  }
+}
+
+// Availability = the qmd entrypoint file exists at the same resolved path
+// search_all executes (src/qmd-path.ts). This remains binary presence only;
+// repo-local index freshness is reported separately below.
+export async function checkQmdStatus(
+  options: OperatorDoctorBuildOptions,
+): Promise<OperatorDoctorStatus["qmd"]> {
+  const resolved = resolveQmdPath();
+  let available = false;
+  try {
+    available = existsSync(resolved.path);
+  } catch (error) {
+    // existsSync swallows ENOENT itself, so reaching here means something
+    // stranger -- a permission error on an ancestor directory, an unmounted
+    // volume. Reporting the binary as simply absent would send the operator
+    // looking for a missing install that is actually present and unreachable.
+    logger.warn("doctor_qmd_probe_failed", {
+      path_source: resolved.source,
+      ...describeError(error),
+    });
+  }
+  return {
+    configured: true,
+    path_source: resolved.source,
+    available,
+    status: available ? "available" : "unavailable",
+    index: await readQmdIndexStatus(options),
+  };
+}

--- a/server/application/operator-doctor-types.ts
+++ b/server/application/operator-doctor-types.ts
@@ -1,0 +1,157 @@
+/**
+ * The frozen `operator_doctor` payload shape and its classification constants.
+ *
+ * Split out of `./operator-doctor.ts` (issue 864) so the builder, the probes,
+ * and the cache each stay under the server/ file rule. The interface is a
+ * FROZEN contract: any field addition or removal requires bumping
+ * `DOCTOR_CONTRACT_VERSION`, and `src/operator-doctor.test.ts` locks the exact
+ * key set against it.
+ */
+import type { AuthInfo, PoolHealth } from "../../src/types.ts";
+
+export const DOCTOR_CONTRACT_VERSION = "2026-08-05.operator-doctor.v4";
+export const DISTILLATION_LAG_TTL_SECONDS_DEFAULT = 7 * 24 * 60 * 60;
+export const DISTILLATION_LAG_WARNING_RATIO = 0.5;
+export const DISTILLATION_LAG_CRITICAL_RATIO = 0.8;
+export const OPTIONAL_TIMEOUT_MS = 2_000;
+export const DOCTOR_CACHE_TTL_MS = 5_000;
+export const QMD_INDEX_STALE_AFTER_HOURS = 48;
+
+// Shared privileged-read predicate for the doctor surface. Consumed by both
+// the MCP tool (src/tools/operator-doctor.ts) and the REST route
+// (src/index.ts) so the gates cannot diverge.
+export function canReadDoctor(auth: AuthInfo | undefined): boolean {
+  return auth?.role === "admin" || auth?.role === "ob-admin";
+}
+
+export interface OperatorDoctorStatus {
+  // unhealthy: the database is unreachable (hard failure).
+  // degraded: DB is connected but migrations are not verified current
+  //   (pending OR unknown), the requested transport is unavailable, a
+  //   CONFIGURED embedding provider is unavailable, or distillation lag is
+  //   critical. Critical lag means live turns are nearing retention expiry;
+  //   unhealthy remains reserved for a database hard failure.
+  // Neutral: warning-level lag, an unconfigured embedding provider, and qmd
+  //   availability or index freshness never affect the tier (issue #270
+  //   optional-dep rule).
+  status: "healthy" | "degraded" | "unhealthy";
+  contract_version: string;
+  generated_at: string;
+  runtime: {
+    service: "open-brain";
+    version: string;
+    contract_version: string;
+    contract_schema_version: number;
+    node_env: "production" | "development" | "test" | "unknown";
+  };
+  database: PoolHealth;
+  migrations: {
+    status: "current" | "pending" | "unknown";
+    applied_count: number | null;
+    expected_count: number;
+    pending_count: number | null;
+    latest_applied: string | null;
+    latest_expected: string | null;
+  };
+  distillation_lag: Array<{
+    namespace: string;
+    undistilled_depth: number;
+    oldest_undistilled_age_seconds: number;
+    ratio: number;
+    level: "ok" | "warning" | "critical";
+  }>;
+  embedding_provider: {
+    configured: boolean;
+    available: boolean;
+    model: string;
+    dimensions: number;
+    recent_failures: {
+      last_failure_code: string | null;
+      consecutive_restartable_failures: number;
+      restart_configured: boolean;
+      restart_in_flight: boolean;
+      last_restart_at: string | null;
+    };
+  };
+  qmd: {
+    // The qmd path always resolves (QMD_PATH env override or the built-in
+    // default used by search_all), so configured is true whenever a path
+    // resolution source exists.
+    configured: boolean;
+    path_source: "env" | "default";
+    // available means the qmd entrypoint file exists at the resolved path --
+    // binary presence only, NOT qmd search health. The raw path is never
+    // included in the payload.
+    available: boolean;
+    status: "available" | "unavailable";
+    index: {
+      path: string;
+      path_source: "option" | "env" | "default";
+      status: "available" | "unavailable";
+      last_updated_at: string | null;
+      age_hours: number | null;
+      freshness: "current" | "stale" | "unknown";
+      stale_after_hours: number;
+      document_count: number | null;
+      collection_count: number | null;
+    };
+  };
+  transport: {
+    mode: "http" | "nats";
+    availability: "available" | "not_runtime_available";
+    fallback_http: boolean;
+    consecutive_failures: number;
+    last_error: "redacted" | null;
+  };
+  log_audit: {
+    request_logger: "enabled";
+    file_log_configured: boolean;
+    rotation_configured: boolean;
+    audit_storage: "available" | "not_available";
+  };
+  optional_dependencies: {
+    embedding_provider: "available" | "unavailable" | "not_configured";
+    qmd: "available" | "unavailable";
+  };
+}
+
+/**
+ * Every value the doctor used to read from `process.env` itself, plus the
+ * build and cache knobs it already took.
+ *
+ * The env-derived fields are REQUIRED: `server/main.ts` holds the parsed
+ * `ServerConfig` and fills them, so there is no ambient fallback to drift from
+ * (`.oxlintrc.json` permits `process.env` only at the composition root). The
+ * legacy call form lives on in the `src/operator-doctor.ts` L5 adapter.
+ */
+export interface OperatorDoctorOptions {
+  /** `package.json` fallback when the file itself cannot be read. */
+  serviceVersionFallback: string;
+  /** One of the three known values, or `unknown` for anything else. */
+  nodeEnvironment: OperatorDoctorStatus["runtime"]["node_env"];
+  /** Whether `LOG_FILE` carries a non-blank value. */
+  fileLogConfigured: boolean;
+  /** Whether either log rotation variable carries a non-blank value. */
+  rotationConfigured: boolean;
+  /** Raw-turn retention seconds: the distillation-lag alarm denominator. */
+  rawTurnTtlSeconds: number;
+  /** Absent means the doctor falls back to its own default index path. */
+  qmdIndexPath?: string;
+  /** Where `qmdIndexPath` came from, reported verbatim in the payload. */
+  qmdIndexPathSource?: "option" | "env";
+  qmdIndexStaleAfterHours?: number;
+  now?: () => number;
+  ttlMs?: number;
+}
+
+/** The subset the payload builder needs; the cache knobs are not its business. */
+export type OperatorDoctorBuildOptions = Omit<OperatorDoctorOptions, "ttlMs">;
+
+/** Classify oldest-undistilled-age / raw-turn-TTL without reading the database. */
+export function classifyDistillationLag(
+  ratio: number,
+): OperatorDoctorStatus["distillation_lag"][number]["level"] {
+  if (ratio >= DISTILLATION_LAG_CRITICAL_RATIO) return "critical";
+  if (ratio >= DISTILLATION_LAG_WARNING_RATIO) return "warning";
+  return "ok";
+}

--- a/server/application/operator-doctor.ts
+++ b/server/application/operator-doctor.ts
@@ -43,6 +43,7 @@ import {
 } from "./operator-doctor-probes.ts";
 
 export * from "./operator-doctor-types.ts";
+export type { NatsBridgeHealth } from "../../src/nats-bridge.ts";
 export {
   probeUrl,
   withTimeout,

--- a/server/application/operator-doctor.ts
+++ b/server/application/operator-doctor.ts
@@ -1,0 +1,258 @@
+/**
+ * `operator_doctor`: assemble the frozen diagnostic payload, and serve it from
+ * a single-flight short-TTL cache.
+ *
+ * Moved out of `src/operator-doctor.ts` (issue 864, L5 of
+ * `_plans/server-hardening-ladder.md`) and split into siblings by
+ * responsibility: `./operator-doctor-types.ts` owns the frozen shape and the
+ * classification constants, `./operator-doctor-probes.ts` asks the individual
+ * diagnostic questions, and this file assembles and caches.
+ *
+ * Every value the old module read from `process.env` now arrives as a field of
+ * the single `OperatorDoctorOptions` parameter, filled by `server/main.ts` from
+ * the parsed `ServerConfig`. The legacy env-reading call form survives on the
+ * `src/operator-doctor.ts` L5 adapter, which retires with `src/` at L6.
+ */
+import type pg from "pg";
+import { CONTRACT_VERSION, CONTRACT_SCHEMA_VERSION } from "../../src/contract.ts";
+import {
+  getEmbeddingProviderDiagnostics,
+  EMBEDDING_DIMENSIONS,
+  EMBEDDING_MODEL,
+} from "../../src/embedding.ts";
+import { checkPoolHealth } from "../../src/db/pool.ts";
+import { logger } from "../../src/logger.ts";
+import { describeError } from "../../src/observability/index.ts";
+import type { NatsBridgeHealth } from "../../src/nats-bridge.ts";
+import type { NatsRuntimeBoundary } from "../../src/nats-runtime.ts";
+import { isRequestedTransportDegraded } from "../../src/nats-runtime.ts";
+import {
+  DOCTOR_CACHE_TTL_MS,
+  DOCTOR_CONTRACT_VERSION,
+  type OperatorDoctorBuildOptions,
+  type OperatorDoctorOptions,
+  type OperatorDoctorStatus,
+} from "./operator-doctor-types.ts";
+import {
+  checkEmbeddingAvailability,
+  checkQmdStatus,
+  readAuditStorageStatus,
+  readDistillationLag,
+  readMigrationStatus,
+  readServiceVersion,
+} from "./operator-doctor-probes.ts";
+
+export * from "./operator-doctor-types.ts";
+export {
+  probeUrl,
+  withTimeout,
+  resetCachedServiceVersion,
+} from "./operator-doctor-probes.ts";
+
+interface DoctorProbeResults {
+  database: OperatorDoctorStatus["database"];
+  migrations: OperatorDoctorStatus["migrations"];
+  distillationLag: OperatorDoctorStatus["distillation_lag"];
+  embeddingAvailable: boolean;
+  serviceVersion: string;
+  auditStorage: OperatorDoctorStatus["log_audit"]["audit_storage"];
+  qmd: OperatorDoctorStatus["qmd"];
+}
+
+async function runDoctorProbes(
+  pool: pg.Pool,
+  options: OperatorDoctorBuildOptions,
+): Promise<DoctorProbeResults> {
+  const [
+    database,
+    migrations,
+    distillationLag,
+    embeddingAvailable,
+    serviceVersion,
+    auditStorage,
+    qmd,
+  ] = await Promise.all([
+    checkPoolHealth(pool),
+    readMigrationStatus(pool),
+    readDistillationLag(pool, options.rawTurnTtlSeconds),
+    checkEmbeddingAvailability(),
+    readServiceVersion(options.serviceVersionFallback),
+    readAuditStorageStatus(pool),
+    checkQmdStatus(options),
+  ]);
+  return {
+    database,
+    migrations,
+    distillationLag,
+    embeddingAvailable,
+    serviceVersion,
+    auditStorage,
+    qmd,
+  };
+}
+
+// Migrations not verified current (pending OR unknown) with a connected
+// DB means an unverified or broken schema: degraded, never silently healthy.
+// A configured-but-unavailable embedding provider hard-fails vector search.
+// Critical distillation lag means acknowledged live turns are nearing TTL
+// expiry, so it degrades service status; warning lag is early signal only.
+function overallStatus(
+  probes: DoctorProbeResults,
+  embeddingConfigured: boolean,
+  transportDegraded: boolean,
+): OperatorDoctorStatus["status"] {
+  if (!probes.database.connected) return "unhealthy";
+  const migrationsDegraded = probes.migrations.status !== "current";
+  const embeddingDegraded = embeddingConfigured && !probes.embeddingAvailable;
+  const distillationDegraded = probes.distillationLag.some(
+    ({ level }) => level === "critical",
+  );
+  return migrationsDegraded ||
+    transportDegraded ||
+    embeddingDegraded ||
+    distillationDegraded
+    ? "degraded"
+    : "healthy";
+}
+
+function embeddingSection(
+  available: boolean,
+): OperatorDoctorStatus["embedding_provider"] {
+  const diagnostics = getEmbeddingProviderDiagnostics();
+  return {
+    configured: diagnostics.configured,
+    available,
+    model: EMBEDDING_MODEL,
+    dimensions: EMBEDDING_DIMENSIONS,
+    recent_failures: {
+      last_failure_code: diagnostics.last_failure_code,
+      consecutive_restartable_failures: diagnostics.consecutive_restartable_failures,
+      restart_configured: diagnostics.restart_configured,
+      restart_in_flight: diagnostics.restart_in_flight,
+      last_restart_at: diagnostics.last_restart_at,
+    },
+  };
+}
+
+export async function buildOperatorDoctorStatus(
+  pool: pg.Pool,
+  natsRuntimeBoundary: NatsRuntimeBoundary,
+  natsBridgeHealth: NatsBridgeHealth | undefined,
+  options: OperatorDoctorBuildOptions,
+): Promise<OperatorDoctorStatus> {
+  const probes = await runDoctorProbes(pool, options);
+  const embeddingDiagnostics = getEmbeddingProviderDiagnostics();
+  const transportAvailability =
+    natsBridgeHealth?.availability ?? natsRuntimeBoundary.nats.availability;
+  const transportDegraded = isRequestedTransportDegraded(
+    natsRuntimeBoundary,
+    transportAvailability,
+  );
+
+  return {
+    status: overallStatus(probes, embeddingDiagnostics.configured, transportDegraded),
+    contract_version: DOCTOR_CONTRACT_VERSION,
+    generated_at: new Date().toISOString(),
+    runtime: {
+      service: "open-brain",
+      version: probes.serviceVersion,
+      contract_version: CONTRACT_VERSION,
+      contract_schema_version: CONTRACT_SCHEMA_VERSION,
+      node_env: options.nodeEnvironment,
+    },
+    database: probes.database,
+    migrations: probes.migrations,
+    distillation_lag: probes.distillationLag,
+    embedding_provider: embeddingSection(probes.embeddingAvailable),
+    qmd: probes.qmd,
+    transport: {
+      mode: natsRuntimeBoundary.requested_transport,
+      availability: transportAvailability,
+      fallback_http: natsRuntimeBoundary.nats.fallback_http,
+      consecutive_failures: natsBridgeHealth?.consecutiveFailures ?? 0,
+      last_error: natsBridgeHealth?.lastError ? "redacted" : null,
+    },
+    log_audit: {
+      request_logger: "enabled",
+      file_log_configured: options.fileLogConfigured,
+      rotation_configured: options.fileLogConfigured && options.rotationConfigured,
+      audit_storage: probes.auditStorage,
+    },
+    optional_dependencies: {
+      embedding_provider: embeddingDiagnostics.configured
+        ? probes.embeddingAvailable
+          ? "available"
+          : "unavailable"
+        : "not_configured",
+      qmd: probes.qmd.status,
+    },
+  };
+}
+
+// --- Single-flight + short-TTL cache -----------------------------------
+//
+// Every doctor build fans out DB scans and an outbound embedding probe;
+// without a cache, a polling dashboard or looping token amplifies probes
+// during the exact incident being diagnosed. All callers (REST route and
+// MCP tool) go through getOperatorDoctorStatus: concurrent callers share
+// one in-flight build, and results are served from cache within the TTL.
+
+interface DoctorCacheEntry {
+  value: OperatorDoctorStatus;
+  expiresAt: number;
+}
+
+let doctorCache: DoctorCacheEntry | null = null;
+let doctorInFlight: Promise<OperatorDoctorStatus> | null = null;
+
+export function resetOperatorDoctorCache(): void {
+  doctorCache = null;
+  doctorInFlight = null;
+}
+
+export async function getOperatorDoctorStatus(
+  pool: pg.Pool,
+  natsRuntimeBoundary: NatsRuntimeBoundary,
+  natsBridgeHealth: NatsBridgeHealth | undefined,
+  options: OperatorDoctorOptions,
+): Promise<OperatorDoctorStatus> {
+  const now = options.now ?? Date.now;
+  const ttlMs = options.ttlMs ?? DOCTOR_CACHE_TTL_MS;
+  if (doctorCache && now() < doctorCache.expiresAt) {
+    return doctorCache.value;
+  }
+  if (doctorInFlight) return doctorInFlight;
+  const build = buildOperatorDoctorStatus(
+    pool,
+    natsRuntimeBoundary,
+    natsBridgeHealth,
+    options,
+  )
+    .then((value) => {
+      doctorCache = { value, expiresAt: now() + ttlMs };
+      return value;
+    })
+    .catch((error: unknown) => {
+      // Logged HERE, at the owning boundary, and then re-thrown unchanged.
+      //
+      // Every consumer of this function converts the rejection into a
+      // deliberately content-free response -- the REST route in src/index.ts
+      // sends `{ error: "operator doctor status unavailable" }` and the MCP tool
+      // sends the same string -- because a raw doctor error can carry paths and
+      // env detail. That is right for the RESPONSE and left alone. But it meant
+      // the reason existed nowhere: the diagnostic surface is gone at exactly
+      // the moment it is needed, and the only trace was a 500 in an access log.
+      //
+      // Logging at this single point covers both consumers at once, and it is
+      // the only place that can: the in-flight promise below is shared, so one
+      // rejection is handed to every concurrent caller, and a per-caller catch
+      // would report the same failure once per waiter.
+      logger.error("doctor_status_build_failed", describeError(error));
+      throw error;
+    })
+    .finally(() => {
+      doctorInFlight = null;
+    });
+  doctorInFlight = build;
+  return build;
+}

--- a/server/config/src-readers.ts
+++ b/server/config/src-readers.ts
@@ -121,6 +121,10 @@ export const srcReaderEnvironmentFields = {
   // `:685-686` (rotation). `QMD_PATH` and `LOG_FILE` are already declared in
   // `server/config.ts`, so they are not repeated here.
   QMD_INDEX_PATH: rawOptional,
+  // `src/operator-doctor.ts:330-336` (lag denominator) and `:58,:63` (version
+  // fallback). Both fall back on an unusable value, so neither rejects.
+  OPENBRAIN_RAW_TURN_TTL_SECONDS: rawOptional,
+  npm_package_version: rawOptional,
   NODE_ENV: rawOptional,
   LOG_MAX_BYTES: rawOptional,
   LOG_MAX_FILES: rawOptional,
@@ -132,6 +136,8 @@ type SrcReaderEnvironment = z.infer<z.ZodObject<typeof srcReaderEnvironmentField
 const DEFAULT_EMBEDDING_MODEL = "gemini-embedding-001";
 /** The three values `src/operator-doctor.ts:649-652` recognizes. */
 const KNOWN_NODE_ENVIRONMENTS = ["production", "development", "test"] as const;
+/** The documented one-week raw-turn TTL — `src/operator-doctor.ts:40`. */
+const DISTILLATION_LAG_TTL_SECONDS_DEFAULT = 7 * 24 * 60 * 60;
 
 export interface EmbeddingWatchdogGroup {
   /** Consecutive restartable failures before a restart is attempted. */
@@ -171,6 +177,10 @@ export interface DoctorConfigGroup {
   readonly nodeEnvironment: (typeof KNOWN_NODE_ENVIRONMENTS)[number] | "unknown";
   /** Whether either rotation variable carries a non-blank value. */
   readonly rotationConfigured: boolean;
+  /** Raw-turn retention seconds: the distillation-lag alarm denominator. */
+  readonly rawTurnTtlSeconds: number;
+  /** Version reported when `package.json` itself cannot be read. */
+  readonly serviceVersionFallback: string;
 }
 
 export function embeddingGroup(parsed: SrcReaderEnvironment): EmbeddingConfigGroup {
@@ -211,6 +221,18 @@ export function mcpAuditGroup(parsed: SrcReaderEnvironment): McpAuditConfigGroup
  * as `ServerConfig.logging.file`, so combining the two here would duplicate a
  * value the consumer already holds.
  */
+/**
+ * The lag denominator, reproducing `readDistillationLagTtlSeconds`
+ * (`src/operator-doctor.ts:330-336`): `Number(...)` rather than `parseInt`, so
+ * a trailing suffix is `NaN` and falls back, and only a positive integer wins.
+ */
+function rawTurnTtlSeconds(raw: string | undefined): number {
+  const configured = Number(raw);
+  return Number.isInteger(configured) && configured > 0
+    ? configured
+    : DISTILLATION_LAG_TTL_SECONDS_DEFAULT;
+}
+
 export function doctorGroup(parsed: SrcReaderEnvironment): DoctorConfigGroup {
   const qmdIndexPath = parsed.QMD_INDEX_PATH;
   const nodeEnvironment = KNOWN_NODE_ENVIRONMENTS.find(
@@ -220,5 +242,7 @@ export function doctorGroup(parsed: SrcReaderEnvironment): DoctorConfigGroup {
     ...(qmdIndexPath !== undefined ? { qmdIndexPath } : {}),
     nodeEnvironment: nodeEnvironment ?? "unknown",
     rotationConfigured: Boolean(parsed.LOG_MAX_BYTES) || Boolean(parsed.LOG_MAX_FILES),
+    rawTurnTtlSeconds: rawTurnTtlSeconds(parsed.OPENBRAIN_RAW_TURN_TTL_SECONDS),
+    serviceVersionFallback: parsed.npm_package_version ?? "unknown",
   };
 }

--- a/server/main.ts
+++ b/server/main.ts
@@ -74,7 +74,7 @@ import {
   composeMaintenanceHandlers,
   MAINTENANCE_GRAPH_AUTH,
 } from "../src/maintenance-bootstrap.ts";
-import { getOperatorDoctorStatus } from "../src/operator-doctor.ts";
+import { getOperatorDoctorStatus } from "./application/operator-doctor.ts";
 import type { ToolDeps } from "../src/tools/index.ts";
 import type { AuthInfo } from "./types.ts";
 
@@ -388,7 +388,16 @@ function composeApplication(input: {
     authenticate,
     logger: logger.child({ component: "rest" }),
     operatorDoctor: () =>
-      getOperatorDoctorStatus(database.pool, nats.boundary, nats.health),
+      getOperatorDoctorStatus(database.pool, nats.boundary, nats.health, {
+        serviceVersionFallback: config.doctor.serviceVersionFallback,
+        nodeEnvironment: config.doctor.nodeEnvironment,
+        fileLogConfigured: Boolean(config.logging.file?.trim()),
+        rotationConfigured: config.doctor.rotationConfigured,
+        rawTurnTtlSeconds: config.doctor.rawTurnTtlSeconds,
+        ...(config.doctor.qmdIndexPath !== undefined
+          ? { qmdIndexPath: config.doctor.qmdIndexPath }
+          : {}),
+      }),
   });
 
   return createShadowApplication({

--- a/src/operator-doctor.ts
+++ b/src/operator-doctor.ts
@@ -1,7 +1,7 @@
 // L5 adapter (issue 864): legacy call form over server/application/operator-doctor.ts; retired with src/ at L6.
 import type pg from "pg";
-import type { NatsBridgeHealth } from "./nats-bridge.ts";
-import type { NatsRuntimeBoundary } from "./nats-runtime.ts";
+import type { NatsBridgeHealth } from "../server/application/operator-doctor.ts";
+import type { NatsRuntimeBoundary } from "../server/application/nats-runtime.ts";
 import {
   buildOperatorDoctorStatus as buildStatus,
   getOperatorDoctorStatus as getStatus,

--- a/src/operator-doctor.ts
+++ b/src/operator-doctor.ts
@@ -1,330 +1,26 @@
-import { existsSync } from "node:fs";
-import { readdir } from "node:fs/promises";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+// L5 adapter (issue 864): legacy call form over server/application/operator-doctor.ts; retired with src/ at L6.
 import type pg from "pg";
-import { CONTRACT_VERSION, CONTRACT_SCHEMA_VERSION } from "./contract.ts";
-import {
-  getEmbeddingProviderDiagnostics,
-  embeddingBaseUrl,
-  embeddingApiKey,
-  EMBEDDING_DIMENSIONS,
-  EMBEDDING_MODEL,
-} from "./embedding.ts";
-import { checkPoolHealth } from "./db/pool.ts";
-import { readMcpAuditConfig } from "./audit-log.ts";
-import { resolveQmdPath } from "./qmd-path.ts";
-import { logger } from "./logger.ts";
-import { describeError } from "./observability/index.ts";
-import type { QmdIndexProbeResult } from "./qmd-index-probe-worker.ts";
 import type { NatsBridgeHealth } from "./nats-bridge.ts";
 import type { NatsRuntimeBoundary } from "./nats-runtime.ts";
-import { isRequestedTransportDegraded } from "./nats-runtime.ts";
-import type { AuthInfo, PoolHealth } from "./types.ts";
+import {
+  buildOperatorDoctorStatus as buildStatus,
+  getOperatorDoctorStatus as getStatus,
+  DISTILLATION_LAG_TTL_SECONDS_DEFAULT,
+  type OperatorDoctorOptions,
+  type OperatorDoctorStatus,
+} from "../server/application/operator-doctor.ts";
 
-const MIGRATIONS_DIR = join(
-  dirname(fileURLToPath(import.meta.url)),
-  "db",
-  "migrations",
-);
-const DEFAULT_QMD_INDEX_PATH = join(
-  dirname(fileURLToPath(import.meta.url)),
-  "..",
-  ".qmd",
-  "index.sqlite",
-);
-
-// Any field addition/removal in OperatorDoctorStatus requires bumping this
-// version. src/operator-doctor.test.ts locks the exact payload shape.
-export const DOCTOR_CONTRACT_VERSION = "2026-08-05.operator-doctor.v4";
-export const DISTILLATION_LAG_TTL_SECONDS_DEFAULT = 7 * 24 * 60 * 60;
-export const DISTILLATION_LAG_WARNING_RATIO = 0.5;
-export const DISTILLATION_LAG_CRITICAL_RATIO = 0.8;
-const OPTIONAL_TIMEOUT_MS = 2_000;
-const DOCTOR_CACHE_TTL_MS = 5_000;
-const QMD_INDEX_STALE_AFTER_HOURS = 48;
-
-let cachedServiceVersion: string | null = null;
-
-async function readServiceVersion(): Promise<string> {
-  if (cachedServiceVersion !== null) return cachedServiceVersion;
-  try {
-    const pkg = (await Bun.file(
-      join(dirname(fileURLToPath(import.meta.url)), "..", "package.json"),
-    ).json()) as { version?: unknown };
-    cachedServiceVersion =
-      typeof pkg.version === "string" && pkg.version.length > 0
-        ? pkg.version
-        : (process.env.npm_package_version ?? "unknown");
-  } catch (error) {
-    // Falling back to the env var is fine; reporting "unknown" as if it were
-    // the answer is not. A doctor that cannot read its own package.json is
-    // telling the operator something about its deployment.
-    cachedServiceVersion = process.env.npm_package_version ?? "unknown";
-    logger.warn("doctor_service_version_unreadable", {
-      fallback: cachedServiceVersion,
-      ...describeError(error),
-    });
-  }
-  return cachedServiceVersion;
-}
-
-// Shared privileged-read predicate for the doctor surface. Consumed by both
-// the MCP tool (src/tools/operator-doctor.ts) and the REST route
-// (src/index.ts) so the gates cannot diverge.
-export function canReadDoctor(auth: AuthInfo | undefined): boolean {
-  return auth?.role === "admin" || auth?.role === "ob-admin";
-}
-
-export interface OperatorDoctorStatus {
-  // unhealthy: the database is unreachable (hard failure).
-  // degraded: DB is connected but migrations are not verified current
-  //   (pending OR unknown), the requested transport is unavailable, a
-  //   CONFIGURED embedding provider is unavailable, or distillation lag is
-  //   critical. Critical lag means live turns are nearing retention expiry;
-  //   unhealthy remains reserved for a database hard failure.
-  // Neutral: warning-level lag, an unconfigured embedding provider, and qmd
-  //   availability or index freshness never affect the tier (issue #270
-  //   optional-dep rule).
-  status: "healthy" | "degraded" | "unhealthy";
-  contract_version: string;
-  generated_at: string;
-  runtime: {
-    service: "open-brain";
-    version: string;
-    contract_version: string;
-    contract_schema_version: number;
-    node_env: "production" | "development" | "test" | "unknown";
-  };
-  database: PoolHealth;
-  migrations: {
-    status: "current" | "pending" | "unknown";
-    applied_count: number | null;
-    expected_count: number;
-    pending_count: number | null;
-    latest_applied: string | null;
-    latest_expected: string | null;
-  };
-  distillation_lag: Array<{
-    namespace: string;
-    undistilled_depth: number;
-    oldest_undistilled_age_seconds: number;
-    ratio: number;
-    level: "ok" | "warning" | "critical";
-  }>;
-  embedding_provider: {
-    configured: boolean;
-    available: boolean;
-    model: string;
-    dimensions: number;
-    recent_failures: {
-      last_failure_code: string | null;
-      consecutive_restartable_failures: number;
-      restart_configured: boolean;
-      restart_in_flight: boolean;
-      last_restart_at: string | null;
-    };
-  };
-  qmd: {
-    // The qmd path always resolves (QMD_PATH env override or the built-in
-    // default used by search_all), so configured is true whenever a path
-    // resolution source exists.
-    configured: boolean;
-    path_source: "env" | "default";
-    // available means the qmd entrypoint file exists at the resolved path --
-    // binary presence only, NOT qmd search health. The raw path is never
-    // included in the payload.
-    available: boolean;
-    status: "available" | "unavailable";
-    index: {
-      path: string;
-      path_source: "option" | "env" | "default";
-      status: "available" | "unavailable";
-      last_updated_at: string | null;
-      age_hours: number | null;
-      freshness: "current" | "stale" | "unknown";
-      stale_after_hours: number;
-      document_count: number | null;
-      collection_count: number | null;
-    };
-  };
-  transport: {
-    mode: "http" | "nats";
-    availability: "available" | "not_runtime_available";
-    fallback_http: boolean;
-    consecutive_failures: number;
-    last_error: "redacted" | null;
-  };
-  log_audit: {
-    request_logger: "enabled";
-    file_log_configured: boolean;
-    rotation_configured: boolean;
-    audit_storage: "available" | "not_available";
-  };
-  optional_dependencies: {
-    embedding_provider: "available" | "unavailable" | "not_configured";
-    qmd: "available" | "unavailable";
-  };
-}
-
-async function withTimeout<T>(
-  task: Promise<T>,
-  fallback: T,
-  timeoutMs = OPTIONAL_TIMEOUT_MS,
-): Promise<T> {
-  // Absorb late rejections: if the timeout wins the race, a subsequent
-  // rejection of the abandoned task must not surface as an unhandled
-  // rejection. Absorbing it is right; discarding it was not -- a probe that
-  // always loses the race and always rejects reported its fallback forever
-  // with nothing anywhere saying why.
-  task.catch((error: unknown) => {
-    logger.debug("doctor_probe_late_rejection", describeError(error));
-  });
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      task,
-      new Promise<T>((resolve) => {
-        timeout = setTimeout(() => resolve(fallback), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeout) clearTimeout(timeout);
-  }
-}
-
-/**
- * Is an HTTP endpoint answering OK? Exported because `/health` in `src/index.ts`
- * asks the same question of the same provider and had its own byte-identical
- * private copy -- including the bare `catch { return false }` this one no longer
- * has. A REST sibling drifting from the module that owns the logic is the exact
- * shape of the PR #277 failure recorded in docs/sme/correctness.md:475, so the
- * two call sites now share one implementation instead of two.
- *
- * Reports only a boolean by design; which of DNS failure, refused connection,
- * or timeout it was goes to the log, because that is the whole diagnosis.
- *
- * `timeoutMs` is a parameter rather than a shared constant because the two
- * callers genuinely differ and neither should silently inherit the other's
- * value: the doctor allows 2s for an optional-dependency probe, `/health`
- * allowed 3s. Sharing the implementation must not quietly change either one.
- */
-export async function probeUrl(
-  url: string,
-  headers: Record<string, string>,
-  timeoutMs = OPTIONAL_TIMEOUT_MS,
-): Promise<boolean> {
-  try {
-    const resp = await fetch(url, {
-      headers,
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-    if (!resp.ok) {
-      // A reachable endpoint answering 401 or 503 is a different problem from
-      // an unreachable one, and `false` says neither.
-      logger.debug("doctor_probe_not_ok", {
-        status: resp.status,
-        timeout_ms: timeoutMs,
-      });
-    }
-    return resp.ok;
-  } catch (error) {
-    // DNS failure, connection refused, or the timeout firing. The caller gets
-    // only a boolean by design; which of the three it was belongs in the log,
-    // because that is the whole diagnosis.
-    logger.debug("doctor_probe_failed", {
-      timeout_ms: timeoutMs,
-      ...describeError(error),
-    });
-    return false;
-  }
-}
-
-async function readMigrationStatus(
-  pool: pg.Pool,
-): Promise<OperatorDoctorStatus["migrations"]> {
-  let files: string[];
-  try {
-    files = (await readdir(MIGRATIONS_DIR))
-      .filter((f) => f.endsWith(".sql"))
-      .sort();
-  } catch (error) {
-    // Never let a filesystem error propagate: thrown messages can carry raw
-    // paths into MCP tool error text or Express error pages. That rule governs
-    // the *response*; the log is where the operator is allowed to learn that
-    // the migrations directory is missing from the deployment entirely, which
-    // "status: unknown" on its own never said.
-    logger.error("doctor_migrations_dir_unreadable", describeError(error));
-    return {
-      status: "unknown",
-      applied_count: null,
-      expected_count: 0,
-      pending_count: null,
-      latest_applied: null,
-      latest_expected: null,
-    };
-  }
-  const latestExpected = files.at(-1) ?? null;
-  try {
-    const { rows } = await pool.query(
-      "SELECT filename FROM _migrations ORDER BY filename",
-    );
-    const applied = rows.map((row) => String(row.filename));
-    const appliedSet = new Set(applied);
-    const pending = files.filter((file) => !appliedSet.has(file));
-    return {
-      status: pending.length === 0 ? "current" : "pending",
-      applied_count: applied.length,
-      expected_count: files.length,
-      pending_count: pending.length,
-      latest_applied: applied.at(-1) ?? null,
-      latest_expected: latestExpected,
-    };
-  } catch (error) {
-    // Two very different deployments produce this same "unknown": a database
-    // the doctor cannot reach at all, and a reachable database with no
-    // `_migrations` table (SQLSTATE 42P01 -- never migrated). The pg fields say
-    // which; the payload shape cannot.
-    logger.error("doctor_migrations_query_failed", describeError(error));
-    return {
-      status: "unknown",
-      applied_count: null,
-      expected_count: files.length,
-      pending_count: null,
-      latest_applied: null,
-      latest_expected: latestExpected,
-    };
-  }
-}
-
-async function readAuditStorageStatus(
-  pool: pg.Pool,
-): Promise<OperatorDoctorStatus["log_audit"]["audit_storage"]> {
-  if (!readMcpAuditConfig().enabled) return "not_available";
-
-  const query: pg.QueryConfig<[string]> & { query_timeout: number } = {
-    text: "SELECT to_regclass($1) AS table_name",
-    values: ["mcp_tool_audit_log"],
-    query_timeout: OPTIONAL_TIMEOUT_MS,
-  };
-  const reachable = await withTimeout(
-    pool
-      .query(query)
-      .then(({ rows }) => rows[0]?.table_name != null)
-      .catch(() => false),
-    false,
-  );
-  return reachable ? "available" : "not_available";
-}
-
-/** Classify oldest-undistilled-age / raw-turn-TTL without reading the database. */
-export function classifyDistillationLag(
-  ratio: number,
-): OperatorDoctorStatus["distillation_lag"][number]["level"] {
-  if (ratio >= DISTILLATION_LAG_CRITICAL_RATIO) return "critical";
-  if (ratio >= DISTILLATION_LAG_WARNING_RATIO) return "warning";
-  return "ok";
-}
+export {
+  canReadDoctor,
+  classifyDistillationLag,
+  probeUrl,
+  resetOperatorDoctorCache,
+  DISTILLATION_LAG_CRITICAL_RATIO,
+  DISTILLATION_LAG_TTL_SECONDS_DEFAULT,
+  DISTILLATION_LAG_WARNING_RATIO,
+  DOCTOR_CONTRACT_VERSION,
+  type OperatorDoctorStatus,
+} from "../server/application/operator-doctor.ts";
 
 /** Read the alarm denominator, falling back to the documented one-week TTL. */
 export function readDistillationLagTtlSeconds(
@@ -336,251 +32,34 @@ export function readDistillationLagTtlSeconds(
     : DISTILLATION_LAG_TTL_SECONDS_DEFAULT;
 }
 
-interface DistillationLagRow {
-  namespace: string;
-  undistilled_depth: string | number;
-  oldest_undistilled_age_seconds: string | number;
-  ratio: string | number;
-}
-
-async function readDistillationLag(
-  pool: pg.Pool,
-): Promise<OperatorDoctorStatus["distillation_lag"]> {
-  const ttlSeconds = readDistillationLagTtlSeconds();
-  // created_at is deliberate and must match issue #395 retention/eviction's
-  // column. If #395 expires on occurred_at, this alarm silently stops catching
-  // its near-loss case.
-  const query: pg.QueryConfig<[number, string, string]> & {
-    query_timeout: number;
-  } = {
-    text: `
-      SELECT
-        namespace,
-        COUNT(*)::integer AS undistilled_depth,
-        GREATEST(
-          0,
-          FLOOR(EXTRACT(EPOCH FROM (now() - MIN(created_at))))
-        )::bigint AS oldest_undistilled_age_seconds,
-        GREATEST(0, EXTRACT(EPOCH FROM (now() - MIN(created_at))))
-          / $1::double precision AS ratio
-      FROM ob_raw_turns
-      WHERE distilled_at IS NULL
-        AND retention_tier = $2
-        -- Parity fixtures are not operator-actionable distillation lag.
-        AND namespace NOT LIKE $3
-      GROUP BY namespace
-      ORDER BY namespace
-    `,
-    values: [ttlSeconds, "live", "parity-raw-turn-%"],
-    query_timeout: OPTIONAL_TIMEOUT_MS,
-  };
-  return withTimeout(
-    pool
-      .query<DistillationLagRow>(query)
-      .then(({ rows }) =>
-        rows.map((row) => {
-          const ratio = Number(row.ratio);
-          return {
-            namespace: row.namespace,
-            undistilled_depth: Number(row.undistilled_depth),
-            oldest_undistilled_age_seconds: Number(
-              row.oldest_undistilled_age_seconds,
-            ),
-            ratio,
-            level: classifyDistillationLag(ratio),
-          };
-        }),
-      )
-      .catch((error: unknown) => {
-        logger.warn(
-          "doctor_distillation_lag_query_failed",
-          describeError(error),
-        );
-        return [];
-      }),
-    [],
-  );
-}
-
-async function checkEmbeddingAvailability(): Promise<boolean> {
-  const baseUrl = embeddingBaseUrl();
-  if (!baseUrl) return false;
-  const headers: Record<string, string> = {};
-  const apiKey = embeddingApiKey();
-  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
-  return withTimeout(probeUrl(`${baseUrl}/models`, headers), false);
-}
-
+/** The legacy options both entry points accepted before the env fields moved. */
 export interface OperatorDoctorBuildOptions {
   now?: () => number;
   qmdIndexPath?: string;
   qmdIndexStaleAfterHours?: number;
 }
 
-type QmdIndexPathSource = "option" | "env" | "default";
-
-interface ResolvedQmdIndexPath {
-  path: string;
-  source: QmdIndexPathSource;
+export interface OperatorDoctorCacheOptions {
+  ttlMs?: number;
+  now?: () => number;
 }
 
-function resolveQmdIndexPath(
-  options: OperatorDoctorBuildOptions,
-): ResolvedQmdIndexPath {
-  if (options.qmdIndexPath !== undefined) {
-    return { path: options.qmdIndexPath, source: "option" };
-  }
-  if (process.env.QMD_INDEX_PATH !== undefined) {
-    return { path: process.env.QMD_INDEX_PATH, source: "env" };
-  }
-  return { path: DEFAULT_QMD_INDEX_PATH, source: "default" };
-}
-
-function unavailableQmdIndexStatus(
-  resolved: ResolvedQmdIndexPath,
-  staleAfterHours: number,
-): OperatorDoctorStatus["qmd"]["index"] {
+/** Read at call time, not at import: the legacy tests flip env per case. */
+function ambientOptions(): OperatorDoctorOptions {
+  const nodeEnv = process.env.NODE_ENV;
   return {
-    path: resolved.path,
-    path_source: resolved.source,
-    status: "unavailable",
-    last_updated_at: null,
-    age_hours: null,
-    freshness: "unknown",
-    stale_after_hours: staleAfterHours,
-    document_count: null,
-    collection_count: null,
-  };
-}
-
-// Concurrent callers share one probe per path. Each probe spawns a Worker that
-// boots a module graph and opens the index, and buildOperatorDoctorStatus is
-// called repeatedly under load (the contract parity suite drives it many times
-// in quick succession). Spawning one per call starved the event loop enough
-// that neighbouring fixtures exceeded their 5s query timeout -- measured as
-// 8-10 parity failures against origin/main's stable 7. The entry is cleared on
-// settle, so the next call re-probes rather than serving a stale reading.
-const inFlightQmdIndexProbes = new Map<
-  string,
-  Promise<QmdIndexProbeResult>
->();
-
-function startQmdIndexProbe(path: string): {
-  task: Promise<QmdIndexProbeResult>;
-  terminate: () => void;
-} {
-  const existing = inFlightQmdIndexProbes.get(path);
-  if (existing) return { task: existing, terminate: () => {} };
-  const spawned = spawnQmdIndexProbe(path);
-  const shared = spawned.task.finally(() => {
-    inFlightQmdIndexProbes.delete(path);
-    spawned.terminate();
-  });
-  // Keep the shared promise from surfacing as an unhandled rejection when the
-  // only awaiting caller has already timed out.
-  shared.catch(() => {});
-  inFlightQmdIndexProbes.set(path, shared);
-  return { task: shared, terminate: () => {} };
-}
-
-function spawnQmdIndexProbe(path: string): {
-  task: Promise<QmdIndexProbeResult>;
-  terminate: () => void;
-} {
-  const worker = new Worker(
-    new URL("./qmd-index-probe-worker.ts", import.meta.url),
-    { type: "module" },
-  );
-  const task = new Promise<QmdIndexProbeResult>((resolve, reject) => {
-    worker.onmessage = (event: MessageEvent<QmdIndexProbeResult>) => {
-      resolve(event.data);
-    };
-    worker.onerror = (event: ErrorEvent) => {
-      reject(event.error ?? new Error(event.message));
-    };
-    worker.postMessage({ path });
-  });
-  return { task, terminate: () => worker.terminate() };
-}
-
-function availableQmdIndexStatus(
-  options: OperatorDoctorBuildOptions,
-  resolved: ResolvedQmdIndexPath,
-  staleAfterHours: number,
-  result: QmdIndexProbeResult,
-): OperatorDoctorStatus["qmd"]["index"] {
-  const modifiedAt = new Date(result.modified_at_ms);
-  const ageHours = Math.max(
-    0,
-    ((options.now ?? Date.now)() - modifiedAt.getTime()) / 3_600_000,
-  );
-  return {
-    path: resolved.path,
-    path_source: resolved.source,
-    status: "available",
-    last_updated_at: modifiedAt.toISOString(),
-    age_hours: Math.round(ageHours * 100) / 100,
-    freshness: ageHours >= staleAfterHours ? "stale" : "current",
-    stale_after_hours: staleAfterHours,
-    document_count: result.document_count,
-    collection_count: result.collection_count,
-  };
-}
-
-async function readQmdIndexStatus(
-  options: OperatorDoctorBuildOptions,
-): Promise<OperatorDoctorStatus["qmd"]["index"]> {
-  const resolved = resolveQmdIndexPath(options);
-  const staleAfterHours =
-    options.qmdIndexStaleAfterHours ?? QMD_INDEX_STALE_AFTER_HOURS;
-  const fallback = unavailableQmdIndexStatus(resolved, staleAfterHours);
-  const probe = startQmdIndexProbe(resolved.path);
-  try {
-    const result = await withTimeout(probe.task, null);
-    if (result === null) return fallback;
-    return availableQmdIndexStatus(
-      options,
-      resolved,
-      staleAfterHours,
-      result,
-    );
-  } catch (error) {
-    logger.warn("doctor_qmd_index_unreadable", {
-      path_source: resolved.source,
-      ...describeError(error),
-    });
-    return fallback;
-  } finally {
-    probe.terminate();
-  }
-}
-
-// Availability = the qmd entrypoint file exists at the same resolved path
-// search_all executes (src/qmd-path.ts). This remains binary presence only;
-// repo-local index freshness is reported separately below.
-async function checkQmdStatus(
-  options: OperatorDoctorBuildOptions,
-): Promise<OperatorDoctorStatus["qmd"]> {
-  const resolved = resolveQmdPath();
-  let available = false;
-  try {
-    available = existsSync(resolved.path);
-  } catch (error) {
-    // existsSync swallows ENOENT itself, so reaching here means something
-    // stranger -- a permission error on an ancestor directory, an unmounted
-    // volume. Reporting the binary as simply absent would send the operator
-    // looking for a missing install that is actually present and unreachable.
-    logger.warn("doctor_qmd_probe_failed", {
-      path_source: resolved.source,
-      ...describeError(error),
-    });
-  }
-  return {
-    configured: true,
-    path_source: resolved.source,
-    available,
-    status: available ? "available" : "unavailable",
-    index: await readQmdIndexStatus(options),
+    serviceVersionFallback: process.env.npm_package_version ?? "unknown",
+    nodeEnvironment:
+      nodeEnv === "production" || nodeEnv === "development" || nodeEnv === "test"
+        ? nodeEnv
+        : "unknown",
+    fileLogConfigured: Boolean(process.env.LOG_FILE?.trim()),
+    rotationConfigured:
+      Boolean(process.env.LOG_MAX_BYTES) || Boolean(process.env.LOG_MAX_FILES),
+    rawTurnTtlSeconds: readDistillationLagTtlSeconds(),
+    ...(process.env.QMD_INDEX_PATH !== undefined
+      ? { qmdIndexPath: process.env.QMD_INDEX_PATH, qmdIndexPathSource: "env" as const }
+      : {}),
   };
 }
 
@@ -590,137 +69,14 @@ export async function buildOperatorDoctorStatus(
   natsBridgeHealth?: NatsBridgeHealth,
   options: OperatorDoctorBuildOptions = {},
 ): Promise<OperatorDoctorStatus> {
-  const [
-    database,
-    migrations,
-    distillationLag,
-    embeddingAvailable,
-    serviceVersion,
-    auditStorage,
-    qmd,
-  ] = await Promise.all([
-    checkPoolHealth(pool),
-    readMigrationStatus(pool),
-    readDistillationLag(pool),
-    checkEmbeddingAvailability(),
-    readServiceVersion(),
-    readAuditStorageStatus(pool),
-    checkQmdStatus(options),
-  ]);
-
-  const embeddingDiagnostics = getEmbeddingProviderDiagnostics();
-  const transportAvailability =
-    natsBridgeHealth?.availability ?? natsRuntimeBoundary.nats.availability;
-  const transportDegraded = isRequestedTransportDegraded(
-    natsRuntimeBoundary,
-    transportAvailability,
-  );
-  // Migrations not verified current (pending OR unknown) with a connected
-  // DB means an unverified or broken schema: degraded, never silently healthy.
-  // A configured-but-unavailable embedding provider hard-fails vector search.
-  // Critical distillation lag means acknowledged live turns are nearing TTL
-  // expiry, so it degrades service status; warning lag is early signal only.
-  const migrationsDegraded = migrations.status !== "current";
-  const embeddingDegraded =
-    embeddingDiagnostics.configured && !embeddingAvailable;
-  const distillationDegraded = distillationLag.some(
-    ({ level }) => level === "critical",
-  );
-  const status: OperatorDoctorStatus["status"] = !database.connected
-    ? "unhealthy"
-    : migrationsDegraded ||
-        transportDegraded ||
-        embeddingDegraded ||
-        distillationDegraded
-      ? "degraded"
-      : "healthy";
-  const fileLogConfigured = Boolean(process.env.LOG_FILE?.trim());
-
-  return {
-    status,
-    contract_version: DOCTOR_CONTRACT_VERSION,
-    generated_at: new Date().toISOString(),
-    runtime: {
-      service: "open-brain",
-      version: serviceVersion,
-      contract_version: CONTRACT_VERSION,
-      contract_schema_version: CONTRACT_SCHEMA_VERSION,
-      node_env:
-        process.env.NODE_ENV === "production" ||
-        process.env.NODE_ENV === "development" ||
-        process.env.NODE_ENV === "test"
-          ? process.env.NODE_ENV
-          : "unknown",
-    },
-    database,
-    migrations,
-    distillation_lag: distillationLag,
-    embedding_provider: {
-      configured: embeddingDiagnostics.configured,
-      available: embeddingAvailable,
-      model: EMBEDDING_MODEL,
-      dimensions: EMBEDDING_DIMENSIONS,
-      recent_failures: {
-        last_failure_code: embeddingDiagnostics.last_failure_code,
-        consecutive_restartable_failures:
-          embeddingDiagnostics.consecutive_restartable_failures,
-        restart_configured: embeddingDiagnostics.restart_configured,
-        restart_in_flight: embeddingDiagnostics.restart_in_flight,
-        last_restart_at: embeddingDiagnostics.last_restart_at,
-      },
-    },
-    qmd,
-    transport: {
-      mode: natsRuntimeBoundary.requested_transport,
-      availability: transportAvailability,
-      fallback_http: natsRuntimeBoundary.nats.fallback_http,
-      consecutive_failures: natsBridgeHealth?.consecutiveFailures ?? 0,
-      last_error: natsBridgeHealth?.lastError ? "redacted" : null,
-    },
-    log_audit: {
-      request_logger: "enabled",
-      file_log_configured: fileLogConfigured,
-      rotation_configured:
-        fileLogConfigured &&
-        (Boolean(process.env.LOG_MAX_BYTES) ||
-          Boolean(process.env.LOG_MAX_FILES)),
-      audit_storage: auditStorage,
-    },
-    optional_dependencies: {
-      embedding_provider: embeddingDiagnostics.configured
-        ? embeddingAvailable
-          ? "available"
-          : "unavailable"
-        : "not_configured",
-      qmd: qmd.status,
-    },
-  };
-}
-
-// --- Single-flight + short-TTL cache -----------------------------------
-//
-// Every doctor build fans out DB scans and an outbound embedding probe;
-// without a cache, a polling dashboard or looping token amplifies probes
-// during the exact incident being diagnosed. All callers (REST route and
-// MCP tool) go through getOperatorDoctorStatus: concurrent callers share
-// one in-flight build, and results are served from cache within the TTL.
-
-interface DoctorCacheEntry {
-  value: OperatorDoctorStatus;
-  expiresAt: number;
-}
-
-export interface OperatorDoctorCacheOptions {
-  ttlMs?: number;
-  now?: () => number;
-}
-
-let doctorCache: DoctorCacheEntry | null = null;
-let doctorInFlight: Promise<OperatorDoctorStatus> | null = null;
-
-export function resetOperatorDoctorCache(): void {
-  doctorCache = null;
-  doctorInFlight = null;
+  const { qmdIndexPath, ...rest } = options;
+  return buildStatus(pool, natsRuntimeBoundary, natsBridgeHealth, {
+    ...ambientOptions(),
+    ...rest,
+    ...(qmdIndexPath !== undefined
+      ? { qmdIndexPath, qmdIndexPathSource: "option" as const }
+      : {}),
+  });
 }
 
 export async function getOperatorDoctorStatus(
@@ -729,42 +85,8 @@ export async function getOperatorDoctorStatus(
   natsBridgeHealth?: NatsBridgeHealth,
   options: OperatorDoctorCacheOptions = {},
 ): Promise<OperatorDoctorStatus> {
-  const now = options.now ?? Date.now;
-  const ttlMs = options.ttlMs ?? DOCTOR_CACHE_TTL_MS;
-  if (doctorCache && now() < doctorCache.expiresAt) {
-    return doctorCache.value;
-  }
-  if (doctorInFlight) return doctorInFlight;
-  const build = buildOperatorDoctorStatus(
-    pool,
-    natsRuntimeBoundary,
-    natsBridgeHealth,
-  )
-    .then((value) => {
-      doctorCache = { value, expiresAt: now() + ttlMs };
-      return value;
-    })
-    .catch((error: unknown) => {
-      // Logged HERE, at the owning boundary, and then re-thrown unchanged.
-      //
-      // Every consumer of this function converts the rejection into a
-      // deliberately content-free response -- the REST route in src/index.ts
-      // sends `{ error: "operator doctor status unavailable" }` and the MCP tool
-      // sends the same string -- because a raw doctor error can carry paths and
-      // env detail. That is right for the RESPONSE and left alone. But it meant
-      // the reason existed nowhere: the diagnostic surface is gone at exactly
-      // the moment it is needed, and the only trace was a 500 in an access log.
-      //
-      // Logging at this single point covers both consumers at once, and it is
-      // the only place that can: the in-flight promise below is shared, so one
-      // rejection is handed to every concurrent caller, and a per-caller catch
-      // would report the same failure once per waiter.
-      logger.error("doctor_status_build_failed", describeError(error));
-      throw error;
-    })
-    .finally(() => {
-      doctorInFlight = null;
-    });
-  doctorInFlight = build;
-  return build;
+  return getStatus(pool, natsRuntimeBoundary, natsBridgeHealth, {
+    ...ambientOptions(),
+    ...options,
+  });
 }


### PR DESCRIPTION
## Summary

- `src/operator-doctor.ts` (770 lines, twelve inline `process.env` reads) moves to `server/application/operator-doctor.ts`, split into three siblings by responsibility: `operator-doctor-types.ts` (the frozen `OperatorDoctorStatus` shape, `DOCTOR_CONTRACT_VERSION`, the distillation-lag ratio constants, `canReadDoctor`, `classifyDistillationLag`, the widened `OperatorDoctorOptions`), `operator-doctor-probes.ts` (the individual diagnostic questions: service version, migrations, audit storage, distillation lag, embedding availability, qmd binary and index probe worker, plus `withTimeout` and `probeUrl`), and `operator-doctor.ts` (assembly of the payload plus the single-flight short-TTL cache). Each satisfies the 500-line file rule and the 100-line function rule, and none reads `process.env`.
- The twelve env reads become fields of ONE options object. The existing 4th parameter type `OperatorDoctorCacheOptions` widened into `OperatorDoctorOptions` with the env-derived fields required there, so the parameter count stays 4 and `getOperatorDoctorStatus(pool, natsRuntimeBoundary, natsBridgeHealth, options)` keeps its signature.
- `server/main.ts:403` fills the options from the parsed `ServerConfig` it already holds: `serviceVersionFallback` ← `config.doctor.serviceVersionFallback`, `nodeEnvironment` ← `config.doctor.nodeEnvironment`, `fileLogConfigured` ← `config.logging.file`, `rotationConfigured` ← `config.doctor.rotationConfigured`, `rawTurnTtlSeconds` ← `config.doctor.rawTurnTtlSeconds`, `qmdIndexPath` ← `config.doctor.qmdIndexPath` (spread only when present, preserving the `!== undefined` branch the old resolver used).

```diff
     operatorDoctor: () =>
-      getOperatorDoctorStatus(database.pool, nats.boundary, nats.health),
+      getOperatorDoctorStatus(database.pool, nats.boundary, nats.health, {
+        serviceVersionFallback: config.doctor.serviceVersionFallback,
+        nodeEnvironment: config.doctor.nodeEnvironment,
+        fileLogConfigured: Boolean(config.logging.file?.trim()),
+        rotationConfigured: config.doctor.rotationConfigured,
+        rawTurnTtlSeconds: config.doctor.rawTurnTtlSeconds,
+        ...(config.doctor.qmdIndexPath !== undefined
+          ? { qmdIndexPath: config.doctor.qmdIndexPath }
+          : {}),
+      }),
```

- **Two keys had no reader in `server/config/src-readers.ts` yet, so this PR adds them** (allowed by the brief, stated here): `OPENBRAIN_RAW_TURN_TTL_SECONDS` (the distillation-lag alarm denominator, reproducing `readDistillationLagTtlSeconds` exactly — `Number()`, not `parseInt`, so a trailing suffix is `NaN` and falls back, and only a positive integer wins) and `npm_package_version` (the version reported when `package.json` itself cannot be read). Both are `rawOptional` fields plus two lines in `doctorGroup`; neither rejects, so start-equivalence holds.
- `src/operator-doctor.ts` becomes the M9 L5 adapter under the required header, importing only from `server/` paths and re-exporting every type and function the legacy callers use (`src/index.ts:196`, `src/tools/operator-doctor.ts:40`, `src/operator-doctor.test.ts`, `src/server.test.ts:13` `resetOperatorDoctorCache`, `src/tools/__tests__/operator-doctor.test.ts:3`, `server/tools/dependency-arrival.test.ts:36`) with the OLD call forms. It reads `process.env` **inside the call**, not at module scope, which is what lets the legacy tests keep flipping env per case and still see the change.
- `server/tools/operator-doctor.ts:85` holds no config object, so it keeps importing the `src/` adapter rather than the `server/` module; it repoints at L6 when the adapter retires.
- Closure count: 39 → 37 (the adapter is excluded by the M9 header regex).
- Tests left in `src/` (retire or move at L6): `src/operator-doctor.test.ts`, `src/server.test.ts`, `src/tools/__tests__/operator-doctor.test.ts` — untouched per M1 EXCEPTION, passing through the adapter unchanged.

## Verification

- Done-means: scripts/done-means/864-moved-out-of-src.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bunx tsc --noEmit` → exit 0. `oxlint --deny-warnings --config .oxlintrc.json` over the six staged paths → exit 0, no findings. `bun run test:isolated src/operator-doctor.test.ts src/server.test.ts src/tools/__tests__/operator-doctor.test.ts server/main.pg.test.ts server/tools/operator-doctor.test.ts server/config-src-readers.test.ts` → 74 pass, 0 fail. `bash scripts/done-means/864-moved-out-of-src.sh src/operator-doctor.ts` → PASS. `rg -n '"src/|src/[a-z-]+\.ts' python/openbrain-memory/tests` → no `operator-doctor` hits, so the M10 python guards need no repoint. The pre-push hook ran the full isolated suite and passed.

## Critical Self-Review

- Highest-risk behavior: the frozen `operator_doctor` payload. `qmd.index.path_source` distinguished `"option"` (caller-supplied) from `"env"` (`QMD_INDEX_PATH`), and the server/ module no longer sees which it was — so `OperatorDoctorOptions` carries an explicit `qmdIndexPathSource`, and the adapter sets `"option"` for a caller argument and `"env"` for the env read, preserving the exact reported value. `src/operator-doctor.test.ts` locks the key set against `DOCTOR_CONTRACT_VERSION` and passes unchanged.
- Assumptions that could be wrong: that no caller outside the six repointed/re-exported sites reaches into the module. Checked with `rg -n "getOperatorDoctorStatus\(|from ['\"].*operator-doctor" --type ts`; every hit is either the adapter, `server/main.ts`, or a re-export the adapter carries.
- Missing/weak tests: nothing covers the `server/main.ts` options wiring end to end — `server/main.pg.test.ts` starts the server but does not assert the doctor payload's `node_env` or `rotation_configured` came from config rather than ambient env. A follow-up could assert that; the value is currently proven only by the src/-side tests going through the adapter.
- Security/permission risk: none new. `canReadDoctor` and the admin/ob-admin gate in the MCP tool are re-exported unchanged, and no error text gained a raw path — the migrations and qmd probes still log paths and return path-free payloads.
- Migration/deploy risk: none. No schema change, no new required env variable — both added config fields are optional with the same fallbacks the old inline readers used.
- Downstream client/runtime risk: none. `docs/downstream-rollout.md` classifies this as internal: no MCP tool schema, transport, or Python client contract changed, and the payload shape is byte-identical under the same `DOCTOR_CONTRACT_VERSION`.
- Rollback/cleanup concern: reverting the commit restores the single `src/` file cleanly. The adapter and the three tests left in `src/` are the L6 cleanup this lane deliberately defers.
- Fixes made before PR: found and closed a latent gap — the old `getOperatorDoctorStatus` called `buildOperatorDoctorStatus` **without forwarding its options**, so a caller's `qmdIndexPath` or `now()` reached the builder only via the uncached direct call. The options are now threaded through both paths.
- Known residual risk: the pre-commit prettier gate reformatted four unrelated statements in `server/main.ts` (staged files are formatted whole). They are formatting-only and carry no behavior change, but they widen this PR's `server/main.ts` diff beyond the one import line plus the options argument.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical L5 move lane under the issue-864 program rules; the reusable lesson (a `path_source` discriminator is lost when an env read is lifted into a caller-supplied option, and must be carried as its own field) is recorded in the PR comment below rather than as a new lane entry.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime contract, transport, or schema changed; the local isolated suite plus the full pre-push suite cover it.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: the doctor payload shape is unchanged and `DOCTOR_CONTRACT_VERSION` is untouched, so no parity fixture moves.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Internal refactor only. No MCP tool schema, transport, Python client, or agent-facing contract changed; `operator_doctor` answers the identical payload from the identical version string.
