### PR TITLE
refactor(l5): move maintenance-bootstrap from src/ into server/maintenance behind an L5 adapter (issue 864)

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -73,7 +73,7 @@ import { generateEmbedding, generateEmbeddingWithMetadata } from "../src/embeddi
 import {
   composeMaintenanceHandlers,
   MAINTENANCE_GRAPH_AUTH,
-} from "../src/maintenance-bootstrap.ts";
+} from "./maintenance/maintenance-bootstrap.ts";
 import { getOperatorDoctorStatus } from "./application/operator-doctor.ts";
 import type { ToolDeps } from "../src/tools/index.ts";
 import type { AuthInfo } from "./types.ts";

--- a/server/maintenance/maintenance-bootstrap.ts
+++ b/server/maintenance/maintenance-bootstrap.ts
@@ -1,0 +1,290 @@
+/**
+ * Production bootstrap for the server-owned maintenance queue (#343 substrate,
+ * #345 handler). This is the piece that was missing: `buildEmbeddingRepairHandlers`
+ * and `MaintenanceQueueRunner` both existed, but nothing in the running server
+ * constructed the durable queue, registered the handler, or started polling — so
+ * an enqueued `embedding.repair` job could never actually run in production.
+ *
+ * `startMaintenanceQueue` constructs the durable `MaintenanceQueue` over the real
+ * pool, composes the server-owned handler map (embedding-repair #345 +
+ * graph-derivation #346, the latter under an explicit global maintenance
+ * identity) with the real embed provider and a content-free logger, and starts
+ * the runner's bounded automatic polling. The returned handle exposes `stop()`,
+ * which the server's shutdown path awaits before `pool.end()` so in-flight jobs
+ * drain (their leases are honored) instead of being stranded mid-run.
+ *
+ * The bootstrap also starts the missing recurring producer from #384. Each
+ * producer tick selects lane-owned undistilled work for memory.distill and reuses
+ * enqueueGraphDerivationJobs for changed source hashes. The producer is
+ * single-flight, uses configured batch bounds, and stops before the runner drains
+ * so shutdown cannot add work after polling has halted.
+ *
+ * THE PRODUCER LOOP ITSELF NOW LIVES IN `maintenance-sweep.ts`, not here. This
+ * bootstrap is reached from the LEGACY `src/index.ts` through the L5 adapter at
+ * `src/maintenance-bootstrap.ts`, which supplies the env-derived values; the serving
+ * entrypoint since the Phase 6 cutover is `server/main.ts`, which composes
+ * maintenance through `server/maintenance/index.ts`. While the loop was private
+ * to this file, only one of those two compositions produced any work at all, so
+ * the serving process polled a queue nothing filled — #384's symptom, surviving
+ * the PR that added the producer. Both compositions now start the same loop.
+ *
+ * #343 invariants preserved verbatim — this only wires them, it changes none:
+ *  - Bounded concurrency: the runner clamps to [1, MAX_CONCURRENCY].
+ *  - No overlapping ticks: `runOnce` is single-flight; `start()` reuses it.
+ *  - Persisted retries/backoff: owned by `MaintenanceQueue.fail`, durable-row-derived.
+ *  - Content-free logs: handlers, runner, and producer log counts/kinds only.
+ *  - No Dream/MCP mutation path: the producer writes only durable maintenance
+ *    jobs. Distill jobs bind the selected lane and namespace; graph jobs retain
+ *    the source snapshot and namespace checks owned by their existing producer.
+ */
+import type pg from "pg";
+import type { BackgroundTraceEmitter } from "../application/background-tracing.ts";
+import { generateEmbeddingWithMetadata } from "../../src/embedding.ts";
+import type { EmbedWithMetaFn } from "../../src/embedding-repair.ts";
+import type { AuthInfo } from "../types.ts";
+import { MaintenanceQueue } from "./maintenance-queue.ts";
+import {
+  MaintenanceQueueRunner,
+  type MaintenanceJobHandler,
+  type MaintenanceQueueLogger,
+} from "./maintenance-queue-runner.ts";
+import { buildEmbeddingRepairHandlers } from "./embedding-repair-handler.ts";
+import {
+  GRAPH_DERIVATION_JOB_KIND,
+  makeGraphDerivationHandler,
+} from "./graph-derivation-handler.ts";
+import { DREAM_LIGHT_JOB_KIND, makeDreamLightHandler } from "./dream-light.ts";
+import { DREAM_REM_JOB_KIND, makeDreamRemHandler } from "./dream-rem.ts";
+import {
+  MEMORY_DISTILL_JOB_KIND,
+  makeMemoryDistillHandler,
+} from "./distill-handler.ts";
+import { startRecurringMaintenanceSweep } from "./maintenance-sweep.ts";
+
+/**
+ * The deliberate, server-owned identity the graph-derivation handler derives
+ * under. It is a global maintenance identity (ob-admin, token-sourced) so the
+ * handler can write into whatever namespace a claimed job carries — but it is
+ * NOT the namespace authority: the persisted job payload's namespace remains the
+ * exact authority, and the handler re-checks canWriteNamespace against it AND
+ * re-validates it against the live source row before deriving. This identity
+ * only grants the cross-namespace write capability a maintenance sweep needs; it
+ * grants no bypass of the per-job namespace/source guards.
+ *
+ * `namespaceSource: "token"` is required: a "header"-sourced identity would pin
+ * every write to a single clientId namespace and could not serve jobs across
+ * namespaces.
+ *
+ * `tokenClientId: "openbrain-promoter"` satisfies the EXISTING shared-kb write
+ * convention (namespace-policy.ts: canWriteNamespace gates shared-kb writes on
+ * isPromoterIdentity, which recognizes an admin/ob-admin token whose
+ * `tokenClientId ?? clientId` is in PROMOTER_CLIENT_IDS). Without it, a claimed
+ * shared-kb graph.derive job fails canWriteNamespace and terminal-dead-letters,
+ * even though ob-admin holds global maintenance capability everywhere else. The
+ * `clientId` stays the fixed maintenance label used for logging/provenance; only
+ * the promoter-convention check reads `tokenClientId`, so this narrowly grants
+ * the shared-kb write capability without weakening canWriteNamespace or adding a
+ * bypass — the per-job namespace and source-snapshot guards remain the authority.
+ */
+export const MAINTENANCE_GRAPH_AUTH: AuthInfo = {
+  role: "ob-admin",
+  clientId: "open-brain-maintenance",
+  tokenClientId: "openbrain-promoter",
+  namespaceSource: "token",
+};
+
+/**
+ * Runtime handle for the started maintenance queue. `stop()` halts polling and
+ * drains in-flight jobs; it is idempotent and safe to call once from shutdown.
+ */
+export interface MaintenanceRuntime {
+  readonly queue: MaintenanceQueue;
+  readonly runner: MaintenanceQueueRunner;
+  stop(): Promise<void>;
+}
+
+export interface StartMaintenanceQueueOptions {
+  pool: pg.Pool;
+  /** Content-free logger; the app logger satisfies this shape. */
+  logger: MaintenanceQueueLogger;
+  /** Injectable embed fn for tests; defaults to the configured provider. */
+  embedFn?: EmbedWithMetaFn;
+  /** Process-owned background tracing emitter; omitted when tracing is disabled. */
+  tracing?: BackgroundTraceEmitter;
+  /** Poll cadence, supplied by the caller from config; else the 5s default. */
+  pollIntervalMs?: number;
+  /** Concurrency, supplied by the caller from config; else the runner default. */
+  concurrency?: number;
+  /** Lease duration, supplied by the caller from config; else the runner default. */
+  leaseMs?: number;
+  /** Maximum turns assigned to one memory.distill job. */
+  distillBatchSize?: number;
+  /** Maximum memory.distill jobs produced by one recurring sweep. */
+  maxDistillBatchesPerTick?: number;
+  /** Maximum graph.derive jobs produced by one recurring sweep. */
+  graphDerivationLimit?: number;
+  /** Start automatic polling and recurring production immediately (default true). */
+  autoStart?: boolean;
+  /**
+   * The server-owned identity the graph-derivation handler derives under.
+   * Defaults to {@link MAINTENANCE_GRAPH_AUTH}. Injectable for tests; must carry
+   * a concrete role/clientId — a handler cannot be registered without a clear
+   * auth identity (see composeMaintenanceHandlers).
+   */
+  graphAuth?: AuthInfo;
+}
+
+/**
+ * Compose the server-owned maintenance handler map without a second bootstrap or
+ * framework: start from the #345 embedding-repair map and register the #346
+ * graph-derivation handler under its kind. Both handlers share the runner's
+ * content-free logger and the same pool.
+ *
+ * The graph handler CANNOT be registered without a clear auth identity: a
+ * missing role or clientId throws before any handler is built, so a mis-wired
+ * bootstrap fails closed at startup instead of dispatching graph jobs under an
+ * ambiguous identity. The identity grants only the cross-namespace write
+ * capability the sweep needs; the per-job namespace and source-snapshot guards
+ * inside the handler remain the authority.
+ */
+export function composeMaintenanceHandlers(input: {
+  pool: pg.Pool;
+  logger: MaintenanceQueueLogger;
+  embedFn: EmbedWithMetaFn;
+  graphAuth: AuthInfo;
+  tracing?: BackgroundTraceEmitter;
+}): ReadonlyMap<string, MaintenanceJobHandler> {
+  if (!input.graphAuth.role || !input.graphAuth.clientId) {
+    throw new Error(
+      "maintenance bootstrap requires a graph-derivation auth identity with a role and clientId",
+    );
+  }
+
+  const handlers = new Map<string, MaintenanceJobHandler>(
+    buildEmbeddingRepairHandlers({
+      db: input.pool,
+      logger: input.logger,
+      embedFn: input.embedFn,
+      ...(input.tracing ? { tracing: input.tracing } : {}),
+    }),
+  );
+  handlers.set(
+    GRAPH_DERIVATION_JOB_KIND,
+    makeGraphDerivationHandler({
+      pool: input.pool,
+      auth: input.graphAuth,
+    }),
+  );
+
+  // The DREAM pipeline: distill -> light -> rem. Registered here because this
+  // Map is the only dispatch surface -- a kind that is not in it can never be
+  // claimed, however many jobs are enqueued under it.
+  //
+  // THIS CLOSES A LIVE WIRING GAP. DREAM_LIGHT_JOB_KIND and
+  // makeDreamLightHandler have existed since #390 (src/dream-light.ts:58, :374)
+  // and were referenced nowhere outside their own module and test -- so
+  // `dream.light` jobs could be enqueued, would be claimed by no handler, and
+  // would burn their retries into the dead-letter state. Light only ever ran
+  // through the manual entrypoint scripts/dream-light-run.ts.
+  //
+  // NONE OF THESE ENQUEUE ANYTHING. Registration is dispatch only. The
+  // recurring producer starts below after this map and the durable queue exist;
+  // manual DREAM cycles remain available through scripts/dream-cycle.ts.
+  handlers.set(
+    MEMORY_DISTILL_JOB_KIND,
+    makeMemoryDistillHandler({
+      pool: input.pool,
+      logger: input.logger,
+      embedFn: input.embedFn,
+      auth: input.graphAuth,
+      ...(input.tracing ? { tracing: input.tracing } : {}),
+    }),
+  );
+  handlers.set(
+    DREAM_LIGHT_JOB_KIND,
+    makeDreamLightHandler({
+      pool: input.pool,
+      logger: input.logger,
+      ...(input.tracing ? { tracing: input.tracing } : {}),
+    }),
+  );
+  handlers.set(
+    DREAM_REM_JOB_KIND,
+    makeDreamRemHandler({
+      pool: input.pool,
+      logger: input.logger,
+      ...(input.tracing ? { tracing: input.tracing } : {}),
+    }),
+  );
+
+  // Deep (#394) is deliberately ABSENT. It is a read-only bundle builder whose
+  // output is a page an operator reads (src/dream-deep.ts), so there is nothing
+  // for a background worker to dispatch -- registering it would create a job
+  // kind whose only effect is to compute a result and discard it.
+  return handlers;
+}
+
+/**
+ * Construct the durable queue + runner, register the embedding-repair handler,
+ * and (by default) start bounded automatic polling. Caller owns `stop()` in its
+ * shutdown lifecycle.
+ *
+ * Every tuning value arrives on `options`, read from `server/config.ts` by the
+ * caller (`parseMaintenanceConfig` owns the env contract). Each is clamped again
+ * by the runner and the sweep, which stay the single owners of their defaults.
+ */
+export function startMaintenanceQueue(
+  options: StartMaintenanceQueueOptions,
+): MaintenanceRuntime {
+  const queue = new MaintenanceQueue(options.pool);
+  // Compose the server-owned handler map: embedding.repair (#345) +
+  // graph.derive (#346), the latter under an explicit global maintenance
+  // identity. currentModel / embeddingUrl are intentionally omitted from the
+  // embedding handler: it defaults to the configured EMBEDDING_MODEL and
+  // endpoint, matching the live write path.
+  const handlers = composeMaintenanceHandlers({
+    pool: options.pool,
+    logger: options.logger,
+    embedFn: options.embedFn ?? generateEmbeddingWithMetadata,
+    graphAuth: options.graphAuth ?? MAINTENANCE_GRAPH_AUTH,
+    ...(options.tracing ? { tracing: options.tracing } : {}),
+  });
+
+  const pollIntervalMs = options.pollIntervalMs ?? 5_000;
+  const runner = new MaintenanceQueueRunner({
+    queue,
+    handlers,
+    logger: options.logger,
+    concurrency: options.concurrency,
+    pollIntervalMs,
+    leaseMs: options.leaseMs,
+  });
+
+  const autoStart = options.autoStart !== false;
+  if (autoStart) runner.start();
+  const sweep = autoStart
+    ? startRecurringMaintenanceSweep({
+        pool: options.pool,
+        queue,
+        logger: options.logger,
+        intervalMs: pollIntervalMs,
+        distillBatchSize: options.distillBatchSize,
+        maxDistillBatchesPerTick: options.maxDistillBatchesPerTick,
+        graphDerivationLimit: options.graphDerivationLimit,
+      })
+    : null;
+
+  let stopped = false;
+  return {
+    queue,
+    runner,
+    async stop(): Promise<void> {
+      // runner.stop() is safe even if start() was never called (null interval,
+      // null tick, empty active set). Guard only against a double shutdown call.
+      if (stopped) return;
+      stopped = true;
+      await sweep?.stop();
+      await runner.stop();
+    },
+  };
+}

