### PR TITLE
refactor(l5): move shared-namespace from src/ into server/security behind an L5 adapter (issue 864)

### DIFF
--- a/server/security/shared-namespace.ts
+++ b/server/security/shared-namespace.ts
@@ -1,0 +1,182 @@
+/**
+ * Canonical vs physical shared-namespace resolution (issue 864, L5).
+ *
+ * `shared-kb` is the ONE public name for shared truth. The legacy `collab`
+ * namespace was retired in #167 — frozen and mirrored, not deleted — so this
+ * module carries a deliberate two-name model:
+ *
+ *   - the CANONICAL name is what callers pass and what results report back, so
+ *     a client never has to know which physical partition a row lives in;
+ *   - the PHYSICAL name is what the `namespace` column actually holds, which is
+ *     what a predicate must bind.
+ *
+ * They are equal in every normal deployment and diverge only when an operator
+ * points them apart during a migration.
+ *
+ * There is NO default legacy namespace: `legacySharedNamespace` is `""` unless
+ * an operator sets one. An empty legacy name must never match caller input, so
+ * every legacy check below tests for non-empty FIRST — otherwise an unset
+ * config would make `""` "legacy" and match unnamespaced input.
+ *
+ * This module reads no environment. Every raw value arrives as a field of the
+ * one {@link SharedNamespaceEnv} options parameter, filled by the caller that
+ * already holds the composition root's config. The legacy zero-argument call
+ * form lives on in the L5 adapter at `src/shared-namespace.ts`.
+ */
+
+import type { AuthInfo } from "../../src/types.ts";
+
+const DEFAULT_SHARED_NAMESPACE = "shared-kb";
+const DEFAULT_LEGACY_SHARED_NAMESPACE = "";
+const DEFAULT_FALLBACK_MIN_RESULTS = 5;
+
+/**
+ * The raw environment values this module resolves a name set from.
+ *
+ * Each field mirrors the environment variable of the same purpose and is
+ * `undefined` when that variable is unset. The caller reads them; this module
+ * only interprets them.
+ */
+export interface SharedNamespaceEnv {
+  /** `SHARED_NAMESPACE_CANONICAL`. */
+  sharedNamespaceCanonical?: string | undefined;
+  /** `SHARED_NAMESPACE_PHYSICAL`. */
+  sharedNamespacePhysical?: string | undefined;
+  /** `OPENBRAIN_SHARED_NAMESPACE`, the fallback for both names above. */
+  openbrainSharedNamespace?: string | undefined;
+  /** `SHARED_NAMESPACE_LEGACY`. */
+  sharedNamespaceLegacy?: string | undefined;
+  /** `OPENBRAIN_LEGACY_SHARED_NAMESPACE`. */
+  openbrainLegacySharedNamespace?: string | undefined;
+  /** `OPENBRAIN_LEGACY_SHARED_FALLBACK`. */
+  legacySharedFallback?: string | undefined;
+  /** `OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS`. */
+  sharedFallbackMinResults?: string | undefined;
+  /** `OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES`. */
+  allowLegacySharedWrites?: string | undefined;
+}
+
+export interface SharedNamespaceConfig {
+  canonicalSharedNamespace: string;
+  physicalSharedNamespace: string;
+  /** Physical shared namespace used by existing read/write call sites. */
+  sharedNamespace: string;
+  legacySharedNamespace: string;
+  legacyFallbackEnabled: boolean;
+  fallbackMinResults: number;
+  allowLegacySharedWrites: boolean;
+}
+
+/** First non-empty trimmed candidate, or `defaultValue` when none is set. */
+function firstNonEmpty(
+  candidates: (string | undefined)[],
+  defaultValue: string,
+): string {
+  for (const candidate of candidates) {
+    const raw = candidate?.trim();
+    if (raw) return raw;
+  }
+  return defaultValue;
+}
+
+/** Truthy spellings accepted for a boolean flag; blank falls back. */
+function asBoolean(raw: string | undefined, defaultValue: boolean): boolean {
+  if (raw === undefined || raw.trim() === "") return defaultValue;
+  return ["1", "true", "yes", "on"].includes(raw.trim().toLowerCase());
+}
+
+/** A positive integer, or `defaultValue` for anything else. */
+function asPositiveInteger(raw: string | undefined, defaultValue: number): number {
+  if (!raw) return defaultValue;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : defaultValue;
+}
+
+/**
+ * Resolve the shared-namespace name set from raw values the caller supplies.
+ *
+ * @param env Raw environment values; every field optional, defaults applied.
+ * @returns The resolved canonical/physical/legacy name set and its flags.
+ */
+export function sharedNamespaceConfig(env: SharedNamespaceEnv): SharedNamespaceConfig {
+  const canonicalSharedNamespace = firstNonEmpty(
+    [env.sharedNamespaceCanonical, env.openbrainSharedNamespace],
+    DEFAULT_SHARED_NAMESPACE,
+  );
+  const physicalSharedNamespace = firstNonEmpty(
+    [env.sharedNamespacePhysical, env.openbrainSharedNamespace],
+    canonicalSharedNamespace,
+  );
+  return {
+    canonicalSharedNamespace,
+    physicalSharedNamespace,
+    sharedNamespace: physicalSharedNamespace,
+    legacySharedNamespace: firstNonEmpty(
+      [env.sharedNamespaceLegacy, env.openbrainLegacySharedNamespace],
+      DEFAULT_LEGACY_SHARED_NAMESPACE,
+    ),
+    legacyFallbackEnabled: asBoolean(env.legacySharedFallback, false),
+    fallbackMinResults: asPositiveInteger(
+      env.sharedFallbackMinResults,
+      DEFAULT_FALLBACK_MIN_RESULTS,
+    ),
+    allowLegacySharedWrites: asBoolean(env.allowLegacySharedWrites, false),
+  };
+}
+
+/** True when `namespace` is either name of the shared partition. */
+export function isSharedNamespace(namespace: string, env: SharedNamespaceEnv): boolean {
+  const config = sharedNamespaceConfig(env);
+  return (
+    namespace === config.canonicalSharedNamespace ||
+    namespace === config.physicalSharedNamespace
+  );
+}
+
+/**
+ * True only when a non-empty legacy shared namespace is configured and matches.
+ * With the default (empty) legacy namespace, no input is ever legacy — this
+ * prevents an empty config from matching unnamespaced input.
+ */
+export function isLegacySharedNamespace(
+  namespace: string,
+  env: SharedNamespaceEnv,
+): boolean {
+  const legacy = sharedNamespaceConfig(env).legacySharedNamespace;
+  return legacy !== "" && namespace === legacy;
+}
+
+/** Translate a physical or legacy name to the canonical one. */
+export function canonicalNamespace(namespace: string, env: SharedNamespaceEnv): string {
+  const config = sharedNamespaceConfig(env);
+  if (
+    config.legacySharedNamespace !== "" &&
+    namespace === config.legacySharedNamespace
+  ) {
+    return config.canonicalSharedNamespace;
+  }
+  return namespace === config.physicalSharedNamespace
+    ? config.canonicalSharedNamespace
+    : namespace;
+}
+
+/** Translate the canonical name to the physical one a predicate must bind. */
+export function physicalNamespace(namespace: string, env: SharedNamespaceEnv): string {
+  const config = sharedNamespaceConfig(env);
+  return namespace === config.canonicalSharedNamespace
+    ? config.physicalSharedNamespace
+    : namespace;
+}
+
+/** True when a non-admin write to the legacy shared namespace must be refused. */
+export function shouldRejectLegacySharedWrite(
+  auth: AuthInfo,
+  targetNamespace: string,
+  env: SharedNamespaceEnv,
+): boolean {
+  const config = sharedNamespaceConfig(env);
+  if (config.allowLegacySharedWrites) return false;
+  if (config.legacySharedNamespace === "") return false;
+  if (targetNamespace !== config.legacySharedNamespace) return false;
+  return auth.role !== "admin" && auth.role !== "ob-admin";
+}

