### PR TITLE
refactor(l5): move embedding from src/ into server/embedding behind a settings reader and an L5 adapter (issue 864)

### DIFF
--- a/docs/sme/correctness.md
+++ b/docs/sme/correctness.md
@@ -2482,3 +2482,45 @@ passes, or fails the rule and is not judged.
   broken fixture is the defect, not a clean run.
 - Ask of any discovery loop: what does a malformed candidate do here — fail, or
   vanish? Vanishing is the bug.
+
+
+# A process-wide settings reader must be restored by whoever replaced it
+
+When a module's configuration moves out of `process.env` and into an injected
+reader, the reader lives in ONE module-level slot for the whole process. Whoever
+installs a reader owns putting the previous one back.
+
+`server/embedding/provider.ts` holds `let readSettings` and
+`setEmbeddingSettingsReader(read)`. Two callers register: the `src/` adapter
+registers an env parse at import, and `server/main.ts` registers a config-backed
+reader when a server starts. Last writer wins, which is correct at runtime — a
+started server should answer from its own config.
+
+It is wrong the moment a server STOPS. `startServer` originally registered and
+never restored, so a server that started and shut down left its own config
+answering for everything that ran afterwards. In a test process, "afterwards" is
+the next test file.
+
+The receipt: `server/main.pg.test.ts` and `src/operator-doctor.test.ts` in one
+run were 114 pass / 0 fail before the move, 112 pass / 2 fail after it, and 151
+pass / 0 fail once `shutdown` restored the reader. The two failures were in
+`src/operator-doctor.test.ts`, which sets `EMBEDDING_BASE_URL` at test time and
+expects the provider to see it — it never did again, because a dead server's
+reader was still installed.
+
+**What to check in review.** For any injected singleton (a reader, a clock, a
+spawner, a transport):
+
+- Does the setter RETURN the value it replaced? If not, restoration is
+  impossible and the design is already wrong.
+- Does every caller that replaces it restore it on every exit path — normal
+  shutdown AND failed start? A `try/finally` around the shutdown body is the
+  cheap shape.
+- Neither file's own tests catch this. Each passes alone; only the combined run
+  shows it. When a change introduces a process-wide slot, run the new module's
+  tests TOGETHER with the tests of anything that starts a server, in one
+  process, and compare the count to the same combined run at `origin/main`. A
+  per-file green is not evidence here.
+
+This is the same class as the `mock.module` leak entry: shared mutable
+process-wide state whose contamination is invisible to any single-file run.

--- a/docs/sme/entries/2026-08-29-a-process-wide-settings-reader-must-be-restored-by-whoever-replaced-it.md
+++ b/docs/sme/entries/2026-08-29-a-process-wide-settings-reader-must-be-restored-by-whoever-replaced-it.md
@@ -1,0 +1,48 @@
+---
+lane: correctness
+severity: MEDIUM
+status: active
+order: 105
+provenance: "issue 864 L5 embedding move; found by a combined test run, not by review"
+---
+
+# A process-wide settings reader must be restored by whoever replaced it
+
+When a module's configuration moves out of `process.env` and into an injected
+reader, the reader lives in ONE module-level slot for the whole process. Whoever
+installs a reader owns putting the previous one back.
+
+`server/embedding/provider.ts` holds `let readSettings` and
+`setEmbeddingSettingsReader(read)`. Two callers register: the `src/` adapter
+registers an env parse at import, and `server/main.ts` registers a config-backed
+reader when a server starts. Last writer wins, which is correct at runtime — a
+started server should answer from its own config.
+
+It is wrong the moment a server STOPS. `startServer` originally registered and
+never restored, so a server that started and shut down left its own config
+answering for everything that ran afterwards. In a test process, "afterwards" is
+the next test file.
+
+The receipt: `server/main.pg.test.ts` and `src/operator-doctor.test.ts` in one
+run were 114 pass / 0 fail before the move, 112 pass / 2 fail after it, and 151
+pass / 0 fail once `shutdown` restored the reader. The two failures were in
+`src/operator-doctor.test.ts`, which sets `EMBEDDING_BASE_URL` at test time and
+expects the provider to see it — it never did again, because a dead server's
+reader was still installed.
+
+**What to check in review.** For any injected singleton (a reader, a clock, a
+spawner, a transport):
+
+- Does the setter RETURN the value it replaced? If not, restoration is
+  impossible and the design is already wrong.
+- Does every caller that replaces it restore it on every exit path — normal
+  shutdown AND failed start? A `try/finally` around the shutdown body is the
+  cheap shape.
+- Neither file's own tests catch this. Each passes alone; only the combined run
+  shows it. When a change introduces a process-wide slot, run the new module's
+  tests TOGETHER with the tests of anything that starts a server, in one
+  process, and compare the count to the same combined run at `origin/main`. A
+  per-file green is not evidence here.
+
+This is the same class as the `mock.module` leak entry: shared mutable
+process-wide state whose contamination is invisible to any single-file run.

