### PR TITLE
refactor(l5): move db/pool and qmd-path from src/ into server/db and server/config behind L5 adapters (issue 864)

### DIFF
--- a/server/application/operator-doctor-probes.ts
+++ b/server/application/operator-doctor-probes.ts
@@ -14,7 +14,7 @@ import { fileURLToPath } from "node:url";
 import type pg from "pg";
 import { embeddingBaseUrl, embeddingApiKey } from "../../src/embedding.ts";
 import { readMcpAuditConfig } from "../../src/audit-log.ts";
-import { resolveQmdPath } from "../../src/qmd-path.ts";
+import { resolveQmdPath } from "../config/qmd-path.ts";
 import { logger } from "../../src/logger.ts";
 import { describeError } from "../../src/observability/index.ts";
 import type { QmdIndexProbeResult } from "../../src/qmd-index-probe-worker.ts";
@@ -429,12 +429,12 @@ async function readQmdIndexStatus(
 }
 
 // Availability = the qmd entrypoint file exists at the same resolved path
-// search_all executes (src/qmd-path.ts). This remains binary presence only;
+// search_all executes (server/config/qmd-path.ts). This remains binary presence only;
 // repo-local index freshness is reported separately below.
 export async function checkQmdStatus(
   options: OperatorDoctorBuildOptions,
 ): Promise<OperatorDoctorStatus["qmd"]> {
-  const resolved = resolveQmdPath();
+  const resolved = resolveQmdPath({ qmdPath: options.qmdPath });
   let available = false;
   try {
     available = existsSync(resolved.path);

--- a/server/application/operator-doctor-types.ts
+++ b/server/application/operator-doctor-types.ts
@@ -135,6 +135,11 @@ export interface OperatorDoctorOptions {
   rotationConfigured: boolean;
   /** Raw-turn retention seconds: the distillation-lag alarm denominator. */
   rawTurnTtlSeconds: number;
+  /**
+   * Raw `QMD_PATH`: absent means the qmd entrypoint default, blank means a
+   * blank path. Not folded to absent -- see `server/config/qmd-path.ts`.
+   */
+  qmdPath?: string;
   /** Absent means the doctor falls back to its own default index path. */
   qmdIndexPath?: string;
   /** Where `qmdIndexPath` came from, reported verbatim in the payload. */

--- a/server/application/operator-doctor.ts
+++ b/server/application/operator-doctor.ts
@@ -20,7 +20,7 @@ import {
   EMBEDDING_DIMENSIONS,
   EMBEDDING_MODEL,
 } from "../../src/embedding.ts";
-import { checkPoolHealth } from "../../src/db/pool.ts";
+import { checkPoolHealth } from "../db/legacy-pool.ts";
 import { logger } from "../../src/logger.ts";
 import { describeError } from "../../src/observability/index.ts";
 import type { NatsBridgeHealth } from "../../src/nats-bridge.ts";

--- a/server/config/qmd-path.ts
+++ b/server/config/qmd-path.ts
@@ -1,0 +1,34 @@
+// Single source of truth for qmd entrypoint path resolution.
+//
+// Both the real qmd caller (src/tools/search-all.ts) and the operator doctor
+// (server/application/operator-doctor-probes.ts) MUST consume resolveQmdPath()
+// so their view of the qmd binary location can never diverge. The default
+// matches the documented prod layout on production-host.
+//
+// The configured path arrives as a parameter rather than being read here:
+// `.oxlintrc.json` permits `process.env` only at the composition root. It is
+// deliberately NOT `QmdConfigGroup` from `./env-groups.ts`: `qmdGroup` folds a
+// blank `QMD_PATH` to absent, while this resolver branches on `=== undefined`
+// and passes a blank value through as an empty path. Reusing that group would
+// change what `QMD_PATH=""` resolves to. The zero-argument call form lives on
+// in the `src/qmd-path.ts` L5 adapter.
+export const DEFAULT_QMD_PATH = "/opt/qmd/src/qmd.ts";
+
+export interface ResolvedQmdPath {
+  path: string;
+  source: "env" | "default";
+}
+
+/** The raw `QMD_PATH` reading, blank preserved and absent meaning unset. */
+export interface QmdPathSettings {
+  readonly qmdPath: string | undefined;
+}
+
+export function resolveQmdPath(settings: QmdPathSettings): ResolvedQmdPath {
+  // Mirror the historical `process.env.QMD_PATH ?? DEFAULT_QMD_PATH` exactly
+  // (no trimming) so search_all behavior is unchanged.
+  if (settings.qmdPath === undefined) {
+    return { path: DEFAULT_QMD_PATH, source: "default" };
+  }
+  return { path: settings.qmdPath, source: "env" };
+}

--- a/server/db/legacy-pool.ts
+++ b/server/db/legacy-pool.ts
@@ -1,0 +1,106 @@
+/**
+ * Direct `pg.Pool` construction and health probing for callers that own a raw
+ * pool rather than the `Database` boundary in `./pool.ts`.
+ *
+ * The connection settings arrive as one `PoolSettings` parameter instead of
+ * being read from the environment here: `.oxlintrc.json` permits `process.env`
+ * only at the composition root, and the doctor already receives its values
+ * through `OperatorDoctorOptions`. The legacy zero-argument call form lives on
+ * in the `src/db/pool.ts` L5 adapter.
+ */
+import pg from "pg";
+import pgvector from "pgvector/pg";
+import { logger } from "../../src/logger.ts";
+import { describeError } from "../../src/observability/index.ts";
+import type { PoolHealth } from "../../src/types.ts";
+
+/** The connection settings `createPool` used to read from the environment. */
+export interface PoolSettings {
+  /** `DB_HOST`; the caller rejects a blank value before calling. */
+  readonly host: string;
+  /** `DB_PORT`, already parsed. */
+  readonly port: number;
+  /** `DB_NAME`. */
+  readonly database: string;
+  /** `DB_USER`; the caller rejects a blank value before calling. */
+  readonly user: string;
+  /** `DB_PASSWORD`, absent when the role authenticates without one. */
+  readonly password?: string;
+  /** `DB_POOL_MAX`, already parsed to a positive integer. */
+  readonly max: number;
+}
+
+function registerVectorTypes(client: pg.PoolClient): void {
+  void pgvector.registerTypes(client).catch((err: unknown) => {
+    // Stable event name, not a sentence: Loki filters on `message`, so the
+    // remediation text moves into a field where it does not fragment the
+    // query surface. The pg fields come along now -- an extension that is
+    // absent and one the role may not use report different SQLSTATEs.
+    logger.error("pgvector_registration_failed", {
+      impact: "vector operations will not work",
+      remediation: "install the pgvector extension (CREATE EXTENSION vector)",
+      ...describeError(err),
+    });
+  });
+}
+
+export function createPool(
+  settings: PoolSettings,
+  overrides?: Partial<pg.PoolConfig>,
+): pg.Pool {
+  const pool = new pg.Pool({
+    host: settings.host,
+    port: settings.port,
+    database: settings.database,
+    user: settings.user,
+    password: settings.password,
+    max: settings.max,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 5000,
+    maxUses: 7500,
+    statement_timeout: 30000,
+    ...overrides,
+  });
+
+  pool.on("connect", registerVectorTypes);
+
+  pool.on("error", (err) => {
+    logger.error("pool_error", describeError(err));
+  });
+
+  return pool;
+}
+
+export async function checkPoolHealth(pool: pg.Pool): Promise<PoolHealth> {
+  try {
+    await pool.query("SELECT 1");
+    return {
+      connected: true,
+      total: pool.totalCount,
+      idle: pool.idleCount,
+      waiting: pool.waitingCount,
+    };
+  } catch (error) {
+    // The most-consulted health signal in the system, and it threw away the one
+    // fact anybody wants: WHY. "connected: false" was returned identically for a
+    // refused connection, a password failure, an exhausted pool, and a database
+    // in recovery. The pg fields distinguish all four.
+    //
+    // The returned shape stays as it was -- callers and the doctor contract
+    // depend on it -- except that the counts are reported as observed rather
+    // than as zeros. A pool with 10 connections and a failing probe has 10
+    // connections; claiming 0 invented a fact.
+    logger.error("pool_health_check_failed", {
+      total: pool.totalCount,
+      idle: pool.idleCount,
+      waiting: pool.waitingCount,
+      ...describeError(error),
+    });
+    return {
+      connected: false,
+      total: pool.totalCount,
+      idle: pool.idleCount,
+      waiting: pool.waitingCount,
+    };
+  }
+}

--- a/server/main.ts
+++ b/server/main.ts
@@ -394,6 +394,7 @@ function composeApplication(input: {
         fileLogConfigured: Boolean(config.logging.file?.trim()),
         rotationConfigured: config.doctor.rotationConfigured,
         rawTurnTtlSeconds: config.doctor.rawTurnTtlSeconds,
+        ...(config.qmd.path !== undefined ? { qmdPath: config.qmd.path } : {}),
         ...(config.doctor.qmdIndexPath !== undefined
           ? { qmdIndexPath: config.doctor.qmdIndexPath }
           : {}),

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,8 +1,12 @@
-import pg from "pg";
-import pgvector from "pgvector/pg";
-import { logger } from "../logger.ts";
-import { describeError } from "../observability/index.ts";
-import type { PoolHealth } from "../types.ts";
+// L5 adapter (issue 864): legacy call form over server/db/legacy-pool.ts; retired with src/ at L6.
+import type pg from "pg";
+import {
+  createPool as createPoolWithSettings,
+  type PoolSettings,
+} from "../../server/db/legacy-pool.ts";
+
+export { checkPoolHealth } from "../../server/db/legacy-pool.ts";
+export type { PoolSettings } from "../../server/db/legacy-pool.ts";
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
@@ -10,79 +14,20 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+/** The legacy form: connection settings read from the environment at call time. */
 export function createPool(overrides?: Partial<pg.PoolConfig>): pg.Pool {
   const host = process.env.DB_HOST;
   if (!host) throw new Error("DB_HOST environment variable is required");
   const user = process.env.DB_USER;
   if (!user) throw new Error("DB_USER environment variable is required");
 
-  const pool = new pg.Pool({
+  const settings: PoolSettings = {
     host,
     port: parseInt(process.env.DB_PORT || "5432", 10),
     database: process.env.DB_NAME || "open_brain",
     user,
     password: process.env.DB_PASSWORD,
     max: parsePositiveInt(process.env.DB_POOL_MAX, 10),
-    idleTimeoutMillis: 30000,
-    connectionTimeoutMillis: 5000,
-    maxUses: 7500,
-    statement_timeout: 30000,
-    ...overrides,
-  });
-
-  pool.on("connect", async (client) => {
-    try {
-      await pgvector.registerTypes(client);
-    } catch (err) {
-      // Stable event name, not a sentence: Loki filters on `message`, so the
-      // remediation text moves into a field where it does not fragment the
-      // query surface. The pg fields come along now -- an extension that is
-      // absent and one the role may not use report different SQLSTATEs.
-      logger.error("pgvector_registration_failed", {
-        impact: "vector operations will not work",
-        remediation: "install the pgvector extension (CREATE EXTENSION vector)",
-        ...describeError(err),
-      });
-    }
-  });
-
-  pool.on("error", (err) => {
-    logger.error("pool_error", describeError(err));
-  });
-
-  return pool;
-}
-
-export async function checkPoolHealth(pool: pg.Pool): Promise<PoolHealth> {
-  try {
-    await pool.query("SELECT 1");
-    return {
-      connected: true,
-      total: pool.totalCount,
-      idle: pool.idleCount,
-      waiting: pool.waitingCount,
-    };
-  } catch (error) {
-    // The most-consulted health signal in the system, and it threw away the one
-    // fact anybody wants: WHY. "connected: false" was returned identically for a
-    // refused connection, a password failure, an exhausted pool, and a database
-    // in recovery. The pg fields distinguish all four.
-    //
-    // The returned shape stays as it was -- callers and the doctor contract
-    // depend on it -- except that the counts are reported as observed rather
-    // than as zeros. A pool with 10 connections and a failing probe has 10
-    // connections; claiming 0 invented a fact.
-    logger.error("pool_health_check_failed", {
-      total: pool.totalCount,
-      idle: pool.idleCount,
-      waiting: pool.waitingCount,
-      ...describeError(error),
-    });
-    return {
-      connected: false,
-      total: pool.totalCount,
-      idle: pool.idleCount,
-      waiting: pool.waitingCount,
-    };
-  }
+  };
+  return createPoolWithSettings(settings, overrides);
 }

--- a/src/operator-doctor.ts
+++ b/src/operator-doctor.ts
@@ -57,6 +57,7 @@ function ambientOptions(): OperatorDoctorOptions {
     rotationConfigured:
       Boolean(process.env.LOG_MAX_BYTES) || Boolean(process.env.LOG_MAX_FILES),
     rawTurnTtlSeconds: readDistillationLagTtlSeconds(),
+    ...(process.env.QMD_PATH !== undefined ? { qmdPath: process.env.QMD_PATH } : {}),
     ...(process.env.QMD_INDEX_PATH !== undefined
       ? { qmdIndexPath: process.env.QMD_INDEX_PATH, qmdIndexPathSource: "env" as const }
       : {}),

--- a/src/qmd-path.ts
+++ b/src/qmd-path.ts
@@ -1,23 +1,15 @@
-// Single source of truth for qmd entrypoint path resolution.
-//
-// Both the real qmd caller (src/tools/search-all.ts) and the operator doctor
-// (src/operator-doctor.ts) MUST consume resolveQmdPath() so their view of the
-// qmd binary location can never diverge. The default matches the documented
-// prod layout on production-host.
-export const DEFAULT_QMD_PATH = "/opt/qmd/src/qmd.ts";
+// L5 adapter (issue 864): legacy call form over server/config/qmd-path.ts; retired with src/ at L6.
+import {
+  resolveQmdPath as resolveQmdPathWithSettings,
+  type ResolvedQmdPath,
+} from "../server/config/qmd-path.ts";
 
-export interface ResolvedQmdPath {
-  path: string;
-  source: "env" | "default";
-}
+export { DEFAULT_QMD_PATH } from "../server/config/qmd-path.ts";
+export type { ResolvedQmdPath } from "../server/config/qmd-path.ts";
 
+/** The legacy form: an optional env record, defaulted to `process.env`. */
 export function resolveQmdPath(
   env: Record<string, string | undefined> = process.env,
 ): ResolvedQmdPath {
-  // Mirror the historical `process.env.QMD_PATH ?? DEFAULT_QMD_PATH` exactly
-  // (no trimming) so search_all behavior is unchanged.
-  if (env.QMD_PATH === undefined) {
-    return { path: DEFAULT_QMD_PATH, source: "default" };
-  }
-  return { path: env.QMD_PATH, source: "env" };
+  return resolveQmdPathWithSettings({ qmdPath: env.QMD_PATH });
 }


### PR DESCRIPTION
## Summary

- L5 of issue 864: two more modules leave `src/` for `server/`.
  - `src/db/pool.ts` -> `server/db/legacy-pool.ts`
  - `src/qmd-path.ts` -> `server/config/qmd-path.ts`
- **Name deviation, stated rather than taken silently:** the brief said
  `server/db/pool.ts`, but that path already holds a different module — the
  `Database` / `DatabaseHealth` / `createDatabase` ownership boundary imported by
  `server/main.ts`, `server/application/index.ts`, `server/transport/health.ts`
  and three `scripts/done-means` drivers. `git mv` onto it would have destroyed
  it. The moved file takes the sibling name `legacy-pool.ts` in the same
  directory, which is also what it is: the raw-`pg.Pool` form the legacy callers
  still use, as against the owned `Database` boundary next to it.
- Both `server/` versions take their former `process.env` readings as fields of
  **one options parameter**, filled by the composition root:

  ```ts
  export interface PoolSettings {
    readonly host: string;      // DB_HOST
    readonly port: number;      // DB_PORT, already parsed
    readonly database: string;  // DB_NAME
    readonly user: string;      // DB_USER
    readonly password?: string; // DB_PASSWORD
    readonly max: number;       // DB_POOL_MAX, already parsed
  }
  export function createPool(settings: PoolSettings, overrides?: Partial<pg.PoolConfig>): pg.Pool

  export interface QmdPathSettings {
    readonly qmdPath: string | undefined; // raw QMD_PATH
  }
  export function resolveQmdPath(settings: QmdPathSettings): ResolvedQmdPath
  ```

- **`resolveQmdPath` deliberately does NOT reuse `QmdConfigGroup`.** The brief
  asked me to reuse the existing `ServerConfig` sub-object when its shape
  matches, and to say which. It does not match, and reusing it would have been a
  silent behavior change: `qmdGroup` (`server/config/env-groups.ts:329`) is
  `parsed.QMD_PATH ? { path: parsed.QMD_PATH } : {}` over a `blankAsAbsent`
  field that trims, so a blank `QMD_PATH` folds to absent and resolves to
  `DEFAULT_QMD_PATH`. The resolver branches on `=== undefined` and passes a blank
  value through untrimmed as an empty path — the exact distinction
  `server/config/src-readers.ts:81-84` was written to preserve. So the module
  keeps its own narrow `QmdPathSettings` carrying the raw reading, and the
  comment in the file records why.

### Importers repointed

- `server/application/operator-doctor.ts` -> `../db/legacy-pool.ts`
- `server/application/operator-doctor-probes.ts` -> `../config/qmd-path.ts`, and
  its one call site becomes `resolveQmdPath({ qmdPath: options.qmdPath })`,
  taking the value from the `OperatorDoctorOptions` it already receives.
- `OperatorDoctorOptions` (`server/application/operator-doctor-types.ts`) gains
  one optional field:

  ```ts
  /**
   * Raw `QMD_PATH`: absent means the qmd entrypoint default, blank means a
   * blank path. Not folded to absent -- see `server/config/qmd-path.ts`.
   */
  qmdPath?: string;
  ```

### `server/main.ts` diff

```diff
         rawTurnTtlSeconds: config.doctor.rawTurnTtlSeconds,
+        ...(config.qmd.path !== undefined ? { qmdPath: config.qmd.path } : {}),
         ...(config.doctor.qmdIndexPath !== undefined
           ? { qmdIndexPath: config.doctor.qmdIndexPath }
           : {}),
```

The legacy blank-`QMD_PATH` behavior is preserved where it was actually
observable: `src/operator-doctor.ts`'s `ambientOptions()` (already an L5 adapter)
now contributes `qmdPath` from the raw `process.env.QMD_PATH`, `!== undefined`,
untrimmed — identical to what `resolveQmdPath()` used to read for itself.

### The two adapters

`src/qmd-path.ts` (15 code lines):

```ts
// L5 adapter (issue 864): legacy call form over server/config/qmd-path.ts; retired with src/ at L6.
import {
  resolveQmdPath as resolveQmdPathWithSettings,
  type ResolvedQmdPath,
} from "../server/config/qmd-path.ts";

export { DEFAULT_QMD_PATH } from "../server/config/qmd-path.ts";
export type { ResolvedQmdPath } from "../server/config/qmd-path.ts";

/** The legacy form: an optional env record, defaulted to `process.env`. */
export function resolveQmdPath(
  env: Record<string, string | undefined> = process.env,
): ResolvedQmdPath {
  return resolveQmdPathWithSettings({ qmdPath: env.QMD_PATH });
}
```

`src/db/pool.ts` (30 code lines) keeps the zero-argument `createPool(overrides?)`
form used by 20 `scripts/` callers plus `src/index.ts` and the dynamic import in
`scripts/deploy-lock.ts:168`. It reads the six `DB_*` variables at call time,
including both required-variable throws, parses them, and hands the result to
`createPoolWithSettings`. Per the M9 note, every relative import in both
adapters — **type imports included** — names a `server/` path; the only other
import is the npm `pg` type.

### Survey receipts, before the first `git mv`

- `fd 'pool|qmd-path' server` — found the `server/db/pool.ts` collision above.
- `rg -n "from ['\"].*(db/pool|qmd-path)\.ts" src server scripts --type ts` — 36
  importers; every non-`server/` one goes through an adapter untouched.
- M12 text-reader survey: `scripts/lane-bootstrap.ts:523`,
  `scripts/test-isolated.ts:317`, `server/config.ts:112`, `server/config.test.ts:85`
  and `server/config/src-readers.ts:81` name these paths in **prose comments
  only** — no `readFileSync`, `Bun.file`, or glob list reads either module by
  path, so nothing silently breaks. Those comments are left as they are: they are
  outside the moved set and its importers (M8), and rewriting them would drag
  unrelated files through the whole-file lint gate.
- M10 python guards: `rg -n '"src/|/ "src"|src/[a-z-]+\.ts' python/openbrain-memory/tests`
  has no hit for either module, so no guard needed repointing and the Python
  package is untouched.
- Tests: there are no `src/db/pool*.test.ts` or `src/qmd-path*.test.ts` files to
  leave behind or move; both modules are covered through their callers.

## Verification

- Done-means: scripts/done-means/864-moved-out-of-src.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts, all against the committed tree:

- `bunx tsc --noEmit` -> exit 0.
- `./node_modules/.bin/oxlint --deny-warnings --config .oxlintrc.json` over all
  nine touched paths -> exit 0, no findings.
- `bun run test:isolated src/operator-doctor.test.ts server/main.pg.test.ts server/db/pool.test.ts`
  -> exit 0, 40 pass / 0 fail, 132 expect() calls.
- `bash scripts/done-means/864-moved-out-of-src.sh` with **no arguments** ->
  `judged=38 shims, 7 adapters` / `PASS`, exit 0. Adapters 5 -> 7 are exactly the
  two this PR adds.
- `closure-count.sh` -> 24 before, 22 after: minus exactly the two files moved.
- Pre-commit gate (gitleaks, oxlint, prettier, whole-project tsc) and the
  pre-push full isolated suite both passed, first attempt, no bypass.

## Critical Self-Review

- Highest-risk behavior: qmd entrypoint resolution. `resolveQmdPath` distinguishes
  an absent `QMD_PATH` from a blank one, and the obvious reuse of
  `config.qmd.path` would have collapsed that distinction. Handled by giving the
  server module its own raw-reading options type and sourcing the doctor's value
  from raw env in the existing `src/operator-doctor.ts` adapter.
- Assumptions that could be wrong: that `config.qmd.path` is an acceptable source
  for `qmdPath` in `server/main.ts`. Under the real service it is — the config
  schema already trims and folds blank, so a blank `QMD_PATH` never reaches
  `main.ts` as blank in the first place, and that folding predates this PR. If a
  future reader wants the raw value at the composition root, `server/config.ts`
  is where it would have to change, and M8 put that out of scope here.
- Missing/weak tests: neither moved module had a dedicated test file before this
  PR, and this PR adds none — it is a move behind adapters, and inventing tests
  for it would exceed the lane. Coverage is indirect, through
  `src/operator-doctor.test.ts` (the qmd path, both branches) and the pre-push
  full suite (every `createPool` caller). A direct unit test asserting
  `QMD_PATH=""` resolves to `{ path: "", source: "env" }` would pin the behavior
  this PR was most careful about, and does not exist.
- Security/permission risk: none identified. No SQL, no auth, no namespace
  predicate, no token handling is touched. `DB_PASSWORD` moves from a direct env
  read to a field on `PoolSettings` passed in-process; it is not logged, and
  gitleaks scanned the staged changes clean.
- Migration/deploy risk: none. No migration, no schema change, no config file
  change, no new environment variable. `server/main.ts` gains one spread of an
  already-validated config value.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or
  Python-client surface is touched, so `docs/downstream-rollout.md` classifies
  this as not applicable. The `python-package` and contract-parity gates both
  self-skipped at pre-push because no client or contract path changed.
- Rollback/cleanup concern: revert the single commit. Both adapters are `src/`
  files scheduled for removal with `src/` at L6, so this PR leaves no cleanup
  debt of its own beyond what the program already owns.
- Fixes made before PR: two. (1) Caught the `server/db/pool.ts` collision during
  the pre-move `fd` survey and renamed the target rather than clobbering a live
  module. (2) Caught the `QmdConfigGroup` blank-folding divergence while wiring
  the config reuse the brief suggested, and backed it out in favor of a raw
  reading — the first version of `server/config/qmd-path.ts` in this branch had
  the reuse and would have shipped a silent behavior change.
- Known residual risk: the `QMD_PATH=""` path stays untested by a direct
  assertion, as noted above. Its two branches are exercised via the doctor
  adapter, but nothing fails loudly if a future edit folds blank to absent.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

Note on the SME line: the lesson is posted as a PR comment on this pull request per the lane's harvest step rather than as a `docs/sme/entries/` file, because the finding is about this refactor program's own move mechanics (reuse a config group only after checking its blank-value semantics) rather than a reviewer-lane pattern, and `docs/sme/` lane files are generated — see the comment below.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no
  running-service behavior changes; this is an internal module move behind
  adapters, with no tool, transport, or schema surface touched.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract or client-facing
  path changed, so the pre-push contract-parity subset self-skipped.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: no MCP tool, schema, protocol, transport, or
  Python-client surface is modified. The only cross-file signature change is
  `OperatorDoctorOptions` gaining one optional field, consumed inside `server/`
  and filled by `server/main.ts` and the `src/operator-doctor.ts` adapter.
