### PR TITLE
refactor(l5): move tiering from src/ into server/domain behind an L5 adapter (issue 864)

### DIFF
--- a/python/openbrain-memory/tests/test_event_vocabulary.py
+++ b/python/openbrain-memory/tests/test_event_vocabulary.py
@@ -137,8 +137,9 @@ def test_mcp_tool_schema_matches_python() -> None:
 
 
 def test_tiering_union_matches_python() -> None:
-    """`src/tiering.ts` `EventType` matches; it decides what gets promoted."""
-    source = (REPO_ROOT / "src" / "tiering.ts").read_text()
+    """`server/domain/tiering.ts` `EventType` matches; it decides what gets promoted."""
+    # Moved here from `src/tiering.ts` by issue 864; the old path is an adapter.
+    source = (REPO_ROOT / "server" / "domain" / "tiering.ts").read_text()
     found = _extract_union(source, "export type EventType")
     assert found == EVENT_TYPES, _drift("tiering EventType", found)
 
@@ -240,7 +241,9 @@ def test_vocabulary_is_declared_exactly_where_expected() -> None:
         # Moved here from `src/contract-schemas.ts` by issue 864; the old path
         # is a re-export shim.
         "server/contracts/schemas-events.ts",
-        "src/tiering.ts",
+        # Moved here from `src/tiering.ts` by issue 864; the old path is an
+        # adapter that re-exports, so it declares no member names.
+        "server/domain/tiering.ts",
         # Moved here from `src/tools/table-constants.ts` by issue 864. The old
         # path keeps a re-export shim, which declares no member names and so
         # never appears in this sweep -- listing it would weaken the census.

--- a/server/domain/candidate-dedupe.test.ts
+++ b/server/domain/candidate-dedupe.test.ts
@@ -32,7 +32,7 @@ import {
   readReinforcement,
   runCandidateDedupe,
 } from "./candidate-dedupe.ts";