--- a/server/embedding/provider-attempt.ts
+++ b/server/embedding/provider-attempt.ts
@@ -1,0 +1,233 @@
+/**
+ * What ONE provider attempt decides: retry after a delay, or stop with an
+ * `EmbeddingError`.
+ *
+ * Split out of `./provider.ts` (issue 864) because the retry loop there carried
+ * every branch inline and failed the whole-file lint the moment the file moved
+ * under `server/`. Nothing about the decisions changed: each function below is
+ * the branch that used to sit in the loop body, with the same order, the same
+ * comparisons, the same log events and fields, and the same messages. The loop
+ * keeps the parts that need its own state — the abort wiring, the timeout, and
+ * `lastError`.
+ */
+import { logger } from "../../src/logger.ts";
+import type { EmbeddingError, EmbeddingResult } from "./provider.ts";
+
+/** Milliseconds waited before each retry, indexed by the attempt just made. */
+export const BACKOFF_DELAYS_MS = [200, 800];
+
+/** Fallback delay when an attempt index runs past `BACKOFF_DELAYS_MS`. */
+const DEFAULT_BACKOFF_MS = 800;
+
+/** Retry after `delayMs`, or stop with `error`. Never both. */
+export type AttemptOutcome =
+  | { readonly retry: true; readonly delayMs: number }
+  | { readonly retry: false; readonly error: EmbeddingError };
+
+function backoffFor(attempt: number): number {
+  return BACKOFF_DELAYS_MS[attempt - 1] ?? DEFAULT_BACKOFF_MS;
+}
+
+/**
+ * Decide what a non-`ok` HTTP response means.
+ *
+ * 4xx is never retried and 5xx is retried while attempts remain, which is the
+ * same rule `isTransient` applies to a thrown error.
+ */
+export function classifyHttpFailure(input: {
+  readonly status: number;
+  readonly attempt: number;
+  readonly totalAttempts: number;
+}): AttemptOutcome {
+  const { status, attempt, totalAttempts } = input;
+
+  if (status >= 400 && status < 500) {
+    const code: EmbeddingError["code"] =
+      status === 400 || status === 422 ? "input_invalid" : "client_error";
+    logger.error("Embedding provider request failed (non-retryable)", {
+      status,
+      attempts: attempt,
+    });
+    return {
+      retry: false,
+      error: {
+        code,
+        message: `Embedding provider returned ${status}`,
+        attempts: attempt,
+        lastStatus: status,
+      },
+    };
+  }
+
+  if (attempt < totalAttempts) {
+    const delayMs = backoffFor(attempt);
+    logger.warn("Embedding request failed, retrying", {
+      attempt,
+      status,
+      code: "server_error",
+      delayMs,
+    });
+    return { retry: true, delayMs };
+  }
+
+  logger.error("Embedding request failed after all attempts", {
+    status,
+    attempts: attempt,
+  });
+  return {
+    retry: false,
+    error: {
+      code: "server_error",
+      message: `Embedding provider returned ${status} after ${attempt} attempt(s)`,
+      attempts: attempt,
+      lastStatus: status,
+    },
+  };
+}
+
+/**
+ * Classify whether an error or HTTP status is transient and worth retrying.
+ * Only 5xx, AbortError (timeout), and network-level errors are retried.
+ * 4xx errors are never retried.
+ */
+export function isTransient(err: unknown, status?: number): boolean {
+  if (status !== undefined && status >= 400 && status < 500) return false;
+  if (status !== undefined && status >= 500) return true;
+  if (err instanceof DOMException && err.name === "AbortError") return true;
+  if (!(err instanceof Error)) return false;
+  return TRANSIENT_MESSAGE_FRAGMENTS.some((fragment) => err.message.includes(fragment));
+}
+
+/** Substrings that mark a fetch rejection as a network-level, retryable one. */
+const TRANSIENT_MESSAGE_FRAGMENTS = [
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "ENETUNREACH",
+  "fetch failed",
+];
+
+export function classifyError(err: unknown, status?: number): EmbeddingError["code"] {
+  if (err instanceof DOMException && err.name === "AbortError") return "timeout";
+  if (status !== undefined && status >= 500) return "server_error";
+  return "network";
+}
+
+/** Decide what a thrown `fetch` rejection means. */
+export function classifyThrownFailure(input: {
+  readonly err: unknown;
+  readonly attempt: number;
+  readonly totalAttempts: number;
+  readonly lastStatus?: number;
+}): AttemptOutcome {
+  const { err, attempt, totalAttempts, lastStatus } = input;
+  const code = classifyError(err);
+  const message = err instanceof Error ? err.message : String(err);
+
+  if (!isTransient(err)) {
+    logger.error("Embedding request failed (non-retryable)", {
+      error: message,
+      attempts: attempt,
+    });
+    return {
+      retry: false,
+      error: {
+        code,
+        message,
+        attempts: attempt,
+        ...(lastStatus === undefined ? {} : { lastStatus }),
+      },
+    };
+  }
+
+  if (attempt < totalAttempts) {
+    const delayMs = backoffFor(attempt);
+    logger.warn("Embedding request failed, retrying", {
+      attempt,
+      code,
+      error: message,
+      delayMs,
+    });
+    return { retry: true, delayMs };
+  }
+
+  logger.error("Embedding request failed after all attempts", {
+    error: message,
+    code,
+    attempts: attempt,
+  });
+  return {
+    retry: false,
+    error: {
+      code,
+      message: `${message} after ${attempt} attempt(s)`,
+      attempts: attempt,
+      ...(lastStatus === undefined ? {} : { lastStatus }),
+    },
+  };
+}
+
+/** Pick out the two numeric usage counters the provider may report. */
+function readUsageDetails(
+  usage:
+    | {
+        prompt_tokens?: unknown;
+        total_tokens?: unknown;
+      }
+    | undefined,
+): Record<string, number> {
+  const usageDetails: Record<string, number> = {};
+  if (typeof usage?.prompt_tokens === "number") {
+    usageDetails.promptTokens = usage.prompt_tokens;
+  }
+  if (typeof usage?.total_tokens === "number") {
+    usageDetails.totalTokens = usage.total_tokens;
+  }
+  return usageDetails;
+}
+
+/** Either a usable result or the error that says why the body was unusable. */
+export type DecodedResponse =
+  | { readonly error: EmbeddingError; readonly result?: undefined }
+  | { readonly error?: undefined; readonly result: EmbeddingResult };
+
+/** Read the provider body and check the vector is the width we asked for. */
+export async function decodeEmbeddingResponse(input: {
+  readonly response: Response;
+  readonly expectedDimensions: number;
+  readonly attempt: number;
+}): Promise<DecodedResponse> {
+  const { response, expectedDimensions, attempt } = input;
+  const json = (await response.json()) as {
+    data?: Array<{ embedding?: unknown }>;
+    usage?: { prompt_tokens?: unknown; total_tokens?: unknown };
+  };
+
+  const embedding = json.data?.[0]?.embedding;
+  if (!Array.isArray(embedding) || embedding.length !== expectedDimensions) {
+    const message = "Embedding provider returned malformed embedding";
+    logger.error(message, {
+      hasData: !!json.data,
+      length: Array.isArray(embedding) ? embedding.length : "not-array",
+      expectedLength: expectedDimensions,
+      attempts: attempt,
+    });
+    return {
+      error: {
+        code: "malformed_response",
+        message,
+        attempts: attempt,
+        lastStatus: response.status,
+      },
+    };
+  }
+
+  const usageDetails = readUsageDetails(json.usage);
+
+  return {
+    result: {
+      embedding: embedding as number[],
+      ...(Object.keys(usageDetails).length === 0 ? {} : { usageDetails }),
+    },
+  };
+}

