### PR TITLE
test(bulk-import): stop replacing src/logger.ts process-wide with mock.module (issue 864)

### DIFF
--- a/scripts/__tests__/bulk-import-fixture.ts
+++ b/scripts/__tests__/bulk-import-fixture.ts
@@ -1,0 +1,116 @@
+// Shared fixture for the bulk-import suites.
+//
+// The suite was split in two (scripts/__tests__/bulk-import.test.ts and
+// scripts/__tests__/bulk-import-routing.test.ts) so each file stays inside the
+// repo's whole-file lint standard. Both need the same module mocks, the same
+// mock pool, and the same log observation, so all of it lives here and is
+// installed by `installBulkImportFixture()` at the top of each file.
+import { mock } from "bun:test";
+import { join } from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import type pg from "pg";
+import { addLogSink } from "../../src/logger.ts";
+
+export const logCalls: {
+  info: Array<[string, Record<string, unknown>?]>;
+  warn: Array<[string, Record<string, unknown>?]>;
+  error: Array<[string, Record<string, unknown>?]>;
+} = { info: [], warn: [], error: [] };
+
+/**
+ * Observes emitted log lines without replacing the logger.
+ *
+ * NOT `mock.module("../../src/logger.ts")`: that mock is process-wide and
+ * permanent in Bun -- keyed by resolved specifier, never scoped to one file,
+ * and not undone by `mock.restore()`. Replacing the logger here replaced it
+ * for every later suite in the run, so any suite that observes real logger
+ * output through `addLogSink` saw an empty buffer and failed with a stack
+ * pointing nowhere near this file. `src/observability/observability.test.ts`
+ * already states that no suite may mock.module the logger, and
+ * `scripts/backfill.test.ts` is the precedent this follows.
+ */
+export function subscribeLogCalls(): () => void {
+  return addLogSink((entry) => {
+    const bucket = logCalls[entry.level as "info" | "warn" | "error"];
+    if (!bucket) return;
+    const { level, message, timestamp, service, ...extra } = entry;
+    void level;
+    void timestamp;
+    void service;
+    bucket.push([message as string, extra]);
+  });
+}
+
+export function resetLogCalls(): void {
+  logCalls.info.length = 0;
+  logCalls.warn.length = 0;
+  logCalls.error.length = 0;
+}
+
+/** Installs the module mocks both bulk-import suites depend on. */
+export function installBulkImportMocks(): void {
+  mock.module("../../src/embedding.ts", () => ({
+    EMBEDDING_MODEL: "embeddinggemma-300m-8bit",
+    contentHash: (text: string) => {
+      // Deterministic hash for testing -- just use a simple string hash
+      const { createHash } = require("node:crypto");
+      const normalized = text.toLowerCase().trim().replace(/\s+/g, " ");
+      return createHash("sha256").update(normalized).digest("hex");
+    },
+    generateEmbedding: mock(async () => null),
+  }));
+
+  // No mock needed for extraction.ts -- tests use extract:false (default).
+  // Mocking it would leak into other test files via bun's global mock.module.
+
+  mock.module("../../src/db/pool.ts", () => ({
+    createPool: () => {
+      throw new Error("createPool should not be called in tests");
+    },
+  }));
+
+  mock.module("pgvector/pg", () => ({
+    toSql: (arr: number[]) => `[${arr.join(",")}]`,
+  }));
+}
+
+export function createMockPool(
+  queryImpl?: (...args: unknown[]) => Promise<{ rows: unknown[]; rowCount: number }>,
+) {
+  const defaultImpl = async () => ({ rows: [], rowCount: 1 });
+  const mockQuery = mock(queryImpl ?? defaultImpl);
+  const mockEnd = mock(async () => {});
+  return {
+    pool: { query: mockQuery, end: mockEnd } as unknown as pg.Pool,
+    mockQuery,
+    mockEnd,
+  };
+}
+
+export const defaultOpts = {
+  extraTags: [] as string[],
+  sourceLabel: "bulk-import",
+  embed: false,
+  extract: false,
+};
+
+export function makeFile(
+  body: string,
+  frontmatter: Record<string, unknown> = {},
+  filePath = "/test/file.md",
+): {
+  filePath: string;
+  frontmatter: Record<string, unknown>;
+  body: string;
+} {
+  return { filePath, frontmatter, body };
+}
+
+export async function makeTempDir(): Promise<string> {
+  return await mkdtemp(join(tmpdir(), "ob-bulk-test-"));
+}
+
+export async function removeTempDir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true });
+}