-import { DEFAULT_DUP_THRESHOLD } from "../../src/tiering.ts";
+import { DEFAULT_DUP_THRESHOLD } from "./tiering.ts";
 import type { MaintenanceQueueLogger } from "../maintenance/maintenance-queue-runner.ts";
 
 const silentLogger: MaintenanceQueueLogger = {

--- a/server/domain/tiering.ts
+++ b/server/domain/tiering.ts
@@ -1,0 +1,423 @@
+import type pg from "pg";
+import { toSql } from "pgvector/pg";
+import { contentHash, EMBEDDING_MODEL } from "../../src/embedding.ts";
+import type { generateEmbedding } from "../../src/embedding.ts";
+import { logger } from "../../src/logger.ts";
+import { describeError } from "../../src/observability/index.ts";
+import { writeThoughtChunks, type ChunkWriteResult } from "../../src/chunk-write.ts";
+
+/**
+ * Lane → own-durable memory tiering (Issue #160).
+ *
+ * Graduates `ob_session_events` lane events into the agent's OWN durable
+ * `thoughts` table within the SAME namespace. This is distinct from shared-kb
+ * promotion (#161): no cross-namespace move, no promoter role required.
+ */
+
+export type EventType =
+  | "fact"
+  | "decision"
+  | "blocker"
+  | "action"
+  | "artifact"
+  | "receipt"
+  | "question"
+  | "correction"
+  | "handoff";
+
+export type Importance = "hot" | "warm" | "cold";
+
+export type Classification = "graduate" | "keep" | "archive" | "manual-review";
+
+/** Default minimum content length for a graduate-eligible event. */
+export const DEFAULT_MIN_CONTENT_LENGTH = 24;
+
+/** Default cosine-distance threshold for near-duplicate detection. */
+export const DEFAULT_DUP_THRESHOLD = 0.08;
+
+/** Event types whose substance warrants durable graduation. */
+const GRADUATE_TYPES: ReadonlySet<EventType> = new Set<EventType>([
+  "fact",
+  "decision",
+  "handoff",
+]);
+
+/** Event types that are operational noise — archive rather than graduate. */
+const ARCHIVE_TYPES: ReadonlySet<EventType> = new Set<EventType>([
+  "question",
+  "action",
+]);
+
+/** Lifecycle actions that explicitly keep a candidate out of automatic own-durable graduation. */
+const OWN_DURABLE_KEEP_LIFECYCLE_ACTIONS: ReadonlySet<string> = new Set([
+  "candidate",
+  "promote",
+  "relegate",
+  "discard",
+]);
+
+/** Minimal shape the classifier needs from a lane event. */
+export interface ClassifiableEvent {
+  event_type: EventType;
+  content: string;
+  importance: Importance;
+  metadata?: Record<string, unknown> | null;
+}
+
+/**
+ * Pure classifier — no DB, no I/O. Decides how a single lane event should be
+ * tiered. Duplicate detection is handled separately (see `findDurableDuplicate`)
+ * because it needs the target table.
+ *
+ * Rules:
+ * - graduate: type ∈ {fact, decision, handoff} AND importance !== "cold"
+ *   AND trimmed content length >= minContentLength.
+ * - archive: type ∈ {question, action} OR importance === "cold".
+ * - manual-review: graduate-eligible by type/importance but content is too
+ *   short to be sure (ambiguous).
+ * - keep: everything else (default short-term retention).
+ *
+ * Archive precedence note: a `cold` fact/decision/handoff archives rather than
+ * graduating — cold importance means the agent has down-tiered it.
+ */
+export function classifyLaneEvent(
+  event: ClassifiableEvent,
+  minContentLength: number = DEFAULT_MIN_CONTENT_LENGTH,
+): Classification {
+  const lifecycleAction = event.metadata?.memory_lifecycle_action;
+  if (
+    typeof lifecycleAction === "string" &&
+    OWN_DURABLE_KEEP_LIFECYCLE_ACTIONS.has(lifecycleAction)
+  ) {
+    return "keep";
+  }
+
+  const isColdOrArchiveType =
+    event.importance === "cold" || ARCHIVE_TYPES.has(event.event_type);
+  if (isColdOrArchiveType) {
+    return "archive";
+  }
+
+  if (GRADUATE_TYPES.has(event.event_type)) {
+    // type + importance qualify; length decides graduate vs ambiguous.
+    const length = event.content.trim().length;
+    return length >= minContentLength ? "graduate" : "manual-review";
+  }
+
+  return "keep";
+}
+
+/** A lane event row joined with its lane's namespace + agent. */
+export interface LaneEventRow {
+  id: string;
+  lane_id: string;
+  namespace: string;
+  agent: string | null;
+  session_key: string;
+  event_type: EventType;
+  content: string;
+  importance: Importance;
+  content_hash: string | null;
+  created_at: string;
+  metadata: Record<string, unknown> | null;
+}
+
+export type DuplicateKind = "exact" | "near";
+
+export interface DuplicateMatch {
+  kind: DuplicateKind;
+  thought_id: string;
+  distance?: number;
+}
+
+/**
+ * Check whether an event is already present in the target durable `thoughts`
+ * table for its namespace. Two passes:
+ *  - exact: identical content_hash in thoughts(namespace).
+ *  - near: cosine distance `embedding <=> embedding < threshold` to an existing
+ *    thought in that namespace (mirrors find-duplicates.ts convention).
+ *
+ * Returns the first match found, or null. SQL is fully parameterized.
+ */
+export interface DuplicateLookup {
+  hash: string | null;
+  embedding: number[] | null;
+  threshold?: number;
+}
+
+export async function findDurableDuplicate(
+  pool: pg.Pool,
+  namespace: string,
+  lookup: DuplicateLookup,
+): Promise<DuplicateMatch | null> {
+  const { hash, embedding } = lookup;
+  const threshold = lookup.threshold ?? DEFAULT_DUP_THRESHOLD;
+  if (hash) {
+    const { rows } = await pool.query(
+      `SELECT id FROM thoughts
+       WHERE content_hash = $1 AND namespace = $2 AND archived_at IS NULL
+       LIMIT 1`,
+      [hash, namespace],
+    );
+    if (rows.length > 0) {
+      return { kind: "exact", thought_id: rows[0].id as string };
+    }
+  }
+
+  if (embedding) {
+    const { rows } = await pool.query(
+      `SELECT id, embedding <=> $1 AS distance
+       FROM thoughts
+       WHERE namespace = $2
+         AND archived_at IS NULL
+         AND embedding IS NOT NULL
+         AND embedding <=> $1 < $3
+       ORDER BY distance ASC
+       LIMIT 1`,
+      [toSql(embedding), namespace, threshold],
+    );
+    if (rows.length > 0) {
+      return {
+        kind: "near",
+        thought_id: rows[0].id as string,
+        distance: Number(rows[0].distance),
+      };
+    }
+  }
+
+  return null;
+}
+
+/** Provenance payload recorded on graduated thoughts. */
+export interface LaneGraduationProvenance {
+  source: "session-lane";
+  lane_id: string;
+  session_key: string;
+  event_id: string;
+  event_type: EventType;
+  importance: Importance;
+  agent: string | null;
+  classification: Classification;
+  reason: string;
+  graduated_at: string;
+}
+
+export interface GraduateResult {
+  thought_id: string;
+  is_new: boolean;
+  /** Chunk receipt for a long graduated event; null when chunking did not run. */
+  chunks?: ChunkWriteResult | null;
+  /** True when the parent committed but per-section writing threw. */
+  chunking_failed?: boolean;
+}
+
+/**
+ * Insert a graduated lane event into the agent's own `thoughts` namespace.
+ * Idempotent via ON CONFLICT (content_hash, namespace) — re-running a batch
+ * produces no duplicate rows (mirrors log-thought.ts). Provenance is stored in
+ * `promoted_from` (the existing provenance column) and surfaced in tags.
+ *
+ * A graduated event becomes an ordinary thought, so it is stored like one:
+ * when `embedFn` is supplied and the content is long, the parent is followed
+ * by per-section chunk rows via the shared thought-write boundary (#605).
+ * `embedFn` is optional so an existing caller that has no embedder still
+ * graduates — it simply does not chunk, which is the pre-#605 behavior rather
+ * than a new failure.
+ */
+export interface GraduateLaneEventOptions {
+  createdBy: string;
+  embedding: number[] | null;
+  reason: string;
+  embedFn?: (text: string) => Promise<number[] | null>;
+}
+
+export async function graduateLaneEvent(
+  pool: pg.Pool,
+  event: LaneEventRow,
+  namespace: string,
+  opts: GraduateLaneEventOptions,
+): Promise<GraduateResult> {
+  const { createdBy, embedding, reason, embedFn } = opts;
+  // Defense-in-depth: a lane event must only graduate into ITS OWN namespace.
+  // Callers already scope the source read by namespace, but assert here so a
+  // future caller that constructs rows differently cannot write cross-namespace.
+  if (event.namespace !== namespace) {
+    throw new Error(
+      `lane event namespace '${event.namespace}' does not match graduation target '${namespace}'`,
+    );
+  }
+  const hash = event.content_hash ?? contentHash(event.content);
+  const tags = [
+    "tiered-from-lane",
+    `lane:${event.session_key}`,
+    `event-type:${event.event_type}`,
+  ];
+  const provenance: LaneGraduationProvenance = {
+    source: "session-lane",
+    lane_id: event.lane_id,
+    session_key: event.session_key,
+    event_id: event.id,
+    event_type: event.event_type,
+    importance: event.importance,
+    agent: event.agent,
+    classification: "graduate",
+    reason,
+    graduated_at: new Date().toISOString(),
+  };
+
+  const { rows } = await pool.query(
+    `INSERT INTO thoughts
+       (content, tags, source, created_by, namespace, embedding, content_hash,
+        embedded_at, embedding_model, promoted_from)
+     VALUES ($1, $2, 'lane-tiering', $3, $4, $5, $6, $7, $8, $9)
+     ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL
+     DO UPDATE SET
+       tags = (
+         SELECT COALESCE(array_agg(DISTINCT tag), '{}')
+         FROM unnest(thoughts.tags || EXCLUDED.tags) AS tag
+         WHERE tag IS NOT NULL
+       ),
+       updated_at = NOW()
+     RETURNING id, (xmax = 0) AS is_new`,
+    [
+      event.content,
+      tags,
+      createdBy,
+      namespace,
+      embedding ? toSql(embedding) : null,
+      hash,
+      embedding ? new Date().toISOString() : null,
+      embedding ? EMBEDDING_MODEL : null,
+      JSON.stringify(provenance),
+    ],
+  );
+
+  const thoughtId = rows[0].id as string;
+  const isNew = rows[0].is_new as boolean;
+
+  if (!embedFn) return { thought_id: thoughtId, is_new: isNew };
+
+  const chunks = await writeThoughtChunks(pool, {
+    parentId: thoughtId,
+    namespace,
+    createdBy,
+    content: event.content,
+    tags,
+    embedFn,
+    source: "lane-tiering-chunk",
+    isNew,
+    caller: "tiering/graduateLaneEvent",
+  });
+
+  return {
+    thought_id: thoughtId,
+    is_new: isNew,
+    chunks: chunks.result,
+    chunking_failed: chunks.failed,
+  };
+}
+
+export interface TierReceipt {
+  scanned: number;
+  graduated: number;
+  kept: number;
+  archived: number;
+  manual_review: number;
+  duplicates: number;
+  dry_run: boolean;
+}
+
+export function newTierReceipt(dryRun: boolean): TierReceipt {
+  return {
+    scanned: 0,
+    graduated: 0,
+    kept: 0,
+    archived: 0,
+    manual_review: 0,
+    duplicates: 0,
+    dry_run: dryRun,
+  };
+}
+
+export interface TierEventOptions {
+  pool: pg.Pool;
+  embedFn: typeof generateEmbedding;
+  namespace: string;
+  createdBy: string;
+  minContentLength?: number;
+  dupThreshold?: number;
+  dryRun: boolean;
+}
+
+/**
+ * Classify + dedup + (optionally) graduate a single lane event, mutating the
+ * receipt in place. Shared by the on-demand `tier_lane` tool and the background
+ * runner so both paths apply identical policy.
+ */
+export async function tierLaneEvent(
+  event: LaneEventRow,
+  receipt: TierReceipt,
+  opts: TierEventOptions,
+): Promise<void> {
+  receipt.scanned += 1;
+
+  const minContentLength = opts.minContentLength ?? DEFAULT_MIN_CONTENT_LENGTH;
+  const classification = classifyLaneEvent(event, minContentLength);
+
+  if (classification === "keep") {
+    receipt.kept += 1;
+    return;
+  }
+  if (classification === "archive") {
+    receipt.archived += 1;
+    return;
+  }
+  if (classification === "manual-review") {
+    receipt.manual_review += 1;
+    return;
+  }
+
+  // classification === "graduate" — needs an embedding for near-dup detection
+  // and for the durable thought. Embedding failures degrade to hash-only dedup.
+  let embedding: number[] | null = null;
+  try {
+    embedding = await opts.embedFn(event.content);
+  } catch (error) {
+    embedding = null;
+    // The degradation is deliberate (hash-only dedup still works, and the
+    // adversarial SME checklist requires it keep working). The silence was not:
+    // a thought graduated without a vector is invisible to semantic recall
+    // afterwards, permanently, and nothing said the provider was down. This is
+    // the standard's degraded path, so it is a warning, not a debug line.
+    logger.warn("tier_embedding_degraded", {
+      namespace: opts.namespace,
+      event_id: event.id,
+      dedup_mode: "hash_only",
+      ...describeError(error),
+    });
+  }
+
+  const hash = event.content_hash ?? contentHash(event.content);
+  const duplicate = await findDurableDuplicate(opts.pool, opts.namespace, {
+    hash,
+    embedding,
+    threshold: opts.dupThreshold ?? DEFAULT_DUP_THRESHOLD,
+  });
+  if (duplicate) {
+    receipt.duplicates += 1;
+    return;
+  }
+
+  if (opts.dryRun) {
+    receipt.graduated += 1;
+    return;
+  }
+
+  await graduateLaneEvent(opts.pool, event, opts.namespace, {
+    createdBy: opts.createdBy,
+    embedding,
+    reason: `lane tiering: ${event.event_type}/${event.importance}`,
+    embedFn: opts.embedFn,
+  });
+  receipt.graduated += 1;
+}

--- a/server/tools/tier-lane.ts
+++ b/server/tools/tier-lane.ts
@@ -37,11 +37,7 @@ import type { AuthIdentity } from "../auth/types.ts";
 import { canWrite } from "../auth/permissions.ts";
 import { canTargetNamespace } from "../auth/namespace-policy.ts";
 import { canonicalNamespace, physicalNamespace } from "./shared-namespace.ts";
-import {
-  newTierReceipt,
-  tierLaneEvent,
-  type LaneEventRow,
-} from "../../src/tiering.ts";
+import { newTierReceipt, tierLaneEvent, type LaneEventRow } from "../domain/tiering.ts";
 import {
   authIdentity,
   errorResult,
@@ -53,11 +49,7 @@ import {
 const DEFAULT_EVENTS_SCANNED = 100;
 
 const tierLaneInputSchema = {
-  session_key: z
-    .string()
-    .min(1)
-    .max(500)
-    .describe("Stable lane identifier to tier"),
+  session_key: z.string().min(1).max(500).describe("Stable lane identifier to tier"),
   namespace: z
     .string()
     .min(1)
@@ -293,10 +285,7 @@ async function handleTierLane(
     );
     return textResult({
       session_key: args.session_key,
-      namespace: canonicalNamespace(
-        namespace,
-        dependencies.sharedNamespaceNames,
-      ),
+      namespace: canonicalNamespace(namespace, dependencies.sharedNamespaceNames),
       ...receipt,
     });
   } catch (error) {

--- a/src/tiering.ts
+++ b/src/tiering.ts
@@ -1,420 +1,59 @@
-import type pg from "pg";
-import { toSql } from "pgvector/pg";
-import { contentHash, EMBEDDING_MODEL } from "./embedding.ts";
-import type { generateEmbedding } from "./embedding.ts";
-import { logger } from "./logger.ts";
-import { describeError } from "./observability/index.ts";
+// L5 adapter (issue 864): legacy call form over server/domain/tiering.ts; retired with src/ at L6.
 import {
-  writeThoughtChunks,
-  type ChunkWriteResult,
-} from "./chunk-write.ts";
+  findDurableDuplicate as findDurableDuplicateServer,
+  graduateLaneEvent as graduateLaneEventServer,
+  type DuplicateMatch,
+  type GraduateResult,
+  type LaneEventRow,
+} from "../server/domain/tiering.ts";
+import type pg from "pg";
 
-/**
- * Lane → own-durable memory tiering (Issue #160).
- *
- * Graduates `ob_session_events` lane events into the agent's OWN durable
- * `thoughts` table within the SAME namespace. This is distinct from shared-kb
- * promotion (#161): no cross-namespace move, no promoter role required.
- */
+export * from "../server/domain/tiering.ts";
 
-export type EventType =
-  | "fact"
-  | "decision"
-  | "blocker"
-  | "action"
-  | "artifact"
-  | "receipt"
-  | "question"
-  | "correction"
-  | "handoff";
+/** Trailing arguments of the pre-864 positional `graduateLaneEvent` form. */
+type LegacyGraduateTail = [
+  createdBy: string,
+  embedding: number[] | null,
+  reason: string,
+  embedFn?: (text: string) => Promise<number[] | null>,
+];
 
-export type Importance = "hot" | "warm" | "cold";
-
-export type Classification = "graduate" | "keep" | "archive" | "manual-review";
-
-/** Default minimum content length for a graduate-eligible event. */
-export const DEFAULT_MIN_CONTENT_LENGTH = 24;
-
-/** Default cosine-distance threshold for near-duplicate detection. */
-export const DEFAULT_DUP_THRESHOLD = 0.08;
-
-/** Event types whose substance warrants durable graduation. */
-const GRADUATE_TYPES: ReadonlySet<EventType> = new Set<EventType>([
-  "fact",
-  "decision",
-  "handoff",
-]);
-
-/** Event types that are operational noise — archive rather than graduate. */
-const ARCHIVE_TYPES: ReadonlySet<EventType> = new Set<EventType>([
-  "question",
-  "action",
-]);
-
-/** Lifecycle actions that explicitly keep a candidate out of automatic own-durable graduation. */
-const OWN_DURABLE_KEEP_LIFECYCLE_ACTIONS: ReadonlySet<string> = new Set([
-  "candidate",
-  "promote",
-  "relegate",
-  "discard",
-]);
-
-/** Minimal shape the classifier needs from a lane event. */
-export interface ClassifiableEvent {
-  event_type: EventType;
-  content: string;
-  importance: Importance;
-  metadata?: Record<string, unknown> | null;
-}
-
-/**
- * Pure classifier — no DB, no I/O. Decides how a single lane event should be
- * tiered. Duplicate detection is handled separately (see `findDurableDuplicate`)
- * because it needs the target table.
- *
- * Rules:
- * - graduate: type ∈ {fact, decision, handoff} AND importance !== "cold"
- *   AND trimmed content length >= minContentLength.
- * - archive: type ∈ {question, action} OR importance === "cold".
- * - manual-review: graduate-eligible by type/importance but content is too
- *   short to be sure (ambiguous).
- * - keep: everything else (default short-term retention).
- *
- * Archive precedence note: a `cold` fact/decision/handoff archives rather than
- * graduating — cold importance means the agent has down-tiered it.
- */
-export function classifyLaneEvent(
-  event: ClassifiableEvent,
-  minContentLength: number = DEFAULT_MIN_CONTENT_LENGTH,
-): Classification {
-  const lifecycleAction = event.metadata?.memory_lifecycle_action;
-  if (
-    typeof lifecycleAction === "string" &&
-    OWN_DURABLE_KEEP_LIFECYCLE_ACTIONS.has(lifecycleAction)
-  ) {
-    return "keep";
-  }
-
-  const isColdOrArchiveType =
-    event.importance === "cold" || ARCHIVE_TYPES.has(event.event_type);
-  if (isColdOrArchiveType) {
-    return "archive";
-  }
-
-  if (GRADUATE_TYPES.has(event.event_type)) {
-    // type + importance qualify; length decides graduate vs ambiguous.
-    const length = event.content.trim().length;
-    return length >= minContentLength ? "graduate" : "manual-review";
-  }
-
-  return "keep";
-}
-
-/** A lane event row joined with its lane's namespace + agent. */
-export interface LaneEventRow {
-  id: string;
-  lane_id: string;
-  namespace: string;
-  agent: string | null;
-  session_key: string;
-  event_type: EventType;
-  content: string;
-  importance: Importance;
-  content_hash: string | null;
-  created_at: string;
-  metadata: Record<string, unknown> | null;
-}
-
-export type DuplicateKind = "exact" | "near";
-
-export interface DuplicateMatch {
-  kind: DuplicateKind;
-  thought_id: string;
-  distance?: number;
-}
-
-/**
- * Check whether an event is already present in the target durable `thoughts`
- * table for its namespace. Two passes:
- *  - exact: identical content_hash in thoughts(namespace).
- *  - near: cosine distance `embedding <=> embedding < threshold` to an existing
- *    thought in that namespace (mirrors find-duplicates.ts convention).
- *
- * Returns the first match found, or null. SQL is fully parameterized.
- */
-export async function findDurableDuplicate(
-  pool: pg.Pool,
-  namespace: string,
+/** Trailing arguments of the pre-864 positional `findDurableDuplicate` form. */
+type LegacyDuplicateTail = [
   hash: string | null,
   embedding: number[] | null,
-  threshold: number = DEFAULT_DUP_THRESHOLD,
-): Promise<DuplicateMatch | null> {
-  if (hash) {
-    const { rows } = await pool.query(
-      `SELECT id FROM thoughts
-       WHERE content_hash = $1 AND namespace = $2 AND archived_at IS NULL
-       LIMIT 1`,
-      [hash, namespace],
-    );
-    if (rows.length > 0) {
-      return { kind: "exact", thought_id: rows[0].id as string };
-    }
-  }
-
-  if (embedding) {
-    const { rows } = await pool.query(
-      `SELECT id, embedding <=> $1 AS distance
-       FROM thoughts
-       WHERE namespace = $2
-         AND archived_at IS NULL
-         AND embedding IS NOT NULL
-         AND embedding <=> $1 < $3
-       ORDER BY distance ASC
-       LIMIT 1`,
-      [toSql(embedding), namespace, threshold],
-    );
-    if (rows.length > 0) {
-      return {
-        kind: "near",
-        thought_id: rows[0].id as string,
-        distance: Number(rows[0].distance),
-      };
-    }
-  }
-
-  return null;
-}
-
-/** Provenance payload recorded on graduated thoughts. */
-export interface LaneGraduationProvenance {
-  source: "session-lane";
-  lane_id: string;
-  session_key: string;
-  event_id: string;
-  event_type: EventType;
-  importance: Importance;
-  agent: string | null;
-  classification: Classification;
-  reason: string;
-  graduated_at: string;
-}
-
-export interface GraduateResult {
-  thought_id: string;
-  is_new: boolean;
-  /** Chunk receipt for a long graduated event; null when chunking did not run. */
-  chunks?: ChunkWriteResult | null;
-  /** True when the parent committed but per-section writing threw. */
-  chunking_failed?: boolean;
-}
+  threshold?: number,
+];
 
 /**
- * Insert a graduated lane event into the agent's own `thoughts` namespace.
- * Idempotent via ON CONFLICT (content_hash, namespace) — re-running a batch
- * produces no duplicate rows (mirrors log-thought.ts). Provenance is stored in
- * `promoted_from` (the existing provenance column) and surfaced in tags.
- *
- * A graduated event becomes an ordinary thought, so it is stored like one:
- * when `embedFn` is supplied and the content is long, the parent is followed
- * by per-section chunk rows via the shared thought-write boundary (#605).
- * `embedFn` is optional so an existing caller that has no embedder still
- * graduates — it simply does not chunk, which is the pre-#605 behavior rather
- * than a new failure.
+ * Pre-864 positional form of `graduateLaneEvent`, kept for `src/` and
+ * `scripts/` callers. The server/ version takes one options object.
  */
 export async function graduateLaneEvent(
   pool: pg.Pool,
   event: LaneEventRow,
   namespace: string,
-  createdBy: string,
-  embedding: number[] | null,
-  reason: string,
-  embedFn?: (text: string) => Promise<number[] | null>,
+  ...tail: LegacyGraduateTail
 ): Promise<GraduateResult> {
-  // Defense-in-depth: a lane event must only graduate into ITS OWN namespace.
-  // Callers already scope the source read by namespace, but assert here so a
-  // future caller that constructs rows differently cannot write cross-namespace.
-  if (event.namespace !== namespace) {
-    throw new Error(
-      `lane event namespace '${event.namespace}' does not match graduation target '${namespace}'`,
-    );
-  }
-  const hash = event.content_hash ?? contentHash(event.content);
-  const tags = [
-    "tiered-from-lane",
-    `lane:${event.session_key}`,
-    `event-type:${event.event_type}`,
-  ];
-  const provenance: LaneGraduationProvenance = {
-    source: "session-lane",
-    lane_id: event.lane_id,
-    session_key: event.session_key,
-    event_id: event.id,
-    event_type: event.event_type,
-    importance: event.importance,
-    agent: event.agent,
-    classification: "graduate",
-    reason,
-    graduated_at: new Date().toISOString(),
-  };
-
-  const { rows } = await pool.query(
-    `INSERT INTO thoughts
-       (content, tags, source, created_by, namespace, embedding, content_hash,
-        embedded_at, embedding_model, promoted_from)
-     VALUES ($1, $2, 'lane-tiering', $3, $4, $5, $6, $7, $8, $9)
-     ON CONFLICT (content_hash, namespace) WHERE content_hash IS NOT NULL
-     DO UPDATE SET
-       tags = (
-         SELECT COALESCE(array_agg(DISTINCT tag), '{}')
-         FROM unnest(thoughts.tags || EXCLUDED.tags) AS tag
-         WHERE tag IS NOT NULL
-       ),
-       updated_at = NOW()
-     RETURNING id, (xmax = 0) AS is_new`,
-    [
-      event.content,
-      tags,
-      createdBy,
-      namespace,
-      embedding ? toSql(embedding) : null,
-      hash,
-      embedding ? new Date().toISOString() : null,
-      embedding ? EMBEDDING_MODEL : null,
-      JSON.stringify(provenance),
-    ],
-  );
-
-  const thoughtId = rows[0].id as string;
-  const isNew = rows[0].is_new as boolean;
-
-  if (!embedFn) return { thought_id: thoughtId, is_new: isNew };
-
-  const chunks = await writeThoughtChunks(pool, {
-    parentId: thoughtId,
-    namespace,
+  const [createdBy, embedding, reason, embedFn] = tail;
+  return graduateLaneEventServer(pool, event, namespace, {
     createdBy,
-    content: event.content,
-    tags,
+    embedding,
+    reason,
     embedFn,
-    source: "lane-tiering-chunk",
-    isNew,
-    caller: "tiering/graduateLaneEvent",
   });
-
-  return {
-    thought_id: thoughtId,
-    is_new: isNew,
-    chunks: chunks.result,
-    chunking_failed: chunks.failed,
-  };
 }
 
-export interface TierReceipt {
-  scanned: number;
-  graduated: number;
-  kept: number;
-  archived: number;
-  manual_review: number;
-  duplicates: number;
-  dry_run: boolean;
-}
-
-export function newTierReceipt(dryRun: boolean): TierReceipt {
-  return {
-    scanned: 0,
-    graduated: 0,
-    kept: 0,
-    archived: 0,
-    manual_review: 0,
-    duplicates: 0,
-    dry_run: dryRun,
-  };
-}
-
-export interface TierEventOptions {
-  pool: pg.Pool;
-  embedFn: typeof generateEmbedding;
-  namespace: string;
-  createdBy: string;
-  minContentLength?: number;
-  dupThreshold?: number;
-  dryRun: boolean;
-}
-
-/**
- * Classify + dedup + (optionally) graduate a single lane event, mutating the
- * receipt in place. Shared by the on-demand `tier_lane` tool and the background
- * runner so both paths apply identical policy.
- */
-export async function tierLaneEvent(
-  event: LaneEventRow,
-  receipt: TierReceipt,
-  opts: TierEventOptions,
-): Promise<void> {
-  receipt.scanned += 1;
-
-  const minContentLength = opts.minContentLength ?? DEFAULT_MIN_CONTENT_LENGTH;
-  const classification = classifyLaneEvent(event, minContentLength);
-
-  if (classification === "keep") {
-    receipt.kept += 1;
-    return;
-  }
-  if (classification === "archive") {
-    receipt.archived += 1;
-    return;
-  }
-  if (classification === "manual-review") {
-    receipt.manual_review += 1;
-    return;
-  }
-
-  // classification === "graduate" — needs an embedding for near-dup detection
-  // and for the durable thought. Embedding failures degrade to hash-only dedup.
-  let embedding: number[] | null = null;
-  try {
-    embedding = await opts.embedFn(event.content);
-  } catch (error) {
-    embedding = null;
-    // The degradation is deliberate (hash-only dedup still works, and the
-    // adversarial SME checklist requires it keep working). The silence was not:
-    // a thought graduated without a vector is invisible to semantic recall
-    // afterwards, permanently, and nothing said the provider was down. This is
-    // the standard's degraded path, so it is a warning, not a debug line.
-    logger.warn("tier_embedding_degraded", {
-      namespace: opts.namespace,
-      event_id: event.id,
-      dedup_mode: "hash_only",
-      ...describeError(error),
-    });
-  }
-
-  const hash = event.content_hash ?? contentHash(event.content);
-  const duplicate = await findDurableDuplicate(
-    opts.pool,
-    opts.namespace,
+/** Pre-864 positional form of `findDurableDuplicate`. */
+export async function findDurableDuplicate(
+  pool: pg.Pool,
+  namespace: string,
+  ...tail: LegacyDuplicateTail
+): Promise<DuplicateMatch | null> {
+  const [hash, embedding, threshold] = tail;
+  return findDurableDuplicateServer(pool, namespace, {
     hash,
     embedding,
-    opts.dupThreshold ?? DEFAULT_DUP_THRESHOLD,
-  );
-  if (duplicate) {
-    receipt.duplicates += 1;
-    return;
-  }
-
-  if (opts.dryRun) {
-    receipt.graduated += 1;
-    return;
-  }
-
-  await graduateLaneEvent(
-    opts.pool,
-    event,
-    opts.namespace,
-    opts.createdBy,
-    embedding,
-    `lane tiering: ${event.event_type}/${event.importance}`,
-    opts.embedFn,
-  );
-  receipt.graduated += 1;
+    threshold,
+  });
 }


### PR DESCRIPTION
## Summary

- Issue 864, L5: `git mv src/tiering.ts server/domain/tiering.ts`. The moved module meets the server/ standard whole (no `process.env`, under 500 code lines, lint clean under `.oxlintrc.json`).
- Two exported functions were over the four-parameter rule, so their trailing positional arguments fold into one options object each. Every other export keeps its signature and behavior is unchanged.

  ```ts
  export async function graduateLaneEvent(
    pool: pg.Pool,
    event: LaneEventRow,
    namespace: string,
    opts: GraduateLaneEventOptions, // { createdBy, embedding, reason, embedFn? }
  ): Promise<GraduateResult>;

  export async function findDurableDuplicate(
    pool: pg.Pool,
    namespace: string,
    lookup: DuplicateLookup, // { hash, embedding, threshold? }
  ): Promise<DuplicateMatch | null>;
  ```

- `src/tiering.ts` is now the L5 adapter (M9), 59 lines: it `export *`s the server/ module and keeps the pre-864 positional call form of both functions behind a labelled rest tuple, so the max-params rule holds for the adapter too. Its every relative import names a `server/` path, type imports included. `scripts/tier-lane-durable.ts`, `scripts/done-means/605-chunk-write-routing.driver.ts` and `src/tools/tier-lane.ts` are untouched.
- Runtime importer `server/tools/tier-lane.ts` repointed to `../domain/tiering.ts`; `server/domain/candidate-dedupe.test.ts` to `./tiering.ts`. Imports of modules still in `src/` (embedding, logger, observability, chunk-write) stay relative per M3.
- Python guard repointed: `python/openbrain-memory/tests/test_event_vocabulary.py` reads the `EventType` union as text, so both the read in `test_tiering_union_matches_python` (:141) and the allowed-files list (:241) now name `server/domain/tiering.ts`, each with a one-line issue-864 comment.
- Runtime closure of `src/` under `server/main.ts`: 30 -> 29.
- Tests left in src/ (retire or move at L6): `src/tiering.test.ts`, per M1 EXCEPTION. It is unmodified and passes through the adapter.

## Verification

- Done-means: scripts/done-means/864-moved-out-of-src.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts:

- `bunx tsc --noEmit` -> exit 0
- `./node_modules/.bin/oxlint --deny-warnings --config .oxlintrc.json` on every staged path -> exit 0
- `bun run test:isolated src/tiering.test.ts server/tools/tiering.pg.test.ts server/domain/candidate-dedupe.test.ts src/tools/__tests__/tier-lane.test.ts` -> 155 pass, 0 fail
- `bun run test:isolated server/tools/tier-lane-denied.test.ts src/tools/__tests__/tier-lane.pg.test.ts scripts/tier-lane-durable.test.ts scripts/done-means/605-chunk-write-routing.check.ts` -> 7 pass, 0 fail
- `bash scripts/done-means/864-moved-out-of-src.sh` (no arguments) -> judged=36 shims, 2 adapters PASS
- `closure-count.sh` -> 30 before, 29 after
- `cd python/openbrain-memory && uv run pytest -q tests/test_event_vocabulary.py` -> 9 passed; `uv run ruff check src tests` -> All checks passed
- Pre-push full isolated suite: first run refused with 2 failures, both in `scripts/__tests__/backup-restore-live*.test.ts` (4021 pass / 2 fail); identical push re-run passed. Never bypassed.

## Critical Self-Review

- Highest-risk behavior: lane-event graduation into the agent's own durable namespace. The two signature changes are argument-shape only; the SQL, the namespace assertion, the dedup passes and the chunk-write call are byte-identical to the pre-move file.
- Assumptions that could be wrong: that an ESM local declaration shadows the same name coming from `export *` in the adapter. `bunx tsc --noEmit` and the passing legacy-caller suites are the evidence; a stale bundler could in principle resolve it the other way.
- Missing/weak tests: no test asserts the adapter's positional form specifically; it is covered indirectly by `src/tiering.test.ts` and the 605 driver, which both still call positionally.
- Security/permission risk: none introduced. The cross-namespace guard in `graduateLaneEvent` and the parameterized SQL are unchanged; the tier-lane tool's auth path was not touched beyond an import specifier.
- Migration/deploy risk: none. No schema change, no migration, no config key.
- Downstream client/runtime risk: no MCP tool, schema, transport, or Python client surface changed. The Python change is a test-side path pin only.
- Rollback/cleanup concern: reverting the commit restores the original `src/tiering.ts` and the old import lines together; the adapter is removed with `src/` at L6.
- Fixes made before PR: `findDurableDuplicate` was also over the four-parameter rule and only surfaced under oxlint after the move, so it was folded the same way and given a legacy positional form in the adapter.
- Known residual risk: `server/tools/tier-lane.ts` also picked up prettier reformatting on three unrelated lines, because the pre-commit gate formats staged files whole. Cosmetic, no behavior change.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical L5 move with no new defect class; the max-params-applies-to-the-adapter lesson is already recorded in the issue-864 lane rules (M9).

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or tool-schema surface changed.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract fixture references this module; the only cross-language pin is the Python `EventType` vocabulary guard, repointed in this commit.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Internal file move plus an adapter that preserves every legacy export and call form. No MCP tool, schema, transport, or client-facing surface changed, so no downstream rollout applies.