--- a/src/maintenance-bootstrap.ts
+++ b/src/maintenance-bootstrap.ts
@@ -1,227 +1,25 @@
-/**
- * Production bootstrap for the server-owned maintenance queue (#343 substrate,
- * #345 handler). This is the piece that was missing: `buildEmbeddingRepairHandlers`
- * and `MaintenanceQueueRunner` both existed, but nothing in the running server
- * constructed the durable queue, registered the handler, or started polling — so
- * an enqueued `embedding.repair` job could never actually run in production.
- *
- * `startMaintenanceQueue` constructs the durable `MaintenanceQueue` over the real
- * pool, composes the server-owned handler map (embedding-repair #345 +
- * graph-derivation #346, the latter under an explicit global maintenance
- * identity) with the real embed provider and a content-free logger, and starts
- * the runner's bounded automatic polling. The returned handle exposes `stop()`,
- * which the server's shutdown path awaits before `pool.end()` so in-flight jobs
- * drain (their leases are honored) instead of being stranded mid-run.
- *
- * The bootstrap also starts the missing recurring producer from #384. Each
- * producer tick selects lane-owned undistilled work for memory.distill and reuses
- * enqueueGraphDerivationJobs for changed source hashes. The producer is
- * single-flight, uses configured batch bounds, and stops before the runner drains
- * so shutdown cannot add work after polling has halted.
- *
- * THE PRODUCER LOOP ITSELF NOW LIVES IN `maintenance-sweep.ts`, not here. This
- * bootstrap is reached only from the LEGACY `src/index.ts`; the serving
- * entrypoint since the Phase 6 cutover is `server/main.ts`, which composes
- * maintenance through `server/maintenance/index.ts`. While the loop was private
- * to this file, only one of those two compositions produced any work at all, so
- * the serving process polled a queue nothing filled — #384's symptom, surviving
- * the PR that added the producer. Both compositions now start the same loop.
- *
- * #343 invariants preserved verbatim — this only wires them, it changes none:
- *  - Bounded concurrency: the runner clamps to [1, MAX_CONCURRENCY].
- *  - No overlapping ticks: `runOnce` is single-flight; `start()` reuses it.
- *  - Persisted retries/backoff: owned by `MaintenanceQueue.fail`, durable-row-derived.
- *  - Content-free logs: handlers, runner, and producer log counts/kinds only.
- *  - No Dream/MCP mutation path: the producer writes only durable maintenance
- *    jobs. Distill jobs bind the selected lane and namespace; graph jobs retain
- *    the source snapshot and namespace checks owned by their existing producer.
- */
-import type pg from "pg";
-import type { BackgroundTraceEmitter } from "./background-tracing.ts";
-import { generateEmbeddingWithMetadata } from "./embedding.ts";
-import type { EmbedWithMetaFn } from "./embedding-repair.ts";
-import type { AuthInfo } from "./types.ts";
+// L5 adapter (issue 864): legacy call form over server/maintenance/maintenance-bootstrap.ts; retired with src/ at L6.
+//
+// The server/ module takes every tuning value on its options object, filled by
+// server/main.ts from server/config.ts. The legacy src/index.ts callers do not
+// hold a config object, so this adapter keeps the old call form: it reads the
+// env overrides at call time and folds them into the options it forwards. It
+// also keeps `maintenanceQueueEnabled`, which is an env predicate with no
+// server/ caller.
 import {
-  MaintenanceQueue,
-  MaintenanceQueueRunner,
-  type MaintenanceJobHandler,
-  type MaintenanceQueueLogger,
-} from "./maintenance-queue.ts";
-import { buildEmbeddingRepairHandlers } from "./embedding-repair-handler.ts";
-import {
-  GRAPH_DERIVATION_JOB_KIND,
-  makeGraphDerivationHandler,
-} from "./graph-derivation-handler.ts";
-import { DREAM_LIGHT_JOB_KIND, makeDreamLightHandler } from "./dream-light.ts";
-import { DREAM_REM_JOB_KIND, makeDreamRemHandler } from "./dream-rem.ts";
-import {
-  MEMORY_DISTILL_JOB_KIND,
-  makeMemoryDistillHandler,
-} from "./distill-handler.ts";
-import { startRecurringMaintenanceSweep } from "./maintenance-sweep.ts";
+  startMaintenanceQueue as startMaintenanceQueueWithOptions,
+  type MaintenanceRuntime,
+  type StartMaintenanceQueueOptions,
+} from "../server/maintenance/maintenance-bootstrap.ts";
 