--- a/src/shared-namespace.ts
+++ b/src/shared-namespace.ts
@@ -1,123 +1,63 @@
-import type { AuthInfo } from "./types.ts";
+// L5 adapter (issue 864): legacy call form over server/security/shared-namespace.ts; retired with src/ at L6.
+//
+// The moved module takes its raw environment values as fields of one options
+// parameter. Every legacy caller here calls without one, so this adapter reads
+// process.env at call time and forwards the set unchanged. It is a src/ file,
+// lint-exempt, and retires with src/ at L6.
 
-const DEFAULT_SHARED_NAMESPACE = "shared-kb";
-// The `collab` namespace was retired (#167). shared-kb is canonical and collab
-// is frozen and mirrored. There is no default legacy shared namespace anymore;
-// an operator can still set SHARED_NAMESPACE_LEGACY explicitly (plus
-// OPENBRAIN_LEGACY_SHARED_FALLBACK=1) as a transient escape hatch during a
-// migration window, but nothing is legacy by default.
-const DEFAULT_LEGACY_SHARED_NAMESPACE = "";
-const DEFAULT_FALLBACK_MIN_RESULTS = 5;
+import type { AuthInfo } from "../server/types.ts";
+import type {
+  SharedNamespaceConfig,
+  SharedNamespaceEnv,
+} from "../server/security/shared-namespace.ts";
+import {
+  canonicalNamespace as canonicalNamespaceWith,
+  isLegacySharedNamespace as isLegacySharedNamespaceWith,
+  isSharedNamespace as isSharedNamespaceWith,
+  physicalNamespace as physicalNamespaceWith,
+  sharedNamespaceConfig as sharedNamespaceConfigWith,
+  shouldRejectLegacySharedWrite as shouldRejectLegacySharedWriteWith,
+} from "../server/security/shared-namespace.ts";
 
