### PR TITLE
fix(contracts): parity scanner sees registrations through L5 adapters, check-parity split under the lint gate (issue 864)

### DIFF
--- a/contracts/check-parity-manifests.ts
+++ b/contracts/check-parity-manifests.ts
@@ -1,0 +1,116 @@
+// Manifest shapes and the loading/scanning helpers behind contracts/check-parity.ts.
+// Split out of check-parity.ts (issue 864) so the checker itself stays under the
+// server/ whole-file lint standard; nothing here changes behaviour.
+
+export type Runtime = "both" | "python" | "ts";
+export type PythonStatus = "implemented";
+export type TsStatus = "pending" | "implemented" | "runtime-specific";
+
+export interface Fixture {
+  id: string;
+  description: string;
+  capability: string;
+  runtime: Runtime;
+  consumers: string[];
+  request: Record<string, unknown>;
+  expectation: Record<string, unknown>;
+}
+
+export interface CapabilityEntry {
+  capability: string;
+  python: PythonStatus;
+  ts: TsStatus;
+  reason?: string;
+}
+
+export interface ParityManifest {
+  id: string;
+  expected_fixture_ids: Record<string, Runtime>;
+  capabilities: CapabilityEntry[];
+  not_yet_extracted?: Array<{
+    capability: string;
+    scenario: string;
+    reason: string;
+  }>;
+}
+
+export interface ServerFixture {
+  id: string;
+  description: string;
+  capability: string;
+  providers: string[];
+  auth: Record<string, unknown>;
+  steps: Array<{
+    tool: string;
+    arguments: Record<string, unknown>;
+    capture?: Record<string, unknown>;
+    expectation: Record<string, unknown>;
+  }>;
+}
+
+export type ServerCapabilityStatus = "implemented" | "scaffold-declared";
+
+export interface ServerParityManifest {
+  id: string;
+  expected_fixture_ids: string[];
+  providers: string[];
+  capabilities: string[];
+  provider_capability_status: Record<string, Record<string, ServerCapabilityStatus>>;
+}
+
+export interface ServerToolGap {
+  tool: string;
+  capability: string;
+  reason: string;
+}
+
+export interface ServerToolGapMap {
+  id: string;
+  source: string;
+  registered_tool_count: number;
+  fixture_covered_tool_count: number;
+  without_parity_fixture_count: number;
+  fixture_covered_tools: string[];
+  without_parity_fixture: ServerToolGap[];
+}
+
+const PLACEHOLDER_REASONS = new Set(["-", "n/a", "na", "none", "todo", "tbd"]);
+
+export const CONSUMER_ALLOWLIST = new Set(["python", "ts"]);
+
+export function isPlaceholderReason(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase() ?? "";
+  return !normalized || PLACEHOLDER_REASONS.has(normalized);
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Registrations live in src/tools/ and, as issue 864 moves each one down, in
+// server/tools/. An L5 adapter left behind in src/tools/ is a bare `export *`
+// and carries no tool-name literal, so scanning src/tools/ alone silently
+// loses every moved registration. Both directories feed the same set with the
+// same pattern, so a tool seen in both is still counted once.
+export async function collectRegisteredTools(
+  dir: URL,
+  into: Set<string>,
+): Promise<void> {
+  const glob = new Bun.Glob("*.ts");
+  for await (const name of glob.scan({ cwd: dir.pathname, onlyFiles: true })) {
+    const source = await Bun.file(new URL(name, dir)).text();
+    for (const match of source.matchAll(
+      /server\.registerTool\(\s*["'`]([^"'`]+)["'`]/g,
+    )) {
+      if (match[1]) into.add(match[1]);
+    }
+  }
+}
+
+export async function readJson<T>(url: URL): Promise<T> {
+  try {
+    return (await Bun.file(url).json()) as T;
+  } catch (error) {
+    throw new Error(`${url.pathname}: ${String(error)}`);
+  }
+}

--- a/contracts/check-parity.ts
+++ b/contracts/check-parity.ts
@@ -1,100 +1,23 @@
 import { SERVER_CONTRACT_PROVIDERS } from "./server-contract-providers.ts";
-
-type Runtime = "both" | "python" | "ts";
-type PythonStatus = "implemented";
-type TsStatus = "pending" | "implemented" | "runtime-specific";
-
-interface Fixture {
-  id: string;
-  description: string;
-  capability: string;
-  runtime: Runtime;
-  consumers: string[];
-  request: Record<string, unknown>;
-  expectation: Record<string, unknown>;
-}
-
-interface CapabilityEntry {
-  capability: string;
-  python: PythonStatus;
-  ts: TsStatus;
-  reason?: string;
-}
-
-interface ParityManifest {
-  id: string;
-  expected_fixture_ids: Record<string, Runtime>;
-  capabilities: CapabilityEntry[];
-  not_yet_extracted?: Array<{
-    capability: string;
-    scenario: string;
-    reason: string;
-  }>;
-}
-
-interface ServerFixture {
-  id: string;
-  description: string;
-  capability: string;
-  providers: string[];
-  auth: Record<string, unknown>;
-  steps: Array<{
-    tool: string;
-    arguments: Record<string, unknown>;
-    capture?: Record<string, unknown>;
-    expectation: Record<string, unknown>;
-  }>;
-}
-
-type ServerCapabilityStatus = "implemented" | "scaffold-declared";
-
-interface ServerParityManifest {
-  id: string;
-  expected_fixture_ids: string[];
-  providers: string[];
-  capabilities: string[];
-  provider_capability_status: Record<string, Record<string, ServerCapabilityStatus>>;
-}
-
-interface ServerToolGap {
-  tool: string;
-  capability: string;
-  reason: string;
-}
-
-interface ServerToolGapMap {
-  id: string;
-  source: string;
-  registered_tool_count: number;
-  fixture_covered_tool_count: number;
-  without_parity_fixture_count: number;
-  fixture_covered_tools: string[];
-  without_parity_fixture: ServerToolGap[];
-}
-
-const PLACEHOLDER_REASONS = new Set(["-", "n/a", "na", "none", "todo", "tbd"]);
-const CONSUMER_ALLOWLIST = new Set(["python", "ts"]);
+import {
+  CONSUMER_ALLOWLIST,
+  collectRegisteredTools,
+  isPlaceholderReason,
+  isRecord,
+  readJson,
+} from "./check-parity-manifests.ts";
+import type {
+  CapabilityEntry,
+  Fixture,
+  ParityManifest,
+  ServerFixture,
+  ServerParityManifest,
+  ServerToolGapMap,
+} from "./check-parity-manifests.ts";
 
 const fixtureDir = new URL("./memory/", import.meta.url);
 const serverFixtureDir = new URL("./server/", import.meta.url);
 const errors: string[] = [];
-
-function isPlaceholderReason(value: string | undefined): boolean {
-  const normalized = value?.trim().toLowerCase() ?? "";
-  return !normalized || PLACEHOLDER_REASONS.has(normalized);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-async function readJson<T>(url: URL): Promise<T> {
-  try {
-    return (await Bun.file(url).json()) as T;
-  } catch (error) {
-    throw new Error(`${url.pathname}: ${String(error)}`);
-  }
-}
 
 const manifest = await readJson<ParityManifest>(
   new URL("parity-manifest.json", fixtureDir),
@@ -141,9 +64,7 @@ for (const entry of manifest.capabilities ?? []) {
     continue;
   }
   if (capabilityMap.has(entry.capability)) {
-    errors.push(
-      `parity-manifest.json: duplicate capability '${entry.capability}'`,
-    );
+    errors.push(`parity-manifest.json: duplicate capability '${entry.capability}'`);
   }
   capabilityMap.set(entry.capability, entry);
   if (entry.python !== "implemented") {
@@ -184,6 +105,27 @@ const serverDeclarations = SERVER_CONTRACT_PROVIDERS.map((provider) => ({
   satisfaction: provider.satisfaction?.("1970-01-01T00:00:00.000Z"),
 }));
 
+// A contract-declaration fixture pins the contract id and schema hash every
+// declared provider must agree with. Hoisted out of the fixture loop so the
+// per-provider comparison is one level of nesting, not four.
+function checkDeclaredContractIdentity(
+  prefix: string,
+  request: Record<string, unknown>,
+): void {
+  for (const { provider, declaration } of serverDeclarations) {
+    if (request.contract_id !== declaration.contractVersion) {
+      errors.push(
+        `${prefix} declared contract_id '${String(request.contract_id)}' does not match ${provider.id} contract '${declaration.contractVersion}'`,
+      );
+    }
+    if (request.schema_hash !== declaration.schemaHash) {
+      errors.push(
+        `${prefix} declared schema_hash '${String(request.schema_hash)}' does not match ${provider.id} schema_hash '${declaration.schemaHash}'`,
+      );
+    }
+  }
+}
+
 const fixtureGlob = new Bun.Glob("*.fixture.json");
 const fixtureIds = new Set<string>();
 const fixtureCapabilities = new Set<string>();
@@ -220,10 +162,7 @@ for await (const name of fixtureGlob.scan({
     errors.push(
       `${prefix} fixture id '${fixture.id}' is absent from parity-manifest.json expected_fixture_ids`,
     );
-  } else if (
-    expectedRuntime !== undefined &&
-    expectedRuntime !== fixture.runtime
-  ) {
+  } else if (expectedRuntime !== undefined && expectedRuntime !== fixture.runtime) {
     errors.push(
       `${prefix} runtime '${String(fixture.runtime)}' does not match expected_fixture_ids runtime '${String(expectedRuntime)}'`,
     );
@@ -279,28 +218,13 @@ for await (const name of fixtureGlob.scan({
   if (!isRecord(fixture.expectation)) {
     errors.push(`${prefix} expectation must be an object`);
   }
-  if (
-    fixture.capability === "contract-declaration" &&
-    isRecord(fixture.request)
-  ) {
+  if (fixture.capability === "contract-declaration" && isRecord(fixture.request)) {
     contractDeclarationChecked = true;
-    for (const { provider, declaration } of serverDeclarations) {
-      if (fixture.request.contract_id !== declaration.contractVersion) {
-        errors.push(
-          `${prefix} declared contract_id '${String(fixture.request.contract_id)}' does not match ${provider.id} contract '${declaration.contractVersion}'`,
-        );
-      }
-      if (fixture.request.schema_hash !== declaration.schemaHash) {
-        errors.push(
-          `${prefix} declared schema_hash '${String(fixture.request.schema_hash)}' does not match ${provider.id} schema_hash '${declaration.schemaHash}'`,
-        );
-      }
-    }
+    checkDeclaredContractIdentity(prefix, fixture.request);
   }
 }
 
-if (fixtureCount === 0)
-  errors.push("contracts/memory: no *.fixture.json files found");
+if (fixtureCount === 0) errors.push("contracts/memory: no *.fixture.json files found");
 if (!contractDeclarationChecked) {
   errors.push(
     "contracts/memory: no contract-declaration fixture asserts the live TS schema_hash",
@@ -357,17 +281,23 @@ const serverCapabilities = new Set(serverManifest.capabilities ?? []);
 for (const providerId of providerIds) {
   const statuses = serverManifest.provider_capability_status?.[providerId];
   if (!statuses) {
-    errors.push(`server/parity-manifest.json: missing capability status for '${providerId}'`);
+    errors.push(
+      `server/parity-manifest.json: missing capability status for '${providerId}'`,
+    );
     continue;
   }
   const declaredCapabilities = Object.keys(statuses).sort();
   const expectedCapabilities = [...serverCapabilities].sort();
   if (JSON.stringify(declaredCapabilities) !== JSON.stringify(expectedCapabilities)) {
-    errors.push(`server/parity-manifest.json: '${providerId}' must declare every capability exactly once`);
+    errors.push(
+      `server/parity-manifest.json: '${providerId}' must declare every capability exactly once`,
+    );
   }
   for (const [capability, status] of Object.entries(statuses)) {
     if (status !== "implemented" && status !== "scaffold-declared") {
-      errors.push(`server/parity-manifest.json: '${providerId}' capability '${capability}' has invalid status '${String(status)}'`);
+      errors.push(
+        `server/parity-manifest.json: '${providerId}' capability '${capability}' has invalid status '${String(status)}'`,
+      );
     }
   }
 }
@@ -376,6 +306,23 @@ const observedServerCapabilities = new Set<string>();
 const observedServerTools = new Set<string>();
 const serverFixtures: ServerFixture[] = [];
 let serverFixtureCount = 0;
+// `capture` binds a value out of a step's response for later steps to
+// substitute. Each entry must be a dot path string; anything else would be
+// silently ignored by the harness and leave the fixture asserting less than it
+// appears to. Hoisted out of the step loop, with an early return in place of
+// the else branch, so the entry walk sits at one level of nesting.
+function checkStepCapture(prefix: string, index: number, capture: unknown): void {
+  if (!isRecord(capture)) {
+    errors.push(`${prefix} step ${index} capture must be an object`);
+    return;
+  }
+  for (const [name, path] of Object.entries(capture)) {
+    if (typeof path !== "string" || path.length === 0) {
+      errors.push(`${prefix} step ${index} capture '${name}' must be a non-empty path`);
+    }
+  }
+}
+
 const serverFixtureGlob = new Bun.Glob("*.fixture.json");
 for await (const name of serverFixtureGlob.scan({
   cwd: serverFixtureDir.pathname,
@@ -388,13 +335,19 @@ for await (const name of serverFixtureGlob.scan({
   observedServerFixtureIds.add(fixture.id);
   observedServerCapabilities.add(fixture.capability);
   if (!expectedServerFixtureIds.has(fixture.id)) {
-    errors.push(`${prefix} fixture id '${fixture.id}' is absent from the server manifest`);
+    errors.push(
+      `${prefix} fixture id '${fixture.id}' is absent from the server manifest`,
+    );
   }
   if (!serverCapabilities.has(fixture.capability)) {
-    errors.push(`${prefix} capability '${fixture.capability}' is absent from the server manifest`);
+    errors.push(
+      `${prefix} capability '${fixture.capability}' is absent from the server manifest`,
+    );
   }
   if (JSON.stringify(fixture.providers) !== JSON.stringify(providerIds)) {
-    errors.push(`${prefix} providers must declare current-src and server-rewrite-scaffold`);
+    errors.push(
+      `${prefix} providers must declare current-src and server-rewrite-scaffold`,
+    );
   }
   if (!fixture.description) errors.push(`${prefix} description must be non-empty`);
   if (!isRecord(fixture.auth)) errors.push(`${prefix} auth must be an object`);
@@ -405,7 +358,8 @@ for await (const name of serverFixtureGlob.scan({
   for (const [index, step] of fixture.steps.entries()) {
     if (!step.tool) errors.push(`${prefix} step ${index} tool must be non-empty`);
     if (step.tool) observedServerTools.add(step.tool);
-    if (!isRecord(step.arguments)) errors.push(`${prefix} step ${index} arguments must be an object`);
+    if (!isRecord(step.arguments))
+      errors.push(`${prefix} step ${index} arguments must be an object`);
     if (!isRecord(step.expectation) || !("is_error" in step.expectation)) {
       errors.push(`${prefix} step ${index} expectation must declare is_error`);
     }
@@ -414,26 +368,22 @@ for await (const name of serverFixtureGlob.scan({
     // silently ignored by the harness and leave the fixture asserting less than
     // it appears to.
     if (step.capture !== undefined) {
-      if (!isRecord(step.capture)) {
-        errors.push(`${prefix} step ${index} capture must be an object`);
-      } else {
-        for (const [name, path] of Object.entries(step.capture)) {
-          if (typeof path !== "string" || path.length === 0) {
-            errors.push(`${prefix} step ${index} capture '${name}' must be a non-empty path`);
-          }
-        }
-      }
+      checkStepCapture(prefix, index, step.capture);
     }
   }
 }
 for (const id of expectedServerFixtureIds) {
   if (!observedServerFixtureIds.has(id)) {
-    errors.push(`server/parity-manifest.json: expected fixture id '${id}' has no fixture file`);
+    errors.push(
+      `server/parity-manifest.json: expected fixture id '${id}' has no fixture file`,
+    );
   }
 }
 for (const capability of serverCapabilities) {
   if (!observedServerCapabilities.has(capability)) {
-    errors.push(`server/parity-manifest.json: capability '${capability}' has no fixture`);
+    errors.push(
+      `server/parity-manifest.json: capability '${capability}' has no fixture`,
+    );
   }
 }
 
@@ -463,6 +413,21 @@ for (const capability of serverCapabilities) {
 // Registering MORE than the contract requires is allowed: the rewrite carries
 // `record_skill_usage`/`skill_usage_report` (#469), which the frozen contract
 // never named. Only a shortfall against a claim can break a client.
+// Map each tool to the capability the server fixtures file it under, so a
+// missing tool can be judged against that capability's declared status. First
+// fixture to name a tool wins, exactly as the inline loop did.
+function mapToolsToCapabilities(fixtures: ServerFixture[]): Map<string, string> {
+  const toolCapability = new Map<string, string>();
+  for (const fixture of fixtures) {
+    for (const step of fixture.steps ?? []) {
+      if (step.tool && !toolCapability.has(step.tool)) {
+        toolCapability.set(step.tool, fixture.capability);
+      }
+    }
+  }
+  return toolCapability;
+}
+
 const satisfactionNotes: string[] = [];
 for (const { provider, satisfaction } of serverDeclarations) {
   if (!satisfaction) continue;
@@ -476,14 +441,7 @@ for (const { provider, satisfaction } of serverDeclarations) {
   const statuses = serverManifest.provider_capability_status?.[provider.id] ?? {};
   // Map each tool to the capability the server fixtures file it under, so a
   // missing tool can be judged against that capability's declared status.
-  const toolCapability = new Map<string, string>();
-  for (const fixture of serverFixtures) {
-    for (const step of fixture.steps ?? []) {
-      if (step.tool && !toolCapability.has(step.tool)) {
-        toolCapability.set(step.tool, fixture.capability);
-      }
-    }
-  }
+  const toolCapability = mapToolsToCapabilities(serverFixtures);
 
   const claimedMissing: string[] = [];
   const scaffoldMissing: string[] = [];
@@ -520,21 +478,9 @@ for (const { provider, satisfaction } of serverDeclarations) {
   }
 }
 
-const toolSourceDir = new URL("../src/tools/", import.meta.url);
-const toolSourceGlob = new Bun.Glob("*.ts");
 const registeredServerTools = new Set<string>();
-for await (const name of toolSourceGlob.scan({
-  cwd: toolSourceDir.pathname,
-  onlyFiles: true,
-})) {
-  const source = await Bun.file(new URL(name, toolSourceDir)).text();
-  for (const match of source.matchAll(
-    /server\.registerTool\(\s*["'`]([^"'`]+)["'`]/g,
-  )) {
-    const tool = match[1];
-    if (!tool) continue;
-    registeredServerTools.add(tool);
-  }
+for (const dir of ["../src/tools/", "../server/tools/"]) {
+  await collectRegisteredTools(new URL(dir, import.meta.url), registeredServerTools);
 }
 
 const declaredCoveredTools = new Set(serverToolGapMap.fixture_covered_tools ?? []);
@@ -552,7 +498,9 @@ for (const entry of serverToolGapMap.without_parity_fixture ?? []) {
     errors.push(`server/tool-gap-map.json: '${entry.tool}' needs a capability`);
   }
   if (isPlaceholderReason(entry.reason)) {
-    errors.push(`server/tool-gap-map.json: '${entry.tool}' needs a non-placeholder reason`);
+    errors.push(
+      `server/tool-gap-map.json: '${entry.tool}' needs a non-placeholder reason`,
+    );
   }
 }
 
@@ -565,7 +513,9 @@ if (JSON.stringify(declaredCoveredSorted) !== JSON.stringify(observedToolsSorted
 }
 for (const tool of declaredCoveredTools) {
   if (declaredGapTools.has(tool)) {
-    errors.push(`server/tool-gap-map.json: '${tool}' is both covered and listed as a gap`);
+    errors.push(
+      `server/tool-gap-map.json: '${tool}' is both covered and listed as a gap`,
+    );
   }
 }
 
@@ -578,19 +528,23 @@ if (JSON.stringify(mappedToolsSorted) !== JSON.stringify(registeredToolsSorted))
   );
 }
 if (serverToolGapMap.registered_tool_count !== registeredServerTools.size) {
-  errors.push("server/tool-gap-map.json: registered_tool_count does not match current-src");
+  errors.push(
+    "server/tool-gap-map.json: registered_tool_count does not match current-src",
+  );
 }
 if (serverToolGapMap.fixture_covered_tool_count !== declaredCoveredTools.size) {
-  errors.push("server/tool-gap-map.json: fixture_covered_tool_count does not match its tool list");
+  errors.push(
+    "server/tool-gap-map.json: fixture_covered_tool_count does not match its tool list",
+  );
 }
 if (serverToolGapMap.without_parity_fixture_count !== declaredGapTools.size) {
-  errors.push("server/tool-gap-map.json: without_parity_fixture_count does not match its gap list");
+  errors.push(
+    "server/tool-gap-map.json: without_parity_fixture_count does not match its gap list",
+  );
 }
 
 if (errors.length > 0) {
-  console.error(
-    `Contract parity check failed with ${errors.length} violation(s):`,
-  );
+  console.error(`Contract parity check failed with ${errors.length} violation(s):`);
   for (const error of errors) console.error(`- ${error}`);
   process.exit(1);
 }
@@ -600,7 +554,16 @@ for (const note of satisfactionNotes) console.log(`note: ${note}`);
 const satisfactionSummary = serverDeclarations
   .filter((entry) => entry.satisfaction)
   .map((entry) => {
-    const { registeredTools, requiredTools, missingTools } = entry.satisfaction!;
+    const { satisfaction } = entry;
+    // The filter above kept only entries whose satisfaction is set; a missing
+    // one here means the registry walk left a hole and the summary would be a
+    // silent lie, so fail with the provider that caused it.
+    if (!satisfaction) {
+      throw new Error(
+        `${entry.provider.id}: satisfaction missing after the registry walk`,
+      );
+    }
+    const { registeredTools, requiredTools, missingTools } = satisfaction;
     const met = requiredTools.length - missingTools.length;
     return `${entry.provider.id} registers ${registeredTools.length} tools covering ${met}/${requiredTools.length} contract-required${missingTools.length > 0 ? ` (${missingTools.length} scaffold-declared, not yet ported)` : ""}`;
   })

--- a/contracts/server/tool-gap-map.json
+++ b/contracts/server/tool-gap-map.json
@@ -2,9 +2,9 @@
   "id": "openbrain.server.tool-gap-map.v1",
   "description": "Complete current-src MCP registration inventory split by observed server fixture coverage. Every registered tool now has at least one fixture step observed from current-src against a live isolated Postgres database; the gap list is empty.",
   "source": "src/tools/**/*.ts server.registerTool literal registrations",
-  "registered_tool_count": 63,
+  "registered_tool_count": 65,
   "fixture_covered_tool_count": 63,
-  "without_parity_fixture_count": 0,
+  "without_parity_fixture_count": 2,
   "fixture_covered_tools": [
     "access_report",
     "adjacent_context",
@@ -70,5 +70,16 @@
     "upsert_repo_fact",
     "working_set_append"
   ],
-  "without_parity_fixture": []
+  "without_parity_fixture": [
+    {
+      "tool": "record_skill_usage",
+      "capability": "skill-usage-telemetry",
+      "reason": "Registered by the server rewrite for issue 469 telemetry; the frozen contract never named it, so it has no parity fixture."
+    },
+    {
+      "tool": "skill_usage_report",
+      "capability": "skill-usage-telemetry",
+      "reason": "Registered by the server rewrite for issue 469 telemetry; the frozen contract never named it, so it has no parity fixture."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- The parity checker scanned only `src/tools/` for `server.registerTool(` name literals. As issue 864 moves each tool module down to `server/tools/`, the file left at the src/ path is an L5 adapter or shim -- a bare `export *` carrying no tool-name literal -- so every moved registration vanished from the scan and `contracts/server/tool-gap-map.json` drifted out of parity with the tree.
- `collectRegisteredTools` now runs over `src/tools/` AND `server/tools/` with the same pattern, feeding one `Set`, so a tool seen in both directories is counted once.
- `contracts/server/tool-gap-map.json` records the two tools with no parity fixture -- `record_skill_usage` and `skill_usage_report` -- as explicit gaps, and carries the registered count of 65.
- `contracts/check-parity.ts` already failed the whole-file pre-commit lint on `main` (529 code lines against the 500 maximum, six max-depth findings, one non-null assertion), so the fix could not be staged without bringing the file to the standard. Per the M14 ruling the split is mechanical and lands here, with no behaviour change: `contracts/check-parity-manifests.ts` (new sibling) takes the manifest and fixture type declarations plus the four load/scan helpers -- `readJson`, `collectRegisteredTools`, `isRecord`, `isPlaceholderReason` -- and the `CONSUMER_ALLOWLIST` constant. That is one boundary: the shapes the checker reads and the IO that produces them, with no assertion logic of their own.
- Three nested blocks became named helpers in `check-parity.ts`: `checkDeclaredContractIdentity` (per-provider contract_id/schema_hash comparison, out of the memory-fixture loop), `checkStepCapture` (capture-entry walk, out of the server-fixture step loop, early return replacing the else branch), `mapToolsToCapabilities` (tool-to-capability map build, out of the provider satisfaction loop). The one non-null assertion in the satisfaction summary became a named guard that throws naming the provider whose registry walk left the hole.
- Counts on `check-parity.ts`, oxlint code lines (blank and comment lines skipped): 529 on `main`, 546 with the scanner fix alone, 488 after the split. Deepest block nesting 6 -> 3; non-null assertions 1 -> 0. The new sibling is 93 code lines.

### The two parity outputs

At `origin/main`, unmodified (`bun contracts/check-parity.ts` -> exit 1):

```
Contract parity check failed with 2 violation(s):
- server/tool-gap-map.json: covered tools plus gaps must exactly match current-src registrations
- server/tool-gap-map.json: registered_tool_count does not match current-src
```

After this change (`bun contracts/check-parity.ts` -> exit 0):

```
note: server-rewrite-scaffold: registers 44 tool(s) beyond the frozen contract (allowed): access_report, adjacent_context, archive_entity, archive_entry, brain_answer, bulk_archive, bulk_set_tier, collect_drop_folder, curate_entries, demote_entry, find_duplicates, find_person, get_entity, get_stats, hydrate_entities, ingest_conversation_facts, ingest_raw_turn, link_entities, list_entities, list_namespaces, list_recent, list_sources, list_stale, log_decision, promote_entry, promote_shared, rate_entry, record_skill_usage, register_source, remove_source, scan_namespace, search_brain, session_load, session_save, set_tier, skill_usage_report, source_ingestion_eligibility, tier_lane, tier_recommendations, unlink_entities, update_entry, update_source, upsert_entity, upsert_person
Contract parity check passed: 52 fixtures across 45 capabilities and 2 server providers; 63/65 current-src MCP tools fixture-covered with 2 explicit gaps; server-rewrite-scaffold registers 65 tools covering 21/21 contract-required.
```

The two differ only in the violation lines becoming the note plus pass line.

### The oxlint receipt

On `main`, `./node_modules/.bin/oxlint --deny-warnings --config .oxlintrc.json contracts/check-parity.ts` -> exit 1:

```
contracts/check-parity.ts:611:3: error eslint(max-lines): File has too many lines (529). help: Maximum allowed is 500.
contracts/check-parity.ts:288:7: error eslint(max-depth): Blocks are nested too deeply (4). Maximum allowed is 3.
contracts/check-parity.ts:293:7: error eslint(max-depth): Blocks are nested too deeply (4). Maximum allowed is 3.
contracts/check-parity.ts:417:7: error eslint(max-depth): Blocks are nested too deeply (4). Maximum allowed is 3.
contracts/check-parity.ts:420:9: error eslint(max-depth): Blocks are nested too deeply (5). Maximum allowed is 3.
contracts/check-parity.ts:421:11: error eslint(max-depth): Blocks are nested too deeply (6). Maximum allowed is 3.
contracts/check-parity.ts:482:7: error eslint(max-depth): Blocks are nested too deeply (4). Maximum allowed is 3.
contracts/check-parity.ts:603:62: error typescript(no-non-null-assertion): Forbidden non-null assertion.
```

After, over both files plus the map -> exit 0, no output. No disable comments were added.

## Verification

- Done-means: scripts/done-means/864-moved-out-of-src.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`bun contracts/check-parity.ts` -> exit 0. `./node_modules/.bin/oxlint --deny-warnings --config .oxlintrc.json contracts/check-parity.ts contracts/check-parity-manifests.ts contracts/server/tool-gap-map.json` -> exit 0. `bunx tsc --noEmit` -> exit 0. `bun run test:isolated contracts/server-contract-providers.test.ts contracts/server-tool-parity.test.ts` -> 77 pass, 0 fail. `bash scripts/done-means/864-moved-out-of-src.sh` with no arguments -> `judged=40 shims, 9 adapters` / `PASS`, exit 0. The pre-push hook ran the full isolated suite and the contract parity subset and passed on the first attempt. `rg -n 'check-parity' python/openbrain-memory/tests` returns nothing, so the M10 Python path guards are untouched; CI invokes `bun contracts/check-parity.ts` by its unchanged path.

## Critical Self-Review

- Highest-risk behavior: the checker itself is the gate that judges every other contract change, so a silently weakened check would let real drift through unnoticed. The move of types and helpers is pure relocation and the three hoists preserve the same predicates and the same `errors.push` strings verbatim; the pass-line counts are byte-identical to a run with the scanner fix alone, which is the evidence that nothing stopped being checked.
- Assumptions that could be wrong: that scanning `server/tools/` with the same `server.registerTool(` regex finds every registration there. If a moved module ever registers through a wrapper or a computed name, neither directory scan sees it and the count would silently undercount -- the same latent weakness the pre-existing `src/tools/` scan had, not one this change introduces.
- Missing/weak tests: the two-directory scan has no unit test of its own; it is covered end to end by the checker's own exit code and by the 77 tests in `contracts/server-tool-parity.test.ts`. A fixture with a registration only under `server/tools/` would pin it directly and does not exist yet.
- Security/permission risk: none. Contract tooling only; no namespace predicate, auth path, or SQL is touched.
- Migration/deploy risk: none. No migration, no runtime code, no server surface -- the changed files run in CI and at pre-push only.
- Downstream client/runtime risk: none applicable per `docs/downstream-rollout.md`. No MCP tool, schema, protocol, or client-facing shape changes; `tool-gap-map.json` records what already exists rather than declaring anything new.
- Rollback/cleanup concern: reverting the commit restores both files and the map together; the new sibling has no importer outside `check-parity.ts`, so there is nothing stranded.
- Fixes made before PR: the split, the three hoists, and the non-null guard were all made in response to the `main` lint failures before the commit was staged; the guard's thrown message names the provider so a future hole is diagnosable rather than a crash on `undefined`.
- Known residual risk: the 488-code-line figure sits under but near the 500 maximum, so the next substantial addition to `check-parity.ts` will hit the same rule and want a second split boundary -- the fixture-loop assertions are the obvious next group.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the pattern here (a text-scanning checker blinded by a re-export shim) is recorded in the commit body and the code comment at `collectRegisteredTools`, and the M14 inherited-lint-debt rule that governs the split is already a head ruling in the session's common rules rather than a review finding.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime, transport, or database behaviour changes; the changed files execute only in CI and git hooks.

## Contract Parity

- Contract parity: [x] fixtures updated
- Contract parity: [ ] runtime-specific because:

`contracts/server/tool-gap-map.json` is the updated artifact: `record_skill_usage` and `skill_usage_report` are declared explicit gaps and `registered_tool_count` is 65. No `*.fixture.json` changed.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Not applicable across the board: this changes a repo-local contract checker and its gap map. No MCP tool is added, removed, or reshaped, no transport or schema changes, and no Python client surface moves -- so there is nothing for a downstream consumer to re-cache or re-canary.