-/**
- * The deliberate, server-owned identity the graph-derivation handler derives
- * under. It is a global maintenance identity (ob-admin, token-sourced) so the
- * handler can write into whatever namespace a claimed job carries — but it is
- * NOT the namespace authority: the persisted job payload's namespace remains the
- * exact authority, and the handler re-checks canWriteNamespace against it AND
- * re-validates it against the live source row before deriving. This identity
- * only grants the cross-namespace write capability a maintenance sweep needs; it
- * grants no bypass of the per-job namespace/source guards.
- *
- * `namespaceSource: "token"` is required: a "header"-sourced identity would pin
- * every write to a single clientId namespace and could not serve jobs across
- * namespaces.
- *
- * `tokenClientId: "openbrain-promoter"` satisfies the EXISTING shared-kb write
- * convention (namespace-policy.ts: canWriteNamespace gates shared-kb writes on
- * isPromoterIdentity, which recognizes an admin/ob-admin token whose
- * `tokenClientId ?? clientId` is in PROMOTER_CLIENT_IDS). Without it, a claimed
- * shared-kb graph.derive job fails canWriteNamespace and terminal-dead-letters,
- * even though ob-admin holds global maintenance capability everywhere else. The
- * `clientId` stays the fixed maintenance label used for logging/provenance; only
- * the promoter-convention check reads `tokenClientId`, so this narrowly grants
- * the shared-kb write capability without weakening canWriteNamespace or adding a
- * bypass — the per-job namespace and source-snapshot guards remain the authority.
- */
-export const MAINTENANCE_GRAPH_AUTH: AuthInfo = {
-  role: "ob-admin",
-  clientId: "open-brain-maintenance",
-  tokenClientId: "openbrain-promoter",
-  namespaceSource: "token",
-};
-
-/**
- * Runtime handle for the started maintenance queue. `stop()` halts polling and
- * drains in-flight jobs; it is idempotent and safe to call once from shutdown.
- */
-export interface MaintenanceRuntime {
-  readonly queue: MaintenanceQueue;
-  readonly runner: MaintenanceQueueRunner;
-  stop(): Promise<void>;
-}
-
-export interface StartMaintenanceQueueOptions {
-  pool: pg.Pool;
-  /** Content-free logger; the app logger satisfies this shape. */
-  logger: MaintenanceQueueLogger;
-  /** Injectable embed fn for tests; defaults to the configured provider. */
-  embedFn?: EmbedWithMetaFn;
-  /** Process-owned background tracing emitter; omitted when tracing is disabled. */
-  tracing?: BackgroundTraceEmitter;
-  /** Poll cadence override; else env, else the runner default. */
-  pollIntervalMs?: number;
-  /** Concurrency override; else env, else the runner default. */
-  concurrency?: number;
-  /** Lease duration override; else env, else the runner default. */
-  leaseMs?: number;
-  /** Maximum turns assigned to one memory.distill job. */
-  distillBatchSize?: number;
-  /** Maximum memory.distill jobs produced by one recurring sweep. */
-  maxDistillBatchesPerTick?: number;
-  /** Maximum graph.derive jobs produced by one recurring sweep. */
-  graphDerivationLimit?: number;
-  /** Start automatic polling and recurring production immediately (default true). */
-  autoStart?: boolean;
-  /**
-   * The server-owned identity the graph-derivation handler derives under.
-   * Defaults to {@link MAINTENANCE_GRAPH_AUTH}. Injectable for tests; must carry
-   * a concrete role/clientId — a handler cannot be registered without a clear
-   * auth identity (see composeMaintenanceHandlers).
-   */
-  graphAuth?: AuthInfo;
-}
-
-/**
- * Compose the server-owned maintenance handler map without a second bootstrap or
- * framework: start from the #345 embedding-repair map and register the #346
- * graph-derivation handler under its kind. Both handlers share the runner's
- * content-free logger and the same pool.
- *
- * The graph handler CANNOT be registered without a clear auth identity: a
- * missing role or clientId throws before any handler is built, so a mis-wired
- * bootstrap fails closed at startup instead of dispatching graph jobs under an
- * ambiguous identity. The identity grants only the cross-namespace write
- * capability the sweep needs; the per-job namespace and source-snapshot guards
- * inside the handler remain the authority.
- */
-export function composeMaintenanceHandlers(input: {
-  pool: pg.Pool;
-  logger: MaintenanceQueueLogger;
-  embedFn: EmbedWithMetaFn;
-  graphAuth: AuthInfo;
-  tracing?: BackgroundTraceEmitter;
-}): ReadonlyMap<string, MaintenanceJobHandler> {
-  if (!input.graphAuth.role || !input.graphAuth.clientId) {
-    throw new Error(
-      "maintenance bootstrap requires a graph-derivation auth identity with a role and clientId",
-    );
-  }
-
-  const handlers = new Map<string, MaintenanceJobHandler>(
-    buildEmbeddingRepairHandlers({
-      db: input.pool,
-      logger: input.logger,
-      embedFn: input.embedFn,
-      ...(input.tracing ? { tracing: input.tracing } : {}),
-    }),
-  );
-  handlers.set(
-    GRAPH_DERIVATION_JOB_KIND,
-    makeGraphDerivationHandler({
-      pool: input.pool,
-      auth: input.graphAuth,
-    }),
-  );
-
-  // The DREAM pipeline: distill -> light -> rem. Registered here because this
-  // Map is the only dispatch surface -- a kind that is not in it can never be
-  // claimed, however many jobs are enqueued under it.
-  //
-  // THIS CLOSES A LIVE WIRING GAP. DREAM_LIGHT_JOB_KIND and
-  // makeDreamLightHandler have existed since #390 (src/dream-light.ts:58, :374)
-  // and were referenced nowhere outside their own module and test -- so
-  // `dream.light` jobs could be enqueued, would be claimed by no handler, and
-  // would burn their retries into the dead-letter state. Light only ever ran
-  // through the manual entrypoint scripts/dream-light-run.ts.
-  //
-  // NONE OF THESE ENQUEUE ANYTHING. Registration is dispatch only. The
-  // recurring producer starts below after this map and the durable queue exist;
-  // manual DREAM cycles remain available through scripts/dream-cycle.ts.
-  handlers.set(
-    MEMORY_DISTILL_JOB_KIND,
-    makeMemoryDistillHandler({
-      pool: input.pool,
-      logger: input.logger,
-      embedFn: input.embedFn,
-      auth: input.graphAuth,
-      ...(input.tracing ? { tracing: input.tracing } : {}),
-    }),
-  );
-  handlers.set(
-    DREAM_LIGHT_JOB_KIND,
-    makeDreamLightHandler({
-      pool: input.pool,
-      logger: input.logger,
-      ...(input.tracing ? { tracing: input.tracing } : {}),
-    }),
-  );
-  handlers.set(
-    DREAM_REM_JOB_KIND,
-    makeDreamRemHandler({
-      pool: input.pool,
-      logger: input.logger,
-      ...(input.tracing ? { tracing: input.tracing } : {}),
-    }),
-  );
-
-  // Deep (#394) is deliberately ABSENT. It is a read-only bundle builder whose
-  // output is a page an operator reads (src/dream-deep.ts), so there is nothing
-  // for a background worker to dispatch -- registering it would create a job
-  // kind whose only effect is to compute a result and discard it.
-  return handlers;
-}
+export {
+  MAINTENANCE_GRAPH_AUTH,
+  composeMaintenanceHandlers,
+} from "../server/maintenance/maintenance-bootstrap.ts";
+export type {
+  MaintenanceRuntime,
+  StartMaintenanceQueueOptions,
+} from "../server/maintenance/maintenance-bootstrap.ts";
 
 /**
  * Parse a positive integer env override, falling back when unset or invalid.
@@ -240,90 +38,33 @@ function envPositiveInt(name: string): number | undefined {
  * `OPEN_BRAIN_MAINTENANCE_ENABLED=0` (or `false`) turns it off so a worker that
  * must not poll (e.g. a read replica) can opt out without code changes.
  */