-function envString(names: string[], defaultValue: string): string {
-  for (const name of names) {
-    const raw = process.env[name]?.trim();
-    if (raw) return raw;
-  }
-  return defaultValue;
-}
+export type { SharedNamespaceConfig };
 
-function envBoolean(name: string, defaultValue: boolean): boolean {
-  const raw = process.env[name];
-  if (raw === undefined || raw.trim() === "") return defaultValue;
-  return ["1", "true", "yes", "on"].includes(raw.trim().toLowerCase());
-}
-
-function envPositiveInteger(name: string, defaultValue: number): number {
-  const raw = process.env[name];
-  if (!raw) return defaultValue;
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : defaultValue;
-}
-
-export interface SharedNamespaceConfig {
-  canonicalSharedNamespace: string;
-  physicalSharedNamespace: string;
-  /** Physical shared namespace used by existing read/write call sites. */
-  sharedNamespace: string;
-  legacySharedNamespace: string;
-  legacyFallbackEnabled: boolean;
-  fallbackMinResults: number;
-  allowLegacySharedWrites: boolean;
-}
-
-export function sharedNamespaceConfig(): SharedNamespaceConfig {
-  const canonicalSharedNamespace = envString(
-    ["SHARED_NAMESPACE_CANONICAL", "OPENBRAIN_SHARED_NAMESPACE"],
-    DEFAULT_SHARED_NAMESPACE,
-  );
-  const physicalSharedNamespace = envString(
-    ["SHARED_NAMESPACE_PHYSICAL", "OPENBRAIN_SHARED_NAMESPACE"],
-    canonicalSharedNamespace,
-  );
+/** Read the shared-namespace environment at call time, as legacy callers expect. */
+function currentEnv(): SharedNamespaceEnv {
   return {
-    canonicalSharedNamespace,
-    physicalSharedNamespace,
-    sharedNamespace: physicalSharedNamespace,
-    legacySharedNamespace: envString(
-      ["SHARED_NAMESPACE_LEGACY", "OPENBRAIN_LEGACY_SHARED_NAMESPACE"],
-      DEFAULT_LEGACY_SHARED_NAMESPACE,
-    ),
-    legacyFallbackEnabled: envBoolean(
-      "OPENBRAIN_LEGACY_SHARED_FALLBACK",
-      false,
-    ),
-    fallbackMinResults: envPositiveInteger(
-      "OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS",
-      DEFAULT_FALLBACK_MIN_RESULTS,
-    ),
-    allowLegacySharedWrites: envBoolean(
-      "OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES",
-      false,
-    ),
+    sharedNamespaceCanonical: process.env["SHARED_NAMESPACE_CANONICAL"],
+    sharedNamespacePhysical: process.env["SHARED_NAMESPACE_PHYSICAL"],
+    openbrainSharedNamespace: process.env["OPENBRAIN_SHARED_NAMESPACE"],
+    sharedNamespaceLegacy: process.env["SHARED_NAMESPACE_LEGACY"],
+    openbrainLegacySharedNamespace: process.env["OPENBRAIN_LEGACY_SHARED_NAMESPACE"],
+    legacySharedFallback: process.env["OPENBRAIN_LEGACY_SHARED_FALLBACK"],
+    sharedFallbackMinResults: process.env["OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS"],
+    allowLegacySharedWrites: process.env["OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES"],
   };
 }
 
-export function isSharedNamespace(namespace: string): boolean {
-  const config = sharedNamespaceConfig();
-  return (
-    namespace === config.canonicalSharedNamespace ||
-    namespace === config.physicalSharedNamespace
-  );
+export function sharedNamespaceConfig(): SharedNamespaceConfig {
+  return sharedNamespaceConfigWith(currentEnv());
 }
 
-/**
- * True only when a non-empty legacy shared namespace is configured and matches.
- * With the default (empty) legacy namespace, no input is ever legacy — this
- * prevents an empty config from matching unnamespaced input.
- */
+export function isSharedNamespace(namespace: string): boolean {
+  return isSharedNamespaceWith(namespace, currentEnv());
+}
+
 export function isLegacySharedNamespace(namespace: string): boolean {
-  const legacy = sharedNamespaceConfig().legacySharedNamespace;
-  return legacy !== "" && namespace === legacy;
+  return isLegacySharedNamespaceWith(namespace, currentEnv());
 }
 
 export function canonicalNamespace(namespace: string): string {
-  const config = sharedNamespaceConfig();
-  if (
-    config.legacySharedNamespace !== "" &&
-    namespace === config.legacySharedNamespace
-  ) {
-    return config.canonicalSharedNamespace;
-  }
-  return namespace === config.physicalSharedNamespace
-    ? config.canonicalSharedNamespace
-    : namespace;
+  return canonicalNamespaceWith(namespace, currentEnv());
 }
 
 export function physicalNamespace(namespace: string): string {
-  const config = sharedNamespaceConfig();
-  return namespace === config.canonicalSharedNamespace
-    ? config.physicalSharedNamespace
-    : namespace;
+  return physicalNamespaceWith(namespace, currentEnv());
 }
 
 export function shouldRejectLegacySharedWrite(
   auth: AuthInfo,
   targetNamespace: string,
 ): boolean {
-  const config = sharedNamespaceConfig();
-  if (config.allowLegacySharedWrites) return false;
-  if (config.legacySharedNamespace === "") return false;
-  if (targetNamespace !== config.legacySharedNamespace) return false;
-  return auth.role !== "admin" && auth.role !== "ob-admin";
+  return shouldRejectLegacySharedWriteWith(auth, targetNamespace, currentEnv());
 }


### PR DESCRIPTION
## Summary

- L5 of issue 864: `git mv src/shared-namespace.ts server/security/shared-namespace.ts`. The moved module reads no environment. Its three former `process.env` readers (`envString`, `envBoolean`, `envPositiveInteger`) become pure interpreters (`firstNonEmpty`, `asBoolean`, `asPositiveInteger`) over raw values that arrive as fields of one `SharedNamespaceEnv` options parameter, so every exported function takes that parameter and the module has no ambient input.
- The options fields, one per environment variable, each optional: `sharedNamespaceCanonical` (`SHARED_NAMESPACE_CANONICAL`), `sharedNamespacePhysical` (`SHARED_NAMESPACE_PHYSICAL`), `openbrainSharedNamespace` (`OPENBRAIN_SHARED_NAMESPACE`, the fallback for both names above), `sharedNamespaceLegacy` (`SHARED_NAMESPACE_LEGACY`), `openbrainLegacySharedNamespace` (`OPENBRAIN_LEGACY_SHARED_NAMESPACE`), `legacySharedFallback` (`OPENBRAIN_LEGACY_SHARED_FALLBACK`), `sharedFallbackMinResults` (`OPENBRAIN_SHARED_FALLBACK_MIN_RESULTS`), `allowLegacySharedWrites` (`OPENBRAIN_ALLOW_LEGACY_SHARED_WRITES`).
- `src/shared-namespace.ts` becomes the M9 adapter: header `// L5 adapter (issue 864): legacy call form over server/security/shared-namespace.ts; retired with src/ at L6.`, 56 code lines, preserving all six legacy exports in their zero-configuration call form. It reads `process.env` at call time inside `currentEnv()` and forwards the set unchanged, so no caller sees a stale value. Every relative import it names resolves under `server/` — `../server/types.ts` and `../server/security/shared-namespace.ts` — the `import type` lines included, per the M9 NOTE.
- server/ importers that do not hold a config in hand keep importing the src/ adapter path per M3, because none of the seven calls a form the adapter is needed for and none has a `ServerConfig` available at the call site: `server/maintenance/graph-derivation-handler.ts`, `server/domain/repo-facts-model.ts`, `server/domain/repo-facts.ts`, `server/domain/source-registry-model.ts`, `server/domain/promotion-service.ts`, `server/domain/read-policy.ts`, `server/security/namespace-policy.ts`. Threading config into those call sites is domain rewiring, not this move lane.
- Every `src/` and `scripts/` importer keeps its import line untouched per M2/M9.
- `server/tools/shared-namespace.ts` is a separate MCP-facing module with its own field shape (`SharedNamespaceGroup` from `server/config/env-groups.ts`, already environment-free) and is **not** a retarget target. Verified against the head census before the move.
- Closure count: **27 -> 26**, minus exactly the one file moved.

### tests left in src/ (retire or move at L6)

- `src/shared-namespace.test.ts` and `src/namespace-policy.test.ts` stay at their src/ paths untouched per M1 EXCEPTION. They exercise the moved code through the adapter with names, order, and assertions unchanged, and they are not staged, so the gate never sees them.

## Verification

- Done-means: scripts/done-means/864-moved-out-of-src.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts, all from the clone at `refactor/864-c5f-shared-namespace`:

- RED, at `origin/main`: `bash scripts/done-means/864-moved-out-of-src.sh src/shared-namespace.ts` -> `FAIL A` / `FAIL B`, exit 1. The file was still a tracked implementation.
- GREEN, on the committed tree: `bash scripts/done-means/864-moved-out-of-src.sh` (no arguments, the verify-lane form) -> `judged=38 shims, 3 adapters` / `PASS`, exit 0.
- `bunx tsc --noEmit` -> exit 0.
- `./node_modules/.bin/oxlint --deny-warnings --config .oxlintrc.json src/shared-namespace.ts server/security/shared-namespace.ts` -> exit 0, no disable comments used.
- `bun run test:isolated src/shared-namespace.test.ts server/tools/shared-namespace-legacy.test.ts src/namespace-policy.test.ts` -> 37 pass, 0 fail, exit 0.
- Closure: `closure-count.sh` -> 27 before, 26 after.
- M10 python guards: `rg -n '"src/|/ "src"|src/[a-z-]+\.ts' python/openbrain-memory/tests` names no shared-namespace path, so no guard repoint was needed and the python package is untouched.
- M12 text readers: `rg -n "shared-namespace" scripts server src python --type ts --type py` found no `readFileSync`/`Bun.file`/glob consumer of `src/shared-namespace.ts`. The prose references in `server/config.ts`, `server/config/env-groups.ts`, and `server/config-equivalence.test.ts` all name `server/tools/shared-namespace.ts`, the module that did not move.
- Pre-commit gate (gitleaks, oxlint, prettier, whole-project tsc) and the pre-push full isolated suite both passed, first attempt, nothing bypassed.

## Critical Self-Review

- Highest-risk behavior: namespace translation is an isolation predicate. `physicalNamespace` feeds the `namespace` column a read binds, so a wrong value here reads another tenant's partition. The risk is contained by the adapter forwarding the identical environment set: precedence order, trimming, the empty-legacy guard, and the write-refusal predicate are byte-for-byte the same logic, only with the raw values passed in rather than read inside.
- Assumptions that could be wrong: that no caller depends on the reader being called lazily per invocation. Checked — the adapter calls `currentEnv()` inside each function, not at module scope, so a test that mutates `process.env` between calls still sees the new value. That is exactly what `scripts/test-support/shared-namespace-env.ts` does, and the 37 passing tests include those mutation paths.
- Missing/weak tests: no test yet calls the server/ functions with an explicit `SharedNamespaceEnv` that differs from the environment, so the injection seam is proven only through the adapter's pass-through. The seam is type-enforced and the parameter is required, so a caller cannot silently omit it, but a direct injection test would be stronger and belongs with the first server/ caller that actually threads config.
- Security/permission risk: `shouldRejectLegacySharedWrite` keeps its ordering — allow-flag first, empty-legacy second, target match third, role check last — so an unset legacy namespace still refuses to match unnamespaced input. Changing that order would turn an empty config into a universal match; it was preserved deliberately and is covered by the moved tests.
- Migration/deploy risk: none. No schema, no migration, no config file, no wire format. `server/main.ts` was not touched.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client path changed; `server/tools/shared-namespace.ts` is untouched and is what the MCP surface uses. The python package gate was skipped by the pre-push hook because no python path changed.
- Rollback/cleanup concern: the adapter is the rollback surface — reverting this commit restores the original file exactly, since the move was `git mv` plus a rewrite in place. The adapter is scheduled to retire with src/ at L6, not left indefinitely.
- Fixes made before PR: the first adapter draft imported `AuthInfo` from `../src/types.ts`, which fails the M9 NOTE (clause A judges type imports too). Repointed to `../server/types.ts` before the commit, and the no-argument done-means run is what confirms it.
- Known residual risk: the seven server/ importers still reach the moved code through a src/ adapter, so `server/` is not yet free of `src/` on this path. That is M3 by design and is L6 work, but it means this lane lowers the closure count without fully cutting the dependency edge for those seven files.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: this is a mechanical L5 move with no new defect class; the M9 adapter pattern and the type-import clause are already recorded in the lane contract's Tightenings from lanes 1 and 10.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime surface, schema, or deployed behavior changed; the module is internal and its callers are unchanged.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no client-facing contract, tool schema, or fixture is involved — this is an internal module relocation with identical exported signatures at the src/ path.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Rollout does not apply: no MCP tool, schema, protocol, or client-facing surface changed. Every legacy export keeps its exact signature at `src/shared-namespace.ts`, so no importer inside or outside this repo sees a different call form.