--- a/server/embedding/provider.ts
+++ b/server/embedding/provider.ts
@@ -1,0 +1,640 @@
+import { createHash } from "node:crypto";
+import { spawn, type ChildProcess } from "node:child_process";
+import { chunkText } from "./chunking.ts";
+import { logger } from "../../src/logger.ts";
+import type { EmbeddingConfigGroup } from "../config/src-readers.ts";
+import {
+  classifyError,
+  classifyHttpFailure,
+  classifyThrownFailure,
+  decodeEmbeddingResponse,
+} from "./provider-attempt.ts";
+
+/**
+ * Every environment-derived value this module used to read from `process.env`.
+ *
+ * The four watchdog and provider fields reuse `EmbeddingConfigGroup`
+ * (`server/config/src-readers.ts`) unchanged — `timeoutMs`, `dimensions`,
+ * `model`, and the nested `watchdog` group carrying `failureThreshold`,
+ * `cooldownMs`, and the optional `restartScript`. The two transport fields
+ * mirror `config.transport.embeddingBaseUrl` and `config.transport.embeddingApiKey`
+ * (`server/config.ts:251-252`), which are the same `readonly string | undefined`
+ * there.
+ */
+export interface EmbeddingProviderSettings extends EmbeddingConfigGroup {
+  /** `config.transport.embeddingBaseUrl` — absent means nothing is configured. */
+  readonly baseUrl?: string;
+  /** `config.transport.embeddingApiKey` — absent means no Authorization header. */
+  readonly apiKey?: string;
+}
+
+/**
+ * The values this module answers with before any caller registers a reader.
+ *
+ * These are exactly what the former `process.env` reads computed when every
+ * `EMBEDDING_*` key was absent: timeout 8000 ms, 768 dimensions, model
+ * `gemini-embedding-001`, watchdog failure threshold 2, watchdog cooldown
+ * 300000 ms, no restart script, no base URL, and no API key.
+ */
+const DEFAULT_SETTINGS: EmbeddingProviderSettings = {
+  timeoutMs: 8000,
+  dimensions: 768,
+  model: "gemini-embedding-001",
+  watchdog: {
+    failureThreshold: 2,
+    cooldownMs: 300000,
+  },
+};
+
+let readSettings: () => EmbeddingProviderSettings = () => DEFAULT_SETTINGS;
+
+/**
+ * Register the function this module calls for every environment-derived value.
+ *
+ * A READER rather than a snapshot, because every former read happened inside a
+ * function body at the moment it was needed: a caller that changes its own
+ * source between two calls changes the answer, exactly as flipping
+ * `process.env` between two calls did. Returns the reader it replaced so a
+ * caller can restore it. Replacement is announced and never refused — the
+ * `src/` adapter registers at import and `server/main.ts` registers afterwards,
+ * so in the server runtime main's reader is the one that answers.
+ */
+export function setEmbeddingSettingsReader(
+  read: () => EmbeddingProviderSettings,
+): () => EmbeddingProviderSettings {
+  const previous = readSettings;
+  readSettings = read;
+  logger.debug("embedding_settings_reader_replaced", {});
+  return previous;
+}
+
+/**
+ * Embedding model identifier. Used to call the provider and stored in
+ * embedding_model columns so we can track which model produced each vector.
+ * A reader rather than a constant: the value now arrives from the registered
+ * settings reader, which may answer differently between two calls.
+ */
+export function embeddingModel(): string {
+  return readSettings().model;
+}
+
+/** Vector width the provider is asked for and the response is checked against. */
+export function embeddingDimensions(): number {
+  return readSettings().dimensions;
+}
+
+const MAX_RETRIES = 2;
+const WATCHDOG_RESTARTABLE_CODES = new Set<EmbeddingError["code"]>([
+  "timeout",
+  "network",
+  "server_error",
+]);
+
+let lastFailureCode: EmbeddingError["code"] | null = null;
+let consecutiveRestartableFailures = 0;
+let lastWatchdogRestartAt = 0;
+let watchdogRestartInFlight = false;
+let restartProcessSpawner = (restartScript: string): ChildProcess =>
+  spawn(restartScript, {
+    detached: true,
+    stdio: "ignore",
+  });
+
+export interface EmbeddingError {
+  code:
+    | "timeout"
+    | "network"
+    | "server_error"
+    | "client_error"
+    | "malformed_response"
+    | "input_invalid"
+    | "no_embedding_url";
+  message: string;
+  attempts: number;
+  lastStatus?: number;
+}
+
+export interface EmbeddingResult {
+  embedding: number[] | null;
+  error?: EmbeddingError;
+  usageDetails?: Record<string, number>;
+}
+
+export interface EmbeddingOptions {
+  signal?: AbortSignal;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function watchdogFailureThreshold(): number {
+  return readSettings().watchdog.failureThreshold;
+}
+
+function watchdogCooldownMs(): number {
+  return readSettings().watchdog.cooldownMs;
+}
+
+function resetWatchdogFailures(): void {
+  lastFailureCode = null;
+  consecutiveRestartableFailures = 0;
+}
+
+function recordWatchdogFailure(error: EmbeddingError): void {
+  if (!WATCHDOG_RESTARTABLE_CODES.has(error.code)) {
+    resetWatchdogFailures();
+    return;
+  }
+
+  lastFailureCode = error.code;
+  consecutiveRestartableFailures += 1;
+
+  logger.warn("embedding_watchdog_failure_recorded", {
+    code: error.code,
+    consecutiveFailures: consecutiveRestartableFailures,
+    threshold: watchdogFailureThreshold(),
+  });
+
+  if (consecutiveRestartableFailures >= watchdogFailureThreshold()) {
+    triggerEmbeddingWatchdogRestart(error.code);
+  }
+}
+
+function triggerEmbeddingWatchdogRestart(code: EmbeddingError["code"]): void {
+  const restartScript = readSettings().watchdog.restartScript;
+  if (!restartScript) return;
+
+  const now = Date.now();
+  const cooldownMs = watchdogCooldownMs();
+  if (watchdogRestartInFlight) {
+    logger.warn("embedding_watchdog_restart_skipped", {
+      code,
+      reason: "restart_in_flight",
+    });
+    return;
+  }
+  if (now - lastWatchdogRestartAt < cooldownMs) {
+    logger.warn("embedding_watchdog_restart_skipped", {
+      code,
+      reason: "cooldown",
+      cooldownMs,
+    });
+    return;
+  }
+
+  watchdogRestartInFlight = true;
+
+  logger.error("embedding_watchdog_restart_triggered", {
+    code,
+    restartScript,
+  });
+
+  let child: ChildProcess;
+  try {
+    child = restartProcessSpawner(restartScript);
+  } catch (err) {
+    watchdogRestartInFlight = false;
+    logger.error("embedding_watchdog_restart_failed", {
+      error: err instanceof Error ? err.message : String(err),
+      restartScript,
+    });
+    return;
+  }
+
+  child.once("error", (err) => {
+    watchdogRestartInFlight = false;
+    logger.error("embedding_watchdog_restart_failed", {
+      error: err.message,
+      restartScript,
+    });
+  });
+
+  child.once("spawn", () => {
+    child.unref();
+  });
+
+  child.once("close", (exitCode) => {
+    watchdogRestartInFlight = false;
+    if (exitCode !== 0) {
+      logger.error("embedding_watchdog_restart_failed", {
+        exitCode,
+        restartScript,
+      });
+      return;
+    }
+
+    lastWatchdogRestartAt = Date.now();
+    resetWatchdogFailures();
+    logger.warn("embedding_watchdog_restart_completed", {
+      restartScript,
+    });
+  });
+}
+
+export function __resetEmbeddingWatchdogForTests(): void {
+  resetWatchdogFailures();
+  lastWatchdogRestartAt = 0;
+  watchdogRestartInFlight = false;
+  restartProcessSpawner = (restartScript: string): ChildProcess =>
+    spawn(restartScript, {
+      detached: true,
+      stdio: "ignore",
+    });
+}
+
+export function __setEmbeddingWatchdogRestartSpawnerForTests(
+  spawner: typeof restartProcessSpawner,
+): void {
+  restartProcessSpawner = spawner;
+}
+
+export function getEmbeddingProviderDiagnostics(): {
+  configured: boolean;
+  model: string;
+  dimensions: number;
+  last_failure_code: EmbeddingError["code"] | null;
+  consecutive_restartable_failures: number;
+  restart_configured: boolean;
+  restart_in_flight: boolean;
+  last_restart_at: string | null;
+} {
+  return {
+    configured: Boolean(embeddingBaseUrl()),
+    model: embeddingModel(),
+    dimensions: embeddingDimensions(),
+    last_failure_code: lastFailureCode,
+    consecutive_restartable_failures: consecutiveRestartableFailures,
+    restart_configured: Boolean(readSettings().watchdog.restartScript),
+    restart_in_flight: watchdogRestartInFlight,
+    last_restart_at:
+      lastWatchdogRestartAt > 0 ? new Date(lastWatchdogRestartAt).toISOString() : null,
+  };
+}
+
+function embeddingFailure(error: EmbeddingError): EmbeddingResult {
+  recordWatchdogFailure(error);
+  return { embedding: null, error };
+}
+
+export function embeddingBaseUrl(explicitUrl?: string): string | undefined {
+  const raw = explicitUrl ?? readSettings().baseUrl;
+  return raw?.replace(/\/+$/, "");
+}
+
+export function embeddingApiKey(): string | undefined {
+  return readSettings().apiKey;
+}
+
+/**
+ * Longest text sent to the provider in ONE request.
+ *
+ * A REQUEST-SHAPING number, not an acceptance rule. Text longer than this is
+ * embedded in segments and combined; nothing is refused and nothing is cut.
+ *
+ * WHAT THIS REPLACES, and why the old number described nothing. The previous
+ * `text.length > 32000` branch returned {embedding: null} for the WHOLE input,
+ * so a caller stored a row no semantic search could ever reach. Measured
+ * 2026-07-30 against the embedder actually configured here
+ * (embeddinggemma-300m-8bit at EMBEDDING_BASE_URL, .env:24): the server accepts
+ * 64,000 characters and answers HTTP 200 with a valid 768-dim vector, so 32,000
+ * was not its limit. Two upstream modules (distiller.ts, distill-exchange.ts)
+ * cut their own content citing that number as a hard provider constraint.
+ *
+ * WHY SEGMENT AT ALL, since the server accepts long input. The same measurement
+ * embedded `<filler> + <distinct tail>` at increasing filler lengths and
+ * compared the two vectors: cosine rose 0.79 (8k) -> 0.96 (16k) -> 0.995 (30k)
+ * -> exactly 1.000000000 (60k). At 60,000 the tail stops changing the vector at
+ * all -- the server truncates internally and still returns 200. Below that the
+ * tail is not lost but is increasingly diluted. Segmenting keeps every part of
+ * the text at full weight in its own vector instead of drowned in one.
+ */
+const EMBEDDING_SEGMENT_CHARS = 6000;
+
+/**
+ * Overlap between adjacent segments, in characters.
+ *
+ * 20% of a segment. A claim that straddles a seam appears whole in both
+ * neighbours, so it is embedded in context at least once rather than split
+ * across two vectors that each hold half of it. Matches the ratio
+ * src/chunking.ts already uses for its own defaults (200 of 2000).
+ */
+const EMBEDDING_SEGMENT_OVERLAP = 1200;
+
+/**
+ * Combine segment vectors into the one vector stored for the whole text.
+ *
+ * Length-weighted so a 6,000-char segment is not outvoted by a 400-char
+ * remainder, then L2-normalised because these vectors are compared by cosine
+ * distance, which assumes unit length.
+ */
+function combineEmbeddings(
+  segments: readonly { embedding: number[]; weight: number }[],
+): number[] {
+  const dimensions = embeddingDimensions();
+  const summed: number[] = Array.from({ length: dimensions }, () => 0);
+  let totalWeight = 0;
+  for (const segment of segments) {
+    totalWeight += segment.weight;
+    for (let i = 0; i < dimensions; i++) {
+      summed[i] = (summed[i] ?? 0) + (segment.embedding[i] ?? 0) * segment.weight;
+    }
+  }
+  if (totalWeight > 0) {
+    for (let i = 0; i < dimensions; i++) {
+      summed[i] = (summed[i] ?? 0) / totalWeight;
+    }
+  }
+  let norm = 0;
+  for (const value of summed) norm += value * value;
+  norm = Math.sqrt(norm);
+  // A zero vector has no direction to normalise. Returning it unchanged is
+  // correct -- it is what the provider produced, and inventing a direction
+  // would silently place the row somewhere in the space it does not belong.
+  if (norm === 0) return summed;
+  return summed.map((value) => value / norm);
+}
+
+export async function generateEmbeddingWithMetadata(
+  text: string,
+  embeddingUrl?: string,
+  options: EmbeddingOptions = {},
+): Promise<EmbeddingResult> {
+  if (!text || text.trim().length === 0) {
+    const msg = "Embedding text empty";
+    logger.warn(msg, { length: text?.length ?? 0 });
+    return {
+      embedding: null,
+      error: {
+        code: "input_invalid",
+        message: msg,
+        attempts: 0,
+      },
+    };
+  }
+
+  // LONG TEXT IS EMBEDDED, NOT REFUSED AND NOT CUT. chunkText splits on
+  // sentence boundaries with overlap, so no segment begins mid-sentence and
+  // the seam between two segments appears in both.
+  if (text.length > EMBEDDING_SEGMENT_CHARS) {
+    return embedSegmented(text, embeddingUrl, options);
+  }
+
+  return embedOnce(text, embeddingUrl, options);
+}
+
+/** Embed text too long for one request, as overlapping segments combined. */
+async function embedSegmented(
+  text: string,
+  embeddingUrl?: string,
+  options: EmbeddingOptions = {},
+): Promise<EmbeddingResult> {
+  const segments = chunkText(text, EMBEDDING_SEGMENT_CHARS, EMBEDDING_SEGMENT_OVERLAP);
+  logger.info("embedding_segmented", {
+    length: text.length,
+    segments: segments.length,
+  });
+  const embedded: { embedding: number[]; weight: number }[] = [];
+  const usageDetails: Record<string, number> = {};
+  for (const segment of segments) {
+    const result = await embedOnce(segment.text, embeddingUrl, options);
+    // One failed segment fails the whole embedding. Combining the survivors
+    // would return a vector silently representing only PART of the text --
+    // a wrong answer wearing the shape of a right one, which is the failure
+    // mode this whole change exists to remove.
+    if (result.embedding === null) {
+      logger.error("embedding_segment_failed", {
+        segment_index: segment.index,
+        segments: segments.length,
+        length: text.length,
+        code: result.error?.code ?? "unknown",
+      });
+      return result;
+    }
+    embedded.push({
+      embedding: result.embedding,
+      weight: segment.text.length,
+    });
+    for (const [key, value] of Object.entries(result.usageDetails ?? {})) {
+      usageDetails[key] = (usageDetails[key] ?? 0) + value;
+    }
+  }
+  return {
+    embedding: combineEmbeddings(embedded),
+    ...(Object.keys(usageDetails).length === 0 ? {} : { usageDetails }),
+  };
+}
+
+/** Everything one request needs, fixed before the first attempt is made. */
+interface PreparedRequest {
+  readonly url: string;
+  readonly headers: Record<string, string>;
+  readonly body: string;
+  readonly expectedDimensions: number;
+}
+
+/**
+ * Resolve the URL, headers, and body once for a request.
+ *
+ * The settings reader is consulted here rather than per attempt, which is where
+ * the module constants were read before: the width asked for and the width the
+ * answer is checked against must be the same number even if the reader answers
+ * differently mid-flight.
+ */
+function prepareRequest(
+  text: string,
+  embeddingUrl?: string,
+):
+  | { error: EmbeddingError; value?: undefined }
+  | { error?: undefined; value: PreparedRequest } {
+  const baseUrl = embeddingBaseUrl(embeddingUrl);
+  if (!baseUrl) {
+    const message = "No embedding URL configured";
+    logger.warn(message);
+    return { error: { code: "no_embedding_url", message, attempts: 0 } };
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  const apiKey = embeddingApiKey();
+  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+
+  const expectedDimensions = embeddingDimensions();
+  return {
+    value: {
+      url: `${baseUrl}/embeddings`,
+      headers,
+      body: JSON.stringify({
+        model: embeddingModel(),
+        input: text,
+        dimensions: expectedDimensions,
+      }),
+      expectedDimensions,
+    },
+  };
+}
+
+/** Retry, stop with an error, or hand back a usable result. */
+type AttemptResolution =
+  | {
+      readonly retry: true;
+      readonly delayMs: number;
+      readonly error?: undefined;
+      readonly result?: undefined;
+    }
+  | {
+      readonly retry: false;
+      readonly error: EmbeddingError;
+      readonly result?: undefined;
+    }
+  | {
+      readonly retry: false;
+      readonly error?: undefined;
+      readonly result: EmbeddingResult;
+    };
+
+/**
+ * Make ONE provider call, with its own abort wiring and timeout.
+ *
+ * The timeout is read per attempt, exactly where the former
+ * `EMBEDDING_TIMEOUT_MS` constant was consulted in the loop body.
+ */
+async function runOneAttempt(input: {
+  readonly request: PreparedRequest;
+  readonly attempt: number;
+  readonly totalAttempts: number;
+  readonly lastStatus?: number;
+  readonly signal?: AbortSignal;
+}): Promise<{
+  readonly outcome: AttemptResolution;
+  readonly status?: number;
+  readonly thrown?: unknown;
+}> {
+  const { request, attempt, totalAttempts, lastStatus, signal } = input;
+  const controller = new AbortController();
+  const abortFromParent = () => controller.abort(signal?.reason);
+  if (signal?.aborted) {
+    abortFromParent();
+  } else {
+    signal?.addEventListener("abort", abortFromParent, { once: true });
+  }
+  const timeoutId = setTimeout(() => controller.abort(), readSettings().timeoutMs);
+  const start = Date.now();
+
+  try {
+    const response = await fetch(request.url, {
+      method: "POST",
+      headers: request.headers,
+      body: request.body,
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return {
+        outcome: classifyHttpFailure({
+          status: response.status,
+          attempt,
+          totalAttempts,
+        }),
+        status: response.status,
+        thrown: new Error(`HTTP ${response.status}`),
+      };
+    }
+
+    const decoded = await decodeEmbeddingResponse({
+      response,
+      expectedDimensions: request.expectedDimensions,
+      attempt,
+    });
+    if (decoded.error) {
+      return {
+        outcome: { retry: false, error: decoded.error },
+        status: response.status,
+      };
+    }
+
+    logger.info("Embedding generated", { latencyMs: Date.now() - start, attempt });
+    return {
+      outcome: { retry: false, result: decoded.result },
+      status: response.status,
+    };
+  } catch (err) {
+    return {
+      outcome: classifyThrownFailure({
+        err,
+        attempt,
+        totalAttempts,
+        ...(lastStatus === undefined ? {} : { lastStatus }),
+      }),
+      thrown: err,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+    signal?.removeEventListener("abort", abortFromParent);
+  }
+}
+
+async function embedOnce(
+  text: string,
+  embeddingUrl?: string,
+  options: EmbeddingOptions = {},
+): Promise<EmbeddingResult> {
+  const request = prepareRequest(text, embeddingUrl);
+  if (request.error) {
+    return { embedding: null, error: request.error };
+  }
+
+  let lastError: unknown = null;
+  let lastStatus: number | undefined;
+  const totalAttempts = MAX_RETRIES + 1;
+
+  for (let attempt = 1; attempt <= totalAttempts; attempt++) {
+    const attempted = await runOneAttempt({
+      request: request.value,
+      attempt,
+      totalAttempts,
+      ...(lastStatus === undefined ? {} : { lastStatus }),
+      ...(options.signal === undefined ? {} : { signal: options.signal }),
+    });
+    lastStatus = attempted.status ?? lastStatus;
+    lastError = attempted.thrown ?? lastError;
+
+    if (attempted.outcome.retry) {
+      await sleep(attempted.outcome.delayMs);
+      continue;
+    }
+    if (attempted.outcome.error) {
+      return embeddingFailure(attempted.outcome.error);
+    }
+    resetWatchdogFailures();
+    return attempted.outcome.result;
+  }
+
+  // Should never reach here, but TypeScript needs it
+  const code = classifyError(lastError);
+  return embeddingFailure({
+    code,
+    message: "Unexpected: exhausted all attempts",
+    attempts: totalAttempts,
+    lastStatus,
+  });
+}
+
+/**
+ * Generate a 768-dimensional embedding vector for the given text.
+ * Returns null on any failure (timeout, network, bad response, etc.).
+ */
+export async function generateEmbedding(
+  text: string,
+  embeddingUrl?: string,
+  options: EmbeddingOptions = {},
+): Promise<number[] | null> {
+  const result = await generateEmbeddingWithMetadata(text, embeddingUrl, options);
+  return result.embedding;
+}
+
+export function contentHash(text: string): string {
+  const normalized = text.toLowerCase().trim().replace(/\s+/g, " ");
+  return createHash("sha256").update(normalized).digest("hex");
+}

--- a/server/main.ts
+++ b/server/main.ts
@@ -75,6 +75,7 @@ import {
   MAINTENANCE_GRAPH_AUTH,
 } from "../src/maintenance-bootstrap.ts";
 import { getOperatorDoctorStatus } from "./application/operator-doctor.ts";
+import { setEmbeddingSettingsReader } from "./embedding/provider.ts";
 import type { ToolDeps } from "../src/tools/index.ts";
 import type { AuthInfo } from "./types.ts";
 
@@ -528,6 +529,27 @@ export async function startServer(
   const config = options.config ?? loadServerConfig();
   const logger = options.logger ?? createLogger(config.logging);
 
+  // The embedding provider reads no environment of its own (issue 864); in the
+  // server runtime its values come from the config this function already holds.
+  // Registered here rather than at module scope because `config` is what the
+  // reader answers from, and the `src/` adapter's env reader is what it
+  // replaces.
+  //
+  // The replaced reader is kept and restored at shutdown. The provider is one
+  // module-level slot in the process, so a started-and-stopped server that left
+  // its own reader installed would keep answering from a dead server's config
+  // for everything that ran afterwards — which in a test process is the next
+  // test file.
+  const previousEmbeddingSettingsReader = setEmbeddingSettingsReader(() => ({
+    ...config.embedding,
+    ...(config.transport.embeddingBaseUrl === undefined
+      ? {}
+      : { baseUrl: config.transport.embeddingBaseUrl }),
+    ...(config.transport.embeddingApiKey === undefined
+      ? {}
+      : { apiKey: config.transport.embeddingApiKey }),
+  }));
+
   // TOKENS FIRST, before anything is allocated. A process with no configured
   // tokens can authenticate nobody, so every request it could ever serve is a
   // 401. `src/index.ts:343-346` checks this only after the pool and the bridge
@@ -592,13 +614,19 @@ export async function startServer(
       server,
       port: boundPort,
       logger,
-      shutdown: () =>
-        shutdown({ application: composed, database, server, logger, tracing }),
+      shutdown: async () => {
+        try {
+          await shutdown({ application: composed, database, server, logger, tracing });
+        } finally {
+          setEmbeddingSettingsReader(previousEmbeddingSettingsReader);
+        }
+      },
     };
   } catch (error: unknown) {
     // A failure anywhere after the pool exists must not leak it. Everything
     // allocated so far is released, and the original failure is rethrown so the
     // caller sees the CAUSE rather than a cleanup error.
+    setEmbeddingSettingsReader(previousEmbeddingSettingsReader);
     await releaseAfterFailedStart({ application, database, tracing });
     throw error;
   }

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -1,634 +1,79 @@
-import { createHash } from "node:crypto";
-import { spawn, type ChildProcess } from "node:child_process";
-import { chunkText } from "./chunking.ts";
-import { logger } from "./logger.ts";
+// L5 adapter (issue 864): legacy call form over server/embedding/provider.ts; retired with src/ at L6.
+//
+// The server/ module reads no environment. Legacy callers here, in scripts/,
+// and in tests expect the zero-argument form that reads `EMBEDDING_*` at the
+// moment of each call, plus the two module constants they import by name. This
+// adapter registers a reader that parses `process.env` on every call, so those
+// callers keep the behaviour they had, and computes the two constants at import
+// time exactly as the original did.
+import {
+  setEmbeddingSettingsReader,
+  type EmbeddingProviderSettings,
+} from "../server/embedding/provider.ts";
 
-const rawTimeout = parseInt(process.env.EMBEDDING_TIMEOUT_MS ?? "8000", 10);
-const EMBEDDING_TIMEOUT_MS = Number.isNaN(rawTimeout) ? 8000 : rawTimeout;
-const rawDimensions = parseInt(process.env.EMBEDDING_DIMENSIONS ?? "768", 10);
-export const EMBEDDING_DIMENSIONS =
-  Number.isNaN(rawDimensions) || rawDimensions <= 0 ? 768 : rawDimensions;
-
-const MAX_RETRIES = 2;
-const BACKOFF_DELAYS_MS = [200, 800];
-const WATCHDOG_RESTARTABLE_CODES = new Set<EmbeddingError["code"]>([
-  "timeout",
-  "network",
-  "server_error",
-]);
-
-let lastFailureCode: EmbeddingError["code"] | null = null;
-let consecutiveRestartableFailures = 0;
-let lastWatchdogRestartAt = 0;
-let watchdogRestartInFlight = false;
-let restartProcessSpawner = (restartScript: string): ChildProcess =>
-  spawn(restartScript, {
-    detached: true,
-    stdio: "ignore",
-  });
-
-/**
- * Embedding model identifier. Used by embedding.ts to call the provider and stored
- * in embedding_model columns so we can track which model produced each vector.
- * Override via EMBEDDING_MODEL env var (must match the provider deployment name).
- */
-export const EMBEDDING_MODEL =
-  process.env.EMBEDDING_MODEL ?? "gemini-embedding-001";
-
-export interface EmbeddingError {
-  code:
-    | "timeout"
-    | "network"
-    | "server_error"
-    | "client_error"
-    | "malformed_response"
-    | "input_invalid"
-    | "no_embedding_url";
-  message: string;
-  attempts: number;
-  lastStatus?: number;
+function parseIntegerSetting(
+  raw: string | undefined,
+  fallback: number,
+  accept: (value: number) => boolean,
+): number {
+  const parsed = parseInt(raw ?? String(fallback), 10);
+  return Number.isNaN(parsed) || !accept(parsed) ? fallback : parsed;
 }
 
-export interface EmbeddingResult {
-  embedding: number[] | null;
-  error?: EmbeddingError;
-  usageDetails?: Record<string, number>;
-}
-
-export interface EmbeddingOptions {
-  signal?: AbortSignal;
-}
-
-/**
- * Classify whether an error or HTTP status is transient and worth retrying.
- * Only 5xx, AbortError (timeout), and network-level errors are retried.
- * 4xx errors are never retried.
- */
-function isTransient(err: unknown, status?: number): boolean {
-  if (status !== undefined && status >= 400 && status < 500) return false;
-  if (status !== undefined && status >= 500) return true;
-  if (err instanceof DOMException && err.name === "AbortError") return true;
-  if (err instanceof Error) {
-    const msg = err.message;
-    if (
-      msg.includes("ECONNRESET") ||
-      msg.includes("ECONNREFUSED") ||
-      msg.includes("ETIMEDOUT") ||
-      msg.includes("ENETUNREACH") ||
-      msg.includes("fetch failed")
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function classifyError(err: unknown, status?: number): EmbeddingError["code"] {
-  if (err instanceof DOMException && err.name === "AbortError")
-    return "timeout";
-  if (status !== undefined && status >= 500) return "server_error";
-  if (err instanceof Error) return "network";
-  return "network";
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function watchdogFailureThreshold(): number {
-  const raw = parseInt(
-    process.env.EMBEDDING_WATCHDOG_FAILURE_THRESHOLD ?? "2",
-    10,
-  );
-  return Number.isNaN(raw) || raw <= 0 ? 2 : raw;
-}
-
-function watchdogCooldownMs(): number {
-  const raw = parseInt(
-    process.env.EMBEDDING_WATCHDOG_COOLDOWN_MS ?? "300000",
-    10,
-  );
-  return Number.isNaN(raw) || raw < 0 ? 300000 : raw;
-}
-
-function resetWatchdogFailures(): void {
-  lastFailureCode = null;
-  consecutiveRestartableFailures = 0;
-}
-
-function recordWatchdogFailure(error: EmbeddingError): void {
-  if (!WATCHDOG_RESTARTABLE_CODES.has(error.code)) {
-    resetWatchdogFailures();
-    return;
-  }
-
-  lastFailureCode = error.code;
-  consecutiveRestartableFailures += 1;
-
-  logger.warn("embedding_watchdog_failure_recorded", {
-    code: error.code,
-    consecutiveFailures: consecutiveRestartableFailures,
-    threshold: watchdogFailureThreshold(),
-  });
-
-  if (consecutiveRestartableFailures >= watchdogFailureThreshold()) {
-    triggerEmbeddingWatchdogRestart(error.code);
-  }
-}
-
-function triggerEmbeddingWatchdogRestart(code: EmbeddingError["code"]): void {
+/** Every `EMBEDDING_*` key, parsed the way the original module parsed it. */
+export function readEmbeddingEnv(): EmbeddingProviderSettings {
   const restartScript = process.env.EMBEDDING_WATCHDOG_RESTART_SCRIPT;
-  if (!restartScript) return;
-
-  const now = Date.now();
-  const cooldownMs = watchdogCooldownMs();
-  if (watchdogRestartInFlight) {
-    logger.warn("embedding_watchdog_restart_skipped", {
-      code,
-      reason: "restart_in_flight",
-    });
-    return;
-  }
-  if (now - lastWatchdogRestartAt < cooldownMs) {
-    logger.warn("embedding_watchdog_restart_skipped", {
-      code,
-      reason: "cooldown",
-      cooldownMs,
-    });
-    return;
-  }
-
-  watchdogRestartInFlight = true;
-
-  logger.error("embedding_watchdog_restart_triggered", {
-    code,
-    restartScript,
-  });
-
-  let child: ChildProcess;
-  try {
-    child = restartProcessSpawner(restartScript);
-  } catch (err) {
-    watchdogRestartInFlight = false;
-    logger.error("embedding_watchdog_restart_failed", {
-      error: err instanceof Error ? err.message : String(err),
-      restartScript,
-    });
-    return;
-  }
-
-  child.once("error", (err) => {
-    watchdogRestartInFlight = false;
-    logger.error("embedding_watchdog_restart_failed", {
-      error: err.message,
-      restartScript,
-    });
-  });
-
-  child.once("spawn", () => {
-    child.unref();
-  });
-
-  child.once("close", (exitCode) => {
-    watchdogRestartInFlight = false;
-    if (exitCode !== 0) {
-      logger.error("embedding_watchdog_restart_failed", {
-        exitCode,
-        restartScript,
-      });
-      return;
-    }
-
-    lastWatchdogRestartAt = Date.now();
-    resetWatchdogFailures();
-    logger.warn("embedding_watchdog_restart_completed", {
-      restartScript,
-    });
-  });
-}
-
-export function __resetEmbeddingWatchdogForTests(): void {
-  resetWatchdogFailures();
-  lastWatchdogRestartAt = 0;
-  watchdogRestartInFlight = false;
-  restartProcessSpawner = (restartScript: string): ChildProcess =>
-    spawn(restartScript, {
-      detached: true,
-      stdio: "ignore",
-    });
-}
-
-export function __setEmbeddingWatchdogRestartSpawnerForTests(
-  spawner: typeof restartProcessSpawner,
-): void {
-  restartProcessSpawner = spawner;
-}
-
-export function getEmbeddingProviderDiagnostics(): {
-  configured: boolean;
-  model: string;
-  dimensions: number;
-  last_failure_code: EmbeddingError["code"] | null;
-  consecutive_restartable_failures: number;
-  restart_configured: boolean;
-  restart_in_flight: boolean;
-  last_restart_at: string | null;
-} {
+  const baseUrl = process.env.EMBEDDING_BASE_URL;
+  const apiKey = process.env.EMBEDDING_API_KEY;
   return {
-    configured: Boolean(embeddingBaseUrl()),
-    model: EMBEDDING_MODEL,
-    dimensions: EMBEDDING_DIMENSIONS,
-    last_failure_code: lastFailureCode,
-    consecutive_restartable_failures: consecutiveRestartableFailures,
-    restart_configured: Boolean(process.env.EMBEDDING_WATCHDOG_RESTART_SCRIPT),
-    restart_in_flight: watchdogRestartInFlight,
-    last_restart_at:
-      lastWatchdogRestartAt > 0
-        ? new Date(lastWatchdogRestartAt).toISOString()
-        : null,
+    timeoutMs: parseIntegerSetting(process.env.EMBEDDING_TIMEOUT_MS, 8000, () => true),
+    dimensions: parseIntegerSetting(
+      process.env.EMBEDDING_DIMENSIONS,
+      768,
+      (value) => value > 0,
+    ),
+    model: process.env.EMBEDDING_MODEL ?? "gemini-embedding-001",
+    watchdog: {
+      failureThreshold: parseIntegerSetting(
+        process.env.EMBEDDING_WATCHDOG_FAILURE_THRESHOLD,
+        2,
+        (value) => value > 0,
+      ),
+      cooldownMs: parseIntegerSetting(
+        process.env.EMBEDDING_WATCHDOG_COOLDOWN_MS,
+        300000,
+        (value) => value >= 0,
+      ),
+      ...(restartScript === undefined ? {} : { restartScript }),
+    },
+    ...(baseUrl === undefined ? {} : { baseUrl }),
+    ...(apiKey === undefined ? {} : { apiKey }),
   };
 }
 
-function embeddingFailure(error: EmbeddingError): EmbeddingResult {
-  recordWatchdogFailure(error);
-  return { embedding: null, error };
-}
-
-export function embeddingBaseUrl(explicitUrl?: string): string | undefined {
-  const raw = explicitUrl ?? process.env.EMBEDDING_BASE_URL;
-  return raw?.replace(/\/+$/, "");
-}
-
-export function embeddingApiKey(): string | undefined {
-  return process.env.EMBEDDING_API_KEY;
-}
+setEmbeddingSettingsReader(readEmbeddingEnv);
 
 /**
- * Longest text sent to the provider in ONE request.
- *
- * A REQUEST-SHAPING number, not an acceptance rule. Text longer than this is
- * embedded in segments and combined; nothing is refused and nothing is cut.
- *
- * WHAT THIS REPLACES, and why the old number described nothing. The previous
- * `text.length > 32000` branch returned {embedding: null} for the WHOLE input,
- * so a caller stored a row no semantic search could ever reach. Measured
- * 2026-07-30 against the embedder actually configured here
- * (embeddinggemma-300m-8bit at EMBEDDING_BASE_URL, .env:24): the server accepts
- * 64,000 characters and answers HTTP 200 with a valid 768-dim vector, so 32,000
- * was not its limit. Two upstream modules (distiller.ts, distill-exchange.ts)
- * cut their own content citing that number as a hard provider constraint.
- *
- * WHY SEGMENT AT ALL, since the server accepts long input. The same measurement
- * embedded `<filler> + <distinct tail>` at increasing filler lengths and
- * compared the two vectors: cosine rose 0.79 (8k) -> 0.96 (16k) -> 0.995 (30k)
- * -> exactly 1.000000000 (60k). At 60,000 the tail stops changing the vector at
- * all -- the server truncates internally and still returns 200. Below that the
- * tail is not lost but is increasingly diluted. Segmenting keeps every part of
- * the text at full weight in its own vector instead of drowned in one.
+ * Vector width, read once at import. Callers import this as a value and a test
+ * re-imports this module with a cache-busting query to observe a new value.
  */
-const EMBEDDING_SEGMENT_CHARS = 6000;
+export const EMBEDDING_DIMENSIONS = readEmbeddingEnv().dimensions;
 
-/**
- * Overlap between adjacent segments, in characters.
- *
- * 20% of a segment. A claim that straddles a seam appears whole in both
- * neighbours, so it is embedded in context at least once rather than split
- * across two vectors that each hold half of it. Matches the ratio
- * src/chunking.ts already uses for its own defaults (200 of 2000).
- */
-const EMBEDDING_SEGMENT_OVERLAP = 1200;
+/** Provider deployment name, read once at import, as the original was. */
+export const EMBEDDING_MODEL = readEmbeddingEnv().model;
 
-/**
- * Combine segment vectors into the one vector stored for the whole text.
- *
- * Length-weighted so a 6,000-char segment is not outvoted by a 400-char
- * remainder, then L2-normalised because these vectors are compared by cosine
- * distance, which assumes unit length.
- */
-function combineEmbeddings(
-  segments: readonly { embedding: number[]; weight: number }[],
-): number[] {
-  const summed = new Array<number>(EMBEDDING_DIMENSIONS).fill(0);
-  let totalWeight = 0;
-  for (const segment of segments) {
-    totalWeight += segment.weight;
-    for (let i = 0; i < EMBEDDING_DIMENSIONS; i++) {
-      summed[i]! += (segment.embedding[i] ?? 0) * segment.weight;
-    }
-  }
-  if (totalWeight > 0) {
-    for (let i = 0; i < EMBEDDING_DIMENSIONS; i++) summed[i]! /= totalWeight;
-  }
-  let norm = 0;
-  for (const value of summed) norm += value * value;
-  norm = Math.sqrt(norm);
-  // A zero vector has no direction to normalise. Returning it unchanged is
-  // correct -- it is what the provider produced, and inventing a direction
-  // would silently place the row somewhere in the space it does not belong.
-  if (norm === 0) return summed;
-  return summed.map((value) => value / norm);
-}
-
-export async function generateEmbeddingWithMetadata(
-  text: string,
-  embeddingUrl?: string,
-  options: EmbeddingOptions = {},
-): Promise<EmbeddingResult> {
-  if (!text || text.trim().length === 0) {
-    const msg = "Embedding text empty";
-    logger.warn(msg, { length: text?.length ?? 0 });
-    return {
-      embedding: null,
-      error: {
-        code: "input_invalid",
-        message: msg,
-        attempts: 0,
-      },
-    };
-  }
-
-  // LONG TEXT IS EMBEDDED, NOT REFUSED AND NOT CUT. chunkText splits on
-  // sentence boundaries with overlap, so no segment begins mid-sentence and
-  // the seam between two segments appears in both.
-  if (text.length > EMBEDDING_SEGMENT_CHARS) {
-    const segments = chunkText(
-      text,
-      EMBEDDING_SEGMENT_CHARS,
-      EMBEDDING_SEGMENT_OVERLAP,
-    );
-    logger.info("embedding_segmented", {
-      length: text.length,
-      segments: segments.length,
-    });
-    const embedded: { embedding: number[]; weight: number }[] = [];
-    const usageDetails: Record<string, number> = {};
-    for (const segment of segments) {
-      const result = await embedOnce(segment.text, embeddingUrl, options);
-      // One failed segment fails the whole embedding. Combining the survivors
-      // would return a vector silently representing only PART of the text --
-      // a wrong answer wearing the shape of a right one, which is the failure
-      // mode this whole change exists to remove.
-      if (result.embedding === null) {
-        logger.error("embedding_segment_failed", {
-          segment_index: segment.index,
-          segments: segments.length,
-          length: text.length,
-          code: result.error?.code ?? "unknown",
-        });
-        return result;
-      }
-      embedded.push({
-        embedding: result.embedding,
-        weight: segment.text.length,
-      });
-      for (const [key, value] of Object.entries(result.usageDetails ?? {})) {
-        usageDetails[key] = (usageDetails[key] ?? 0) + value;
-      }
-    }
-    return {
-      embedding: combineEmbeddings(embedded),
-      ...(Object.keys(usageDetails).length === 0 ? {} : { usageDetails }),
-    };
-  }
-
-  return embedOnce(text, embeddingUrl, options);
-}
-
-/** Embed one text that already fits in a single provider request. */
-async function embedOnce(
-  text: string,
-  embeddingUrl?: string,
-  options: EmbeddingOptions = {},
-): Promise<EmbeddingResult> {
-  const baseUrl = embeddingBaseUrl(embeddingUrl);
-  if (!baseUrl) {
-    const msg = "No embedding URL configured";
-    logger.warn(msg);
-    return {
-      embedding: null,
-      error: {
-        code: "no_embedding_url",
-        message: msg,
-        attempts: 0,
-      },
-    };
-  }
-
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  };
-  const apiKey = embeddingApiKey();
-  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
-
-  const body = JSON.stringify({
-    model: EMBEDDING_MODEL,
-    input: text,
-    dimensions: EMBEDDING_DIMENSIONS,
-  });
-
-  let lastError: unknown = null;
-  let lastStatus: number | undefined;
-  const totalAttempts = MAX_RETRIES + 1;
-
-  for (let attempt = 1; attempt <= totalAttempts; attempt++) {
-    const controller = new AbortController();
-    const abortFromParent = () => controller.abort(options.signal?.reason);
-    if (options.signal?.aborted) {
-      abortFromParent();
-    } else {
-      options.signal?.addEventListener("abort", abortFromParent, {
-        once: true,
-      });
-    }
-    const timeoutId = setTimeout(
-      () => controller.abort(),
-      EMBEDDING_TIMEOUT_MS,
-    );
-    const start = Date.now();
-
-    try {
-      const response = await fetch(`${baseUrl}/embeddings`, {
-        method: "POST",
-        headers,
-        body,
-        signal: controller.signal,
-      });
-
-      lastStatus = response.status;
-
-      if (!response.ok) {
-        lastError = new Error(`HTTP ${response.status}`);
-
-        // 4xx: don't retry
-        if (response.status >= 400 && response.status < 500) {
-          const code: EmbeddingError["code"] =
-            response.status === 400 || response.status === 422
-              ? "input_invalid"
-              : response.status === 401 || response.status === 403
-                ? "client_error"
-                : "client_error";
-          const msg = `Embedding provider returned ${response.status}`;
-          logger.error("Embedding provider request failed (non-retryable)", {
-            status: response.status,
-            attempts: attempt,
-          });
-          return embeddingFailure({
-            code,
-            message: msg,
-            attempts: attempt,
-            lastStatus: response.status,
-          });
-        }
-
-        // 5xx: retry if attempts remain
-        if (attempt < totalAttempts) {
-          const delay = BACKOFF_DELAYS_MS[attempt - 1] ?? 800;
-          logger.warn("Embedding request failed, retrying", {
-            attempt,
-            status: response.status,
-            code: "server_error",
-            delayMs: delay,
-          });
-          await sleep(delay);
-          continue;
-        }
-
-        // Final attempt exhausted
-        logger.error("Embedding request failed after all attempts", {
-          status: response.status,
-          attempts: attempt,
-        });
-        return embeddingFailure({
-          code: "server_error",
-          message: `Embedding provider returned ${response.status} after ${attempt} attempt(s)`,
-          attempts: attempt,
-          lastStatus: response.status,
-        });
-      }
-
-      const json = (await response.json()) as {
-        data?: Array<{ embedding?: unknown }>;
-        usage?: {
-          prompt_tokens?: unknown;
-          total_tokens?: unknown;
-        };
-      };
-
-      const embedding = json.data?.[0]?.embedding;
-
-      if (
-        !Array.isArray(embedding) ||
-        embedding.length !== EMBEDDING_DIMENSIONS
-      ) {
-        const msg = "Embedding provider returned malformed embedding";
-        logger.error(msg, {
-          hasData: !!json.data,
-          length: Array.isArray(embedding) ? embedding.length : "not-array",
-          expectedLength: EMBEDDING_DIMENSIONS,
-          attempts: attempt,
-        });
-        return embeddingFailure({
-          code: "malformed_response",
-          message: msg,
-          attempts: attempt,
-          lastStatus: response.status,
-        });
-      }
-
-      const latency = Date.now() - start;
-      logger.info("Embedding generated", { latencyMs: latency, attempt });
-
-      resetWatchdogFailures();
-      const usageDetails: Record<string, number> = {};
-      if (typeof json.usage?.prompt_tokens === "number") {
-        usageDetails.promptTokens = json.usage.prompt_tokens;
-      }
-      if (typeof json.usage?.total_tokens === "number") {
-        usageDetails.totalTokens = json.usage.total_tokens;
-      }
-      return {
-        embedding: embedding as number[],
-        ...(Object.keys(usageDetails).length === 0 ? {} : { usageDetails }),
-      };
-    } catch (err) {
-      lastError = err;
-
-      if (!isTransient(err)) {
-        const code = classifyError(err);
-        const msg = err instanceof Error ? err.message : String(err);
-        logger.error("Embedding request failed (non-retryable)", {
-          error: msg,
-          attempts: attempt,
-        });
-        return embeddingFailure({
-          code,
-          message: msg,
-          attempts: attempt,
-          lastStatus,
-        });
-      }
-
-      if (attempt < totalAttempts) {
-        const delay = BACKOFF_DELAYS_MS[attempt - 1] ?? 800;
-        const code = classifyError(err);
-        logger.warn("Embedding request failed, retrying", {
-          attempt,
-          code,
-          error: err instanceof Error ? err.message : String(err),
-          delayMs: delay,
-        });
-        await sleep(delay);
-        continue;
-      }
-
-      // Final attempt exhausted
-      const code = classifyError(err);
-      const msg = err instanceof Error ? err.message : String(err);
-      logger.error("Embedding request failed after all attempts", {
-        error: msg,
-        code,
-        attempts: attempt,
-      });
-      return embeddingFailure({
-        code,
-        message: `${msg} after ${attempt} attempt(s)`,
-        attempts: attempt,
-        lastStatus,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-      options.signal?.removeEventListener("abort", abortFromParent);
-    }
-  }
-
-  // Should never reach here, but TypeScript needs it
-  const code = classifyError(lastError);
-  return embeddingFailure({
-    code,
-    message: "Unexpected: exhausted all attempts",
-    attempts: totalAttempts,
-    lastStatus,
-  });
-}
-
-/**
- * Generate a 768-dimensional embedding vector for the given text.
- * Returns null on any failure (timeout, network, bad response, etc.).
- */
-export async function generateEmbedding(
-  text: string,
-  embeddingUrl?: string,
-  options: EmbeddingOptions = {},
-): Promise<number[] | null> {
-  const result = await generateEmbeddingWithMetadata(
-    text,
-    embeddingUrl,
-    options,
-  );
-  return result.embedding;
-}
-
-export function contentHash(text: string): string {
-  const normalized = text.toLowerCase().trim().replace(/\s+/g, " ");
-  return createHash("sha256").update(normalized).digest("hex");
-}
+export {
+  contentHash,
+  embeddingApiKey,
+  embeddingBaseUrl,
+  generateEmbedding,
+  generateEmbeddingWithMetadata,
+  getEmbeddingProviderDiagnostics,
+  setEmbeddingSettingsReader,
+  __resetEmbeddingWatchdogForTests,
+  __setEmbeddingWatchdogRestartSpawnerForTests,
+  type EmbeddingError,
+  type EmbeddingOptions,
+  type EmbeddingProviderSettings,
+  type EmbeddingResult,
+} from "../server/embedding/provider.ts";


### PR DESCRIPTION
## Summary

- Moved `src/embedding.ts` -> `server/embedding/provider.ts` (issue 864, L5 of `_plans/server-hardening-ladder.md`). The moved module reads no `process.env`.
- **The reader contract.** The module holds `let readSettings: () => EmbeddingProviderSettings` and exports `setEmbeddingSettingsReader(read)`, which installs the reader, **returns the one it replaced**, and logs the replacement at debug through the logger the module already imported. There is no idempotence guard and no snapshot — last writer wins. Every place that used to read an `EMBEDDING_*` key now calls `readSettings().<field>` **at the same moment it used to read env**, so per-call laziness is unchanged: the watchdog threshold and cooldown inside their own functions, the restart script inside the trigger, base URL and API key inside the request, the timeout on each attempt.
- **Defaults before any reader is set** are exactly what the original computed with every key absent: `timeoutMs` 8000, `dimensions` 768, `model` `gemini-embedding-001`, `watchdog.failureThreshold` 2, `watchdog.cooldownMs` 300000, no `restartScript`, no `baseUrl`, no `apiKey`.
- **Types reused, not redeclared.** `EmbeddingProviderSettings extends EmbeddingConfigGroup` from `server/config/src-readers.ts` unchanged (`timeoutMs`, `dimensions`, `model`, and the nested `watchdog` group of `failureThreshold`/`cooldownMs`/optional `restartScript`) and adds `baseUrl?`/`apiKey?`, which mirror `config.transport.embeddingBaseUrl` and `config.transport.embeddingApiKey` (`server/config.ts:251-252`) and are the same `readonly string | undefined` there.
- `EMBEDDING_MODEL` and `EMBEDDING_DIMENSIONS` could not stay constants under a reader, so `server/` exports them as `embeddingModel()` and `embeddingDimensions()`.
- **The adapter.** `src/embedding.ts` is now an L5 adapter: `readEmbeddingEnv()` parses `process.env` with the original defaults and the original bare-`parseInt` shape, `setEmbeddingSettingsReader(readEmbeddingEnv)` runs at import, the two legacy constants are computed from env **at import time exactly as the original did**, and everything else is re-exported from `server/`. Every relative import names a `server/` path. `src/embedding.test.ts:760,786` re-import it cache-busted and still observe dimensions 3.
- **`server/embedding/provider-attempt.ts`** is a new sibling holding the per-attempt decisions. See "inherited lint debt" below.

### The `server/main.ts` diff

```ts
+import { setEmbeddingSettingsReader } from "./embedding/provider.ts";

   const config = options.config ?? loadServerConfig();
   const logger = options.logger ?? createLogger(config.logging);
+
+  const previousEmbeddingSettingsReader = setEmbeddingSettingsReader(() => ({
+    ...config.embedding,
+    ...(config.transport.embeddingBaseUrl === undefined
+      ? {} : { baseUrl: config.transport.embeddingBaseUrl }),
+    ...(config.transport.embeddingApiKey === undefined
+      ? {} : { apiKey: config.transport.embeddingApiKey }),
+  }));
```

Every value is one `main` already held; no new env read, no `server/config.ts` edit.

**Beyond the one import and one call, `shutdown` restores the reader** (and so does the failed-start path). This is not decoration — it is a defect the tests caught. The provider holds ONE module-level slot per process, so a started-and-stopped server that left its own reader installed kept answering from a dead server's config for everything that ran afterwards, which in a test process is the next test file. Measured: the combined run of `server/main.pg.test.ts` with `src/operator-doctor.test.ts` is **114 pass / 0 fail at origin/main**, went to **112 pass / 2 fail** without the restore (`src/operator-doctor.test.ts` sets `EMBEDDING_BASE_URL` at test time and expects it seen), and is **151 pass / 0 fail** with it.

### Inherited lint debt (M14)

The file failed the whole-file `server/` lint the moment it moved: `max-lines` 524, `embedOnce` at 192 lines and complexity 35, two `max-depth`, `generateEmbeddingWithMetadata` complexity 15, `isTransient` complexity 14, `no-new-array`. Split mechanically in this commit, behavior unchanged:

- `provider-attempt.ts` — `classifyHttpFailure`, `classifyThrownFailure`, `decodeEmbeddingResponse`, `isTransient`, `classifyError`, `readUsageDetails`. Same order, same comparisons, same log events, fields, and messages.
- `provider.ts` — `prepareRequest`, `runOneAttempt`, `embedSegmented` hoisted out of the loop; the loop keeps the state that is its own (`lastError`, `lastStatus`).
- One dead ternary arm collapsed: `status === 401 || status === 403 ? "client_error" : "client_error"` had two identical arms and is now `"client_error"`.
- `new Array(n).fill(0)` -> `Array.from({ length: n }, () => 0)`; the two `summed[i]!` assertions became `(summed[i] ?? 0)`, exact because the array is pre-filled over the whole range.

Closure count: **18 -> 17**.

Tests left in `src/` (retire or move at L6): `src/embedding.test.ts`, `src/embedding-repair*.test.ts` — untouched per M1 EXCEPTION, testing the moved code through the adapter.

## Verification

- Done-means: scripts/done-means/864-moved-out-of-src.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

Receipts:

- probe (delete `EMBEDDING_WATCHDOG_RESTART_SCRIPT`, import, set it after, drive two failures) at `origin/main` and after the change -> **identical** `spawnCount=1` / `restart_configured=true`
- `bunx tsc --noEmit` -> exit 0
- `oxlint --deny-warnings --config .oxlintrc.json` on all four staged paths -> exit 0
- `bun run test:isolated src/embedding.test.ts` -> **37 pass 0 fail**
- `bun run test:isolated server/config-src-readers.test.ts server/main.pg.test.ts src/operator-doctor.test.ts src/embedding.test.ts server/embedding/embedding-canonical.test.ts server/embedding/embedding-targets.test.ts server/embedding/chunking.test.ts` -> **151 pass 0 fail**
- `bash scripts/done-means/864-moved-out-of-src.sh` (no arguments) -> **PASS** (judged=40 shims, 10 adapters)
- `bash closure-count.sh` -> 18 before, 17 after
- pre-commit (gitleaks, oxlint, prettier, tsc) and pre-push (full isolated suite) both passed; nothing bypassed
- M10: `rg -n '"src/|src/[a-z-]+\.ts' python/openbrain-memory/tests` -> no hit names embedding; Python guards need no repoint
- M12 text readers: `scripts/done-means/724-backlog-recallable.sh:245` and `scripts/__tests__/bulk-import.test.ts:32,65` read `src/embedding.ts` by path; the adapter keeps that path exporting the same names, so both keep working unchanged

## Critical Self-Review

- Highest-risk behavior: which reader answers, and when. Two readers exist (the adapter's env parse, main's config reader) over one module-level slot, so ordering decides the answer. Mitigated by making `setEmbeddingSettingsReader` return the previous reader and having `main` restore it on shutdown and on failed start.
- Assumptions that could be wrong: that no caller depends on `EMBEDDING_MODEL`/`EMBEDDING_DIMENSIONS` being live rather than import-time. The original computed both once at import, and the adapter does the same, so this preserves the original behavior rather than assuming about it.
- Missing/weak tests: no test asserts the reader-restore directly — it is proven only by the combined-run count going 112/2 -> 151/0. A dedicated test in `server/embedding/` would be a better guard; it is not in this lane's moved set.
- Security/permission risk: none new. `apiKey` moves from an env read to a settings field and is still never logged; gitleaks scanned the staged changes and found nothing.
- Migration/deploy risk: none. No schema, no migration. In the server runtime the values come from `config`, which is the same env parse `server/config/src-readers.ts` already performed and `server/config-src-readers.test.ts` already proves agrees with the src/ parse.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface changed; `src/embedding.ts` keeps every export name and arity.
- Rollback/cleanup concern: revert is one commit. The adapter and both `server/embedding/` files are retired together at L6.
- Fixes made before PR: the reader-restore in `server/main.ts` (found by the combined test run, not by review); the dead ternary arm; the two non-null assertions in `combineEmbeddings`.
- Known residual risk: a future caller that registers a reader and never restores it would repeat the cross-file leak this PR fixes. The returned-previous-reader contract makes the fix available but does not force it.
- SME review-memory update: [x] `docs/sme/` updated or [ ] not applicable because:

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no live service surface changed; the dogfood service is unaffected by a pure module move behind an adapter that preserves every export.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no client-facing contract, fixture, or wire shape changed; the move is internal to the TypeScript server and the pre-push contract-parity gate reported the client/contract paths unchanged.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- No MCP tool, schema, protocol, or client-facing surface changed, so every downstream item is not applicable. The pre-push gate confirmed it independently: "Python package unchanged; skipping Python package gate", "Client/contract paths unchanged; skipping contract parity subset".