-export function maintenanceQueueEnabled(
-  env: NodeJS.ProcessEnv = process.env,
-): boolean {
+export function maintenanceQueueEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env.OPEN_BRAIN_MAINTENANCE_ENABLED?.trim().toLowerCase();
   return raw !== "0" && raw !== "false";
 }
 
-/**
- * Construct the durable queue + runner, register the embedding-repair handler,
- * and (by default) start bounded automatic polling. Caller owns `stop()` in its
- * shutdown lifecycle.
- *
- * Env-configurable safe defaults (each clamped again by the runner):
- *  - OPEN_BRAIN_MAINTENANCE_POLL_MS              runner + producer cadence (5000)
- *  - OPEN_BRAIN_MAINTENANCE_CONCURRENCY          concurrent jobs (runner default 2)
- *  - OPEN_BRAIN_MAINTENANCE_LEASE_MS             job lease window (default 30000)
- *  - OPEN_BRAIN_MAINTENANCE_DISTILL_BATCH_SIZE   turns assigned per distill job
- *  - OPEN_BRAIN_MAINTENANCE_MAX_DISTILL_BATCHES  distill jobs produced per tick
- *  - OPEN_BRAIN_MAINTENANCE_GRAPH_LIMIT          graph jobs produced per tick
- */
+/** Legacy call form: explicit options win, then env, then the module default. */
 export function startMaintenanceQueue(
   options: StartMaintenanceQueueOptions,
 ): MaintenanceRuntime {
-  const queue = new MaintenanceQueue(options.pool);
-  // Compose the server-owned handler map: embedding.repair (#345) +
-  // graph.derive (#346), the latter under an explicit global maintenance
-  // identity. currentModel / embeddingUrl are intentionally omitted from the
-  // embedding handler: it defaults to the configured EMBEDDING_MODEL and
-  // endpoint, matching the live write path.
-  const handlers = composeMaintenanceHandlers({
-    pool: options.pool,
-    logger: options.logger,
-    embedFn: options.embedFn ?? generateEmbeddingWithMetadata,
-    graphAuth: options.graphAuth ?? MAINTENANCE_GRAPH_AUTH,
-    ...(options.tracing ? { tracing: options.tracing } : {}),
-  });
-
-  const pollIntervalMs =
-    options.pollIntervalMs ??
-    envPositiveInt("OPEN_BRAIN_MAINTENANCE_POLL_MS") ??
-    5_000;
-  const runner = new MaintenanceQueueRunner({
-    queue,
-    handlers,
-    logger: options.logger,
+  const overrides: Record<string, number | undefined> = {
+    pollIntervalMs:
+      options.pollIntervalMs ?? envPositiveInt("OPEN_BRAIN_MAINTENANCE_POLL_MS"),
     concurrency:
-      options.concurrency ??
-      envPositiveInt("OPEN_BRAIN_MAINTENANCE_CONCURRENCY"),
-    pollIntervalMs,
-    leaseMs:
-      options.leaseMs ?? envPositiveInt("OPEN_BRAIN_MAINTENANCE_LEASE_MS"),
-  });
-
-  const autoStart = options.autoStart !== false;
-  if (autoStart) runner.start();
-  const sweep = autoStart
-    ? startRecurringMaintenanceSweep({
-        pool: options.pool,
-        queue,
-        logger: options.logger,
-        intervalMs: pollIntervalMs,
-        distillBatchSize:
-          options.distillBatchSize ??
-          envPositiveInt("OPEN_BRAIN_MAINTENANCE_DISTILL_BATCH_SIZE"),
-        maxDistillBatchesPerTick:
-          options.maxDistillBatchesPerTick ??
-          envPositiveInt("OPEN_BRAIN_MAINTENANCE_MAX_DISTILL_BATCHES"),
-        graphDerivationLimit:
-          options.graphDerivationLimit ??
-          envPositiveInt("OPEN_BRAIN_MAINTENANCE_GRAPH_LIMIT"),
-      })
-    : null;
-
-  let stopped = false;
-  return {
-    queue,
-    runner,
-    async stop(): Promise<void> {
-      // runner.stop() is safe even if start() was never called (null interval,
-      // null tick, empty active set). Guard only against a double shutdown call.
-      if (stopped) return;
-      stopped = true;
-      await sweep?.stop();
-      await runner.stop();
-    },
+      options.concurrency ?? envPositiveInt("OPEN_BRAIN_MAINTENANCE_CONCURRENCY"),
+    leaseMs: options.leaseMs ?? envPositiveInt("OPEN_BRAIN_MAINTENANCE_LEASE_MS"),
+    distillBatchSize:
+      options.distillBatchSize ??
+      envPositiveInt("OPEN_BRAIN_MAINTENANCE_DISTILL_BATCH_SIZE"),
+    maxDistillBatchesPerTick:
+      options.maxDistillBatchesPerTick ??
+      envPositiveInt("OPEN_BRAIN_MAINTENANCE_MAX_DISTILL_BATCHES"),
+    graphDerivationLimit:
+      options.graphDerivationLimit ??
+      envPositiveInt("OPEN_BRAIN_MAINTENANCE_GRAPH_LIMIT"),
   };
+  const resolved = Object.fromEntries(
+    Object.entries(overrides).filter(([, value]) => value !== undefined),
+  );
+  return startMaintenanceQueueWithOptions({ ...options, ...resolved });
 }


### PR DESCRIPTION
## Summary

- `git mv src/maintenance-bootstrap.ts server/maintenance/maintenance-bootstrap.ts` (issue 864, L5). Closure count 27 -> 26.
- The server/ version reads no `process.env`. The six tuning values and the poll cadence arrive as fields of its existing single options parameter (`StartMaintenanceQueueOptions`, unchanged shape); the runner and the sweep remain the single owners of their own defaults, so behavior is identical.
- `server/config/maintenance.ts` already parses every one of those keys, so **no new config reader was needed** and `server/config.ts` is untouched.
- `server/main.ts` changes by exactly one import path. It imports only `composeMaintenanceHandlers` and `MAINTENANCE_GRAPH_AUTH`, neither of which ever took an env value, so no argument threading was required:

```diff
-} from "../src/maintenance-bootstrap.ts";
+} from "./maintenance/maintenance-bootstrap.ts";
```

- `src/maintenance-bootstrap.ts` becomes the M9 **adapter** (under 60 code lines; every relative import names a `server/` path, type imports included). It preserves the old call forms for `src/index.ts:43` and `src/maintenance-sweep.test.ts:4`, reading the six `OPEN_BRAIN_MAINTENANCE_*` overrides at call time and folding them into the forwarded options, and it keeps `maintenanceQueueEnabled` (an env predicate with no `server/` caller):

```ts
// L5 adapter (issue 864): legacy call form over server/maintenance/maintenance-bootstrap.ts; retired with src/ at L6.
export function startMaintenanceQueue(
  options: StartMaintenanceQueueOptions,
): MaintenanceRuntime {
  const overrides: Record<string, number | undefined> = {
    pollIntervalMs:
      options.pollIntervalMs ?? envPositiveInt("OPEN_BRAIN_MAINTENANCE_POLL_MS"),
    // ... concurrency, leaseMs, distillBatchSize, maxDistillBatchesPerTick, graphDerivationLimit
  };
  const resolved = Object.fromEntries(
    Object.entries(overrides).filter(([, value]) => value !== undefined),
  );
  return startMaintenanceQueueWithOptions({ ...options, ...resolved });
}
```

- Imports of the handlers, queue runner, sweep, and dream modules now name the `server/maintenance/` siblings directly. `MaintenanceQueueRunner`, `MaintenanceJobHandler`, and `MaintenanceQueueLogger` live in the split sibling `server/maintenance/maintenance-queue-runner.ts`, so that import was retargeted there. Still-in-src imports (`../../src/embedding.ts`, `../../src/embedding-repair.ts`) stay relative per M3.

### tests left in src/ (retire or move at L6)

- `src/maintenance-bootstrap.test.ts` — M1 EXCEPTION; unmodified, exercises the moved code through the adapter.
- `src/maintenance-sweep.test.ts` — belongs to a different module; its `startMaintenanceQueue` import is untouched and resolves through the adapter.

### text readers / python guards

- M12 survey: `rg -n "maintenance-bootstrap" scripts server src python --type ts --type py` — every non-importer hit is prose in a doc comment (`server/maintenance/index.ts`, `server/maintenance/maintenance-sweep.ts`, `server/config/maintenance.ts`, `scripts/repair-embeddings.ts`, `server/config/maintenance.test.ts`). No `readFileSync`/glob consumer reads this module by path, so nothing else needed repointing.
- M10: `rg -n 'maintenance-bootstrap' python/` returns nothing; the Python path guards do not pin this module. Python package unchanged.

## Verification

- Done-means: scripts/done-means/864-moved-out-of-src.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts (all from the committed tree at `refactor/864-c7e-bootstrap`):

- `bunx tsc --noEmit` -> exit 0.
- `./node_modules/.bin/oxlint --deny-warnings --config .oxlintrc.json server/maintenance/maintenance-bootstrap.ts src/maintenance-bootstrap.ts server/main.ts` -> exit 0.
- `bun run test:isolated src/maintenance-bootstrap.test.ts server/maintenance/maintenance.pg.test.ts` -> exit 0, 25 pass / 0 fail.
- `bun run test:isolated src/maintenance-sweep.test.ts` -> exit 0, 8 pass / 0 fail.
- `bun run test:isolated server/main.pg.test.ts` -> exit 0, 8 pass / 0 fail.
- `bash scripts/done-means/864-moved-out-of-src.sh` (no arguments) -> exit 0, `judged=38 shims, 2 adapters` / `PASS`.
- `bash closure-count.sh` -> 27 before, 26 after.
- Pre-commit gate (gitleaks, oxlint on staged content, prettier, whole-project tsc) and the pre-push full isolated suite both passed; nothing was bypassed.

## Critical Self-Review

- Highest-risk behavior: the env-override resolution order for the maintenance runner and sweep. Previously the module itself did `options.X ?? envPositiveInt(KEY) ?? default`; now the adapter does the `options.X ?? env` half and the server/ module does the `?? default` half. The adapter drops `undefined` keys before spreading, so an unset env key does not overwrite a caller value with `undefined` — that filter is the whole correctness of the change and is what `src/maintenance-bootstrap.test.ts` and `src/maintenance-sweep.test.ts` exercise.
- Assumptions that could be wrong: that `server/main.ts` needs no env values from this module. Checked directly — it imports only `composeMaintenanceHandlers` and `MAINTENANCE_GRAPH_AUTH`, and `startMaintenanceQueue`/`maintenanceQueueEnabled` have no `server/` caller (`rg` over `src server scripts --type ts`). If a future `server/` caller wants the queue started, it passes the values from `parseMaintenanceConfig`, which already produces exactly this field set.
- Missing/weak tests: no test asserts that an explicitly-passed option still wins over a set env var through the adapter. The existing suite covers option-passed values and covers `maintenanceQueueEnabled`'s env parsing, but not the two-source precedence in one call. Left as-is because adding it would mutate `process.env` inside a test, which the moved-test standard forbids and which races concurrent suites.
- Security/permission risk: none new. `MAINTENANCE_GRAPH_AUTH` is re-exported byte-identical, and the `composeMaintenanceHandlers` fail-closed check on a missing role/clientId is unchanged and still covered.
- Migration/deploy risk: none. No schema, no migration, no config key added or removed; the same six env keys are read, one call frame earlier.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface is touched; `rg -n 'maintenance-bootstrap' python/` is empty and the pre-push gate skipped the Python and contract-parity subsets because those paths are unchanged.
- Rollback/cleanup concern: single commit, revertable as one. The adapter is deliberately temporary and is removed with `src/` at L6.
- Fixes made before PR: the first import rewrite pointed `EmbedWithMetaFn` at `./embedding-repair-handler.ts` and `BackgroundTraceEmitter` at `../../src/background-tracing.ts`; `tsc` caught both, and they now name `../../src/embedding-repair.ts` and `../application/background-tracing.ts` respectively, matching the sibling handler. `tsc` also caught the `maintenance-queue.ts` -> `maintenance-queue-runner.ts` split for the three runner symbols.
- Known residual risk: the precedence gap named under "Missing/weak tests" — an env var set alongside an explicit option is covered by reading, not by a test.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical L5 move under the issue-864 program with no new failure pattern; the adapter shape is already codified as rule M9 in the lane brief.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or tool surface changed; this is an internal module relocation proven by the isolated suite.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no client-facing contract, schema, or fixture is touched; the pre-push gate reported "Client/contract paths unchanged; skipping contract parity subset".

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable on every line: this is an internal source relocation behind an adapter. No MCP tool name, schema, transport shape, or Python client call form changes, so no downstream consumer can observe it.