--- a/scripts/__tests__/bulk-import-routing.test.ts
+++ b/scripts/__tests__/bulk-import-routing.test.ts
@@ -1,0 +1,547 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { expectDefined } from "../test-support/expect-defined.ts";
+import {
+  createMockPool,
+  defaultOpts,
+  installBulkImportMocks,
+  logCalls,
+  makeFile,
+  makeTempDir,
+  removeTempDir,
+  resetLogCalls,
+  subscribeLogCalls,
+} from "./bulk-import-fixture.ts";
+
+installBulkImportMocks();
+
+// Import after mocks
+const { readFiles, importThought, importDecision, importSession, parseArgs } =
+  await import("../bulk-import.ts");
+const { contentHash } = await import("../../src/embedding.ts");
+
+let tmpDir: string;
+let unsubscribeLogSink: (() => void) | undefined;
+
+beforeEach(async () => {
+  tmpDir = await makeTempDir();
+  unsubscribeLogSink = subscribeLogCalls();
+  resetLogCalls();
+});
+
+afterEach(async () => {
+  unsubscribeLogSink?.();
+  unsubscribeLogSink = undefined;
+  await removeTempDir(tmpDir);
+});
+
+// ===========================================================================
+// TABLE ROUTING: thoughts vs decisions vs sessions
+// ===========================================================================
+
+describe("table routing", () => {
+  it("importThought uses INSERT INTO thoughts", async () => {
+    const file = makeFile(
+      "A thought about testing table routing in the bulk import script.",
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importThought(pool, file, defaultOpts);
+
+    const [sql] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("INSERT INTO thoughts");
+    expect(sql).toContain("namespace");
+    expect(sql).not.toContain("INSERT INTO decisions");
+    expect(sql).not.toContain("INSERT INTO sessions");
+  });
+
+  it("importDecision uses INSERT INTO decisions with title and rationale", async () => {
+    const file = makeFile(
+      "We decided to use Bun because it is faster than Node for our workload.",
+      { title: "Use Bun Runtime", tags: ["infrastructure"] },
+      "/test/decision.md",
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importDecision(pool, file, defaultOpts);
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("INSERT INTO decisions");
+    expect(sql).toContain("title");
+    expect(sql).toContain("rationale");
+    expect(sql).toContain("context");
+    expect(sql).toContain("namespace");
+    expect(params[0]).toBe("Use Bun Runtime"); // title from frontmatter
+    expect(params[1]).toBe(
+      "We decided to use Bun because it is faster than Node for our workload.",
+    ); // rationale = body
+    expect(params[3]).toContain("Imported from:"); // context
+    expect(params[5]).toBe("shared-kb"); // namespace
+  });
+
+  it("importDecision falls back to first line of body for title when no frontmatter title", async () => {
+    const file = makeFile(
+      "# Switch to PostgreSQL\n\nBecause it has better vector support than SQLite.",
+      {},
+      "/test/decision-no-title.md",
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importDecision(pool, file, defaultOpts);
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    // Title is derived from first line with leading # stripped
+    expect(params[0]).toBe("Switch to PostgreSQL");
+  });
+
+  it("importDecision uses frontmatter.name as fallback title", async () => {
+    const file = makeFile(
+      "This decision has a name field instead of a title field in frontmatter.",
+      { name: "Named Decision" },
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importDecision(pool, file, defaultOpts);
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[0]).toBe("Named Decision");
+  });
+});
+
+describe("table routing: sessions", () => {
+  it("importSession uses INSERT INTO sessions with project and summary", async () => {
+    const file = makeFile(
+      "We worked on the bulk import feature and added comprehensive test coverage.",
+      { project: "open-brain", tags: ["session"] },
+      "/test/session.md",
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importSession(pool, file, {
+      extraTags: [],
+      sourceLabel: "bulk-import",
+      embed: false,
+    });
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("INSERT INTO sessions");
+    expect(sql).toContain("project");
+    expect(sql).toContain("summary");
+    expect(params[0]).toBe("open-brain"); // project from frontmatter
+    expect(params[1]).toBe(
+      "We worked on the bulk import feature and added comprehensive test coverage.",
+    ); // summary = body
+    expect(params[2]).toEqual(["session"]); // tags
+    expect(params[3]).toBe("bulk-import"); // created_by
+    expect(params[4]).toBe("shared-kb"); // namespace
+  });
+
+  it("importSession sets project to null when not in frontmatter", async () => {
+    const file = makeFile(
+      "Session without a project field in the frontmatter metadata.",
+      {},
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importSession(pool, file, {
+      extraTags: [],
+      sourceLabel: "bulk-import",
+      embed: false,
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[0]).toBeNull(); // project
+  });
+
+  it("importSession dedups on the canonical summary|project hash (WHERE NOT EXISTS)", async () => {
+    // Sessions used to hash summary + a live timestamp so every import created a
+    // fresh row. That hash can never be reproduced by the embedding-repair
+    // registry, so every imported session was permanently source_drift. The
+    // writer now hashes the canonical summary|project source and dedups on it,
+    // matching the live session writers.
+    const file = makeFile(
+      "Session content that maps to a stable canonical source hash.",
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importSession(pool, file, {
+      extraTags: [],
+      sourceLabel: "bulk-import",
+      embed: false,
+    });
+
+    const [sql] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("WHERE NOT EXISTS");
+  });
+});
+
+// ===========================================================================
+// TAG HANDLING: --tags flag merges with frontmatter tags
+// ===========================================================================
+
+describe("tag handling", () => {
+  it("merges extraTags with frontmatter tags for thoughts", async () => {
+    const file = makeFile(
+      "Content with both frontmatter and CLI tags for testing merge behavior.",
+      { tags: ["fm-tag-1", "fm-tag-2"] },
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importThought(pool, file, {
+      ...defaultOpts,
+      extraTags: ["cli-tag-1", "cli-tag-2"],
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[1]).toEqual(["fm-tag-1", "fm-tag-2", "cli-tag-1", "cli-tag-2"]);
+  });
+
+  it("uses only extraTags when frontmatter has no tags", async () => {
+    const file = makeFile(
+      "Content without frontmatter tags but with CLI-provided tags.",
+      {},
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importThought(pool, file, {
+      ...defaultOpts,
+      extraTags: ["added-tag"],
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[1]).toEqual(["added-tag"]);
+  });
+
+  it("uses only frontmatter tags when no extraTags", async () => {
+    const file = makeFile(
+      "Content with frontmatter tags and no extra CLI tags provided.",
+      { tags: ["only-fm"] },
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importThought(pool, file, defaultOpts);
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[1]).toEqual(["only-fm"]);
+  });
+
+  it("handles non-array frontmatter tags gracefully", async () => {
+    const file = makeFile(
+      "Content where frontmatter tags is a string instead of an array.",
+      { tags: "not-an-array" },
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importThought(pool, file, {
+      ...defaultOpts,
+      extraTags: ["extra"],
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    // Non-array tags should be treated as empty, only extraTags used
+    expect(params[1]).toEqual(["extra"]);
+  });
+
+  it("merges tags for decisions the same way", async () => {
+    const file = makeFile(
+      "Decision content for testing tag merge behavior in the decisions table.",
+      { title: "Tag Test", tags: ["decision-tag"] },
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importDecision(pool, file, {
+      ...defaultOpts,
+      extraTags: ["cli-tag"],
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[2]).toEqual(["decision-tag", "cli-tag"]); // tags is param index 2 for decisions
+  });
+
+  it("merges tags for sessions the same way", async () => {
+    const file = makeFile(
+      "Session content for testing tag merge behavior in the sessions table.",
+      { tags: ["session-tag"] },
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importSession(pool, file, {
+      extraTags: ["cli-tag"],
+      sourceLabel: "bulk-import",
+      embed: false,
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[2]).toEqual(["session-tag", "cli-tag"]); // tags is param index 2 for sessions
+  });
+});
+
+// ===========================================================================
+// DRY RUN: no DB calls
+// ===========================================================================
+
+describe("dry run", () => {
+  it("readFiles works but no DB calls are needed in dry-run mode", async () => {
+    // Simulate what the main function does in dry-run: read files, print them, exit
+    for (let i = 0; i < 5; i++) {
+      await Bun.write(
+        join(tmpDir, `note-${i}.md`),
+        `---\ntitle: Note ${i}\n---\n\nThis is note ${i} with enough content to pass the minimum length check.`,
+      );
+    }
+
+    const files = await readFiles(tmpDir, "**/*.md");
+    expect(files).toHaveLength(5);
+
+    // In dry-run mode, the script just prints files and exits without calling pool.query
+    const { mockQuery } = createMockPool();
+
+    // Dry-run: iterate and collect output but do NOT call any import function
+    const dryRunOutput: string[] = [];
+    for (const f of files) {
+      const title =
+        (f.frontmatter.title as string) || (f.body.split("\n")[0] ?? "").slice(0, 80);
+      dryRunOutput.push(`${f.filePath} -> ${title}`);
+    }
+
+    expect(dryRunOutput).toHaveLength(5);
+    expect(dryRunOutput[0]).toContain("->");
+    // Verify NO database calls were made
+    expect(mockQuery).not.toHaveBeenCalled();
+    // Pool.end should not be called in dry-run either (pool is never created)
+  });
+});
+
+// ===========================================================================
+// PARSE ARGS
+// ===========================================================================
+
+describe("parseArgs", () => {
+  it("parses source directory as positional argument", () => {
+    const result = parseArgs(["bun", "script.ts", "/some/dir"]);
+    expect(result.sourceDir).toBe("/some/dir");
+    expect(result.table).toBe("thoughts"); // default
+    expect(result.dryRun).toBe(false);
+    expect(result.pattern).toBe("**/*.md");
+  });
+
+  it("parses --table flag", () => {
+    const result = parseArgs(["bun", "script.ts", "/dir", "--table", "decisions"]);
+    expect(result.table).toBe("decisions");
+  });
+
+  it("parses --tags flag with comma-separated values", () => {
+    const result = parseArgs(["bun", "script.ts", "/dir", "--tags", "a,b,c"]);
+    expect(result.extraTags).toEqual(["a", "b", "c"]);
+  });
+
+  it("parses --source flag", () => {
+    const result = parseArgs(["bun", "script.ts", "/dir", "--source", "my-source"]);
+    expect(result.sourceLabel).toBe("my-source");
+  });
+
+  it("parses --pattern flag", () => {
+    const result = parseArgs(["bun", "script.ts", "/dir", "--pattern", "*.txt"]);
+    expect(result.pattern).toBe("*.txt");
+  });
+
+  it("parses boolean flags: --embed, --extract, --dry-run", () => {
+    const result = parseArgs([
+      "bun",
+      "script.ts",
+      "/dir",
+      "--embed",
+      "--extract",
+      "--dry-run",
+    ]);
+    expect(result.embed).toBe(true);
+    expect(result.extract).toBe(true);
+    expect(result.dryRun).toBe(true);
+  });
+
+  it("parses all options together", () => {
+    const result = parseArgs([
+      "bun",
+      "script.ts",
+      "/my/dir",
+      "--table",
+      "sessions",
+      "--tags",
+      "x,y",
+      "--source",
+      "custom",
+      "--pattern",
+      "notes/*.md",
+      "--embed",
+      "--dry-run",
+    ]);
+    expect(result.sourceDir).toBe("/my/dir");
+    expect(result.table).toBe("sessions");
+    expect(result.extraTags).toEqual(["x", "y"]);
+    expect(result.sourceLabel).toBe("custom");
+    expect(result.pattern).toBe("notes/*.md");
+    expect(result.embed).toBe(true);
+    expect(result.extract).toBe(false);
+    expect(result.dryRun).toBe(true);
+  });
+
+  it("trims whitespace from tag values", () => {
+    const result = parseArgs(["bun", "script.ts", "/dir", "--tags", " a , b , c "]);
+    expect(result.extraTags).toEqual(["a", "b", "c"]);
+  });
+});
+
+// ===========================================================================
+// EDGE CASES
+// ===========================================================================
+
+describe("edge cases", () => {
+  it("skips empty files (< 10 chars body)", async () => {
+    await Bun.write(join(tmpDir, "empty.md"), "");
+    await Bun.write(join(tmpDir, "short.md"), "hi");
+    await Bun.write(join(tmpDir, "nine.md"), "123456789"); // exactly 9 chars
+
+    const files = await readFiles(tmpDir, "**/*.md");
+    expect(files).toHaveLength(0);
+  });
+
+  it("includes files with exactly 10 chars body", async () => {
+    await Bun.write(join(tmpDir, "ten.md"), "1234567890"); // exactly 10 chars
+
+    const files = await readFiles(tmpDir, "**/*.md");
+    expect(files).toHaveLength(1);
+  });
+
+  it("handles files with frontmatter but empty body", async () => {
+    await Bun.write(
+      join(tmpDir, "fm-only.md"),
+      `---\ntitle: All Frontmatter\ntags: [a, b]\n---\n`,
+    );
+
+    const files = await readFiles(tmpDir, "**/*.md");
+    expect(files).toHaveLength(0);
+  });
+
+  it("handles files with frontmatter and very short body", async () => {
+    await Bun.write(join(tmpDir, "fm-short.md"), `---\ntitle: Short Body\n---\n\nHi`);
+
+    const files = await readFiles(tmpDir, "**/*.md");
+    expect(files).toHaveLength(0); // "Hi" is < 10 chars
+  });
+
+  it("handles nested directories with glob pattern", async () => {
+    await Bun.write(
+      join(tmpDir, "a", "b", "c", "deep.md"),
+      "Deeply nested file content with enough text for the import.",
+    );
+    await Bun.write(
+      join(tmpDir, "a", "sibling.md"),
+      "Sibling file content with enough text for the import test.",
+    );
+
+    const files = await readFiles(tmpDir, "**/*.md");
+    expect(files).toHaveLength(2);
+  });
+
+  it("custom source label propagates to SQL params for thoughts", async () => {
+    const file = makeFile(
+      "Content with a custom source label for testing propagation.",
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importThought(pool, file, {
+      ...defaultOpts,
+      sourceLabel: "my-custom-source",
+    });
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[2]).toBe("my-custom-source");
+  });
+
+  it("decision context includes file path", async () => {
+    const file = makeFile(
+      "Decision body with enough content for the minimum length check.",
+      { title: "Test Decision" },
+      "/my/notes/decision-001.md",
+    );
+    const { pool, mockQuery } = createMockPool();
+
+    await importDecision(pool, file, defaultOpts);
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[3]).toBe("Imported from: /my/notes/decision-001.md");
+  });
+});
+
+describe("edge cases: error logging and hashing", () => {
+  it("importThought logs warning on query error", async () => {
+    const file = makeFile(
+      "Content that triggers a database error for testing error handling.",
+    );
+    const { pool } = createMockPool(async () => {
+      throw new Error("test-db-error");
+    });
+
+    const result = await importThought(pool, file, defaultOpts);
+
+    expect(result).toBe("error");
+    const warnCall = logCalls.warn.find(([msg]) => msg === "Import error");
+    expect(warnCall).toBeTruthy();
+    expect(
+      expectDefined(expectDefined(warnCall, "warnCall")[1], "warnCall[1]").error,
+    ).toBe("test-db-error");
+  });
+
+  it("importDecision logs warning on query error", async () => {
+    const file = makeFile(
+      "Decision content that triggers a database error for testing.",
+      { title: "Error Decision" },
+    );
+    const { pool } = createMockPool(async () => {
+      throw new Error("decision-db-error");
+    });
+
+    const result = await importDecision(pool, file, defaultOpts);
+
+    expect(result).toBe("error");
+    const warnCall = logCalls.warn.find(
+      ([, extra]) => extra?.error === "decision-db-error",
+    );
+    expect(warnCall).toBeTruthy();
+  });
+
+  it("importSession logs warning on query error", async () => {
+    const file = makeFile(
+      "Session content that triggers a database error for testing.",
+    );
+    const { pool } = createMockPool(async () => {
+      throw new Error("session-db-error");
+    });
+
+    const result = await importSession(pool, file, {
+      extraTags: [],
+      sourceLabel: "test",
+      embed: false,
+    });
+
+    expect(result).toBe("error");
+  });
+
+  it("content hash is deterministic for identical content", () => {
+    const hash1 = contentHash("Hello world test content");
+    const hash2 = contentHash("Hello world test content");
+    expect(hash1).toBe(hash2);
+  });
+
+  it("content hash differs for different content", () => {
+    const hash1 = contentHash("Content version A for hash testing");
+    const hash2 = contentHash("Content version B for hash testing");
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("content hash normalizes whitespace", () => {
+    const hash1 = contentHash("hello  world");
+    const hash2 = contentHash("hello world");
+    expect(hash1).toBe(hash2);
+  });
+});

--- a/scripts/__tests__/bulk-import.test.ts
+++ b/scripts/__tests__/bulk-import.test.ts
@@ -1,118 +1,36 @@
-import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { join } from "node:path";
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import type pg from "pg";
+import { expectDefined } from "../test-support/expect-defined.ts";
+import {
+  createMockPool,
+  defaultOpts,
+  installBulkImportMocks,
+  makeFile,
+  makeTempDir,
+  removeTempDir,
+  resetLogCalls,
+  subscribeLogCalls,
+} from "./bulk-import-fixture.ts";
 
-// ---------------------------------------------------------------------------
-// Mocks -- must be set up before importing the module under test
-// ---------------------------------------------------------------------------
-
-const logCalls: {
-  info: Array<[string, Record<string, unknown>?]>;
-  warn: Array<[string, Record<string, unknown>?]>;
-  error: Array<[string, Record<string, unknown>?]>;
-} = { info: [], warn: [], error: [] };
-
-mock.module("../../src/logger.ts", () => ({
-  logger: {
-    info: (msg: string, extra?: Record<string, unknown>) => {
-      logCalls.info.push([msg, extra]);
-    },
-    warn: (msg: string, extra?: Record<string, unknown>) => {
-      logCalls.warn.push([msg, extra]);
-    },
-    error: (msg: string, extra?: Record<string, unknown>) => {
-      logCalls.error.push([msg, extra]);
-    },
-    debug: mock(() => {}),
-  },
-}));
-
-mock.module("../../src/embedding.ts", () => ({
-  EMBEDDING_MODEL: "embeddinggemma-300m-8bit",
-  contentHash: (text: string) => {
-    // Deterministic hash for testing -- just use a simple string hash
-    const { createHash } = require("node:crypto");
-    const normalized = text.toLowerCase().trim().replace(/\s+/g, " ");
-    return createHash("sha256").update(normalized).digest("hex");
-  },
-  generateEmbedding: mock(async () => null),
-}));
-
-// No mock needed for extraction.ts -- tests use extract:false (default).
-// Mocking it would leak into other test files via bun's global mock.module.
-
-mock.module("../../src/db/pool.ts", () => ({
-  createPool: () => {
-    throw new Error("createPool should not be called in tests");
-  },
-}));
-
-mock.module("pgvector/pg", () => ({
-  toSql: (arr: number[]) => `[${arr.join(",")}]`,
-}));
+installBulkImportMocks();
 
 // Import after mocks
-const {
-  parseFrontmatter,
-  readFiles,
-  importThought,
-  importDecision,
-  importSession,
-  parseArgs,
-} = await import("../bulk-import.ts");
-const { contentHash } = await import("../../src/embedding.ts");
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+const { parseFrontmatter, readFiles, importThought } =
+  await import("../bulk-import.ts");
 
 let tmpDir: string;
-
-function createMockPool(
-  queryImpl?: (
-    ...args: unknown[]
-  ) => Promise<{ rows: unknown[]; rowCount: number }>,
-) {
-  const defaultImpl = async () => ({ rows: [], rowCount: 1 });
-  const mockQuery = mock(queryImpl ?? defaultImpl);
-  const mockEnd = mock(async () => {});
-  return {
-    pool: { query: mockQuery, end: mockEnd } as unknown as pg.Pool,
-    mockQuery,
-    mockEnd,
-  };
-}
-
-const defaultOpts = {
-  extraTags: [] as string[],
-  sourceLabel: "bulk-import",
-  embed: false,
-  extract: false,
-};
-
-function makeFile(
-  body: string,
-  frontmatter: Record<string, unknown> = {},
-  filePath = "/test/file.md",
-): {
-  filePath: string;
-  frontmatter: Record<string, unknown>;
-  body: string;
-} {
-  return { filePath, frontmatter, body };
-}
+let unsubscribeLogSink: (() => void) | undefined;
 
 beforeEach(async () => {
-  tmpDir = await mkdtemp(join(tmpdir(), "ob-bulk-test-"));
-  logCalls.info.length = 0;
-  logCalls.warn.length = 0;
-  logCalls.error.length = 0;
+  tmpDir = await makeTempDir();
+  unsubscribeLogSink = subscribeLogCalls();
+  resetLogCalls();
 });
 
 afterEach(async () => {
-  await rm(tmpDir, { recursive: true, force: true });
+  unsubscribeLogSink?.();
+  unsubscribeLogSink = undefined;
+  await removeTempDir(tmpDir);
 });
 
 // ===========================================================================
@@ -141,9 +59,7 @@ This is the body content.`;
     const result = parseFrontmatter(raw);
 
     expect(result.frontmatter).toEqual({});
-    expect(result.body).toBe(
-      "Just plain markdown content with no frontmatter.",
-    );
+    expect(result.body).toBe("Just plain markdown content with no frontmatter.");
   });
 
   it("handles frontmatter with quoted string values", () => {
@@ -236,8 +152,8 @@ describe("readFiles", () => {
     const files = await readFiles(tmpDir, "**/*.md");
 
     expect(files).toHaveLength(1);
-    expect(files[0]!.frontmatter.title).toBe("Test Note");
-    expect(files[0]!.body).toContain("This is a test note");
+    expect(expectDefined(files[0], "files[0]").frontmatter.title).toBe("Test Note");
+    expect(expectDefined(files[0], "files[0]").body).toContain("This is a test note");
   });
 
   it("skips files with body shorter than 10 characters", async () => {
@@ -250,7 +166,7 @@ describe("readFiles", () => {
     const files = await readFiles(tmpDir, "**/*.md");
 
     expect(files).toHaveLength(1);
-    expect(files[0]!.body).toContain("enough content");
+    expect(expectDefined(files[0], "files[0]").body).toContain("enough content");
   });
 
   it("skips files with only frontmatter and no body", async () => {
@@ -339,24 +255,22 @@ describe("small: single file import", () => {
     expect(sql).toContain("content_hash");
     expect(sql).toContain("WHERE NOT EXISTS");
     // params: content, tags, source, created_by, namespace, embedding, hash, embedded_at, model, extracted
-    expect(params![0]).toBe(
+    expect(params[0]).toBe(
       "This is my thought content for testing the import function.",
     );
-    expect(params![1]).toEqual(["ai", "test"]);
-    expect(params![2]).toBe("bulk-import"); // sourceLabel
-    expect(params![3]).toBe("bulk-import"); // created_by
-    expect(params![4]).toBe("shared-kb"); // namespace
-    expect(params![5]).toBeNull(); // embedding (embed=false)
-    expect(typeof params![6]).toBe("string"); // hash
-    expect(params![7]).toBeNull(); // embedded_at
-    expect(params![8]).toBeNull(); // embedding_model
-    expect(params![9]).toBeNull(); // extracted_metadata
+    expect(params[1]).toEqual(["ai", "test"]);
+    expect(params[2]).toBe("bulk-import"); // sourceLabel
+    expect(params[3]).toBe("bulk-import"); // created_by
+    expect(params[4]).toBe("shared-kb"); // namespace
+    expect(params[5]).toBeNull(); // embedding (embed=false)
+    expect(typeof params[6]).toBe("string"); // hash
+    expect(params[7]).toBeNull(); // embedded_at
+    expect(params[8]).toBeNull(); // embedding_model
+    expect(params[9]).toBeNull(); // extracted_metadata
   });
 
   it("returns 'duplicate' when rowCount is 0", async () => {
-    const file = makeFile(
-      "Duplicate content that already exists in the database.",
-    );
+    const file = makeFile("Duplicate content that already exists in the database.");
     const { pool } = createMockPool(async () => ({ rows: [], rowCount: 0 }));
 
     const result = await importThought(pool, file, defaultOpts);
@@ -364,9 +278,7 @@ describe("small: single file import", () => {
   });
 
   it("returns 'error' when query throws", async () => {
-    const file = makeFile(
-      "Content that will cause a database error during insert.",
-    );
+    const file = makeFile("Content that will cause a database error during insert.");
     const { pool } = createMockPool(async () => {
       throw new Error("connection refused");
     });
@@ -510,543 +422,5 @@ describe("large: 100-file import", () => {
     // file 0 imports, files 10,20,30,40,50,60,70,80,90 are dupes of file 0
     expect(duplicates).toBe(9);
     expect(imported).toBe(91);
-  });
-});
-
-// ===========================================================================
-// TABLE ROUTING: thoughts vs decisions vs sessions
-// ===========================================================================
-
-describe("table routing", () => {
-  it("importThought uses INSERT INTO thoughts", async () => {
-    const file = makeFile(
-      "A thought about testing table routing in the bulk import script.",
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importThought(pool, file, defaultOpts);
-
-    const [sql] = mockQuery.mock.calls[0] as [string, unknown[]];
-    expect(sql).toContain("INSERT INTO thoughts");
-    expect(sql).toContain("namespace");
-    expect(sql).not.toContain("INSERT INTO decisions");
-    expect(sql).not.toContain("INSERT INTO sessions");
-  });
-
-  it("importDecision uses INSERT INTO decisions with title and rationale", async () => {
-    const file = makeFile(
-      "We decided to use Bun because it is faster than Node for our workload.",
-      { title: "Use Bun Runtime", tags: ["infrastructure"] },
-      "/test/decision.md",
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importDecision(pool, file, defaultOpts);
-
-    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-    expect(sql).toContain("INSERT INTO decisions");
-    expect(sql).toContain("title");
-    expect(sql).toContain("rationale");
-    expect(sql).toContain("context");
-    expect(sql).toContain("namespace");
-    expect(params![0]).toBe("Use Bun Runtime"); // title from frontmatter
-    expect(params![1]).toBe(
-      "We decided to use Bun because it is faster than Node for our workload.",
-    ); // rationale = body
-    expect(params![3]).toContain("Imported from:"); // context
-    expect(params![5]).toBe("shared-kb"); // namespace
-  });
-
-  it("importDecision falls back to first line of body for title when no frontmatter title", async () => {
-    const file = makeFile(
-      "# Switch to PostgreSQL\n\nBecause it has better vector support than SQLite.",
-      {},
-      "/test/decision-no-title.md",
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importDecision(pool, file, defaultOpts);
-
-    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-    // Title is derived from first line with leading # stripped
-    expect(params![0]).toBe("Switch to PostgreSQL");
-  });
-
-  it("importDecision uses frontmatter.name as fallback title", async () => {
-    const file = makeFile(
-      "This decision has a name field instead of a title field in frontmatter.",
-      { name: "Named Decision" },
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importDecision(pool, file, defaultOpts);
-
-    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-    expect(params![0]).toBe("Named Decision");
-  });
-
-  it("importSession uses INSERT INTO sessions with project and summary", async () => {
-    const file = makeFile(
-      "We worked on the bulk import feature and added comprehensive test coverage.",
-      { project: "open-brain", tags: ["session"] },
-      "/test/session.md",
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importSession(pool, file, {
-      extraTags: [],
-      sourceLabel: "bulk-import",
-      embed: false,
-    });
-
-    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-    expect(sql).toContain("INSERT INTO sessions");
-    expect(sql).toContain("project");
-    expect(sql).toContain("summary");
-    expect(params![0]).toBe("open-brain"); // project from frontmatter
-    expect(params![1]).toBe(
-      "We worked on the bulk import feature and added comprehensive test coverage.",
-    ); // summary = body
-    expect(params![2]).toEqual(["session"]); // tags
-    expect(params![3]).toBe("bulk-import"); // created_by
-    expect(params![4]).toBe("shared-kb"); // namespace
-  });
-
-  it("importSession sets project to null when not in frontmatter", async () => {
-    const file = makeFile(
-      "Session without a project field in the frontmatter metadata.",
-      {},
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importSession(pool, file, {
-      extraTags: [],
-      sourceLabel: "bulk-import",
-      embed: false,
-    });
-
-    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-    expect(params![0]).toBeNull(); // project
-  });
-
-  it("importSession dedups on the canonical summary|project hash (WHERE NOT EXISTS)", async () => {
-    // Sessions used to hash summary + a live timestamp so every import created a
-    // fresh row. That hash can never be reproduced by the embedding-repair
-    // registry, so every imported session was permanently source_drift. The
-    // writer now hashes the canonical summary|project source and dedups on it,
-    // matching the live session writers.
-    const file = makeFile(
-      "Session content that maps to a stable canonical source hash.",
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importSession(pool, file, {
-      extraTags: [],
-      sourceLabel: "bulk-import",
-      embed: false,
-    });
-
-    const [sql] = mockQuery.mock.calls[0] as [string, unknown[]];
-    expect(sql).toContain("WHERE NOT EXISTS");
-  });
-});
-
-// ===========================================================================
-// TAG HANDLING: --tags flag merges with frontmatter tags
-// ===========================================================================
-
-describe("tag handling", () => {
-  it("merges extraTags with frontmatter tags for thoughts", async () => {
-    const file = makeFile(
-      "Content with both frontmatter and CLI tags for testing merge behavior.",
-      { tags: ["fm-tag-1", "fm-tag-2"] },
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importThought(pool, file, {
-      ...defaultOpts,
-      extraTags: ["cli-tag-1", "cli-tag-2"],
-    });
-
-    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-    expect(params![1]).toEqual([
-      "fm-tag-1",
-      "fm-tag-2",
-      "cli-tag-1",
-      "cli-tag-2",
-    ]);
-  });
-
-  it("uses only extraTags when frontmatter has no tags", async () => {
-    const file = makeFile(
-      "Content without frontmatter tags but with CLI-provided tags.",
-      {},
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importThought(pool, file, {
-      ...defaultOpts,
-      extraTags: ["added-tag"],
-    });
-
-    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-    expect(params![1]).toEqual(["added-tag"]);
-  });
-
-  it("uses only frontmatter tags when no extraTags", async () => {
-    const file = makeFile(
-      "Content with frontmatter tags and no extra CLI tags provided.",
-      { tags: ["only-fm"] },
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importThought(pool, file, defaultOpts);
-
-    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-    expect(params![1]).toEqual(["only-fm"]);
-  });
-
-  it("handles non-array frontmatter tags gracefully", async () => {
-    const file = makeFile(
-      "Content where frontmatter tags is a string instead of an array.",
-      { tags: "not-an-array" },
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importThought(pool, file, {
-      ...defaultOpts,
-      extraTags: ["extra"],
-    });
-
-    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-    // Non-array tags should be treated as empty, only extraTags used
-    expect(params![1]).toEqual(["extra"]);
-  });
-
-  it("merges tags for decisions the same way", async () => {
-    const file = makeFile(
-      "Decision content for testing tag merge behavior in the decisions table.",
-      { title: "Tag Test", tags: ["decision-tag"] },
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importDecision(pool, file, {
-      ...defaultOpts,
-      extraTags: ["cli-tag"],
-    });
-
-    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-    expect(params![2]).toEqual(["decision-tag", "cli-tag"]); // tags is param index 2 for decisions
-  });
-
-  it("merges tags for sessions the same way", async () => {
-    const file = makeFile(
-      "Session content for testing tag merge behavior in the sessions table.",
-      { tags: ["session-tag"] },
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importSession(pool, file, {
-      extraTags: ["cli-tag"],
-      sourceLabel: "bulk-import",
-      embed: false,
-    });
-
-    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-    expect(params![2]).toEqual(["session-tag", "cli-tag"]); // tags is param index 2 for sessions
-  });
-});
-
-// ===========================================================================
-// DRY RUN: no DB calls
-// ===========================================================================
-
-describe("dry run", () => {
-  it("readFiles works but no DB calls are needed in dry-run mode", async () => {
-    // Simulate what the main function does in dry-run: read files, print them, exit
-    for (let i = 0; i < 5; i++) {
-      await Bun.write(
-        join(tmpDir, `note-${i}.md`),
-        `---\ntitle: Note ${i}\n---\n\nThis is note ${i} with enough content to pass the minimum length check.`,
-      );
-    }
-
-    const files = await readFiles(tmpDir, "**/*.md");
-    expect(files).toHaveLength(5);
-
-    // In dry-run mode, the script just prints files and exits without calling pool.query
-    const { pool, mockQuery } = createMockPool();
-
-    // Dry-run: iterate and collect output but do NOT call any import function
-    const dryRunOutput: string[] = [];
-    for (const f of files) {
-      const title =
-        (f.frontmatter.title as string) ||
-        (f.body.split("\n")[0] ?? "").slice(0, 80);
-      dryRunOutput.push(`${f.filePath} -> ${title}`);
-    }
-
-    expect(dryRunOutput).toHaveLength(5);
-    expect(dryRunOutput[0]).toContain("->");
-    // Verify NO database calls were made
-    expect(mockQuery).not.toHaveBeenCalled();
-    // Pool.end should not be called in dry-run either (pool is never created)
-  });
-});
-
-// ===========================================================================
-// PARSE ARGS
-// ===========================================================================
-
-describe("parseArgs", () => {
-  it("parses source directory as positional argument", () => {
-    const result = parseArgs(["bun", "script.ts", "/some/dir"]);
-    expect(result.sourceDir).toBe("/some/dir");
-    expect(result.table).toBe("thoughts"); // default
-    expect(result.dryRun).toBe(false);
-    expect(result.pattern).toBe("**/*.md");
-  });
-
-  it("parses --table flag", () => {
-    const result = parseArgs([
-      "bun",
-      "script.ts",
-      "/dir",
-      "--table",
-      "decisions",
-    ]);
-    expect(result.table).toBe("decisions");
-  });
-
-  it("parses --tags flag with comma-separated values", () => {
-    const result = parseArgs(["bun", "script.ts", "/dir", "--tags", "a,b,c"]);
-    expect(result.extraTags).toEqual(["a", "b", "c"]);
-  });
-
-  it("parses --source flag", () => {
-    const result = parseArgs([
-      "bun",
-      "script.ts",
-      "/dir",
-      "--source",
-      "my-source",
-    ]);
-    expect(result.sourceLabel).toBe("my-source");
-  });
-
-  it("parses --pattern flag", () => {
-    const result = parseArgs([
-      "bun",
-      "script.ts",
-      "/dir",
-      "--pattern",
-      "*.txt",
-    ]);
-    expect(result.pattern).toBe("*.txt");
-  });
-
-  it("parses boolean flags: --embed, --extract, --dry-run", () => {
-    const result = parseArgs([
-      "bun",
-      "script.ts",
-      "/dir",
-      "--embed",
-      "--extract",
-      "--dry-run",
-    ]);
-    expect(result.embed).toBe(true);
-    expect(result.extract).toBe(true);
-    expect(result.dryRun).toBe(true);
-  });
-
-  it("parses all options together", () => {
-    const result = parseArgs([
-      "bun",
-      "script.ts",
-      "/my/dir",
-      "--table",
-      "sessions",
-      "--tags",
-      "x,y",
-      "--source",
-      "custom",
-      "--pattern",
-      "notes/*.md",
-      "--embed",
-      "--dry-run",
-    ]);
-    expect(result.sourceDir).toBe("/my/dir");
-    expect(result.table).toBe("sessions");
-    expect(result.extraTags).toEqual(["x", "y"]);
-    expect(result.sourceLabel).toBe("custom");
-    expect(result.pattern).toBe("notes/*.md");
-    expect(result.embed).toBe(true);
-    expect(result.extract).toBe(false);
-    expect(result.dryRun).toBe(true);
-  });
-
-  it("trims whitespace from tag values", () => {
-    const result = parseArgs([
-      "bun",
-      "script.ts",
-      "/dir",
-      "--tags",
-      " a , b , c ",
-    ]);
-    expect(result.extraTags).toEqual(["a", "b", "c"]);
-  });
-});
-
-// ===========================================================================
-// EDGE CASES
-// ===========================================================================
-
-describe("edge cases", () => {
-  it("skips empty files (< 10 chars body)", async () => {
-    await Bun.write(join(tmpDir, "empty.md"), "");
-    await Bun.write(join(tmpDir, "short.md"), "hi");
-    await Bun.write(join(tmpDir, "nine.md"), "123456789"); // exactly 9 chars
-
-    const files = await readFiles(tmpDir, "**/*.md");
-    expect(files).toHaveLength(0);
-  });
-
-  it("includes files with exactly 10 chars body", async () => {
-    await Bun.write(join(tmpDir, "ten.md"), "1234567890"); // exactly 10 chars
-
-    const files = await readFiles(tmpDir, "**/*.md");
-    expect(files).toHaveLength(1);
-  });
-
-  it("handles files with frontmatter but empty body", async () => {
-    await Bun.write(
-      join(tmpDir, "fm-only.md"),
-      `---\ntitle: All Frontmatter\ntags: [a, b]\n---\n`,
-    );
-
-    const files = await readFiles(tmpDir, "**/*.md");
-    expect(files).toHaveLength(0);
-  });
-
-  it("handles files with frontmatter and very short body", async () => {
-    await Bun.write(
-      join(tmpDir, "fm-short.md"),
-      `---\ntitle: Short Body\n---\n\nHi`,
-    );
-
-    const files = await readFiles(tmpDir, "**/*.md");
-    expect(files).toHaveLength(0); // "Hi" is < 10 chars
-  });
-
-  it("handles nested directories with glob pattern", async () => {
-    await Bun.write(
-      join(tmpDir, "a", "b", "c", "deep.md"),
-      "Deeply nested file content with enough text for the import.",
-    );
-    await Bun.write(
-      join(tmpDir, "a", "sibling.md"),
-      "Sibling file content with enough text for the import test.",
-    );
-
-    const files = await readFiles(tmpDir, "**/*.md");
-    expect(files).toHaveLength(2);
-  });
-
-  it("custom source label propagates to SQL params for thoughts", async () => {
-    const file = makeFile(
-      "Content with a custom source label for testing propagation.",
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importThought(pool, file, {
-      ...defaultOpts,
-      sourceLabel: "my-custom-source",
-    });
-
-    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-    expect(params![2]).toBe("my-custom-source");
-  });
-
-  it("decision context includes file path", async () => {
-    const file = makeFile(
-      "Decision body with enough content for the minimum length check.",
-      { title: "Test Decision" },
-      "/my/notes/decision-001.md",
-    );
-    const { pool, mockQuery } = createMockPool();
-
-    await importDecision(pool, file, defaultOpts);
-
-    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-    expect(params![3]).toBe("Imported from: /my/notes/decision-001.md");
-  });
-
-  it("importThought logs warning on query error", async () => {
-    const file = makeFile(
-      "Content that triggers a database error for testing error handling.",
-    );
-    const { pool } = createMockPool(async () => {
-      throw new Error("test-db-error");
-    });
-
-    const result = await importThought(pool, file, defaultOpts);
-
-    expect(result).toBe("error");
-    const warnCall = logCalls.warn.find(([msg]) => msg === "Import error");
-    expect(warnCall).toBeTruthy();
-    expect(warnCall![1]!.error).toBe("test-db-error");
-  });
-
-  it("importDecision logs warning on query error", async () => {
-    const file = makeFile(
-      "Decision content that triggers a database error for testing.",
-      { title: "Error Decision" },
-    );
-    const { pool } = createMockPool(async () => {
-      throw new Error("decision-db-error");
-    });
-
-    const result = await importDecision(pool, file, defaultOpts);
-
-    expect(result).toBe("error");
-    const warnCall = logCalls.warn.find(
-      ([, extra]) => extra?.error === "decision-db-error",
-    );
-    expect(warnCall).toBeTruthy();
-  });
-
-  it("importSession logs warning on query error", async () => {
-    const file = makeFile(
-      "Session content that triggers a database error for testing.",
-    );
-    const { pool } = createMockPool(async () => {
-      throw new Error("session-db-error");
-    });
-
-    const result = await importSession(pool, file, {
-      extraTags: [],
-      sourceLabel: "test",
-      embed: false,
-    });
-
-    expect(result).toBe("error");
-  });
-
-  it("content hash is deterministic for identical content", () => {
-    const hash1 = contentHash("Hello world test content");
-    const hash2 = contentHash("Hello world test content");
-    expect(hash1).toBe(hash2);
-  });
-
-  it("content hash differs for different content", () => {
-    const hash1 = contentHash("Content version A for hash testing");
-    const hash2 = contentHash("Content version B for hash testing");
-    expect(hash1).not.toBe(hash2);
-  });
-
-  it("content hash normalizes whitespace", () => {
-    const hash1 = contentHash("hello  world");
-    const hash2 = contentHash("hello world");
-    expect(hash1).toBe(hash2);
   });
 });

--- a/scripts/done-means/864-logger-never-mocked-process-wide.sh
+++ b/scripts/done-means/864-logger-never-mocked-process-wide.sh
@@ -1,0 +1,87 @@
+#!/opt/homebrew/bin/bash
+# DONE-MEANS check for issue 864 -- no test suite replaces the logger module
+# process-wide, and the suites that depend on a real logger still pass.
+#
+#   bash scripts/done-means/864-logger-never-mocked-process-wide.sh
+#
+# THE MECHANISM. bun's `mock.module()` is process-wide, not file-scoped: a
+# single suite calling `mock.module("../../src/logger.ts", ...)` swaps the
+# logger for EVERY suite that loads afterwards in the same run. The
+# observability suite asserts on real log records, so it observes the
+# replacement rather than the module it imported, and the failure surfaces in
+# a file that changed nothing. The offending call is the defect, not the suite
+# that reports it.
+#
+# Clause A -- NO PROCESS-WIDE LOGGER MOCK. `mock.module(... logger ...)` appears
+#   on no non-comment line of any *.test.ts under src, server or scripts.
+#   Comment lines are excluded on purpose: the two surviving mentions
+#   (src/observability/observability.test.ts and scripts/backfill.test.ts) are
+#   prose warning the next author off the call, and a gate that failed on its
+#   own documentation would push that warning out of the tree.
+#
+#   RED at origin/main:
+#     git show origin/main:scripts/__tests__/bulk-import.test.ts | rg -n 'mock\.module'
+#     -> `17:mock.module("../../src/logger.ts", () => ({`, exit 0.
+#   That one call is what clause A rejects.
+#
+# Clause B -- THE SUITES STILL PASS. `bun run test:isolated` over the two
+#   bulk-import suites plus the observability suite exits 0. The observability
+#   suite is the detector: it is the one that notices a replaced logger, and
+#   running it in the SAME process as the bulk-import suites is what makes the
+#   clause meaningful. Running them apart would pass with the mock restored.
+#
+# Exit 0: both clauses pass.
+# Exit 1: either clause fails.
+# Exit 3: harness error -- rg or bun missing, or not in a git tree.
+set -uo pipefail
+
+cd "$(dirname "$0")/../.." || exit 3
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || {
+  printf 'HARNESS-ERROR: not run from a checkout\n' >&2
+  exit 3
+}
+command -v rg >/dev/null 2>&1 || { printf 'HARNESS-ERROR: rg not on PATH\n' >&2; exit 3; }
+command -v bun >/dev/null 2>&1 || { printf 'HARNESS-ERROR: bun not on PATH\n' >&2; exit 3; }
+
+# Every match, then the comment lines removed. Both counts print, so a reader
+# can see that the documentation mentions were found and deliberately excused.
+ALL_HITS="$(rg -n 'mock\.module\([^)]*logger' --glob '*.test.ts' src server scripts || true)"
+CODE_HITS="$(printf '%s\n' "$ALL_HITS" | rg -v ':[[:space:]]*(//|\*|/\*)' | rg -v '^$' || true)"
+
+ALL_COUNT=0
+[ -n "$ALL_HITS" ] && ALL_COUNT="$(printf '%s\n' "$ALL_HITS" | rg -c '' || true)"
+CODE_COUNT=0
+[ -n "$CODE_HITS" ] && CODE_COUNT="$(printf '%s\n' "$CODE_HITS" | rg -c '' || true)"
+
+CLAUSE_A=PASS
+if [ "$CODE_COUNT" -ne 0 ]; then
+  CLAUSE_A=FAIL
+fi
+
+printf '=== DONE-MEANS 864 (the logger is never replaced process-wide) ===\n'
+printf 'mentions        : %s (comments included)\n' "$ALL_COUNT"
+printf 'calls           : %s (comment lines excluded)\n' "$CODE_COUNT"
+if [ "$CLAUSE_A" = FAIL ]; then
+  printf '%s\n' "$CODE_HITS"
+fi
+printf 'CLAUSE A no process-wide logger mock: %s\n' "$CLAUSE_A"
+
+CLAUSE_B=PASS
+TEST_OUT="$(bun run test:isolated \
+  scripts/__tests__/bulk-import.test.ts \
+  scripts/__tests__/bulk-import-routing.test.ts \
+  src/observability/observability.test.ts 2>&1)" || CLAUSE_B=FAIL
+
+printf '%s\n' "$TEST_OUT" | rg -n '^[[:space:]]*[0-9]+ (pass|fail)' || true
+printf 'CLAUSE B the three suites pass in one process: %s\n' "$CLAUSE_B"
+
+if [ "$CLAUSE_A" = PASS ] && [ "$CLAUSE_B" = PASS ]; then
+  printf 'RESULT: PASS\n'
+  exit 0
+fi
+
+if [ "$CLAUSE_B" = FAIL ]; then
+  printf '%s\n' "$TEST_OUT" | tail -40
+fi
+printf 'RESULT: FAIL\n'
+exit 1


### PR DESCRIPTION
## Summary

- `scripts/__tests__/bulk-import.test.ts` replaced `src/logger.ts` with a stub object through `mock.module`. That mock is process-wide and permanent in Bun -- keyed by resolved specifier, never scoped to one file, and not undone by `mock.restore()` -- so once this file had loaded, every later suite in the run received the stub instead of the real logger.
- The visible failure: a suite that registers an `addLogSink` observer and asserts on the lines the logger emits captures nothing, because the stub has no sink machinery and pushes into this file's own arrays instead. Such a suite passes alone and fails in the full run, with a stack pointing nowhere near this file.
- `src/observability/observability.test.ts:19` already states that no suite may `mock.module` the logger, and `scripts/backfill.test.ts:10` is the precedent for the alternative. This file now observes through `addLogSink`, which composes with other suites instead of overwriting them. The two assertions it makes on `logCalls.warn` are unchanged.
- Bringing the file to the whole-file lint standard came with it (M14 inherited lint debt), since the pre-commit gate lints staged files whole and this one carried 38 findings at `main`: 35 non-null assertions removed (`params![n]` loses an assertion the surrounding `as [string, unknown[]]` already makes redundant; the `files[0]!` and `warnCall![1]!` sites use `expectDefined` from `scripts/test-support/expect-defined.ts`), the 816-code-line file split by responsibility into `scripts/__tests__/bulk-import.test.ts` (parsing, reading, small/medium/large import paths) and `scripts/__tests__/bulk-import-routing.test.ts` (table routing, tag handling, dry run, argument parsing, edge cases) over a shared `scripts/__tests__/bulk-import-fixture.ts`, and two over-long describe callbacks split at a responsibility seam into `table routing` / `table routing: sessions` and `edge cases` / `edge cases: error logging and hashing`.
- No `it` name, body, order, or assertion changed. Neither file is a `*.pg.test.ts`, so `scripts/assert-db-tests-ran.ts` is untouched. 59 tests before, 59 after.

## Verification

- Done-means: scripts/done-means/864-logger-never-mocked-process-wide.sh
- [x] Relevant Open Brain tests/typecheck/migrations passed
- [x] Python package checks passed or are not applicable
- [x] Live Open Brain smoke passed or is not applicable

`./node_modules/.bin/oxlint --deny-warnings --config .oxlintrc.json` on all three staged paths -> exit 0, no findings (38 at `main` on the single file). `bunx tsc --noEmit` -> exit 0. `bun run test:isolated scripts/__tests__/bulk-import.test.ts scripts/__tests__/bulk-import-routing.test.ts` -> 59 pass, 0 fail, the same 59 the single file ran. The pre-push hook ran the whole isolated suite and passed, which is the receipt that no other suite depended on the stub.

The Done-means is `scripts/done-means/864-logger-never-mocked-process-wide.sh`, added by this branch: clause A rejects any `mock.module(... logger ...)` on a non-comment line of a `*.test.ts` under `src`, `server` or `scripts`, and clause B runs the two bulk-import suites together with `src/observability/observability.test.ts` under `bun run test:isolated` -- the observability suite is the one that detects a replaced logger, so running them in one process is what makes the clause mean anything. It is RED at `origin/main`, where `git show origin/main:scripts/__tests__/bulk-import.test.ts | rg -n 'mock\.module'` prints `17:mock.module("../../src/logger.ts", () => ({`, and GREEN here at 114 pass, 0 fail, `RESULT: PASS`.

## Critical Self-Review

- Highest-risk behavior: log observation. The stub captured `(msg, extra)` pairs directly; `addLogSink` delivers a whole entry, so the fixture strips `level`, `message`, `timestamp` and `service` and pushes the rest as `extra`. The two assertions that read `extra` (`warnCall[1].error`, and the `extra?.error === "decision-db-error"` finder) both pass, which is what proves the reshaping is faithful.
- Assumptions that could be wrong: that no other suite relied on this file's logger stub being installed. The pre-push full-suite run is the evidence against that, not an assumption.
- Missing/weak tests: none added. This is a test-infrastructure fix; the assertions it protects already exist, and the split preserves every one of them.
- Security/permission risk: none. No production code, no auth path, no namespace predicate is touched.
- Migration/deploy risk: none. Test files only; nothing ships.
- Downstream client/runtime risk: none. No MCP tool, schema, transport, or Python client surface changes; `docs/downstream-rollout.md` classifies this as not applicable.
- Rollback/cleanup concern: reverting restores the process-wide stub and with it the cross-file contamination. The three files move together.
- Fixes made before PR: the unused `pool` binding in the dry-run test and the unused imports each half no longer needs were removed rather than underscore-prefixed, since nothing reads them.
- Known residual risk: `describe` names changed for the two split groups. Nothing in the repo keys on these names -- neither file is a `*.pg.test.ts`, so the `scripts/assert-db-tests-ran.ts` manifest, which is the one place suite names are pinned, does not list them.
- SME review-memory update: [ ] `docs/sme/` updated or [x] not applicable because: the pattern is already recorded in-tree at `src/observability/observability.test.ts:19` and `scripts/backfill.test.ts:10`, which are the two places a reviewer of this file would look, and the fix cites both.

## Review Gate

- [x] Critical self-review fields above are filled with specific, non-placeholder content
- [x] MEDIUM+ review findings were captured in `docs/sme/` or explicitly marked not applicable
- Live Open Brain checks: [ ] linked below or [x] not applicable because: no runtime surface changes.

## Contract Parity

- Contract parity: [ ] fixtures updated
- Contract parity: [x] runtime-specific because: no contract, fixture, or client-facing shape is touched; the pre-push hook reported the contract parity subset skipped for exactly that reason.

## Downstream Rollout

- [x] I checked `docs/downstream-rollout.md`
- [x] rtech-mcps handoff is complete or not applicable
- [x] mcp2cli cache/skill refresh is complete or not applicable
- [x] rtech-hermes Python runtime/plugin changes are complete or not applicable
- [x] Hermes live rollout/canaries are complete or not applicable

Notes/evidence:

- Test-only change. The pre-push hook reported `Python package unchanged; skipping Python package gate` and `Client/contract paths unchanged; skipping contract parity subset`.

Refs issue 864.

